### PR TITLE
Sleep AI calculation thread when idle

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -84,6 +84,8 @@ public class AI {
     private ScheduledExecutorService scheduler;
     private Thread calculationThread;
 
+    private final Object calculationLock = new Object();
+
     private volatile boolean keepCalculating = true;
 
     private volatile long currentBoardState = -1;
@@ -229,17 +231,31 @@ public class AI {
         log.info("Perform Move");
         mainEngine.performMove(currentBestMove);
         currentBoardState = mainEngine.getBoardStateHash();
+        synchronized (calculationLock) {
+            calculationLock.notifyAll();
+        }
         //currentBestMove = -1; // Reset currentBestMove after performing it
     }
 
     private void calculateLine() {
         log.debug("keepCalculating: {}, interrupted: {}", keepCalculating, Thread.currentThread().isInterrupted());
         while (keepCalculating && !Thread.currentThread().isInterrupted()) {
-            if (positionChanged()) {
-                currentBoardState = mainEngine.getBoardStateHash();
-                beforeCalculationBoardState = mainEngine.getBoardStateHash();
-                performCalculation();
+            synchronized (calculationLock) {
+                while (!positionChanged() && keepCalculating && !Thread.currentThread().isInterrupted()) {
+                    try {
+                        calculationLock.wait();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
             }
+            if (!keepCalculating || Thread.currentThread().isInterrupted()) {
+                break;
+            }
+            currentBoardState = mainEngine.getBoardStateHash();
+            beforeCalculationBoardState = currentBoardState;
+            performCalculation();
         }
     }
 
@@ -757,6 +773,9 @@ public class AI {
 
     public void updateBoardStateHash() {
         currentBoardState = mainEngine.getBoardStateHash();
+        synchronized (calculationLock) {
+            calculationLock.notifyAll();
+        }
     }
 
     private void updateKillerMoves(int depth, int move) {

--- a/src/test/java/julius/game/chessengine/ai/CalculationThreadIdleTest.java
+++ b/src/test/java/julius/game/chessengine/ai/CalculationThreadIdleTest.java
@@ -1,0 +1,42 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.engine.Engine;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CalculationThreadIdleTest {
+
+    @Test
+    void calculationThreadWaitsWhenNoPositionChange() throws Exception {
+        Engine engine = new Engine();
+        AI ai = new AI(engine);
+        ai.setTimeLimit(1);
+
+        long hash = engine.getBoardStateHash();
+        Field currentField = AI.class.getDeclaredField("currentBoardState");
+        currentField.setAccessible(true);
+        currentField.setLong(ai, hash);
+        Field beforeField = AI.class.getDeclaredField("beforeCalculationBoardState");
+        beforeField.setAccessible(true);
+        beforeField.setLong(ai, hash);
+
+        Method startCalc = AI.class.getDeclaredMethod("startCalculationThread");
+        startCalc.setAccessible(true);
+        startCalc.invoke(ai);
+
+        Field threadField = AI.class.getDeclaredField("calculationThread");
+        threadField.setAccessible(true);
+        Thread calcThread = (Thread) threadField.get(ai);
+
+        for (int i = 0; i < 100 && calcThread.getState() != Thread.State.WAITING; i++) {
+            Thread.sleep(20);
+        }
+
+        assertEquals(Thread.State.WAITING, calcThread.getState());
+        ai.stopCalculation();
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce a `calculationLock` and use `wait/notify` so `calculateLine` blocks when the position hasn't changed
- Notify the lock in `performMove` and `updateBoardStateHash` to resume calculations when the board updates
- Add test ensuring the calculation thread enters a waiting state when no changes occur

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c00591dc90832a9868ac2de439a186