### PR TITLE
Refactor promotion moves to use shared constant

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -22,6 +22,8 @@ import static julius.game.chessengine.helper.KnightHelper.knightMoveTable;
 @Getter
 public class BitBoard {
 
+    private static final PieceType[] PROMOTION_PIECES = {PieceType.QUEEN, PieceType.ROOK, PieceType.BISHOP, PieceType.KNIGHT};
+
     BishopHelper bishopHelper = BishopHelper.getInstance();
     RookHelper rookHelper = RookHelper.getInstance();
 
@@ -573,8 +575,7 @@ public class BitBoard {
     }
 
     private void addPromotionMoves(MoveList moves, int fromIndex, int toIndex, boolean whitesTurn, boolean isCapture, PieceType capturedType) {
-        PieceType[] promotionPieces = {PieceType.ROOK, PieceType.QUEEN, PieceType.BISHOP, PieceType.KNIGHT};
-        for (PieceType promotionPiece : promotionPieces) {
+        for (PieceType promotionPiece : PROMOTION_PIECES) {
             moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, isCapture, false, false, promotionPiece, capturedType, false, false, lastMoveDoubleStepPawnIndex));
         }
     }


### PR DESCRIPTION
## Summary
- Add static PROMOTION_PIECES list to BitBoard with queen prioritized
- Reuse PROMOTION_PIECES in addPromotionMoves to reduce allocations and improve ordering

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c05abfd504832a8fdbc2a67907ad7c