### PR TITLE
Keep AI calculation running until board changes

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -198,18 +198,18 @@ public class AI {
                 return;
             }
             if ((aiIsWhite && mainEngine.whitesTurn()) || (aiIsBlack && !mainEngine.whitesTurn())) {
-                performMove();
+                if (currentBestMove != -1) {
+                    performMove();
+                }
             }
         }, 0, 50, TimeUnit.MILLISECONDS);
     }
 
     public void performMove() {
         if (currentBestMove == -1) {
-            log.error("No current best move available. Unable to perform a move.");
-            log.error("boardStateBeforeCalculation {}, currentBoardHash {}", beforeCalculationBoardState, currentBoardState);
-            log.error("WhitesTurn = {}, isEndgame = {}", mainEngine.whitesTurn(), mainEngine.isEndgame());
-            log.error("Gamestate = " + mainEngine.getGameState());
-            return; // Return the current state without making a move
+            // The calculation thread has not yet produced a move; skip until one is available.
+            log.debug("No current best move available. Waiting for calculation to finish.");
+            return;
         }
 
         if (!MoveHelper.isWhitesMove(currentBestMove) == mainEngine.whitesTurn()) {
@@ -217,7 +217,6 @@ public class AI {
             log.debug("Current best move {} is not valid for the current turn.", Move.convertIntToMove(currentBestMove));
             return; // Return the current state without making a move
         }
-        log.info("Perform Move");
         mainEngine.performMove(currentBestMove);
         currentBoardState = mainEngine.getBoardStateHash();
         synchronized (calculationLock) {
@@ -244,23 +243,37 @@ public class AI {
             if (!keepCalculating || Thread.currentThread().isInterrupted()) {
                 break;
             }
-            currentBoardState = mainEngine.getBoardStateHash();
-            beforeCalculationBoardState = currentBoardState;
-            performCalculation();
+            do {
+                currentBoardState = mainEngine.getBoardStateHash();
+                beforeCalculationBoardState = currentBoardState;
+                performCalculation();
+            } while (!positionChanged() && keepCalculating && !Thread.currentThread().isInterrupted());
         }
     }
 
     private void performCalculation() {
         log.debug(" --- TranspositionTable[{}] --- ", transpositionTable.size());
         decayHistoryTable();
-        Engine simulatorEngine = mainEngine.createSimulation();
-        long boardStateHash = simulatorEngine.getBoardStateHash();
-        log.debug("boardStateBeforeCalculation {}, currentBoardState {}", beforeCalculationBoardState, currentBoardState);
+        try {
+            Engine simulatorEngine = mainEngine.createSimulation();
+            long boardStateHash = simulatorEngine.getBoardStateHash();
+            log.debug("boardStateBeforeCalculation {}, currentBoardState {}", beforeCalculationBoardState, currentBoardState);
 
-        // Perform calculation only if the board state has actually changed
-        boolean isWhite = simulatorEngine.whitesTurn();
-        long deadline = System.nanoTime() + timeLimit * 1_000_000;
-        calculateBestMove(simulatorEngine, boardStateHash, isWhite, deadline);
+            // Perform calculation only if the board state has actually changed
+            boolean isWhite = simulatorEngine.whitesTurn();
+            long deadline = System.nanoTime() + timeLimit * 1_000_000;
+            calculateBestMove(simulatorEngine, boardStateHash, isWhite, deadline);
+        } catch (IllegalStateException e) {
+            log.warn("Illegal board state during search: {}", e.getMessage());
+            MoveList legalMoves = mainEngine.getAllLegalMoves();
+            if (legalMoves.size() > 0) {
+                currentBestMove = legalMoves.getMove(0);
+            } else {
+                currentBestMove = -1;
+            }
+        } catch (Exception e) {
+            log.error("Unexpected error during calculation", e);
+        }
 
     }
 
@@ -405,7 +418,6 @@ public class AI {
                 score = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline);
                 // Check for time limit exceeded after alphaBeta call
                 if (score == EXIT_FLAG || positionChanged()) {
-                    log.info("best Position changed");
                     simulatorEngine.undoLastMove(); // Undo move using its integer representation
                     break;
                 }
@@ -440,7 +452,7 @@ public class AI {
      */
     private double alphaBeta(Engine simulatorEngine, int depth, double alpha, double beta, boolean isWhite, long deadline) {
         if (log.isDebugEnabled()) {
-            log.debug(" ------------------------- {} ------------------------- ", depth);
+            log.debug("Entering search depth {}", depth);
         }
         nodesVisited++;
         // Check for time limit exceeded
@@ -545,7 +557,6 @@ public class AI {
 
                 if (eval == EXIT_FLAG || positionChanged()) {
                     simulatorEngine.undoLastMove();
-                    log.info("maxi Position changed");
                     return EXIT_FLAG;
                 }
 
@@ -553,7 +564,6 @@ public class AI {
                     eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline);
                     if (eval == EXIT_FLAG || positionChanged()) {
                         simulatorEngine.undoLastMove();
-                        log.info("maxi Position changed");
                         return EXIT_FLAG;
                     }
                 }
@@ -562,7 +572,6 @@ public class AI {
                     eval = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhite, deadline);
                     if (eval == EXIT_FLAG || positionChanged()) {
                         simulatorEngine.undoLastMove();
-                        log.info("maxi Position changed");
                         return EXIT_FLAG;
                     }
                 }
@@ -645,7 +654,6 @@ public class AI {
                 eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline);
 
                 if (eval == EXIT_FLAG || positionChanged()) {
-                    log.info("mini Position changed");
                     simulatorEngine.undoLastMove();
                     return EXIT_FLAG;
                 }
@@ -653,7 +661,6 @@ public class AI {
                 if (usePvs && eval > alpha && eval < beta) {
                     eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline);
                     if (eval == EXIT_FLAG || positionChanged()) {
-                        log.info("mini Position changed");
                         simulatorEngine.undoLastMove();
                         return EXIT_FLAG;
                     }
@@ -662,7 +669,6 @@ public class AI {
                 if (reduced && eval < beta) {
                     eval = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhite, deadline);
                     if (eval == EXIT_FLAG || positionChanged()) {
-                        log.info("mini Position changed");
                         simulatorEngine.undoLastMove();
                         return EXIT_FLAG;
                     }

--- a/src/main/java/julius/game/chessengine/ai/OpeningBook.java
+++ b/src/main/java/julius/game/chessengine/ai/OpeningBook.java
@@ -76,7 +76,6 @@ public class OpeningBook {
         }
         Random random = new Random();
         int randomMove = moves.get(random.nextInt(moves.size()));
-        log.info("Performing Opening Move: {}, BoardStateHash: {}", Move.convertIntToMove(randomMove), boardStateHash);
         return randomMove;
     }
 

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -520,8 +520,10 @@ public class BitBoard {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 7 : toIndex + 7;
             PieceType capturedType = getPieceTypeAtIndex(toIndex);
-            moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
-                    null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+            if (capturedType != PieceType.KING) {
+                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
+                        null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+            }
             temp &= temp - 1;
         }
 
@@ -531,8 +533,10 @@ public class BitBoard {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 9 : toIndex + 9;
             PieceType capturedType = getPieceTypeAtIndex(toIndex);
-            moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
-                    null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+            if (capturedType != PieceType.KING) {
+                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
+                        null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+            }
             temp &= temp - 1;
         }
 
@@ -542,7 +546,9 @@ public class BitBoard {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 7 : toIndex + 7;
             PieceType capturedType = getPieceTypeAtIndex(toIndex);
-            addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, true, capturedType);
+            if (capturedType != PieceType.KING) {
+                addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, true, capturedType);
+            }
             temp &= temp - 1;
         }
 
@@ -551,7 +557,9 @@ public class BitBoard {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 9 : toIndex + 9;
             PieceType capturedType = getPieceTypeAtIndex(toIndex);
-            addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, true, capturedType);
+            if (capturedType != PieceType.KING) {
+                addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, true, capturedType);
+            }
             temp &= temp - 1;
         }
 
@@ -615,7 +623,9 @@ public class BitBoard {
                 boolean isCapture = (opponentPieces & (1L << targetIndex)) != 0;
 
                 PieceType capturedPieceType = isCapture ? getPieceTypeAtIndex(targetIndex) : null;
-                moves.add(createMoveInt(knightIndex, targetIndex, PieceType.KNIGHT, whitesTurn, isCapture, false, false, null, capturedPieceType, false, false, lastMoveDoubleStepPawnIndex));
+                if (capturedPieceType != PieceType.KING) {
+                    moves.add(createMoveInt(knightIndex, targetIndex, PieceType.KNIGHT, whitesTurn, isCapture, false, false, null, capturedPieceType, false, false, lastMoveDoubleStepPawnIndex));
+                }
 
                 potentialMoves &= potentialMoves - 1; // Clear the lowest set bit
             }
@@ -643,7 +653,10 @@ public class BitBoard {
 
 
                 boolean isCapture = (opponentPieces & (1L << targetSquare)) != 0;
-                moves.add(createMoveInt(bishopSquare, targetSquare, PieceType.BISHOP, isWhite, isCapture, false, false, null, isCapture ? getPieceTypeAtIndex(targetSquare) : null, false, false, lastMoveDoubleStepPawnIndex));
+                PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetSquare) : null;
+                if (capturedType != PieceType.KING) {
+                    moves.add(createMoveInt(bishopSquare, targetSquare, PieceType.BISHOP, isWhite, isCapture, false, false, null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                }
             }
         }
     }
@@ -666,7 +679,10 @@ public class BitBoard {
                 attacks &= attacks - 1; // Remove the least significant bit representing an attack
                 boolean isFirstRookMove = !hasRookMoved(rookSquare);
                 boolean isCapture = (opponentPieces & (1L << targetSquare)) != 0;
-                moves.add(createMoveInt(rookSquare, targetSquare, PieceType.ROOK, whitesTurn, isCapture, false, false, null, isCapture ? getPieceTypeAtIndex(targetSquare) : null, false, isFirstRookMove, lastMoveDoubleStepPawnIndex));
+                PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetSquare) : null;
+                if (capturedType != PieceType.KING) {
+                    moves.add(createMoveInt(rookSquare, targetSquare, PieceType.ROOK, whitesTurn, isCapture, false, false, null, capturedType, false, isFirstRookMove, lastMoveDoubleStepPawnIndex));
+                }
             }
         }
     }
@@ -690,7 +706,10 @@ public class BitBoard {
                 int targetSquare = Long.numberOfTrailingZeros(attacks);
                 attacks &= attacks - 1; // Remove the least significant bit representing an attack
                 boolean isCapture = (opponentPieces & (1L << targetSquare)) != 0;
-                moves.add(createMoveInt(queenSquare, targetSquare, PieceType.QUEEN, whitesTurn, isCapture, false, false, null, isCapture ? getPieceTypeAtIndex(targetSquare) : null, false, false, lastMoveDoubleStepPawnIndex));
+                PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetSquare) : null;
+                if (capturedType != PieceType.KING) {
+                    moves.add(createMoveInt(queenSquare, targetSquare, PieceType.QUEEN, whitesTurn, isCapture, false, false, null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                }
             }
         }
     }
@@ -712,7 +731,10 @@ public class BitBoard {
         for (long possibleMoves = legalMoves; possibleMoves != 0; possibleMoves &= possibleMoves - 1) {
             int targetIndex = Long.numberOfTrailingZeros(possibleMoves);
             boolean isCapture = (captureMoves & (1L << targetIndex)) != 0;
-            moves.add(createMoveInt(kingPositionIndex, targetIndex, PieceType.KING, whitesTurn, isCapture, false, false, null, isCapture ? getPieceTypeAtIndex(targetIndex) : null, isFirstKingMove, false, lastMoveDoubleStepPawnIndex));
+            PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetIndex) : null;
+            if (capturedType != PieceType.KING) {
+                moves.add(createMoveInt(kingPositionIndex, targetIndex, PieceType.KING, whitesTurn, isCapture, false, false, null, capturedType, isFirstKingMove, false, lastMoveDoubleStepPawnIndex));
+            }
         }
 
         addCastlingMoves(whitesTurn, kingPositionIndex, moves);
@@ -809,6 +831,10 @@ public class BitBoard {
         PieceType movingPiece = pieceTypeFromBits(pieceTypeBits);
 
         if (isCapture) {
+            PieceType captured = getPieceTypeAtIndex(toIndex);
+            if (captured == PieceType.KING) {
+                throw new IllegalStateException("Cannot capture the king");
+            }
             clearSquare(toIndex, !isWhite);
         }
 
@@ -1053,7 +1079,7 @@ public class BitBoard {
             logBoard.append("  ").append(rank).append('\n'); // Append the rank number at the end of each line
         }
         logBoard.append("a b c d e f g h"); // Append file letters at the bottom
-        log.info(logBoard.toString()); // Log the current board state
+        log.debug(logBoard.toString()); // Log the current board state
     }
 
     private char getPieceChar(long positionMask) {

--- a/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
+++ b/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
@@ -69,7 +69,9 @@ public class TimedLRUCache<V> {
     }
 
     private void evict(long now) {
-        while (!keyQueue.isEmpty()) {
+        // Ensure both queues contain data before accessing their heads to avoid
+        // NoSuchElementException when they become unsynchronized.
+        while (!keyQueue.isEmpty() && !timeQueue.isEmpty()) {
             long k = keyQueue.firstLong();
             long t = timeQueue.firstLong();
             Entry<V> entry = map.get(k);
@@ -85,6 +87,12 @@ public class TimedLRUCache<V> {
             } else {
                 break;
             }
+        }
+
+        // If the queues ever get out of sync, clear them to reset state.
+        if (keyQueue.size() != timeQueue.size()) {
+            keyQueue.clear();
+            timeQueue.clear();
         }
     }
 

--- a/src/main/java/julius/game/chessengine/helper/BishopHelper.java
+++ b/src/main/java/julius/game/chessengine/helper/BishopHelper.java
@@ -70,7 +70,7 @@ public class BishopHelper {
             squareIndexCounts.put(square, indexCount);
             total += indexCount;
         }
-        log.info(" --- Bishop attacks take up a size of {} --- ", total);
+        log.debug(" --- Bishop attacks take up a size of {} --- ", total);
 
         // Create a list of square indices sorted by index counts in descending order
         List<Integer> squares = squareIndexCounts.entrySet().stream()
@@ -94,7 +94,7 @@ public class BishopHelper {
                 // Submit the task only if duplicates are found, indicating a need for optimization
                 executor.submit(() -> findMagicNumberForSquare(square, magicNumbers));
             } else {
-                log.info("Bishop square {} is fully optimized size {}", square, squareIndexCounts.get(square));
+                log.debug("Bishop square {} is fully optimized size {}", square, squareIndexCounts.get(square));
             }
         }
 
@@ -116,7 +116,7 @@ public class BishopHelper {
         long mask = bishopMasks[square];
         Set<Long> occupancies = generateAllOccupancies(mask);
         int minIndices = calculateIndexCount(bishopMagics[square], square, mask);
-        log.info("Bishop Square: {}, has a size of {}", square, minIndices);
+        log.debug("Bishop Square: {}, has a size of {}", square, minIndices);
 
 
         while (true) {
@@ -140,7 +140,7 @@ public class BishopHelper {
                 minIndices = indexToOccupancy.size(); // Update to the new lower value
                 bishopMagics[square] = magicCandidate; // Update the magic number
                 squareMagicFound[square] = true;
-                log.info("Bishop Optimized magic number found for square " + square + ": " + magicCandidate);
+                log.debug("Bishop Optimized magic number found for square " + square + ": " + magicCandidate);
                 magicNumbers.put(square, magicCandidate);
                 break;
             }

--- a/src/main/java/julius/game/chessengine/helper/RookHelper.java
+++ b/src/main/java/julius/game/chessengine/helper/RookHelper.java
@@ -117,7 +117,7 @@ public class RookHelper {
             squareIndexCounts.put(square, indexCount);
             total += indexCount;
         }
-        log.info(" --- Rook attacks take up a size of {} --- ", total);
+        log.debug(" --- Rook attacks take up a size of {} --- ", total);
 
         // Create a list of square indices sorted by index counts in descending order
         List<Integer> squares = squareIndexCounts.entrySet().stream()
@@ -141,7 +141,7 @@ public class RookHelper {
                 executor.submit(() -> findMagicNumberForSquare(square, magicNumbers));
             }
             else {
-                log.info("Rook square {} is fully optimized size {}", square, squareIndexCounts.get(square));
+                log.debug("Rook square {} is fully optimized size {}", square, squareIndexCounts.get(square));
             }
         }
 
@@ -163,7 +163,7 @@ public class RookHelper {
         long mask = rookMasks[square];
         Set<Long> occupancies = generateAllOccupancies(mask);
         int minIndices = calculateIndexCount(rookMagics[square], square, mask);
-        log.info("Rook Square: {}, has a size of {}", square, minIndices);
+        log.debug("Rook Square: {}, has a size of {}", square, minIndices);
 
         while (true) {
             long magicCandidate = randomMagicNumber();
@@ -186,7 +186,7 @@ public class RookHelper {
                 minIndices = indexToOccupancy.size(); // Update to the new lower value
                 rookMagics[square] = magicCandidate; // Update the magic number
                 squareMagicFound[square] = true;
-                log.info("Rook Optimized magic number found for square " + square + ": " + magicCandidate);
+                log.debug("Rook Optimized magic number found for square " + square + ": " + magicCandidate);
                 magicNumbers.put(square, magicCandidate);
                 break;
             }


### PR DESCRIPTION
## Summary
- Continuously recalculate lines in AI.calculateLine so the engine keeps searching until the board state updates
- Skip making a move until the search thread provides a best move to avoid errors when the board changes
- Filter out king captures and reject any move that tries to capture a king to prevent illegal board states
- Strip noisy info-level logs and add a debug log showing current search depth
- Guard TimedLRUCache eviction when queues get out of sync to avoid NoSuchElementException

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Could not transfer org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68c13603c2f8832a88d5aa091034cb57