### PR TITLE
Optimize move generation

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -44,6 +44,9 @@ public class BitBoard {
     private long allPieces = 0L;
     private PieceType[] pieceBoard = new PieceType[64];
 
+    // Reusable buffer for move generation to avoid frequent allocations.
+    private final MoveList moveGenerationBuffer = new MoveList();
+
     // This variable needs to be set whenever a move is made
     //TODO only write to it if en passant is possible then you can also hash it
     @Getter
@@ -298,7 +301,10 @@ public class BitBoard {
     }
 
     public MoveList generateAllPossibleMoves(boolean whitesTurn) {
-        MoveList moves = new MoveList();
+        // Reuse the internal buffer to cut down on object creation and garbage
+        // collection pressure during heavy search operations.
+        MoveList moves = moveGenerationBuffer;
+        moves.clear();
 
         generatePawnMoves(whitesTurn, moves);
         generateKnightMoves(whitesTurn, moves);

--- a/src/main/java/julius/game/chessengine/board/MoveList.java
+++ b/src/main/java/julius/game/chessengine/board/MoveList.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 public class MoveList {
     private int[] moves;
     private int moveCount;
-    private static final int INITIAL_SIZE = 30;
     private static final int MAX_SIZE = 218; // Maximum number of legal moves
 
     private String stringRepresentation;
@@ -16,36 +15,30 @@ public class MoveList {
 
 
     public MoveList() {
-        this.moves = new int[INITIAL_SIZE];
+        // Pre-allocate the maximum required size to avoid costly resizes during
+        // move generation. This significantly speeds up move generation by
+        // eliminating array reallocation and copy overhead.
+        this.moves = new int[MAX_SIZE];
         this.moveCount = 0;
     }
 
     // Deep copy constructor
     public MoveList(MoveList original) {
         this.moveCount = original.moveCount;
-        this.moves = new int[original.moves.length];
+        // Ensure the cloned list also has the full capacity so that it can be
+        // reused without triggering resizes.
+        this.moves = new int[MAX_SIZE];
         System.arraycopy(original.moves, 0, this.moves, 0, original.moveCount);
     }
 
     public void add(int move) {
-        if (moveCount >= moves.length) {
-            resizeArray();
-        }
+        // Since the array is pre-allocated to the maximum size, we can skip
+        // expensive bounds checks and resizes. The check against MAX_SIZE is
+        // kept as a safety measure.
         if (moveCount < MAX_SIZE) {
-            moves[moveCount] = move;
-            moveCount++;
+            moves[moveCount++] = move;
         }
         isStringRepresentationStale = true;
-    }
-
-    private void resizeArray() {
-        if (moves.length >= MAX_SIZE) {
-            return; // Do not resize beyond the maximum size
-        }
-        int newSize = Math.min(moves.length * 2, MAX_SIZE);
-        int[] newArray = new int[newSize];
-        System.arraycopy(moves, 0, newArray, 0, moveCount); // Copy only used elements
-        moves = newArray;
     }
 
     public int size() {


### PR DESCRIPTION
## Summary
- Preallocate MoveList to maximum capacity and streamline additions to avoid dynamic resizing.
- Reuse a single MoveList buffer in BitBoard for generating moves, cutting repeated allocations.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf150c7234832abb6cc21e8b983008