### PR TITLE
Implement null move pruning with tests

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -5,6 +5,7 @@ import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.MoveList;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
+import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.utils.Score;
 import lombok.Getter;
 import lombok.Setter;
@@ -91,6 +92,10 @@ public class AI {
     @Setter
     private long timeLimit; // milliseconds
 
+    private boolean useNullMovePruning = true;
+    private long nodesVisited = 0;
+    private long nullMoveCount = 0;
+
 
     public AI(Engine mainEngine) {
         this.mainEngine = mainEngine;
@@ -103,6 +108,23 @@ public class AI {
                 killerMoves[i][j] = -1; // Initialize with an invalid move
             }
         }
+    }
+
+    public void setUseNullMovePruning(boolean useNullMovePruning) {
+        this.useNullMovePruning = useNullMovePruning;
+    }
+
+    public long getNodesVisited() {
+        return nodesVisited;
+    }
+
+    public long getNullMoveCount() {
+        return nullMoveCount;
+    }
+
+    public void resetCounters() {
+        nodesVisited = 0;
+        nullMoveCount = 0;
     }
 
     private void startCalculationThread() {
@@ -336,6 +358,7 @@ public class AI {
      */
     private double alphaBeta(Engine simulatorEngine, int depth, double alpha, double beta, boolean isWhite, long startTime, long timeLimit) {
         log.debug(" ------------------------- {} ------------------------- ", depth);
+        nodesVisited++;
         // Check for time limit exceeded
         if (System.currentTimeMillis() - startTime > timeLimit) {
             return EXIT_FLAG;
@@ -372,6 +395,18 @@ public class AI {
             }
         }
 
+        if (useNullMovePruning && depth >= 3 && !isSideInCheck(simulatorEngine, isWhite) && !simulatorEngine.isEndgame()) {
+            int ep = simulatorEngine.doNullMove();
+            nullMoveCount++;
+            double nullScore = alphaBeta(simulatorEngine, depth - 1 - 2, alpha, beta, !isWhite, startTime, timeLimit);
+            simulatorEngine.undoNullMove(ep);
+
+            if (isWhite && nullScore >= beta) {
+                return beta;
+            } else if (!isWhite && nullScore <= alpha) {
+                return alpha;
+            }
+        }
 
         double alphaOriginal = alpha; // Store the original alpha value
         double betaOriginal = beta;   // Store the original beta value
@@ -383,6 +418,11 @@ public class AI {
         } else {
             return minimizer(simulatorEngine, depth, alpha, beta, isWhite, boardHash, betaOriginal, moves, startTime, timeLimit);
         }
+    }
+
+    private boolean isSideInCheck(Engine engine, boolean isWhite) {
+        GameStateEnum state = engine.getGameState().getState();
+        return (isWhite && state == GameStateEnum.WHITE_IN_CHECK) || (!isWhite && state == GameStateEnum.BLACK_IN_CHECK);
     }
 
     private double maximizer(Engine simulatorEngine, int depth, double alpha, double beta, boolean isWhite, long boardHash, double alphaOriginal, MoveList moves, long startTime, long timeLimit) {

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -146,6 +146,10 @@ public class BitBoard {
         this.pieceBoard = Arrays.copyOf(other.pieceBoard, other.pieceBoard.length);
     }
 
+    public void setLastMoveDoubleStepPawnIndex(int index) {
+        this.lastMoveDoubleStepPawnIndex = index;
+    }
+
 
     public boolean hasInsufficientMaterial() {
         // Early return if any side has pawns, rooks, or queens, as these can achieve checkmate

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -245,6 +245,22 @@ public class Engine {
         return bitBoard.whitesTurn;
     }
 
+    public int doNullMove() {
+        int prev = bitBoard.getLastMoveDoubleStepPawnIndex();
+        bitBoard.setLastMoveDoubleStepPawnIndex(0);
+        bitBoard.whitesTurn = !bitBoard.whitesTurn;
+        generateLegalMoves();
+        gameState.updateState(bitBoard, legalMoves, false);
+        return prev;
+    }
+
+    public void undoNullMove(int previousDoubleStep) {
+        bitBoard.whitesTurn = !bitBoard.whitesTurn;
+        bitBoard.setLastMoveDoubleStepPawnIndex(previousDoubleStep);
+        generateLegalMoves();
+        gameState.updateState(bitBoard, legalMoves, false);
+    }
+
     public void undoLastMove() {
         if (!line.isEmpty()) {
             gameState.undo(bitBoard.getBoardStateHash());

--- a/src/test/java/julius/game/chessengine/ai/NullMovePruningTest.java
+++ b/src/test/java/julius/game/chessengine/ai/NullMovePruningTest.java
@@ -1,0 +1,46 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.engine.Engine;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NullMovePruningTest {
+
+    private double runSearch(AI ai, Engine engine, int depth) throws Exception {
+        Method m = AI.class.getDeclaredMethod("alphaBeta", Engine.class, int.class, double.class, double.class, boolean.class, long.class, long.class);
+        m.setAccessible(true);
+        ai.resetCounters();
+        return (double) m.invoke(ai, engine, depth, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, engine.whitesTurn(), System.currentTimeMillis(), Long.MAX_VALUE);
+    }
+
+    @Test
+    void nullMoveImprovesPerformance() throws Exception {
+        Engine engine = new Engine();
+        engine.startNewGame();
+        AI ai = new AI(engine);
+
+        ai.setUseNullMovePruning(true);
+        runSearch(ai, engine, 4);
+        long withNull = ai.getNodesVisited();
+        assertTrue(ai.getNullMoveCount() > 0);
+
+        ai.setUseNullMovePruning(false);
+        runSearch(ai, engine, 4);
+        long withoutNull = ai.getNodesVisited();
+
+        assertTrue(withNull < withoutNull);
+    }
+
+    @Test
+    void nullMoveSkippedInPawnEndgame() throws Exception {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("8/8/8/8/8/8/PPPPPPPP/4kK2 w - - 0 1");
+        AI ai = new AI(engine);
+
+        runSearch(ai, engine, 4);
+        assertEquals(0, ai.getNullMoveCount());
+    }
+}


### PR DESCRIPTION
## Summary
- Add configurable null move pruning in alpha-beta search
- Support null move and en passant reset in Engine and BitBoard
- Track node and null-move counts and add tests for performance and endgame behavior

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for julius.game:chess-engine:3.0.2)*

------
https://chatgpt.com/codex/tasks/task_e_68bf387baa48832a9114087762108b6d