### PR TITLE
feat: display active player turn

### DIFF
--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -218,7 +218,7 @@ body {
     background-color: #32CD32; /* Unified button color */
 }
 
-#score, #calculatedLine {
+#score, #calculatedLine, #turnIndicator {
     text-align: center;
     font-size: large;
     color: lime;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -43,8 +43,9 @@
 
         <section id="section3" class="game-section">
             <button class="btn arrow" id="undoMove">←</button>
-            
+
             <div id="scoreAndLineContainer">
+                <div id="turnIndicator">Turn: --</div>
                 <div id="score">Score</div>
                 <div id="calculatedLine">Calculated Line: <span></span></div>
                 <div class="record-move-checkbox">

--- a/src/main/resources/static/js/chess-data-fetching.js
+++ b/src/main/resources/static/js/chess-data-fetching.js
@@ -35,6 +35,11 @@ const updateCalculatedLine = () => {
         updateKingGlow(gameState); // Update the king glow based on game state
         updateGameDetails(data);
     });
+
+    makeRequest('GET', 'http://localhost:8080/chess/search/status', (status) => {
+        const side = status.sideToMove.charAt(0) + status.sideToMove.slice(1).toLowerCase();
+        document.getElementById('turnIndicator').textContent = `Turn: ${side}`;
+    });
 };
 
 // Add an event listener to the "View Details" button


### PR DESCRIPTION
## Summary
- show which side is to move in the UI
- style turn indicator to match existing score area
- fetch turn info from `search/status` endpoint

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c199a9a794832a8161025e7e82242a