### PR TITLE
Replace synchronized cache with fastutil LRU

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,13 +63,18 @@
 			<version>2.3-groovy-4.0</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.groovy</groupId>
-			<artifactId>groovy</artifactId>
-			<version>4.0.28</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.apache.groovy</groupId>
+                        <artifactId>groovy</artifactId>
+                        <version>4.0.28</version>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>it.unimi.dsi</groupId>
+                        <artifactId>fastutil</artifactId>
+                        <version>8.5.13</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
+++ b/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
@@ -1,115 +1,95 @@
 package julius.game.chessengine.cache;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue;
+
+import java.util.function.BiConsumer;
 
 /**
- * A cache implementation that combines Least Recently Used (LRU) and timed eviction policies.
- * Entries in this cache are automatically removed when they become older than a specified age or
- * when the cache exceeds a specified size.
+ * A lightweight, unsynchronized LRU cache with time based eviction. Keys are primitives and
+ * timestamps are stored alongside values to avoid a secondary map. The cache is not thread safe and
+ * any required synchronization should happen at a higher level.
  *
- * @param <K> the type of keys maintained by this cache
- * @param <V> the type of mapped values
+ * @param <V> value type
  */
-public class TimedLRUCache<K, V> extends LinkedHashMap<K, V> {
-    private final long maxAge;
-    private final int maxSize;
-    private final Map<K, Long> timeMap = new ConcurrentHashMap<>();
+public class TimedLRUCache<V> {
 
-    /**
-     * Constructs an empty TimedLRUCache with the specified maximum size and maximum age for entries.
-     *
-     * @param maxSize the maximum number of entries this cache can hold.
-     * @param maxAge  the maximum time (in milliseconds) an entry can stay in the cache before it is eligible for removal.
-     */
+    private static final class Entry<V> {
+        final V value;
+        long time;
+
+        Entry(V value, long time) {
+            this.value = value;
+            this.time = time;
+        }
+    }
+
+    private final int maxSize;
+    private final long maxAge;
+
+    private final Long2ObjectOpenHashMap<Entry<V>> map = new Long2ObjectOpenHashMap<>();
+    private final LongArrayFIFOQueue keyQueue = new LongArrayFIFOQueue();
+    private final LongArrayFIFOQueue timeQueue = new LongArrayFIFOQueue();
+
     public TimedLRUCache(int maxSize, long maxAge) {
-        super(16, 0.75f, true); // Initialize LinkedHashMap with access order
         this.maxSize = maxSize;
         this.maxAge = maxAge;
     }
 
-    /**
-     * Determines whether the eldest entry should be removed or not. An entry is removed if
-     * the cache size exceeds the maximum size or if the entry's age exceeds the maximum age.
-     *
-     * @param eldest the eldest entry in the cache
-     * @return true if the eldest entry should be removed; false otherwise
-     */
-    @Override
-    protected synchronized boolean removeEldestEntry(Map.Entry<K, V> eldest) {
-        Long addedAt = timeMap.get(eldest.getKey());
-        if (addedAt == null) {
-            return false; // should not happen, but keep the entry if we have no timestamp
+    public V get(long key) {
+        Entry<V> entry = map.get(key);
+        if (entry == null) {
+            return null;
         }
-        boolean remove = size() > maxSize || System.currentTimeMillis() - addedAt > maxAge;
-        if (remove) {
-            timeMap.remove(eldest.getKey());
-        }
-        return remove;
-    }
-    /**
-     * Associates the specified value with the specified key in this cache. If the cache previously
-     * contained a mapping for the key, the old value is replaced. The current time is recorded for
-     * the key for timed eviction purposes.
-     *
-     * @param key   key with which the specified value is to be associated
-     * @param value value to be associated with the specified key
-     * @return the previous value associated with the key, or null if there was no mapping for the key
-     */
-    @Override
-    public synchronized V put(K key, V value) {
-        timeMap.put(key, System.currentTimeMillis());
-        return super.put(key, value);
-    }
-
-    /**
-     * Retrieves a value from the cache. Accessing an entry updates its
-     * position in the LRU order.
-     *
-     * @param key key whose associated value is to be returned
-     * @return the value associated with the specified key, or {@code null}
-     *         if the cache contains no mapping for the key
-     */
-    @Override
-    public synchronized V get(Object key) {
-        return super.get(key);
-    }
-
-    /**
-     * Checks whether a key is present in the cache.
-     *
-     * @param key key whose presence in this cache is to be tested
-     * @return {@code true} if this cache contains a mapping for the
-     *         specified key
-     */
-    @Override
-    public synchronized boolean containsKey(Object key) {
-        return super.containsKey(key);
-    }
-
-    /**
-     * Returns the number of key-value mappings in this cache.
-     *
-     * @return the number of entries in the cache
-     */
-    @Override
-    public synchronized int size() {
-        return super.size();
-    }
-
-    /**
-     * Cleans up the cache by removing entries that are older than the maximum allowed age.
-     * This method should be called periodically to ensure timely removal of old entries.
-     */
-    public synchronized void cleanup() {
         long now = System.currentTimeMillis();
-        for (Iterator<Map.Entry<K, Long>> it = timeMap.entrySet().iterator(); it.hasNext();) {
-            Map.Entry<K, Long> entry = it.next();
-            if (now - entry.getValue() > maxAge) {
-                it.remove();
-                super.remove(entry.getKey());
+        entry.time = now;
+        keyQueue.enqueue(key);
+        timeQueue.enqueue(now);
+        return entry.value;
+    }
+
+    public void put(long key, V value) {
+        long now = System.currentTimeMillis();
+        map.put(key, new Entry<>(value, now));
+        keyQueue.enqueue(key);
+        timeQueue.enqueue(now);
+        evict(now);
+    }
+
+    public boolean containsKey(long key) {
+        return map.containsKey(key);
+    }
+
+    public int size() {
+        return map.size();
+    }
+
+    public void cleanup() {
+        evict(System.currentTimeMillis());
+    }
+
+    private void evict(long now) {
+        while (!keyQueue.isEmpty()) {
+            long k = keyQueue.firstLong();
+            long t = timeQueue.firstLong();
+            Entry<V> entry = map.get(k);
+            if (entry == null || entry.time != t) {
+                keyQueue.dequeueLong();
+                timeQueue.dequeueLong();
+                continue;
+            }
+            if (now - t > maxAge || map.size() > maxSize) {
+                map.remove(k);
+                keyQueue.dequeueLong();
+                timeQueue.dequeueLong();
+            } else {
+                break;
             }
         }
     }
 
+    public void forEach(BiConsumer<Long, V> action) {
+        map.long2ObjectEntrySet().forEach(e -> action.accept(e.getLongKey(), e.getValue().value));
+    }
 }
+

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -19,7 +19,7 @@ public class Engine {
     private static final int MAX_SIZE = 5_000_000;
     private static final int MAX_AGE = 10_000;
 
-    private TimedLRUCache<Long, MoveList> legalMovesCache = new TimedLRUCache<>(MAX_SIZE, MAX_AGE);
+    private TimedLRUCache<MoveList> legalMovesCache = new TimedLRUCache<>(MAX_SIZE, MAX_AGE);
 
     @Getter
     private OpeningBook openingBook;

--- a/src/test/java/julius/game/chessengine/engine/EngineSimulationTest.java
+++ b/src/test/java/julius/game/chessengine/engine/EngineSimulationTest.java
@@ -27,8 +27,8 @@ public class EngineSimulationTest {
 
         Field cacheField = Engine.class.getDeclaredField("legalMovesCache");
         cacheField.setAccessible(true);
-        TimedLRUCache<Long, MoveList> mainCache = (TimedLRUCache<Long, MoveList>) cacheField.get(main);
-        TimedLRUCache<Long, MoveList> simCache = (TimedLRUCache<Long, MoveList>) cacheField.get(sim);
+        TimedLRUCache<MoveList> mainCache = (TimedLRUCache<MoveList>) cacheField.get(main);
+        TimedLRUCache<MoveList> simCache = (TimedLRUCache<MoveList>) cacheField.get(sim);
         assertNotSame(mainCache, simCache);
     }
 }


### PR DESCRIPTION
## Summary
- Implement unsynchronized LRU cache using fastutil primitives and array queue, storing timestamps per entry
- Wire Engine and tests to use new primitive cache
- Add fastutil dependency

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c02f1a939c832a941268d54cc47288