### PR TITLE
feat: add fixed-size transposition table

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -42,29 +42,18 @@ public class AI {
     private static final int CAPTURE_TRANSPOSITION_TABLE_MAX_ENTRIES = 500_000;
 
     /**
-     * Transposition table with LRU eviction policy. The map is synchronized to
-     * allow concurrent access from the search threads while keeping the memory
-     * footprint bounded.
+     * Fixed-size transposition table backed by an array with open addressing.
+     * The structure relies on atomic operations for thread safety and does not
+     * grow beyond the predefined capacity.
      */
-    private static final Map<Long, TranspositionTableEntry> transpositionTable =
-            Collections.synchronizedMap(new LinkedHashMap<Long, TranspositionTableEntry>(16, 0.75f, true) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry<Long, TranspositionTableEntry> eldest) {
-                    return size() > TRANSPOSITION_TABLE_MAX_ENTRIES;
-                }
-            });
+    private static final FixedSizeTranspositionTable<TranspositionTableEntry> transpositionTable =
+            new FixedSizeTranspositionTable<>(TRANSPOSITION_TABLE_MAX_ENTRIES);
 
     /**
-     * Separate table for capture searches. Also bounded with LRU eviction to
-     * avoid unbounded growth.
+     * Separate table for capture searches using the same fixed-size structure.
      */
-    private static final Map<Long, CaptureTranspositionTableEntry> captureTranspositionTable =
-            Collections.synchronizedMap(new LinkedHashMap<Long, CaptureTranspositionTableEntry>(16, 0.75f, true) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry<Long, CaptureTranspositionTableEntry> eldest) {
-                    return size() > CAPTURE_TRANSPOSITION_TABLE_MAX_ENTRIES;
-                }
-            });
+    private static final FixedSizeTranspositionTable<CaptureTranspositionTableEntry> captureTranspositionTable =
+            new FixedSizeTranspositionTable<>(CAPTURE_TRANSPOSITION_TABLE_MAX_ENTRIES);
 
     private final int[][] killerMoves; // 2D array for killer moves, initialized in the constructor
     private final int numKillerMoves = 2;
@@ -315,8 +304,8 @@ public class AI {
         Set<Long> seenBoardHashes = new HashSet<>();
         int movesPerformed = 0; // Counter for the number of moves performed
 
-        while (transpositionTable.containsKey(currentBoardHash)) {
-            TranspositionTableEntry entry = transpositionTable.get(currentBoardHash);
+        TranspositionTableEntry entry;
+        while ((entry = transpositionTable.get(currentBoardHash)) != null) {
             if (entry.bestMove == -1 || !seenBoardHashes.add(currentBoardHash)) {
                 // Exit if no best move is found or repetition is detected
                 break;

--- a/src/main/java/julius/game/chessengine/ai/FixedSizeTranspositionTable.java
+++ b/src/main/java/julius/game/chessengine/ai/FixedSizeTranspositionTable.java
@@ -1,0 +1,92 @@
+package julius.game.chessengine.ai;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+/**
+ * Simple fixed-size hash table with open addressing. The table uses linear
+ * probing and overwrites old entries when the table is full. The implementation
+ * is thread-safe using atomic operations which makes it usable in concurrent
+ * search scenarios without additional locking. Keys are {@code long} hashes
+ * representing board states.
+ *
+ * @param <V> type of value stored in the table
+ */
+public class FixedSizeTranspositionTable<V> {
+
+    private static final class Entry<V> {
+        final long key;
+        final V value;
+
+        Entry(long key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+
+    private final AtomicReferenceArray<Entry<V>> table;
+    private final int mask; // table.length - 1 (power of two size)
+    private final AtomicInteger size = new AtomicInteger();
+
+    public FixedSizeTranspositionTable(int capacity) {
+        int n = 1;
+        while (n < capacity) {
+            n <<= 1;
+        }
+        this.table = new AtomicReferenceArray<>(n);
+        this.mask = n - 1;
+    }
+
+    private int index(long key) {
+        return (int) (key) & mask;
+    }
+
+    public V get(long key) {
+        int idx = index(key);
+        for (int i = 0; i < table.length(); i++) {
+            Entry<V> e = table.get(idx);
+            if (e == null) {
+                return null;
+            }
+            if (e.key == key) {
+                return e.value;
+            }
+            idx = (idx + 1) & mask;
+        }
+        return null;
+    }
+
+    public void put(long key, V value) {
+        int idx = index(key);
+        Entry<V> newEntry = new Entry<>(key, value);
+        for (int i = 0; i < table.length(); i++) {
+            Entry<V> cur = table.get(idx);
+            if (cur == null) {
+                if (table.compareAndSet(idx, null, newEntry)) {
+                    size.incrementAndGet();
+                    return;
+                } else {
+                    continue; // CAS failed, retry same slot
+                }
+            } else if (cur.key == key) {
+                table.set(idx, newEntry);
+                return;
+            } else {
+                idx = (idx + 1) & mask;
+            }
+        }
+        // table full, overwrite the initial slot
+        table.set(idx, newEntry);
+    }
+
+    public void clear() {
+        for (int i = 0; i < table.length(); i++) {
+            table.set(i, null);
+        }
+        size.set(0);
+    }
+
+    public int size() {
+        return size.get();
+    }
+}

--- a/src/test/java/julius/game/chessengine/ai/HistoryHeuristicTest.java
+++ b/src/test/java/julius/game/chessengine/ai/HistoryHeuristicTest.java
@@ -5,7 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.Map;
+
+import julius.game.chessengine.ai.FixedSizeTranspositionTable;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -20,15 +21,14 @@ public class HistoryHeuristicTest {
                 engine.whitesTurn(), System.currentTimeMillis(), Long.MAX_VALUE);
     }
 
-    @SuppressWarnings("unchecked")
     private void clearTranspositionTables() throws Exception {
         Field mainField = AI.class.getDeclaredField("transpositionTable");
         mainField.setAccessible(true);
-        ((Map<Long, ?>) mainField.get(null)).clear();
+        ((FixedSizeTranspositionTable<?>) mainField.get(null)).clear();
 
         Field captureField = AI.class.getDeclaredField("captureTranspositionTable");
         captureField.setAccessible(true);
-        ((Map<Long, ?>) captureField.get(null)).clear();
+        ((FixedSizeTranspositionTable<?>) captureField.get(null)).clear();
     }
 
     @Test

--- a/src/test/java/julius/game/chessengine/ai/LateMoveReductionTest.java
+++ b/src/test/java/julius/game/chessengine/ai/LateMoveReductionTest.java
@@ -5,7 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.Map;
+
+import julius.game.chessengine.ai.FixedSizeTranspositionTable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -20,15 +21,14 @@ public class LateMoveReductionTest {
                 engine.whitesTurn(), System.currentTimeMillis(), Long.MAX_VALUE);
     }
 
-    @SuppressWarnings("unchecked")
     private void clearTranspositionTables() throws Exception {
         Field mainField = AI.class.getDeclaredField("transpositionTable");
         mainField.setAccessible(true);
-        ((Map<Long, ?>) mainField.get(null)).clear();
+        ((FixedSizeTranspositionTable<?>) mainField.get(null)).clear();
 
         Field captureField = AI.class.getDeclaredField("captureTranspositionTable");
         captureField.setAccessible(true);
-        ((Map<Long, ?>) captureField.get(null)).clear();
+        ((FixedSizeTranspositionTable<?>) captureField.get(null)).clear();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- replace map-based transposition tables with fixed-size arrays using open addressing
- add thread-safe `FixedSizeTranspositionTable` implementation
- adjust tests for new table API

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c023bc91b4832a9284f2e4401b1406