### PR TITLE
Require all pieces on starting squares for penalty

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -630,12 +630,12 @@ public class Score {
 
     private boolean areAllPiecesOnStartingSquares(long knights, long bishops, long rooks, boolean isWhite) {
         if (isWhite) {
-            return (knights == INITIAL_WHITE_KNIGHT_POSITION ||
-                    bishops == INITIAL_WHITE_BISHOP_POSITION ||
+            return (knights == INITIAL_WHITE_KNIGHT_POSITION &&
+                    bishops == INITIAL_WHITE_BISHOP_POSITION &&
                     rooks == INITIAL_WHITE_ROOK_POSITION);
         } else {
-            return (knights == INITIAL_BLACK_KNIGHT_POSITION ||
-                    bishops == INITIAL_BLACK_BISHOP_POSITION ||
+            return (knights == INITIAL_BLACK_KNIGHT_POSITION &&
+                    bishops == INITIAL_BLACK_BISHOP_POSITION &&
                     rooks == INITIAL_BLACK_ROOK_POSITION);
         }
     }

--- a/src/test/java/julius/game/chessengine/utils/StartingSquarePenaltyTest.java
+++ b/src/test/java/julius/game/chessengine/utils/StartingSquarePenaltyTest.java
@@ -1,0 +1,34 @@
+package julius.game.chessengine.utils;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StartingSquarePenaltyTest {
+
+    @Test
+    void noPenaltyWhenOnlyKnightsOnStartingSquares() {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/R1B2B1R/1N2K1N1 w - - 0 1");
+        Score score = new Score();
+        score.initializeScore(board);
+        assertEquals(0, score.getWhiteStartingSquarePenalty());
+    }
+
+    @Test
+    void noPenaltyWhenOnlyBishopsOnStartingSquares() {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/2N2N2/R6R/2B1KB2 w - - 0 1");
+        Score score = new Score();
+        score.initializeScore(board);
+        assertEquals(0, score.getWhiteStartingSquarePenalty());
+    }
+
+    @Test
+    void noPenaltyWhenOnlyRooksOnStartingSquares() {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/2B2B2/2N2N2/8/R3K2R w - - 0 1");
+        Score score = new Score();
+        score.initializeScore(board);
+        assertEquals(0, score.getWhiteStartingSquarePenalty());
+    }
+}


### PR DESCRIPTION
## Summary
- Ensure starting-square penalty is applied only when all knights, bishops, and rooks remain on their initial squares
- Add tests confirming no penalty when only one piece type stays on its starting square

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `mvn -o -q test` *(fails: Cannot access central Maven repository in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c0378b4fd0832ab7087cdd98b91ca0