### PR TITLE
Use dynamic backend URL and improve mobile chessboard touch controls

### DIFF
--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -3,6 +3,7 @@ body {
     background-color: #00008B; /* Dark blue */
     animation: colorChange 20s infinite alternate;
     box-shadow: inset 0 0 30px rgba(0, 255, 0, 0.5); /* Subtle glow */
+    overflow-x: hidden;
 }
 
 @keyframes colorChange {
@@ -15,7 +16,8 @@ body {
 /* Section and Container Styles */
 #section1, #section2, #section3 {
     margin: 0 auto;
-    width: 1024px;
+    width: 100%;
+    max-width: 1024px;
     transition: all 0.5s ease; /* Smooth transition */
 }
 
@@ -68,7 +70,8 @@ body {
 
 #section1 > div, #section3 > div {
     margin: 0 auto;
-    width: 512px;
+    width: 100%;
+    max-width: 512px;
     text-align: center;
     color: #32CD32;
     background-color: rgba(0, 0, 0, 0.5);
@@ -77,7 +80,8 @@ body {
 
 #section2 > div {
     margin: 0 auto;
-    width: 512px;
+    width: 100%;
+    max-width: 512px;
 }
 
 /* Slider Container */
@@ -134,7 +138,8 @@ body {
 
 
 #section3 {
-    width: 800px; /* or any other value smaller than 512px */
+    width: 100%;
+    max-width: 800px; /* or any other value smaller than 512px */
     margin: 0 auto;
     display: flex;
     align-items: center;
@@ -177,7 +182,10 @@ body {
 
 
 #board {
-    width: 512px;
+    width: 100%;
+    max-width: 95vw;
+    touch-action: none;
+    -ms-touch-action: none;
 }
 
 /* Top Bar Styles */
@@ -188,6 +196,7 @@ body {
     display: flex;
     justify-content: center;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 .top-bar li {
@@ -230,7 +239,8 @@ body {
 
 .game-section {
     margin: 0 auto;
-    width: 512px;
+    width: 100%;
+    max-width: 512px;
     color: lime;
     border: 3px solid lime;
     background-color: rgba(0, 0, 0, 0.5);

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -5,6 +5,7 @@
     <title>Alieknek</title>
     <meta name="description" content="The HTML5 Herald">
     <meta name="author" content="SitePoint">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link rel="stylesheet" href="css/chessboard-1.0.0.min.css">
     <link rel="stylesheet" href="css/details.css">

--- a/src/main/resources/static/js/chess-data-fetching.js
+++ b/src/main/resources/static/js/chess-data-fetching.js
@@ -9,9 +9,10 @@ let lastPossibleMoves = [];
 let previousPiecesData = null;
 
 // Function to make API requests
+const apiBaseUrl = window.location.origin;
 const makeRequest = async (method, url, callback) => {
     try {
-        const response = await fetch(url, { method });
+        const response = await fetch(`${apiBaseUrl}${url}`, { method });
         if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
         const data = await response.json();
         if (callback) callback(data);
@@ -22,7 +23,7 @@ const makeRequest = async (method, url, callback) => {
 
 // Update the calculated line and game details
 const updateCalculatedLine = () => {
-    makeRequest('GET', 'http://localhost:8080/chess/state', (data) => {
+    makeRequest('GET', '/chess/state', (data) => {
         latestStateData = data;
         const lineText = data.move || "No moves yet";
         const gameState = data.gameState.state;
@@ -36,7 +37,7 @@ const updateCalculatedLine = () => {
         updateGameDetails(data);
     });
 
-    makeRequest('GET', 'http://localhost:8080/chess/search/status', (status) => {
+    makeRequest('GET', '/chess/search/status', (status) => {
         const side = status.sideToMove.charAt(0) + status.sideToMove.slice(1).toLowerCase();
         document.getElementById('turnIndicator').textContent = `Turn: ${side}`;
     });
@@ -46,7 +47,7 @@ const updateCalculatedLine = () => {
 document.getElementById('PGN').addEventListener('click', async function(event) {
     event.preventDefault();
     try {
-        const response = await fetch('http://localhost:8080/chess/pgn', { method: 'GET' });
+        const response = await fetch(`${apiBaseUrl}/chess/pgn`, { method: 'GET' });
         if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
         const pgnData = await response.json();
 
@@ -65,7 +66,7 @@ const updateSliderValue = (value) => {
 const handleSliderChange = () => {
     const sliderValue = $('#autoplaySlider').val();
     updateSliderValue(sliderValue);
-    makeRequest('PATCH', `http://localhost:8080/chess/autoplay/timelimit/${sliderValue}`, reloadBoard);
+    makeRequest('PATCH', `/chess/autoplay/timelimit/${sliderValue}`, reloadBoard);
 };
 
 // Initialize slider event listener
@@ -209,14 +210,14 @@ const checkState = (state) => {
 // Function to import FEN
 function importFEN(fenString) {
     var encodedFenString = encodeURIComponent(fenString);
-    makeRequest('PATCH', `http://localhost:8080/chess/fen?fen=${encodedFenString}`, () => {
+    makeRequest('PATCH', `/chess/fen?fen=${encodedFenString}`, () => {
         reloadBoard();
     });
 }
 
 // Function to make a move
 const autoPlayColor = (color) => {
-    makeRequest('PATCH', `http://localhost:8080/chess/autoplay/${color}`, (data) => {
+    makeRequest('PATCH', `/chess/autoplay/${color}`, (data) => {
         checkState(data.state);
         reloadBoard();
     });
@@ -224,12 +225,12 @@ const autoPlayColor = (color) => {
 // Function for onDrop event
 const onDrop = (source, target) => {
     const saveToOpeningBook = document.getElementById('recordOpeningMove').checked;
-    const url = `http://localhost:8080/chess/figure/move/${source}/${target}?saveToOpeningBook=${saveToOpeningBook}`;
+    const url = `/chess/figure/move/${source}/${target}?saveToOpeningBook=${saveToOpeningBook}`;
     makeRequest('PATCH', url, reloadBoard);
 };
 
 const onMouseoverSquare = (square) => {
-    makeRequest('GET', `http://localhost:8080/chess/figure/move/possible/${square}`, (moves) => {
+    makeRequest('GET', `/chess/figure/move/possible/${square}`, (moves) => {
         if (moves.length === 0) return;
         highlightSquare(square, true);
         moves.forEach(move => highlightSquare(move.x + move.y, true));
@@ -281,7 +282,7 @@ const initBoard = () => {
 };
 
 const reloadBoard = () => {
-    makeRequest('GET', 'http://localhost:8080/chess/figure/frontend', (newData) => {
+    makeRequest('GET', '/chess/figure/frontend', (newData) => {
         if (board) {
             // Compare new data with previous data
 

--- a/src/main/resources/static/js/ffb.js
+++ b/src/main/resources/static/js/ffb.js
@@ -1,9 +1,10 @@
 $(document).ready(function () {
     let computerColor = 'black'; // Default computer color
 
+    const apiBaseUrl = window.location.origin;
     const makeRequest = async (method, url, callback) => {
         try {
-            const response = await fetch(url, { method });
+            const response = await fetch(`${apiBaseUrl}${url}`, { method });
             if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
             const data = await response.json();
             if (callback) callback(data);
@@ -15,7 +16,7 @@ $(document).ready(function () {
     let latestGameData = null; 
 
     const updateCalculatedLine = () => {
-        makeRequest('GET', 'http://localhost:8080/chess/state', (data) => {
+        makeRequest('GET', '/chess/state', (data) => {
             latestGameData = data;    
             const lineText = data.move || "No moves yet";
             const gameState = data.gameState.state;
@@ -80,7 +81,7 @@ $(document).ready(function () {
 
     function importFEN(fenString) {
         var encodedFenString = encodeURIComponent(fenString);
-        makeRequest('PATCH', `http://localhost:8080/chess/fen?fen=${encodedFenString}`, () => {
+        makeRequest('PATCH', `/chess/fen?fen=${encodedFenString}`, () => {
             reloadBoard();
         });
     }
@@ -142,18 +143,18 @@ $(document).ready(function () {
     };
 
     const makeMove = (type, color) => {
-        makeRequest('PATCH', `http://localhost:8080/chess/figure/move/${type}/${color}`, (data) => {
+        makeRequest('PATCH', `/chess/figure/move/${type}/${color}`, (data) => {
             checkState(data.state);
             reloadBoard();
         });
     };
 
     const onDrop = (source, target) => {
-        makeRequest('PATCH', `http://localhost:8080/chess/figure/move/${source}/${target}`, reloadBoard);
+        makeRequest('PATCH', `/chess/figure/move/${source}/${target}`, reloadBoard);
     };
 
     const reloadBoard = () => {
-        makeRequest('GET', 'http://localhost:8080/chess/figure/frontend', (data) => {
+        makeRequest('GET', '/chess/figure/frontend', (data) => {
             board.position(data.renderBoard);
             updateCalculatedLine(); // Update the calculated line
         });
@@ -166,7 +167,7 @@ $(document).ready(function () {
     };
 
     const onMouseoverSquare = (square) => {
-        makeRequest('GET', `http://localhost:8080/chess/figure/move/possible/${square}`, (moves) => {
+        makeRequest('GET', `/chess/figure/move/possible/${square}`, (moves) => {
             if (moves.length === 0) return;
             highlightSquare(square, true);
             moves.forEach(move => highlightSquare(move.x + move.y, true));
@@ -182,17 +183,17 @@ $(document).ready(function () {
             makeMove('intelligent', computerColor);
         });
         $('#resetBoard').on('click', () => {
-            makeRequest('PUT', 'http://localhost:8080/chess/reset', () => {
+            makeRequest('PUT', '/chess/reset', () => {
                 reloadBoard();
             });
         });
         $('#undoMove').on('click', () => {
-            makeRequest('GET', 'http://localhost:8080/chess/undo', () => {
+            makeRequest('GET', '/chess/undo', () => {
                 reloadBoard();
             });
         });
         $('#autoPlay').on('click', () => {
-            makeRequest('GET', 'http://localhost:8080/chess/autoplay', () => {
+            makeRequest('GET', '/chess/autoplay', () => {
                 reloadBoard();
             });
         });
@@ -230,6 +231,23 @@ $(document).ready(function () {
     };
 
     const board = Chessboard('board', boardConfig);
+
+    // Keep board responsive to screen size
+    $(window).resize(board.resize);
+
+    // Prevent the page from scrolling when interacting with the board on touch devices
+    const boardElement = document.getElementById('board');
+    const preventScroll = e => { if (e.cancelable) e.preventDefault(); };
+
+    boardElement.addEventListener('touchmove', preventScroll, { passive: false });
+    boardElement.addEventListener('touchstart', () => {
+        document.body.addEventListener('touchmove', preventScroll, { passive: false });
+    });
+    ['touchend', 'touchcancel'].forEach(evt => {
+        boardElement.addEventListener(evt, () => {
+            document.body.removeEventListener('touchmove', preventScroll);
+        });
+    });
 
     initEventListeners();
     initColorChoiceEventListeners();

--- a/src/main/resources/static/js/ui-interactions.js
+++ b/src/main/resources/static/js/ui-interactions.js
@@ -17,16 +17,16 @@ $(document).ready(function () {
         $('#playWhite').on('click', () => chooseColorAndAutoPlay('white'));
         $('#playBlack').on('click', () => chooseColorAndAutoPlay('black'));
         $('#resetBoard').on('click', () => {
-            makeRequest('PUT', 'http://localhost:8080/chess/reset', reloadBoard); // Assuming makeRequest and reloadBoard are defined in chess-data-fetching.js
+            makeRequest('PUT', '/chess/reset', reloadBoard); // Assuming makeRequest and reloadBoard are defined in chess-data-fetching.js
         });
         $('#undoMove').on('click', () => {
-            makeRequest('GET', 'http://localhost:8080/chess/undo', reloadBoard); // Assuming makeRequest and reloadBoard are defined in chess-data-fetching.js
+            makeRequest('GET', '/chess/undo', reloadBoard); // Assuming makeRequest and reloadBoard are defined in chess-data-fetching.js
         });
         $('#redoMove').on('click', () => {
-            makeRequest('GET', 'http://localhost:8080/chess/redo', reloadBoard); 
+            makeRequest('GET', '/chess/redo', reloadBoard);
         });
         $('#autoPlay').on('click', () => {
-            makeRequest('GET', 'http://localhost:8080/chess/autoplay', reloadBoard); // Assuming makeRequest and reloadBoard are defined in chess-data-fetching.js
+            makeRequest('GET', '/chess/autoplay', reloadBoard); // Assuming makeRequest and reloadBoard are defined in chess-data-fetching.js
         });
         $('#importFEN').on('click', function () {
             var fenString = prompt("Please enter FEN:");


### PR DESCRIPTION
## Summary
- Build frontend API requests using `window.location.origin` so the app auto-targets whatever host/port serves it
- Replace hard-coded `http://localhost:8080` URLs with relative paths across JS files
- Make the layout responsive on phones and block scrolling while dragging pieces

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cb125fa0832a9516897f2eb025a7