### PR TITLE
Fix typos in board move comment

### DIFF
--- a/src/main/java/julius/game/chessengine/board/Move.java
+++ b/src/main/java/julius/game/chessengine/board/Move.java
@@ -28,7 +28,7 @@ public class Move {
     //same like pieceType
 
 
-    //  from      to   pieceColor   pieceType      sp     pp   isKingsfirstMove isRooksFirstMove  isCheck  isCheckMate   isAmbigousMove
+    //  from      to   pieceColor   pieceType      sp     pp   isKingsfirstMove isRooksFirstMove  isCheck  isCheckMate   isAmbiguousMove
     //<111111> <111111>   <1>         <111>       <11>   <000>        <1>             <1>           <1>         <1>           <1>
 
     // Getters for all the fields


### PR DESCRIPTION
## Summary
- fix typo in the Move comment so it reads `isAmbiguousMove`

## Testing
- `./mvnw -q test` *(fails: `UnknownHostException`)*

------
https://chatgpt.com/codex/tasks/task_e_682a362aae24832a885cf48bd0955b65