### PR TITLE
Optimize move ordering with array-based sorting

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -623,36 +623,56 @@ public class AI {
     }
 
 
-    private ArrayList<Integer> sortMovesByEfficiency(MoveList moves, Engine simulatorEngine, boolean isWhite, int currentDepth, long startTime, long timeLimit) {
-        PriorityQueue<Integer> sortedMoves = new PriorityQueue<>(
-                Comparator.comparingDouble((Integer moveInt) -> {
-                    // Prioritize killer moves
-                    for (int killerMove : killerMoves[currentDepth]) {
-                        if (moveInt == killerMove) {
-                            return KILLER_MOVE_SCORE;
-                        }
-                    }
+    ArrayList<Integer> sortMovesByEfficiency(MoveList moves, Engine simulatorEngine, boolean isWhite, int currentDepth, long startTime, long timeLimit) {
+        int size = moves.size();
 
-                    // Prioritize captures using MVV-LVA
-                    int mvvLvaScore = calculateMvvLvaScore(moveInt);
-                    if (mvvLvaScore != 0) {
-                        return mvvLvaScore;
-                    }
+        int[] moveBuffer = new int[size];
+        int[] scoreBuffer = new int[size];
 
-                    // History heuristic for quiet moves
+        for (int i = 0; i < size; i++) {
+            int moveInt = moves.getMove(i);
+            int score;
+
+            boolean isKiller = false;
+            for (int killerMove : killerMoves[currentDepth]) {
+                if (moveInt == killerMove) {
+                    score = KILLER_MOVE_SCORE;
+                    isKiller = true;
+                    break;
+                }
+            }
+
+            if (!isKiller) {
+                int mvvLvaScore = calculateMvvLvaScore(moveInt);
+                if (mvvLvaScore != 0) {
+                    score = mvvLvaScore;
+                } else {
                     int from = moveInt & 0x3F;
                     int to = (moveInt >> 6) & 0x3F;
-                    return historyTable[from][to];
-                }).reversed()
-        );
+                    score = historyTable[from][to];
+                }
+            }
 
-        for (int i = 0; i < moves.size(); i++) {
-            sortedMoves.add(moves.getMove(i));
+            moveBuffer[i] = moveInt;
+            scoreBuffer[i] = score;
         }
 
-        ArrayList<Integer> sortedMoveList = new ArrayList<>();
-        while (!sortedMoves.isEmpty()) {
-            sortedMoveList.add(sortedMoves.poll());
+        for (int i = 1; i < size; i++) {
+            int keyMove = moveBuffer[i];
+            int keyScore = scoreBuffer[i];
+            int j = i - 1;
+            while (j >= 0 && scoreBuffer[j] < keyScore) {
+                moveBuffer[j + 1] = moveBuffer[j];
+                scoreBuffer[j + 1] = scoreBuffer[j];
+                j--;
+            }
+            moveBuffer[j + 1] = keyMove;
+            scoreBuffer[j + 1] = keyScore;
+        }
+
+        ArrayList<Integer> sortedMoveList = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            sortedMoveList.add(moveBuffer[i]);
         }
 
         return sortedMoveList;

--- a/src/test/java/julius/game/chessengine/ai/SortMovesByEfficiencyBenchmark.java
+++ b/src/test/java/julius/game/chessengine/ai/SortMovesByEfficiencyBenchmark.java
@@ -1,0 +1,33 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.board.MoveList;
+import julius.game.chessengine.engine.Engine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Simple micro benchmark for {@link AI#sortMovesByEfficiency} to ensure the
+ * array based implementation performs as expected. The benchmark does not
+ * assert timing but prints the total execution time so it can be compared
+ * manually when needed.
+ */
+public class SortMovesByEfficiencyBenchmark {
+
+    @Test
+    public void benchmarkSortMoves() {
+        Engine engine = new Engine();
+        engine.startNewGame();
+        AI ai = new AI(engine);
+        MoveList moves = engine.getAllLegalMoves();
+
+        for (int i = 0; i < 1000; i++) {
+            ai.sortMovesByEfficiency(moves, engine, engine.whitesTurn(), 0, 0, Long.MAX_VALUE);
+        }
+
+        long start = System.nanoTime();
+        for (int i = 0; i < 10000; i++) {
+            ai.sortMovesByEfficiency(moves, engine, engine.whitesTurn(), 0, 0, Long.MAX_VALUE);
+        }
+        long elapsed = System.nanoTime() - start;
+        System.out.println("sortMovesByEfficiency benchmark: " + (elapsed / 1_000_000) + " ms for 10000 iterations");
+    }
+}


### PR DESCRIPTION
## Summary
- Refactor move ordering to use pre-scored arrays and insertion sort instead of PriorityQueue
- Add simple JUnit benchmark to measure new move ordering performance

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0080c0a38832a98d54df8a1948c89