### PR TITLE
Isolate legal move state in Engine simulations

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -43,11 +43,11 @@ public class Engine {
         this.gameState = new GameState(other.gameState); // Assuming GameState's constructor is a deep copy constructor
         this.line = new ArrayList<>(other.line);
         this.redoLine = new ArrayList<>(other.redoLine);
-        //this.legalMoves = new MoveList(other.legalMoves);
-        this.legalMoves = other.legalMoves;
+        this.legalMoves = other.legalMoves == null ? null : new MoveList(other.legalMoves);
         this.legalMovesNeedUpdate = other.legalMovesNeedUpdate;
         this.openingBook = other.openingBook;
-        this.legalMovesCache = other.legalMovesCache;
+        this.legalMovesCache = new TimedLRUCache<>(MAX_SIZE, MAX_AGE);
+        other.legalMovesCache.forEach((k, v) -> this.legalMovesCache.put(k, new MoveList(v)));
     }
 
     public MoveList getAllLegalMoves() {

--- a/src/test/java/julius/game/chessengine/engine/EngineSimulationTest.java
+++ b/src/test/java/julius/game/chessengine/engine/EngineSimulationTest.java
@@ -1,0 +1,34 @@
+package julius.game.chessengine.engine;
+
+import julius.game.chessengine.board.MoveList;
+import julius.game.chessengine.cache.TimedLRUCache;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EngineSimulationTest {
+
+    @Test
+    public void simulationDoesNotAffectMainEngineLegalMoves() throws Exception {
+        Engine main = new Engine();
+        MoveList mainMoves = main.getAllLegalMoves();
+        assertTrue(mainMoves.size() > 0);
+        int mainSize = mainMoves.size();
+
+        Engine sim = main.createSimulation();
+        MoveList simMoves = sim.getAllLegalMoves();
+        assertNotSame(mainMoves, simMoves);
+
+        sim.performMove(simMoves.getMove(0));
+
+        assertEquals(mainSize, main.getAllLegalMoves().size());
+
+        Field cacheField = Engine.class.getDeclaredField("legalMovesCache");
+        cacheField.setAccessible(true);
+        TimedLRUCache<Long, MoveList> mainCache = (TimedLRUCache<Long, MoveList>) cacheField.get(main);
+        TimedLRUCache<Long, MoveList> simCache = (TimedLRUCache<Long, MoveList>) cacheField.get(sim);
+        assertNotSame(mainCache, simCache);
+    }
+}


### PR DESCRIPTION
## Summary
- deep copy legal moves and cache when cloning Engine
- add regression test to ensure simulator does not alter main engine legal moves

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c007318668832a84cf0260e49176f8