### PR TITLE
Cache attack maps for incremental updates

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -47,6 +47,7 @@ public class BitBoard {
      */
     private long whiteAttackMap = 0L;
     private long blackAttackMap = 0L;
+    private boolean attackMapsDirty = true;
     private PieceType[] pieceBoard = new PieceType[64];
 
     // Reusable buffer for move generation to avoid frequent allocations.
@@ -97,6 +98,7 @@ public class BitBoard {
         this.whiteKingHasCastled = whiteKingHasCastled;
         this.blackKingHasCastled = blackKingHasCastled;
         initPieceBoardFromBitboards();
+        recomputeAttackMaps();
     }
 
     public BitBoard() {
@@ -140,6 +142,9 @@ public class BitBoard {
 
         this.blackKingHasCastled = other.blackKingHasCastled;
         this.whiteKingHasCastled = other.whiteKingHasCastled;
+        this.whiteAttackMap = other.whiteAttackMap;
+        this.blackAttackMap = other.blackAttackMap;
+        this.attackMapsDirty = other.attackMapsDirty;
 
         this.pieceBoard = Arrays.copyOf(other.pieceBoard, other.pieceBoard.length);
     }
@@ -209,6 +214,7 @@ public class BitBoard {
 
         lastMoveDoubleStepPawnIndex = 0;
         initPieceBoardFromBitboards();
+        recomputeAttackMaps();
     }
 
     private void initPieceBoardFromBitboards() {
@@ -225,6 +231,8 @@ public class BitBoard {
         setPieces(blackQueens, PieceType.QUEEN);
         setPieces(whiteKing, PieceType.KING);
         setPieces(blackKing, PieceType.KING);
+
+        attackMapsDirty = true;
     }
 
     private void setPieces(long bitboard, PieceType type) {
@@ -298,6 +306,7 @@ public class BitBoard {
 
         // After setting the bitboard, update the aggregated bitboards
         updateAggregatedBitboards();
+        attackMapsDirty = true;
     }
     // Call these methods within the movePiece method when a king or rook moves
 
@@ -315,11 +324,9 @@ public class BitBoard {
         MoveList moves = moveGenerationBuffer;
         moves.clear();
 
-        // Pre-compute attack maps for both sides once and reuse them during move
-        // generation.  This avoids repeatedly recalculating the same information
-        // for castling checks and attack lookups.
-        whiteAttackMap = generateAttackBitboard(true);
-        blackAttackMap = generateAttackBitboard(false);
+        if (attackMapsDirty) {
+            recomputeAttackMaps();
+        }
 
         generatePawnMoves(whitesTurn, moves);
         generateKnightMoves(whitesTurn, moves);
@@ -393,6 +400,12 @@ public class BitBoard {
         whitePieces = whitePawns | whiteKnights | whiteBishops | whiteRooks | whiteQueens | whiteKing;
         blackPieces = blackPawns | blackKnights | blackBishops | blackRooks | blackQueens | blackKing;
         allPieces = whitePieces | blackPieces;
+    }
+
+    private void recomputeAttackMaps() {
+        whiteAttackMap = generateAttackBitboard(true);
+        blackAttackMap = generateAttackBitboard(false);
+        attackMapsDirty = false;
     }
 
     private void generatePawnMoves(boolean whitesTurn, MoveList moves) {
@@ -733,6 +746,9 @@ public class BitBoard {
     }
 
     private boolean isSquareUnderAttack(int index, boolean colorWhite) {
+        if (attackMapsDirty) {
+            recomputeAttackMaps();
+        }
         long attacks = colorWhite ? blackAttackMap : whiteAttackMap;
         return (attacks & (1L << index)) != 0;
     }
@@ -830,6 +846,7 @@ public class BitBoard {
             clearSquare(capturedPawnIndex, !isWhite);
         }
         updateAggregatedBitboards();
+        recomputeAttackMaps();
         whitesTurn = !whitesTurn;
     }
 
@@ -852,6 +869,7 @@ public class BitBoard {
         }
         pieceBoard[index] = null;
         updateAggregatedBitboards();
+        attackMapsDirty = true;
     }
 
 
@@ -1143,6 +1161,7 @@ public class BitBoard {
         // Update the aggregated bitboards and piece board
         updateAggregatedBitboards();
         initPieceBoardFromBitboards();
+        recomputeAttackMaps();
         whitesTurn = !whitesTurn;
     }
 

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -7,8 +7,7 @@ import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Test;
 
 import static julius.game.chessengine.board.MoveHelper.convertStringToIndex;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @Log4j2
 public class BitBoardTest {
@@ -162,6 +161,32 @@ public class BitBoardTest {
 
         endTime = System.nanoTime();
         log.info("(1-6) Time taken for move calculation: {} ms", (endTime - startTime) / 1e6);
+    }
+
+    @Test
+    public void testAttackMapsUpdateAndCaching() {
+        BitBoard board = new BitBoard();
+        long initialWhite = board.getWhiteAttackMap();
+        int e2 = convertStringToIndex("e2");
+        int e4 = convertStringToIndex("e4");
+        int move = MoveHelper.createMoveInt(e2, e4, PieceType.PAWN, true,
+                false, false, false, null, null, false, false,
+                board.getLastMoveDoubleStepPawnIndex());
+        board.performMove(move);
+        long afterWhite = board.getWhiteAttackMap();
+        assertNotEquals(initialWhite, afterWhite, "Attack map should change after a move");
+        int d5 = convertStringToIndex("d5");
+        int f5 = convertStringToIndex("f5");
+        assertTrue(((afterWhite >>> d5) & 1L) != 0L);
+        assertTrue(((afterWhite >>> f5) & 1L) != 0L);
+
+        // Modify board externally and ensure maps are recomputed on demand
+        int g1 = convertStringToIndex("g1");
+        board.clearSquare(g1, true); // remove knight without using performMove
+        long stale = board.getWhiteAttackMap();
+        board.generateAllPossibleMoves(board.whitesTurn);
+        long refreshed = board.getWhiteAttackMap();
+        assertNotEquals(stale, refreshed, "Attack map should refresh after external change");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Maintain cached white and black attack bitboards with a dirty flag.
- Recompute attack maps only when board state changes and reuse them during move generation.
- Update attack maps after each move and add tests ensuring they refresh when needed.

## Testing
- ⚠️ `mvn -q test` *(dependency resolution failed: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c0565268bc832a80c8cabaf1d60ed2