### PR TITLE
Add bishop pair bonus evaluation

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -63,6 +63,8 @@ public class Score {
     private int blackRooksHalfOpenFileBonus = 0;
     private int whiteRooksOpenFileBonus = 0;
     private int blackRooksOpenFileBonus = 0;
+    private int whiteBishopPairBonus = 0;
+    private int blackBishopPairBonus = 0;
 
     // Initialize positional values
     private int whitePawnsPosition = 0;
@@ -109,6 +111,7 @@ public class Score {
     private static final int MOBILITY_BONUS = 5;
     private static final int MISSING_PAWN_SHIELD_PENALTY = -15;
     private static final int KING_ATTACK_PENALTY = -10;
+    public static final int BISHOP_PAIR_BONUS = 50;
 
     private static final long NOT_A_FILE = ~FileMasks[0];
     private static final long NOT_H_FILE = ~FileMasks[7];
@@ -159,6 +162,8 @@ public class Score {
         this.blackRooksHalfOpenFileBonus = other.blackRooksHalfOpenFileBonus;
         this.whiteRooksOpenFileBonus = other.whiteRooksOpenFileBonus;
         this.blackRooksOpenFileBonus = other.blackRooksOpenFileBonus;
+        this.whiteBishopPairBonus = other.whiteBishopPairBonus;
+        this.blackBishopPairBonus = other.blackBishopPairBonus;
 
         this.whitePawnsPosition = other.whitePawnsPosition;
         this.blackPawnsPosition = other.blackPawnsPosition;
@@ -208,6 +213,8 @@ public class Score {
         initializePawnScore(whitePawns, blackPawns);
         initializeKnightScore(whiteKnights, blackKnights);
         initializeBishopScore(whiteBishops, blackBishops);
+        whiteBishopPairBonus = Long.bitCount(whiteBishops) == 2 ? BISHOP_PAIR_BONUS : 0;
+        blackBishopPairBonus = Long.bitCount(blackBishops) == 2 ? BISHOP_PAIR_BONUS : 0;
         initializeRookScore(whiteRooks, blackRooks);
         initializeQueenScore(whiteQueens, blackQueens);
 
@@ -273,6 +280,7 @@ public class Score {
         totalWhiteScore += whiteBishopsAmountScore;
         totalWhiteScore += whiteRooksAmountScore;
         totalWhiteScore += whiteQueensAmountScore;
+        totalWhiteScore += whiteBishopPairBonus;
 
         totalWhiteScore += whiteCenterPawnBonus;
         totalWhiteScore += whiteDoubledPawnPenalty;
@@ -311,6 +319,7 @@ public class Score {
         totalBlackScore += blackBishopsAmountScore;
         totalBlackScore += blackRooksAmountScore;
         totalBlackScore += blackQueensAmountScore;
+        totalBlackScore += blackBishopPairBonus;
 
         totalBlackScore += blackCenterPawnBonus;
         totalBlackScore += blackDoubledPawnPenalty;
@@ -696,12 +705,14 @@ public class Score {
         this.whiteBishopsAmountScore = Long.bitCount(whiteBishops) * BISHOP_VALUE;
         updateBishopsPositionBonusWhite(whiteBishops);
         updateStartingSquarePenaltyWhite(whiteKnights, whiteBishops, whiteRooks);
+        whiteBishopPairBonus = Long.bitCount(whiteBishops) == 2 ? BISHOP_PAIR_BONUS : 0;
     }
 
     public void updateBlackBishopValues(long blackBishops, long blackKnights, long blackRooks) {
         this.blackBishopsAmountScore = Long.bitCount(blackBishops) * BISHOP_VALUE;
         updateBishopsPositionBonusBlack(blackBishops);
         updateStartingSquarePenaltyBlack(blackKnights, blackBishops, blackRooks);
+        blackBishopPairBonus = Long.bitCount(blackBishops) == 2 ? BISHOP_PAIR_BONUS : 0;
     }
 
     public void updateWhiteRookValues(BitBoard bitBoard) {

--- a/src/test/java/julius/game/chessengine/utils/BishopPairBonusTest.java
+++ b/src/test/java/julius/game/chessengine/utils/BishopPairBonusTest.java
@@ -1,0 +1,29 @@
+package julius.game.chessengine.utils;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BishopPairBonusTest {
+
+    @Test
+    void whiteBishopsPairGetsBonus() {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/8/2B1KB2 w - - 0 1");
+        Score score = new Score();
+        score.initializeScore(board);
+        assertEquals(Score.BISHOP_PAIR_BONUS, score.getWhiteBishopPairBonus());
+        assertEquals(0, score.getBlackBishopPairBonus());
+    }
+
+    @Test
+    void blackBishopsPairGetsBonus() {
+        BitBoard board = FEN.translateFENtoBitBoard("2b1kb2/8/8/8/8/8/8/4K3 w - - 0 1");
+        Score score = new Score();
+        score.initializeScore(board);
+        assertEquals(Score.BISHOP_PAIR_BONUS, score.getBlackBishopPairBonus());
+        assertEquals(0, score.getWhiteBishopPairBonus());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add bishop pair bonus constant and score fields
- include bishop pair bonus in score initialization and updates
- test bishop pair bonus for both colors

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c03be0c26c832aa0401dfb8070bfd1