### PR TITLE
Use bit-pop loop for positional value calculation

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -632,10 +632,10 @@ public class Score {
 
     private int applyPositionalValues(long bitboard, int[] positionalValues) {
         int score = 0;
-        for (int i = Long.numberOfTrailingZeros(bitboard); i < 64 - Long.numberOfLeadingZeros(bitboard); i++) {
-            if (((1L << i) & bitboard) != 0) {
-                score += positionalValues[i];
-            }
+        while (bitboard != 0) {
+            long sq = bitboard & -bitboard;
+            score += positionalValues[Long.numberOfTrailingZeros(sq)];
+            bitboard ^= sq;
         }
         return score;
     }


### PR DESCRIPTION
## Summary
- replace indexed loop in `applyPositionalValues` with bit-pop loop for efficiency

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c03ab39f48832a8222c43f7e7b5226