### PR TITLE
Clamp depth when ordering moves

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -351,7 +351,7 @@ public class AI {
         int bestMove = -1; // Use an integer to represent the best move
         double bestScore = isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
 
-        ArrayList<Integer> sortedMoves = sortMovesByEfficiency(simulatorEngine.getAllLegalMoves(), isWhitesTurn, depth);
+        ArrayList<Integer> sortedMoves = sortMovesByEfficiency(simulatorEngine.getAllLegalMoves(), depth);
 
         for (int moveInt : sortedMoves) {
 
@@ -468,7 +468,7 @@ public class AI {
         double maxEval = Double.NEGATIVE_INFINITY;
         int bestMoveAtThisNode = -1; // Variable to track the best move at this node
 
-        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, isWhite, depth);
+        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth);
         for (int index = 0; index < orderedMoves.size(); index++) {
             int move = orderedMoves.get(index);
             simulatorEngine.performMove(move);
@@ -551,7 +551,7 @@ public class AI {
         double minEval = Double.POSITIVE_INFINITY;
         int bestMoveAtThisNode = -1; // Track the best move at this node
 
-        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, isWhite, depth);
+        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth);
         for (int index = 0; index < orderedMoves.size(); index++) {
             int move = orderedMoves.get(index);
             simulatorEngine.performMove(move);
@@ -623,18 +623,21 @@ public class AI {
     }
 
 
-    ArrayList<Integer> sortMovesByEfficiency(MoveList moves, boolean isWhite, int currentDepth) {
+    ArrayList<Integer> sortMovesByEfficiency(MoveList moves, int currentDepth) {
         int size = moves.size();
 
         int[] moveBuffer = new int[size];
         int[] scoreBuffer = new int[size];
+
+        // Ensure the depth index is within the killerMoves array bounds
+        int depthIndex = Math.max(0, Math.min(currentDepth, killerMoves.length - 1));
 
         for (int i = 0; i < size; i++) {
             int moveInt = moves.getMove(i);
             int score = 0;
 
             boolean isKiller = false;
-            for (int killerMove : killerMoves[currentDepth]) {
+            for (int killerMove : killerMoves[depthIndex]) {
                 if (moveInt == killerMove) {
                     score = KILLER_MOVE_SCORE;
                     isKiller = true;
@@ -799,20 +802,22 @@ public class AI {
     }
 
     private void updateKillerMoves(int depth, int move) {
-        int numKillerMoves = killerMoves[depth].length; // Get the number of killer moves for this depth
+        // Ensure depth is within bounds of the killerMoves array
+        int depthIndex = Math.max(0, Math.min(depth, killerMoves.length - 1));
+        int numKillerMoves = killerMoves[depthIndex].length; // Get the number of killer moves for this depth
 
         // Check if the move is already in the killer moves array
         for (int i = 0; i < numKillerMoves; i++) {
-            if (killerMoves[depth][i] == move) {
+            if (killerMoves[depthIndex][i] == move) {
                 return; // If move is already a killer move, no need to update
             }
         }
 
         // Shift existing killer moves down and insert the new move at the beginning
         for (int i = numKillerMoves - 1; i > 0; i--) {
-            killerMoves[depth][i] = killerMoves[depth][i - 1];
+            killerMoves[depthIndex][i] = killerMoves[depthIndex][i - 1];
         }
-        killerMoves[depth][0] = move; // Insert new killer move at the top
+        killerMoves[depthIndex][0] = move; // Insert new killer move at the top
     }
 
     private boolean isKillerMove(int depth, int move) {

--- a/src/test/java/julius/game/chessengine/ai/SortMovesByEfficiencyBenchmark.java
+++ b/src/test/java/julius/game/chessengine/ai/SortMovesByEfficiencyBenchmark.java
@@ -20,12 +20,12 @@ public class SortMovesByEfficiencyBenchmark {
         MoveList moves = engine.getAllLegalMoves();
 
         for (int i = 0; i < 1000; i++) {
-            ai.sortMovesByEfficiency(moves, engine.whitesTurn(), 0);
+            ai.sortMovesByEfficiency(moves, 0);
         }
 
         long start = System.nanoTime();
         for (int i = 0; i < 10000; i++) {
-            ai.sortMovesByEfficiency(moves, engine.whitesTurn(), 0);
+            ai.sortMovesByEfficiency(moves, 0);
         }
         long elapsed = System.nanoTime() - start;
         System.out.println("sortMovesByEfficiency benchmark: " + (elapsed / 1_000_000) + " ms for 10000 iterations");


### PR DESCRIPTION
## Summary
- Prevent ArrayIndexOutOfBoundsException in move ordering by clamping depth index
- Remove unused `isWhite` parameter from move ordering and update callers
- Guard `updateKillerMoves` against invalid depth indices

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c00a8d97cc832aa374181e2b26d400