### PR TITLE
Increase rook open file bonus and add test

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -104,7 +104,7 @@ public class Score {
     private static final int CASTLING_BONUS = 75;
 
     private static final int ROOK_HALF_OPEN_FILE_BONUS = 25;
-    private static final int ROOK_OPEN_FILE_BONUS = 12;
+    private static final int ROOK_OPEN_FILE_BONUS = 35;
 
     private static final int MOBILITY_BONUS = 5;
     private static final int MISSING_PAWN_SHIELD_PENALTY = -15;

--- a/src/test/java/julius/game/chessengine/utils/RookOpenFileBonusTest.java
+++ b/src/test/java/julius/game/chessengine/utils/RookOpenFileBonusTest.java
@@ -1,0 +1,24 @@
+package julius.game.chessengine.utils;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RookOpenFileBonusTest {
+
+    @Test
+    void rooksOnOpenFilesScoreHigherThanHalfOpen() {
+        BitBoard openFile = FEN.translateFENtoBitBoard("4k3/p7/8/8/8/8/8/1R2K3 w - - 0 1");
+        Score openScore = new Score();
+        openScore.initializeScore(openFile);
+
+        BitBoard halfOpenFile = FEN.translateFENtoBitBoard("4k3/p7/8/8/8/8/8/R3K3 w - - 0 1");
+        Score halfScore = new Score();
+        halfScore.initializeScore(halfOpenFile);
+
+        assertTrue(openScore.getWhiteRooksOpenFileBonus() > halfScore.getWhiteRooksHalfOpenFileBonus());
+        assertTrue(openScore.getScoreDifference() > halfScore.getScoreDifference());
+    }
+}


### PR DESCRIPTION
## Summary
- Raise rook open file bonus above half-open to properly reward open files
- Add regression test confirming open-file rooks outscore half-open rooks

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c039fa2828832a8beec270c37880c1