### PR TITLE
Remove MoveList bound check

### DIFF
--- a/src/main/java/julius/game/chessengine/board/MoveList.java
+++ b/src/main/java/julius/game/chessengine/board/MoveList.java
@@ -33,11 +33,11 @@ public class MoveList {
 
     public void add(int move) {
         // Since the array is pre-allocated to the maximum size, we can skip
-        // expensive bounds checks and resizes. The check against MAX_SIZE is
-        // kept as a safety measure.
-        if (moveCount < MAX_SIZE) {
-            moves[moveCount++] = move;
-        }
+        // expensive bounds checks and resizes. Rely on callers to ensure
+        // the list never exceeds MAX_SIZE. The assertion will help catch
+        // violations in development builds.
+        assert moveCount < MAX_SIZE : "MoveList capacity exceeded";
+        moves[moveCount++] = move;
         isStringRepresentationStale = true;
     }
 


### PR DESCRIPTION
## Summary
- rely on callers to avoid exceeding MoveList capacity by replacing a bounds check with an assertion

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c05b3c0cb4832a8e4f0a4d41fb8b9d