### PR TITLE
Restrict en passant target to capturable cases

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -708,7 +708,13 @@ public class BitBoard {
         }
 
         if (pieceTypeBits == 1 && Math.abs(fromIndex / 8 - toIndex / 8) == 2) {
-            lastMoveDoubleStepPawnIndex = toIndex;
+            // A pawn moved two squares forward. Only expose the en passant
+            // target square if an opposing pawn could actually capture it.
+            long enemyPawns = isWhite ? blackPawns : whitePawns;
+            int file = toIndex % 8;
+            boolean leftEnemy = file > 0 && ((enemyPawns & (1L << (toIndex - 1))) != 0);
+            boolean rightEnemy = file < 7 && ((enemyPawns & (1L << (toIndex + 1))) != 0);
+            lastMoveDoubleStepPawnIndex = (leftEnemy || rightEnemy) ? toIndex : 0;
         } else {
             lastMoveDoubleStepPawnIndex = 0;
         }

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -2,6 +2,7 @@ package julius.game.chessengine.board;
 
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.utils.Color;
+import julius.game.chessengine.figures.PieceType;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Test;
 
@@ -47,6 +48,44 @@ public class BitBoardTest {
         b.logBoard();
 
         assertEquals(a.getBoardStateHash(), b.getBoardStateHash());
+    }
+
+    @Test
+    public void testEnPassantIndexOnlyWhenCapturePossible() {
+        BitBoard board = new BitBoard();
+
+        int e2 = convertStringToIndex("e2");
+        int e4 = convertStringToIndex("e4");
+        int move = MoveHelper.createMoveInt(e2, e4, PieceType.PAWN, true,
+                false, false, false, null, null, false, false,
+                board.getLastMoveDoubleStepPawnIndex());
+        board.performMove(move);
+
+        // No black pawn can capture the pawn on e4, so en passant index should be 0
+        assertEquals(0, board.getLastMoveDoubleStepPawnIndex());
+
+        // Make a series of moves to place a white pawn next to a black pawn that double steps
+        int a7 = convertStringToIndex("a7");
+        int a6 = convertStringToIndex("a6");
+        move = MoveHelper.createMoveInt(a7, a6, PieceType.PAWN, false,
+                false, false, false, null, null, false, false,
+                board.getLastMoveDoubleStepPawnIndex());
+        board.performMove(move);
+
+        int e5 = convertStringToIndex("e5");
+        move = MoveHelper.createMoveInt(e4, e5, PieceType.PAWN, true,
+                false, false, false, null, null, false, false,
+                board.getLastMoveDoubleStepPawnIndex());
+        board.performMove(move);
+
+        int d7 = convertStringToIndex("d7");
+        int d5 = convertStringToIndex("d5");
+        move = MoveHelper.createMoveInt(d7, d5, PieceType.PAWN, false,
+                false, false, false, null, null, false, false,
+                board.getLastMoveDoubleStepPawnIndex());
+        board.performMove(move);
+
+        assertEquals(d5, board.getLastMoveDoubleStepPawnIndex());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- ensure en passant target square is stored only when an opposing pawn can capture it
- add regression test verifying en passant state handling

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bef6b92414832a889c521806b88471