### PR TITLE
Precompute pawn move tables and refactor pawn moves

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -17,6 +17,8 @@ import static julius.game.chessengine.helper.BitHelper.*;
 import static julius.game.chessengine.helper.BitboardHelper.lineBetweenIndices;
 import static julius.game.chessengine.helper.KingHelper.KING_ATTACKS;
 import static julius.game.chessengine.helper.KnightHelper.knightMoveTable;
+import static julius.game.chessengine.helper.PawnMoveTables.PAWN_ATTACKS;
+import static julius.game.chessengine.helper.PawnMoveTables.PAWN_PUSHES;
 
 @Log4j2
 @Getter
@@ -324,34 +326,52 @@ public class BitBoard {
     }
 
     private void generatePawnMoves(boolean whitesTurn, MoveList moves) {
-        long pawns = whitesTurn ? whitePawns : blackPawns;
-
+        long pawnBitboard = whitesTurn ? whitePawns : blackPawns;
+        long pawns = pawnBitboard;
         long opponentPieces = whitesTurn ? blackPieces : whitePieces;
         long emptySquares = ~(whitePieces | blackPieces);
+        int colorIndex = whitesTurn ? 0 : 1;
 
-        long singleStepForward = whitesTurn ? pawns << 8 : pawns >>> 8;
-        singleStepForward &= emptySquares;
+        while (pawns != 0) {
+            int fromIndex = Long.numberOfTrailingZeros(pawns);
+            pawns &= pawns - 1;
 
-        long attacksLeft = whitesTurn ? (pawns & ~FileMasks[0]) << 7 : (pawns & ~FileMasks[0]) >>> 9;
-        long attacksRight = whitesTurn ? (pawns & ~FileMasks[7]) << 9 : (pawns & ~FileMasks[7]) >>> 7;
+            long singlePush = PAWN_PUSHES[colorIndex][fromIndex] & emptySquares;
+            if (singlePush != 0) {
+                int toIndex = Long.numberOfTrailingZeros(singlePush);
+                boolean isPromotion = whitesTurn ? toIndex >= 56 : toIndex < 8;
+                if (isPromotion) {
+                    addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, false, null);
+                } else {
+                    moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false, null, null, false, false, lastMoveDoubleStepPawnIndex));
+                }
 
-        long doubleStepForward;
-        if (whitesTurn) {
-            doubleStepForward = ((pawns & RankMasks[1]) << 8 & emptySquares) << 8 & emptySquares;
-        } else {
-            doubleStepForward = ((pawns & RankMasks[6]) >>> 8 & emptySquares) >>> 8 & emptySquares;
+                int rank = fromIndex / 8;
+                if ((whitesTurn && rank == 1) || (!whitesTurn && rank == 6)) {
+                    long doublePush = PAWN_PUSHES[colorIndex][toIndex] & emptySquares;
+                    if (doublePush != 0) {
+                        int doubleTo = Long.numberOfTrailingZeros(doublePush);
+                        moves.add(createMoveInt(fromIndex, doubleTo, PieceType.PAWN, whitesTurn, false, false, false, null, null, false, false, lastMoveDoubleStepPawnIndex));
+                    }
+                }
+            }
+
+            long attacks = PAWN_ATTACKS[colorIndex][fromIndex] & opponentPieces;
+            while (attacks != 0) {
+                int toIndex = Long.numberOfTrailingZeros(attacks);
+                PieceType capturedType = getPieceTypeAtIndex(toIndex);
+                boolean isPromotion = whitesTurn ? toIndex >= 56 : toIndex < 8;
+                if (isPromotion) {
+                    addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, true, capturedType);
+                } else {
+                    moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false, null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                }
+                attacks &= attacks - 1;
+            }
         }
 
-        attacksLeft &= opponentPieces;
-        attacksRight &= opponentPieces;
-
-        addPawnMoves(moves, singleStepForward, 8, false, whitesTurn);
-        addPawnMoves(moves, doubleStepForward, 16, false, whitesTurn);
-        addPawnMoves(moves, attacksLeft, whitesTurn ? 7 : 9, true, whitesTurn);
-        addPawnMoves(moves, attacksRight, whitesTurn ? 9 : 7, true, whitesTurn);
-
         if (lastMoveDoubleStepPawnIndex != 0) {
-            generateEnPassantMoves(moves, pawns, whitesTurn);
+            generateEnPassantMoves(moves, pawnBitboard, whitesTurn);
         }
 
     }
@@ -386,25 +406,6 @@ public class BitBoard {
     private void addEnPassantMove(MoveList moves, int fromIndex, int toIndex, boolean whitesTurn) {
         moves.add(
                 createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, true, null, PieceType.PAWN, false, false, lastMoveDoubleStepPawnIndex));
-    }
-
-    private void addPawnMoves(MoveList moves, long bitboard, int shift, boolean isCapture, boolean whitesTurn) {
-        while (bitboard != 0) {
-            int toIndex = Long.numberOfTrailingZeros(bitboard);
-            int fromIndex = whitesTurn ? toIndex - shift : toIndex + shift;
-
-            // Determine if the move results in a promotion by checking the target rank
-            boolean isPromotion = whitesTurn ? toIndex >= 56 : toIndex < 8;
-            PieceType capturedType = isCapture ? getPieceTypeAtIndex(toIndex) : null;
-
-            if (isPromotion) {
-                addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, isCapture, capturedType);
-            } else {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, isCapture, false, false, null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
-            }
-
-            bitboard &= bitboard - 1; // Clear the processed bit
-        }
     }
 
     private void addPromotionMoves(MoveList moves, int fromIndex, int toIndex, boolean whitesTurn, boolean isCapture, PieceType capturedType) {

--- a/src/main/java/julius/game/chessengine/helper/PawnMoveTables.java
+++ b/src/main/java/julius/game/chessengine/helper/PawnMoveTables.java
@@ -1,0 +1,56 @@
+package julius.game.chessengine.helper;
+
+/**
+ * Precomputed pawn move tables for quick lookup of pawn pushes and attacks.
+ * PAWN_ATTACKS[color][square] gives bitboard of attack targets for a pawn of the
+ * given color on the given square. PAWN_PUSHES[color][square] gives the square
+ * one step forward. These tables are initialised once at class load time.
+ */
+public class PawnMoveTables {
+
+    public static final long[][] PAWN_ATTACKS = new long[2][64];
+    public static final long[][] PAWN_PUSHES = new long[2][64];
+
+    static {
+        for (int square = 0; square < 64; square++) {
+            int rank = square / 8;
+            int file = square % 8;
+
+            long whiteAttacks = 0L;
+            long blackAttacks = 0L;
+            long whitePush = 0L;
+            long blackPush = 0L;
+
+            // White moves upwards (towards higher ranks)
+            if (rank < 7) {
+                whitePush = 1L << ((rank + 1) * 8 + file);
+                if (file > 0) {
+                    whiteAttacks |= 1L << ((rank + 1) * 8 + (file - 1));
+                }
+                if (file < 7) {
+                    whiteAttacks |= 1L << ((rank + 1) * 8 + (file + 1));
+                }
+            }
+
+            // Black moves downwards (towards lower ranks)
+            if (rank > 0) {
+                blackPush = 1L << ((rank - 1) * 8 + file);
+                if (file > 0) {
+                    blackAttacks |= 1L << ((rank - 1) * 8 + (file - 1));
+                }
+                if (file < 7) {
+                    blackAttacks |= 1L << ((rank - 1) * 8 + (file + 1));
+                }
+            }
+
+            PAWN_PUSHES[0][square] = whitePush;
+            PAWN_PUSHES[1][square] = blackPush;
+            PAWN_ATTACKS[0][square] = whiteAttacks;
+            PAWN_ATTACKS[1][square] = blackAttacks;
+        }
+    }
+
+    private PawnMoveTables() {
+        // utility class
+    }
+}


### PR DESCRIPTION
## Summary
- Precompute pawn attack and push targets for each square and color
- Use lookup tables in `BitBoard` to generate pawn moves and double pushes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for julius.game:chess-engine:3.0.1: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf17213bb4832a958175ae948a2fbe