### PR TITLE
Handle missing king in move generation

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -584,6 +584,9 @@ public class BitBoard {
 
     private void generateKingMoves(boolean whitesTurn, MoveList moves) {
         long kingBitboard = whitesTurn ? whiteKing : blackKing;
+        if (kingBitboard == 0L) {
+            return; // No king present for the given color; cannot generate moves
+        }
         int kingPositionIndex = Long.numberOfTrailingZeros(kingBitboard);
         long kingAttacks = KING_ATTACKS[kingPositionIndex];
         boolean isFirstKingMove = hasKingNotMoved(whitesTurn);


### PR DESCRIPTION
## Summary
- Avoid ArrayIndexOutOfBounds in king move generation by returning early when the king bitboard is empty

## Testing
- `mvn -q test` *(fails: Network is unreachable for maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c01dbf1364832a8f3e1b89074c40be