### PR TITLE
Implement late move reductions with regression test

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -69,6 +69,11 @@ public class AI {
     private final int[][] killerMoves; // 2D array for killer moves, initialized in the constructor
     private final int numKillerMoves = 2;
 
+    // Late move reduction configuration
+    private static final int LMR_MOVE_INDEX_THRESHOLD = 3; // Moves after this index may be reduced
+    private static final int LMR_DEPTH_REDUCTION = 1; // How much to reduce the search depth
+    private static final int LMR_MIN_DEPTH = 3; // Apply only when enough depth remains
+
     private ScheduledExecutorService scheduler;
     private Thread calculationThread;
 
@@ -93,6 +98,7 @@ public class AI {
     private long timeLimit; // milliseconds
 
     private boolean useNullMovePruning = true;
+    private boolean useLateMoveReductions = true;
     private long nodesVisited = 0;
     private long nullMoveCount = 0;
 
@@ -112,6 +118,10 @@ public class AI {
 
     public void setUseNullMovePruning(boolean useNullMovePruning) {
         this.useNullMovePruning = useNullMovePruning;
+    }
+
+    public void setUseLateMoveReductions(boolean useLateMoveReductions) {
+        this.useLateMoveReductions = useLateMoveReductions;
     }
 
     public long getNodesVisited() {
@@ -430,7 +440,9 @@ public class AI {
         double maxEval = Double.NEGATIVE_INFINITY;
         int bestMoveAtThisNode = -1; // Variable to track the best move at this node
 
-        for (int move : sortMovesByEfficiency(moves, simulatorEngine, isWhite, depth, startTime, timeLimit)) {
+        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, simulatorEngine, isWhite, depth, startTime, timeLimit);
+        for (int index = 0; index < orderedMoves.size(); index++) {
+            int move = orderedMoves.get(index);
             simulatorEngine.performMove(move);
             long newBoardHash = simulatorEngine.getBoardStateHash();
 
@@ -440,13 +452,29 @@ public class AI {
             if (entry != null && entry.depth >= depth) {
                 eval = entry.score; // Use the score from the transposition table
             } else {
-                eval = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhite, startTime, timeLimit);
+                int nextDepth = depth - 1;
+                boolean reduced = false;
+                if (useLateMoveReductions && depth >= LMR_MIN_DEPTH && index >= LMR_MOVE_INDEX_THRESHOLD
+                        && !MoveHelper.isCapture(move) && !isKillerMove(depth, move)) {
+                    nextDepth = depth - 1 - LMR_DEPTH_REDUCTION;
+                    reduced = true;
+                }
+
+                eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, startTime, timeLimit);
 
                 if (eval == EXIT_FLAG || positionChanged()) {
-                    // If time limit exceeded, exit the loop
                     simulatorEngine.undoLastMove();
                     log.info("maxi Position changed");
                     return EXIT_FLAG;
+                }
+
+                if (reduced && eval > alpha) {
+                    eval = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhite, startTime, timeLimit);
+                    if (eval == EXIT_FLAG || positionChanged()) {
+                        simulatorEngine.undoLastMove();
+                        log.info("maxi Position changed");
+                        return EXIT_FLAG;
+                    }
                 }
             }
 
@@ -494,7 +522,9 @@ public class AI {
         double minEval = Double.POSITIVE_INFINITY;
         int bestMoveAtThisNode = -1; // Track the best move at this node
 
-        for (int move : sortMovesByEfficiency(moves, simulatorEngine, isWhite, depth, startTime, timeLimit)) {
+        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, simulatorEngine, isWhite, depth, startTime, timeLimit);
+        for (int index = 0; index < orderedMoves.size(); index++) {
+            int move = orderedMoves.get(index);
             simulatorEngine.performMove(move);
             long newBoardHash = simulatorEngine.getBoardStateHash();
             double eval;
@@ -503,12 +533,29 @@ public class AI {
             if (entry != null && entry.depth >= depth) {
                 eval = entry.score;
             } else {
-                eval = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhite, startTime, timeLimit);
+                int nextDepth = depth - 1;
+                boolean reduced = false;
+                if (useLateMoveReductions && depth >= LMR_MIN_DEPTH && index >= LMR_MOVE_INDEX_THRESHOLD
+                        && !MoveHelper.isCapture(move) && !isKillerMove(depth, move)) {
+                    nextDepth = depth - 1 - LMR_DEPTH_REDUCTION;
+                    reduced = true;
+                }
+
+                eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, startTime, timeLimit);
 
                 if (eval == EXIT_FLAG || positionChanged()) {
                     log.info("mini Position changed");
                     simulatorEngine.undoLastMove();
                     return EXIT_FLAG;
+                }
+
+                if (reduced && eval < beta) {
+                    eval = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhite, startTime, timeLimit);
+                    if (eval == EXIT_FLAG || positionChanged()) {
+                        log.info("mini Position changed");
+                        simulatorEngine.undoLastMove();
+                        return EXIT_FLAG;
+                    }
                 }
             }
 
@@ -727,6 +774,18 @@ public class AI {
             killerMoves[depth][i] = killerMoves[depth][i - 1];
         }
         killerMoves[depth][0] = move; // Insert new killer move at the top
+    }
+
+    private boolean isKillerMove(int depth, int move) {
+        if (depth >= killerMoves.length) {
+            return false;
+        }
+        for (int killerMove : killerMoves[depth]) {
+            if (killerMove == move) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private int calculateMvvLvaScore(int move) {

--- a/src/test/java/julius/game/chessengine/ai/LateMoveReductionTest.java
+++ b/src/test/java/julius/game/chessengine/ai/LateMoveReductionTest.java
@@ -1,0 +1,52 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.engine.Engine;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LateMoveReductionTest {
+
+    private double runSearch(AI ai, Engine engine, int depth) throws Exception {
+        Method m = AI.class.getDeclaredMethod("alphaBeta", Engine.class, int.class, double.class, double.class,
+                boolean.class, long.class, long.class);
+        m.setAccessible(true);
+        ai.resetCounters();
+        return (double) m.invoke(ai, engine, depth, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
+                engine.whitesTurn(), System.currentTimeMillis(), Long.MAX_VALUE);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void clearTranspositionTables() throws Exception {
+        Field mainField = AI.class.getDeclaredField("transpositionTable");
+        mainField.setAccessible(true);
+        ((Map<Long, ?>) mainField.get(null)).clear();
+
+        Field captureField = AI.class.getDeclaredField("captureTranspositionTable");
+        captureField.setAccessible(true);
+        ((Map<Long, ?>) captureField.get(null)).clear();
+    }
+
+    @Test
+    void lmrProducesSameScoreAsBaseline() throws Exception {
+        Engine baseEngine = new Engine();
+        baseEngine.startNewGame();
+        AI baselineAI = new AI(baseEngine);
+        baselineAI.setUseLateMoveReductions(false);
+        double baseline = runSearch(baselineAI, baseEngine, 3);
+
+        clearTranspositionTables();
+
+        Engine lmrEngine = new Engine();
+        lmrEngine.startNewGame();
+        AI lmrAI = new AI(lmrEngine);
+        lmrAI.setUseLateMoveReductions(true);
+        double withLmr = runSearch(lmrAI, lmrEngine, 3);
+
+        assertEquals(baseline, withLmr, 0.0001);
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce configurable late move reduction constants and toggle in AI
- Apply LMR in maximizer/minimizer using move indexes and re-search when necessary
- Add regression test ensuring LMR matches baseline scores

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for julius.game:chess-engine:3.0.2)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3da43d94832aa7ef790dd2bc3f5c