### PR TITLE
Discourage draws when ahead

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -771,6 +771,12 @@ public class AI {
         }
 
         if (simulatorEngine.getGameState().isInStateDraw()) {
+            double scoreDiff = simulatorEngine.getGameState().getScore().getScoreDifference();
+            if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
+                return DRAW - 1; // discourage draws when ahead
+            } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {
+                return DRAW + 1; // prefer draws when behind
+            }
             return DRAW;
         }
 
@@ -834,6 +840,12 @@ public class AI {
         if (gameState.isInStateDraw()) {
             if (log.isDebugEnabled()) {
                 log.debug("DRAW");
+            }
+            double scoreDiff = gameState.getScore().getScoreDifference();
+            if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
+                return DRAW - 1; // avoid draws when ahead
+            } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {
+                return DRAW + 1; // accept draws when behind
             }
             return DRAW;
         }


### PR DESCRIPTION
## Summary
- Penalize draws in board and static evaluations when the side to move has a material edge, encouraging the engine to play for a win.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c052530548832aa601a1654e65b2fb