### PR TITLE
Integrate static exchange evaluation to filter bad captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Chess Engine
+
+This project is a work-in-progress chess engine.
+
+## Static Exchange Evaluation
+
+The engine uses a **Static Exchange Evaluation (SEE)** helper to analyze the
+material balance of capture sequences. SEE detects losing captures and allows
+the search to skip or heavily de-prioritize them, preventing unsound sacrifices
+like dropping a bishop for an unprotected pawn.

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1,5 +1,6 @@
 package julius.game.chessengine.ai;
 
+import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.Move;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.MoveList;
@@ -390,7 +391,7 @@ public class AI {
         double bestScore = isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
 
         ArrayList<Integer> sortedMoves = sortMovesByEfficiency(simulatorEngine.getAllLegalMoves(), depth,
-                simulatorEngine.getBoardStateHash());
+                simulatorEngine.getBoardStateHash(), simulatorEngine.getBitBoard());
 
         for (int moveInt : sortedMoves) {
 
@@ -525,7 +526,7 @@ public class AI {
         double maxEval = Double.NEGATIVE_INFINITY;
         int bestMoveAtThisNode = -1; // Variable to track the best move at this node
 
-        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth, boardHash);
+        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, simulatorEngine.getBitBoard());
         for (int index = 0; index < orderedMoves.size(); index++) {
             if (Thread.currentThread().isInterrupted() || positionChanged() || System.nanoTime() > deadline) {
                 return EXIT_FLAG;
@@ -627,7 +628,7 @@ public class AI {
         double minEval = Double.POSITIVE_INFINITY;
         int bestMoveAtThisNode = -1; // Track the best move at this node
 
-        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth, boardHash);
+        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, simulatorEngine.getBitBoard());
         for (int index = 0; index < orderedMoves.size(); index++) {
             if (Thread.currentThread().isInterrupted() || positionChanged() || System.nanoTime() > deadline) {
                 return EXIT_FLAG;
@@ -719,7 +720,7 @@ public class AI {
     }
 
 
-    ArrayList<Integer> sortMovesByEfficiency(MoveList moves, int currentDepth, long boardHash) {
+    ArrayList<Integer> sortMovesByEfficiency(MoveList moves, int currentDepth, long boardHash, BitBoard board) {
         final int size = moves.size();
         final int depthIndex = Math.max(0, Math.min(currentDepth, killerMoves.length - 1));
 
@@ -768,17 +769,21 @@ public class AI {
                 int base = calculateMvvLvaScore(moveInt); // promotion-captures benefit, quiet promos keep 0
                 score = base + PROMOTION_ORDER_BONUS;
             } else if (isCapture) {
-                // MVV-LVA for captures; classify as good/equal/bad without SEE
-                final int mvvLva = calculateMvvLvaScore(moveInt); // victim - attacker (can be negative)
-                if (mvvLva > 0) {
-                    category = CAT_CAP_GOOD;
-                } else if (mvvLva == 0) {
-                    category = CAT_CAP_EQUAL;
-                } else {
+                final int see = Score.staticExchangeEval(board, moveInt);
+                if (see < 0) {
                     category = CAT_CAP_BAD;
+                    score = see; // negative SEE pushes to bottom
+                } else {
+                    final int mvvLva = calculateMvvLvaScore(moveInt);
+                    if (mvvLva > 0) {
+                        category = CAT_CAP_GOOD;
+                    } else if (mvvLva == 0) {
+                        category = CAT_CAP_EQUAL;
+                    } else {
+                        category = CAT_CAP_BAD;
+                    }
+                    score = (mvvLva * 16) + see;
                 }
-                // Scale captures so bigger victims / smaller attackers bubble up
-                score = (mvvLva * 16); // small scale keeps room for tie-breaks
             } else if (moveInt == k0) {
                 category = CAT_KILLER0;
                 score = KILLER_MOVE_SCORE + KILLER0_BONUS;
@@ -902,9 +907,12 @@ public class AI {
         MoveList moves = inCheck ? simulatorEngine.getAllLegalMoves() : getPossibleCapturesOrPromotions(simulatorEngine);
 
         // Order them (captures first via MVV-LVA/promotion bonus, killers/history still help)
-        ArrayList<Integer> ordered = sortMovesByEfficiency(moves, 0, simulatorEngine.getBoardStateHash());
+        ArrayList<Integer> ordered = sortMovesByEfficiency(moves, 0, simulatorEngine.getBoardStateHash(), simulatorEngine.getBitBoard());
 
         for (int m : ordered) {
+            if (!inCheck && Score.staticExchangeEval(simulatorEngine.getBitBoard(), m) < 0) {
+                continue;
+            }
             simulatorEngine.performMove(m);
             // FIX: propagate timeout BEFORE negation
             double child = quiescenceSearch(simulatorEngine, !isWhitesTurn, -beta, -alpha, deadline, depth + 1);

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -30,6 +30,7 @@ public class Engine {
     @Getter
     private ArrayList<Integer> line = new ArrayList<>();
     private ArrayList<Integer> redoLine = new ArrayList<>();
+    @Getter
     private BitBoard bitBoard = new BitBoard();
     @Getter
     private GameState gameState = new GameState(bitBoard);

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -2,13 +2,17 @@ package julius.game.chessengine.utils;
 
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveList;
+import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.helper.BishopHelper;
+import julius.game.chessengine.helper.RookHelper;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 
 import static julius.game.chessengine.helper.BishopHelper.BISHOP_POSITIONAL_VALUES;
 import static julius.game.chessengine.helper.KingHelper.*;
 import static julius.game.chessengine.helper.KnightHelper.KNIGHT_POSITIONAL_VALUES;
+import static julius.game.chessengine.helper.KnightHelper.knightMoveTable;
 import static julius.game.chessengine.helper.PawnHelper.*;
 import static julius.game.chessengine.helper.PawnMoveTables.PAWN_ATTACKS;
 import static julius.game.chessengine.helper.PawnMoveTables.PAWN_PUSHES;
@@ -59,6 +63,10 @@ public class Score {
     private static final int MISSING_PAWN_SHIELD_PENALTY = -15;
     private static final int KING_ATTACK_PENALTY = -10;
     public static final int BISHOP_PAIR_BONUS = 40;
+
+    private static final int[] PIECE_VALUES = {0, PAWN_VALUE, KNIGHT_VALUE, BISHOP_VALUE, ROOK_VALUE, QUEEN_VALUE, CHECKMATE};
+    private static final BishopHelper bishopHelper = BishopHelper.getInstance();
+    private static final RookHelper rookHelper = RookHelper.getInstance();
 
     private Double cachedScoreDifference = null;
 
@@ -139,6 +147,200 @@ public class Score {
     private static final long INITIAL_WHITE_ROOK_POSITION = 0x0000000000000081L; // Rooks on a1 and h1
     private static final long INITIAL_BLACK_ROOK_POSITION = 0x8100000000000000L; // Rooks on a8 and h8
 
+
+    /**
+     * Static exchange evaluation (SEE) for a potential move.
+     * Returns the net material gain (in centipawns) assuming optimal captures
+     * on the target square by both sides. Negative values indicate that the
+     * capture loses material.
+     */
+    public static int staticExchangeEval(BitBoard board, int move) {
+        int from = MoveHelper.deriveFromIndex(move);
+        int to = MoveHelper.deriveToIndex(move);
+        boolean isWhite = MoveHelper.isWhitesMove(move);
+        int movingPiece = MoveHelper.derivePieceTypeBits(move);
+        int promotionPiece = MoveHelper.derivePromotionPieceTypeBits(move);
+        int capturedPiece = MoveHelper.deriveCapturedPieceTypeBits(move);
+
+        long[] pawns = {board.getWhitePawns(), board.getBlackPawns()};
+        long[] knights = {board.getWhiteKnights(), board.getBlackKnights()};
+        long[] bishops = {board.getWhiteBishops(), board.getBlackBishops()};
+        long[] rooks = {board.getWhiteRooks(), board.getBlackRooks()};
+        long[] queens = {board.getWhiteQueens(), board.getBlackQueens()};
+        long[] kings = {board.getWhiteKing(), board.getBlackKing()};
+
+        long occupied = board.getAllPieces();
+        int side = isWhite ? 0 : 1;
+        int currentPieceType = promotionPiece != 0 ? promotionPiece : movingPiece;
+
+        long fromMask = 1L << from;
+        long toMask = 1L << to;
+
+        int[] gains = new int[32];
+        int depth = 0;
+
+        // Remove captured piece
+        if (MoveHelper.isEnPassantMove(move)) {
+            long epPawn = isWhite ? (1L << (to - 8)) : (1L << (to + 8));
+            occupied ^= epPawn;
+            pawns[1 - side] ^= epPawn;
+            gains[depth] = PAWN_VALUE;
+        } else {
+            long capMask = toMask;
+            switch (capturedPiece) {
+                case 1 -> pawns[1 - side] ^= capMask;
+                case 2 -> knights[1 - side] ^= capMask;
+                case 3 -> bishops[1 - side] ^= capMask;
+                case 4 -> rooks[1 - side] ^= capMask;
+                case 5 -> queens[1 - side] ^= capMask;
+                case 6 -> kings[1 - side] ^= capMask;
+            }
+            if (capturedPiece != 0) {
+                occupied ^= capMask;
+                gains[depth] = PIECE_VALUES[capturedPiece];
+            } else {
+                gains[depth] = 0;
+            }
+        }
+
+        // Move attacking piece to target square
+        switch (movingPiece) {
+            case 1 -> pawns[side] ^= fromMask;
+            case 2 -> knights[side] ^= fromMask;
+            case 3 -> bishops[side] ^= fromMask;
+            case 4 -> rooks[side] ^= fromMask;
+            case 5 -> queens[side] ^= fromMask;
+            case 6 -> kings[side] ^= fromMask;
+        }
+        occupied ^= fromMask;
+
+        switch (currentPieceType) {
+            case 1 -> pawns[side] |= toMask;
+            case 2 -> knights[side] |= toMask;
+            case 3 -> bishops[side] |= toMask;
+            case 4 -> rooks[side] |= toMask;
+            case 5 -> queens[side] |= toMask;
+            case 6 -> kings[side] |= toMask;
+        }
+        occupied |= toMask;
+
+        long whiteAttackers = attackersToSquare(to, occupied, pawns, knights, bishops, rooks, queens, kings, true);
+        long blackAttackers = attackersToSquare(to, occupied, pawns, knights, bishops, rooks, queens, kings, false);
+        if (side == 0) {
+            whiteAttackers &= ~toMask;
+        } else {
+            blackAttackers &= ~toMask;
+        }
+
+        side ^= 1;
+        long attackersSide = side == 0 ? whiteAttackers : blackAttackers;
+
+        while (attackersSide != 0) {
+            long fromSq;
+            int pieceType;
+            if ((attackersSide & pawns[side]) != 0) {
+                fromSq = attackersSide & pawns[side];
+                pieceType = 1;
+            } else if ((attackersSide & knights[side]) != 0) {
+                fromSq = attackersSide & knights[side];
+                pieceType = 2;
+            } else if ((attackersSide & bishops[side]) != 0) {
+                fromSq = attackersSide & bishops[side];
+                pieceType = 3;
+            } else if ((attackersSide & rooks[side]) != 0) {
+                fromSq = attackersSide & rooks[side];
+                pieceType = 4;
+            } else if ((attackersSide & queens[side]) != 0) {
+                fromSq = attackersSide & queens[side];
+                pieceType = 5;
+            } else {
+                fromSq = attackersSide & kings[side];
+                pieceType = 6;
+            }
+            fromSq &= -fromSq; // isolate least significant bit
+
+            depth++;
+            gains[depth] = PIECE_VALUES[pieceType] - gains[depth - 1];
+
+            // Remove attacker from its square
+            switch (pieceType) {
+                case 1 -> pawns[side] ^= fromSq;
+                case 2 -> knights[side] ^= fromSq;
+                case 3 -> bishops[side] ^= fromSq;
+                case 4 -> rooks[side] ^= fromSq;
+                case 5 -> queens[side] ^= fromSq;
+                case 6 -> kings[side] ^= fromSq;
+            }
+            occupied ^= fromSq;
+
+            // Remove the piece currently on the target square from the opponent
+            int other = side ^ 1;
+            switch (currentPieceType) {
+                case 1 -> pawns[other] ^= toMask;
+                case 2 -> knights[other] ^= toMask;
+                case 3 -> bishops[other] ^= toMask;
+                case 4 -> rooks[other] ^= toMask;
+                case 5 -> queens[other] ^= toMask;
+                case 6 -> kings[other] ^= toMask;
+            }
+
+            // Place capturing piece on target square
+            currentPieceType = pieceType;
+            switch (pieceType) {
+                case 1 -> pawns[side] |= toMask;
+                case 2 -> knights[side] |= toMask;
+                case 3 -> bishops[side] |= toMask;
+                case 4 -> rooks[side] |= toMask;
+                case 5 -> queens[side] |= toMask;
+                case 6 -> kings[side] |= toMask;
+            }
+            occupied |= toMask;
+
+            whiteAttackers = attackersToSquare(to, occupied, pawns, knights, bishops, rooks, queens, kings, true);
+            blackAttackers = attackersToSquare(to, occupied, pawns, knights, bishops, rooks, queens, kings, false);
+            if (side == 0) {
+                whiteAttackers &= ~toMask;
+            } else {
+                blackAttackers &= ~toMask;
+            }
+
+            side ^= 1;
+            attackersSide = side == 0 ? whiteAttackers : blackAttackers;
+        }
+
+        while (--depth > 0) {
+            gains[depth - 1] = -Math.max(-gains[depth - 1], gains[depth]);
+        }
+        return gains[0];
+    }
+
+    private static long attackersToSquare(int square, long occupied,
+                                          long[] pawns, long[] knights, long[] bishops,
+                                          long[] rooks, long[] queens, long[] kings,
+                                          boolean white) {
+        long target = 1L << square;
+        long attackers = 0L;
+        if (white) {
+            attackers |= ((target >>> 7) & NOT_H_FILE) & pawns[0];
+            attackers |= ((target >>> 9) & NOT_A_FILE) & pawns[0];
+            attackers |= knightMoveTable[square] & knights[0];
+            long diag = bishopHelper.calculateMovesUsingBishopMagic(square, occupied);
+            attackers |= diag & (bishops[0] | queens[0]);
+            long straight = rookHelper.calculateMovesUsingRookMagic(square, occupied);
+            attackers |= straight & (rooks[0] | queens[0]);
+            attackers |= KING_ATTACKS[square] & kings[0];
+        } else {
+            attackers |= ((target << 7) & NOT_A_FILE) & pawns[1];
+            attackers |= ((target << 9) & NOT_H_FILE) & pawns[1];
+            attackers |= knightMoveTable[square] & knights[1];
+            long diag = bishopHelper.calculateMovesUsingBishopMagic(square, occupied);
+            attackers |= diag & (bishops[1] | queens[1]);
+            long straight = rookHelper.calculateMovesUsingRookMagic(square, occupied);
+            attackers |= straight & (rooks[1] | queens[1]);
+            attackers |= KING_ATTACKS[square] & kings[1];
+        }
+        return attackers;
+    }
 
     public Score() {
         this.whiteScore = 0;

--- a/src/test/java/julius/game/chessengine/ai/StaticExchangeEvalTest.java
+++ b/src/test/java/julius/game/chessengine/ai/StaticExchangeEvalTest.java
@@ -1,0 +1,43 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.board.MoveList;
+import julius.game.chessengine.utils.Score;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StaticExchangeEvalTest {
+
+    @Test
+    void bishopSacrificeIsDeprioritized() {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("4k3/5p2/8/8/2B5/8/8/4K3 w - - 0 1");
+        BitBoard board = engine.getBitBoard();
+
+        MoveList moves = engine.getAllLegalMoves();
+        int from = MoveHelper.convertStringToIndex("c4");
+        int to = MoveHelper.convertStringToIndex("f7");
+        int sacrifice = -1;
+        for (int i = 0; i < moves.size(); i++) {
+            int m = moves.getMove(i);
+            if (MoveHelper.deriveFromIndex(m) == from && MoveHelper.deriveToIndex(m) == to) {
+                sacrifice = m;
+                break;
+            }
+        }
+        assertNotEquals(-1, sacrifice, "Sacrifice move not found");
+
+        int see = Score.staticExchangeEval(board, sacrifice);
+        assertTrue(see < 0, "SEE should detect material loss");
+
+        AI ai = new AI(engine);
+        ArrayList<Integer> ordered = ai.sortMovesByEfficiency(moves, 0, engine.getBoardStateHash(), board);
+        assertEquals(sacrifice, ordered.get(ordered.size() - 1), "Losing capture should be last");
+        assertNotEquals(sacrifice, ordered.get(0), "Engine should keep material parity");
+    }
+}


### PR DESCRIPTION
## Summary
- implement SEE helper in `Score` to evaluate capture sequences
- call SEE from move ordering and quiescence search to drop losing captures
- add regression test for bishop sacrifice and document SEE in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f8271898832a9d11d6626abd7a6b