### PR TITLE
Use non-atomic transposition table in single-thread mode

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -41,19 +41,26 @@ public class AI {
      */
     private static final int CAPTURE_TRANSPOSITION_TABLE_MAX_ENTRIES = 500_000;
 
+    /** Number of threads used for searching. Configurable via the system property
+     * {@code chessengine.searchThreads}. Defaults to single-threaded search. */
+    private static final int SEARCH_THREADS = Integer.getInteger("chessengine.searchThreads", 1);
+
     /**
-     * Fixed-size transposition table backed by an array with open addressing.
-     * The structure relies on atomic operations for thread safety and does not
-     * grow beyond the predefined capacity.
+     * Fixed-size transposition table. Uses a non-atomic implementation when running
+     * with a single search thread to avoid the overhead of atomic operations.
      */
-    private static final FixedSizeTranspositionTable<TranspositionTableEntry> transpositionTable =
-            new FixedSizeTranspositionTable<>(TRANSPOSITION_TABLE_MAX_ENTRIES);
+    private static final TranspositionTable<TranspositionTableEntry> transpositionTable =
+            SEARCH_THREADS == 1
+                    ? new PlainFixedSizeTranspositionTable<>(TRANSPOSITION_TABLE_MAX_ENTRIES, TranspositionTableEntry.class)
+                    : new FixedSizeTranspositionTable<>(TRANSPOSITION_TABLE_MAX_ENTRIES);
 
     /**
      * Separate table for capture searches using the same fixed-size structure.
      */
-    private static final FixedSizeTranspositionTable<CaptureTranspositionTableEntry> captureTranspositionTable =
-            new FixedSizeTranspositionTable<>(CAPTURE_TRANSPOSITION_TABLE_MAX_ENTRIES);
+    private static final TranspositionTable<CaptureTranspositionTableEntry> captureTranspositionTable =
+            SEARCH_THREADS == 1
+                    ? new PlainFixedSizeTranspositionTable<>(CAPTURE_TRANSPOSITION_TABLE_MAX_ENTRIES, CaptureTranspositionTableEntry.class)
+                    : new FixedSizeTranspositionTable<>(CAPTURE_TRANSPOSITION_TABLE_MAX_ENTRIES);
 
     private final int[][] killerMoves; // 2D array for killer moves, initialized in the constructor
     private final int numKillerMoves = 2;

--- a/src/main/java/julius/game/chessengine/ai/FixedSizeTranspositionTable.java
+++ b/src/main/java/julius/game/chessengine/ai/FixedSizeTranspositionTable.java
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  *
  * @param <V> type of value stored in the table
  */
-public class FixedSizeTranspositionTable<V> {
+public class FixedSizeTranspositionTable<V> implements TranspositionTable<V> {
 
     private static final class Entry<V> {
         final long key;
@@ -41,6 +41,7 @@ public class FixedSizeTranspositionTable<V> {
         return (int) (key) & mask;
     }
 
+    @Override
     public V get(long key) {
         int idx = index(key);
         for (int i = 0; i < table.length(); i++) {
@@ -56,6 +57,7 @@ public class FixedSizeTranspositionTable<V> {
         return null;
     }
 
+    @Override
     public void put(long key, V value) {
         int idx = index(key);
         Entry<V> newEntry = new Entry<>(key, value);
@@ -79,6 +81,7 @@ public class FixedSizeTranspositionTable<V> {
         table.set(idx, newEntry);
     }
 
+    @Override
     public void clear() {
         for (int i = 0; i < table.length(); i++) {
             table.set(i, null);
@@ -86,6 +89,7 @@ public class FixedSizeTranspositionTable<V> {
         size.set(0);
     }
 
+    @Override
     public int size() {
         return size.get();
     }

--- a/src/main/java/julius/game/chessengine/ai/PlainFixedSizeTranspositionTable.java
+++ b/src/main/java/julius/game/chessengine/ai/PlainFixedSizeTranspositionTable.java
@@ -1,0 +1,83 @@
+package julius.game.chessengine.ai;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+
+/**
+ * Fixed-size transposition table implementation for single-threaded search.
+ * It uses plain arrays and does not perform any atomic operations.
+ *
+ * @param <V> value type stored in the table
+ */
+public class PlainFixedSizeTranspositionTable<V> implements TranspositionTable<V> {
+
+    private final long[] keys;
+    private final V[] values;
+    private final int mask; // table.length - 1 (power of two size)
+    private int size;
+
+    @SuppressWarnings("unchecked")
+    public PlainFixedSizeTranspositionTable(int capacity, Class<V> valueClass) {
+        int n = 1;
+        while (n < capacity) {
+            n <<= 1;
+        }
+        this.keys = new long[n];
+        this.values = (V[]) Array.newInstance(valueClass, n);
+        this.mask = n - 1;
+    }
+
+    private int index(long key) {
+        return (int) key & mask;
+    }
+
+    @Override
+    public V get(long key) {
+        int idx = index(key);
+        for (int i = 0; i < values.length; i++) {
+            V v = values[idx];
+            if (v == null) {
+                return null;
+            }
+            if (keys[idx] == key) {
+                return v;
+            }
+            idx = (idx + 1) & mask;
+        }
+        return null;
+    }
+
+    @Override
+    public void put(long key, V value) {
+        int idx = index(key);
+        for (int i = 0; i < values.length; i++) {
+            V v = values[idx];
+            if (v == null) {
+                keys[idx] = key;
+                values[idx] = value;
+                size++;
+                return;
+            } else if (keys[idx] == key) {
+                values[idx] = value;
+                return;
+            } else {
+                idx = (idx + 1) & mask;
+            }
+        }
+        // table full, overwrite the initial slot
+        keys[idx] = key;
+        values[idx] = value;
+    }
+
+    @Override
+    public void clear() {
+        Arrays.fill(values, null);
+        Arrays.fill(keys, 0L);
+        size = 0;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+}

--- a/src/main/java/julius/game/chessengine/ai/TranspositionTable.java
+++ b/src/main/java/julius/game/chessengine/ai/TranspositionTable.java
@@ -1,0 +1,12 @@
+package julius.game.chessengine.ai;
+
+/**
+ * Minimal abstraction for a transposition table used by the search.
+ * Implementations may or may not be thread-safe.
+ */
+public interface TranspositionTable<V> {
+    V get(long key);
+    void put(long key, V value);
+    void clear();
+    int size();
+}

--- a/src/test/java/julius/game/chessengine/ai/HistoryHeuristicTest.java
+++ b/src/test/java/julius/game/chessengine/ai/HistoryHeuristicTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import julius.game.chessengine.ai.FixedSizeTranspositionTable;
+import julius.game.chessengine.ai.TranspositionTable;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -24,11 +24,11 @@ public class HistoryHeuristicTest {
     private void clearTranspositionTables() throws Exception {
         Field mainField = AI.class.getDeclaredField("transpositionTable");
         mainField.setAccessible(true);
-        ((FixedSizeTranspositionTable<?>) mainField.get(null)).clear();
+        ((TranspositionTable<?>) mainField.get(null)).clear();
 
         Field captureField = AI.class.getDeclaredField("captureTranspositionTable");
         captureField.setAccessible(true);
-        ((FixedSizeTranspositionTable<?>) captureField.get(null)).clear();
+        ((TranspositionTable<?>) captureField.get(null)).clear();
     }
 
     @Test

--- a/src/test/java/julius/game/chessengine/ai/LateMoveReductionTest.java
+++ b/src/test/java/julius/game/chessengine/ai/LateMoveReductionTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import julius.game.chessengine.ai.FixedSizeTranspositionTable;
+import julius.game.chessengine.ai.TranspositionTable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -24,11 +24,11 @@ public class LateMoveReductionTest {
     private void clearTranspositionTables() throws Exception {
         Field mainField = AI.class.getDeclaredField("transpositionTable");
         mainField.setAccessible(true);
-        ((FixedSizeTranspositionTable<?>) mainField.get(null)).clear();
+        ((TranspositionTable<?>) mainField.get(null)).clear();
 
         Field captureField = AI.class.getDeclaredField("captureTranspositionTable");
         captureField.setAccessible(true);
-        ((FixedSizeTranspositionTable<?>) captureField.get(null)).clear();
+        ((TranspositionTable<?>) captureField.get(null)).clear();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add `TranspositionTable` abstraction with a simple array-backed implementation for single-threaded use.
- Switch AI to the non-atomic table when `chessengine.searchThreads` is 1.
- Replace CAS loops with plain assignments in the single-threaded table and update tests accordingly.

## Testing
- ⚠️ `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c02dee4b74832a887927a33f2b53bd