### PR TITLE
Ensure LegalMovesCache enforces size limit safely

### DIFF
--- a/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
+++ b/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
@@ -57,16 +57,51 @@ public class TimedLRUCache<K, V> extends LinkedHashMap<K, V> {
      * @return the previous value associated with the key, or null if there was no mapping for the key
      */
     @Override
-    public V put(K key, V value) {
+    public synchronized V put(K key, V value) {
         timeMap.put(key, System.currentTimeMillis());
         return super.put(key, value);
+    }
+
+    /**
+     * Retrieves a value from the cache. Accessing an entry updates its
+     * position in the LRU order.
+     *
+     * @param key key whose associated value is to be returned
+     * @return the value associated with the specified key, or {@code null}
+     *         if the cache contains no mapping for the key
+     */
+    @Override
+    public synchronized V get(Object key) {
+        return super.get(key);
+    }
+
+    /**
+     * Checks whether a key is present in the cache.
+     *
+     * @param key key whose presence in this cache is to be tested
+     * @return {@code true} if this cache contains a mapping for the
+     *         specified key
+     */
+    @Override
+    public synchronized boolean containsKey(Object key) {
+        return super.containsKey(key);
+    }
+
+    /**
+     * Returns the number of key-value mappings in this cache.
+     *
+     * @return the number of entries in the cache
+     */
+    @Override
+    public synchronized int size() {
+        return super.size();
     }
 
     /**
      * Cleans up the cache by removing entries that are older than the maximum allowed age.
      * This method should be called periodically to ensure timely removal of old entries.
      */
-    public void cleanup() {
+    public synchronized void cleanup() {
         long now = System.currentTimeMillis();
         for (Iterator<Map.Entry<K, Long>> it = timeMap.entrySet().iterator(); it.hasNext();) {
             Map.Entry<K, Long> entry = it.next();

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -131,8 +131,8 @@ public class Engine {
         legalMovesCache.put(boardStateHash, this.legalMoves);
 
         int size = legalMovesCache.size();
-        if(size > MAX_SIZE + 100) {
-            throw new RuntimeException(String.format("LegalMovesCache size %s is larger then MAX_SIZE %s", size, MAX_SIZE));
+        if (size > MAX_SIZE) {
+            throw new RuntimeException(String.format("LegalMovesCache size %s is larger than MAX_SIZE %s", size, MAX_SIZE));
         }
     }
 


### PR DESCRIPTION
## Summary
- synchronize TimedLRUCache methods to make cache thread-safe and honour its max size
- remove safety buffer and correct overflow check in Engine

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68befd7012e4832a980830ec572b8232