### PR TITLE
Fix cache timeMap cleanup

### DIFF
--- a/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
+++ b/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
@@ -41,7 +41,11 @@ public class TimedLRUCache<K, V> extends LinkedHashMap<K, V> {
         if (elapsedTime == null) {
             return false; // or handle this case as needed
         }
-        return size() > maxSize || System.currentTimeMillis() - elapsedTime > maxAge;
+        boolean shouldRemove = size() > maxSize || System.currentTimeMillis() - elapsedTime > maxAge;
+        if (shouldRemove) {
+            timeMap.remove(eldest.getKey());
+        }
+        return shouldRemove;
     }
     /**
      * Associates the specified value with the specified key in this cache. If the cache previously

--- a/src/test/java/julius/game/chessengine/cache/TimedLRUCacheTest.java
+++ b/src/test/java/julius/game/chessengine/cache/TimedLRUCacheTest.java
@@ -1,0 +1,42 @@
+package julius.game.chessengine.cache;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TimedLRUCacheTest {
+
+    @SuppressWarnings("unchecked")
+    private static <K,V> Map<K, Long> getTimeMap(TimedLRUCache<K,V> cache) throws Exception {
+        Field f = TimedLRUCache.class.getDeclaredField("timeMap");
+        f.setAccessible(true);
+        return (Map<K, Long>) f.get(cache);
+    }
+
+    @Test
+    public void eldestRemovalRemovesFromTimeMap() throws Exception {
+        TimedLRUCache<String, String> cache = new TimedLRUCache<>(2, 100000);
+        cache.put("a", "1");
+        cache.put("b", "2");
+        Map<String, Long> timeMap = getTimeMap(cache);
+        assertEquals(2, timeMap.size());
+        cache.put("c", "3");
+        assertFalse(cache.containsKey("a"));
+        assertFalse(timeMap.containsKey("a"));
+        assertEquals(cache.size(), timeMap.size());
+    }
+
+    @Test
+    public void agedEntryRemovalCleansTimeMap() throws Exception {
+        TimedLRUCache<String, String> cache = new TimedLRUCache<>(10, 50);
+        cache.put("x", "1");
+        Thread.sleep(60);
+        cache.put("y", "2");
+        Map<String, Long> timeMap = getTimeMap(cache);
+        assertFalse(cache.containsKey("x"));
+        assertFalse(timeMap.containsKey("x"));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure TimedLRUCache clears timeMap when removing eldest entry
- add unit tests for size and age eviction

## Testing
- `sh mvnw -o -q test` *(fails: UnknownHostException repo.maven.apache.org)*