### PR TITLE
Add center pawn bonus evaluation

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -96,6 +96,7 @@ public class Score {
     private static final int DOUBLED_PAWN_PENALTY = -20; // Example penalty value for doubled pawns
     private static final int ISOLATED_PAWN_PENALTY = -10; // Penalty for isolated pawns
     public static final int PASSED_PAWN_BONUS = 60;     // Bonus for passed pawns
+    public static final int CENTER_PAWN_BONUS = 20;     // Bonus for pawns in the center
 
     // Other bonuses and penalties
     private static final int NOT_CASTLED_AND_ROOK_MOVE_PENALTY = -50;
@@ -200,6 +201,9 @@ public class Score {
         long blackQueens = bitBoard.getBlackQueens();
         long whiteKing = bitBoard.getWhiteKing();
         long blackKing = bitBoard.getBlackKing();
+
+        updateCenterPawnBonusWhite(whitePawns);
+        updateCenterPawnBonusBlack(blackPawns);
 
         initializePawnScore(whitePawns, blackPawns);
         initializeKnightScore(whiteKnights, blackKnights);
@@ -389,6 +393,14 @@ public class Score {
 
     public void updatePassedPawnBonusBlack(long blackPawns, long whitePawns) {
         blackPassedPawnBonus = calculatePassedPawnBonus(blackPawns, whitePawns, false);
+    }
+
+    public void updateCenterPawnBonusWhite(long whitePawns) {
+        whiteCenterPawnBonus = countCenterPawns(whitePawns) * CENTER_PAWN_BONUS;
+    }
+
+    public void updateCenterPawnBonusBlack(long blackPawns) {
+        blackCenterPawnBonus = countCenterPawns(blackPawns) * CENTER_PAWN_BONUS;
     }
 
     private int calculatePassedPawnBonus(long pawns, long opponentPawns, boolean isWhite) {
@@ -647,6 +659,7 @@ public class Score {
         updateIsolatedPawnPenaltyWhite(whitePawns);
         updateDoubledPawnPenaltyWhite(whitePawns);
         updatePawnsPositionBonusWhite(whitePawns);
+        updateCenterPawnBonusWhite(whitePawns);
 
         //check if Rook is now on an HalfOpen/Open File
         updateBlackRookValues(bitBoard);
@@ -660,6 +673,7 @@ public class Score {
         updateIsolatedPawnPenaltyBlack(blackPawns);
         updateDoubledPawnPenaltyBlack(blackPawns);
         updatePawnsPositionBonusBlack(blackPawns);
+        updateCenterPawnBonusBlack(blackPawns);
 
         //check if Rook is now on an HalfOpen/Open File
         updateBlackRookValues(bitBoard);

--- a/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
@@ -36,4 +36,24 @@ public class ScoreEvaluationTest {
         assertTrue(scoreExposed.getBlackKingSafetyScore() < scoreSafe.getBlackKingSafetyScore());
         assertTrue(scoreExposed.getScoreDifference() > scoreSafe.getScoreDifference());
     }
+
+    @Test
+    void centerPawnsGrantBonusToWhite() {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/4P3/8/8/4K3 w - - 0 1");
+        Score score = new Score();
+        score.initializeScore(board);
+
+        assertEquals(Score.CENTER_PAWN_BONUS, score.getWhiteCenterPawnBonus());
+        assertEquals(0, score.getBlackCenterPawnBonus());
+    }
+
+    @Test
+    void centerPawnsGrantBonusToBlack() {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/4p3/8/8/8/4K3 w - - 0 1");
+        Score score = new Score();
+        score.initializeScore(board);
+
+        assertEquals(0, score.getWhiteCenterPawnBonus());
+        assertEquals(Score.CENTER_PAWN_BONUS, score.getBlackCenterPawnBonus());
+    }
 }


### PR DESCRIPTION
## Summary
- add CENTER_PAWN_BONUS constant and update methods
- compute center pawn bonuses during initialization and pawn updates
- add tests ensuring center pawns grant bonuses to both sides

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c038c06d2c832a85931f830dff3d34