### PR TITLE
Refactor search to use lightweight bitboard position

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -4,8 +4,6 @@ import julius.game.chessengine.board.Move;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.MoveList;
 import julius.game.chessengine.engine.Engine;
-import julius.game.chessengine.engine.GameState;
-import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.utils.Score;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,7 +14,6 @@ import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static julius.game.chessengine.utils.Score.*;
 import static julius.game.chessengine.utils.Score.DRAW;
@@ -247,14 +244,13 @@ public class AI {
         log.debug(" --- TranspositionTable[{}] --- ", transpositionTable.size());
         decayHistoryTable();
         try {
-            Engine simulatorEngine = mainEngine.createSimulation();
-            long boardStateHash = simulatorEngine.getBoardStateHash();
+            SearchPosition pos = new SearchPosition(mainEngine.cloneBitBoard());
+            long boardStateHash = pos.hash();
             log.debug("boardStateBeforeCalculation {}, currentBoardState {}", beforeCalculationBoardState, currentBoardState);
 
-            // Perform calculation only if the board state has actually changed
-            boolean isWhite = simulatorEngine.whitesTurn();
-            long deadline = System.nanoTime() + timeLimit * 1_000_000;
-            calculateBestMove(simulatorEngine, boardStateHash, isWhite, deadline);
+            boolean isWhite = pos.whiteToMove();
+            long deadline = System.nanoTime() + timeLimit * 1_000_000L;
+            calculateBestMove(pos, boardStateHash, isWhite, deadline);
         } catch (IllegalStateException e) {
             log.warn("Illegal board state during search: {}", e.getMessage());
             MoveList legalMoves = mainEngine.getAllLegalMoves();
@@ -269,455 +265,262 @@ public class AI {
 
     }
 
-
-    private void calculateBestMove(Engine simulatorEngine, long boardStateHash, boolean isWhite, long deadline) {
+    private void calculateBestMove(SearchPosition pos, long boardHash, boolean isWhite, long deadline) {
         double bestScore = isWhite ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
-        int bestMove = mainEngine.getOpeningBook().getRandomMoveForBoardStateHash(boardStateHash); // if none found returns -1
+        int bestMove = mainEngine.getOpeningBook().getRandomMoveForBoardStateHash(boardHash);
         if (bestMove != -1) {
             currentBestMove = bestMove;
+            fillCalculatedLineFromTT(pos);
             return;
         }
 
         double alpha = Double.NEGATIVE_INFINITY;
         double beta = Double.POSITIVE_INFINITY;
 
-        try {
-            for (int currentDepth = 1; currentDepth <= maxDepth; currentDepth++) {
-                if (shouldStopCalculating(deadline)) {
-                    break;
-                }
-
-                MoveAndScore moveAndScore;
-                double localAlpha = alpha;
-                double localBeta = beta;
-                while (true) {
-                    if (shouldStopCalculating(deadline)) {
-                        moveAndScore = null;
-                        break;
-                    }
-
-                    moveAndScore = getBestMove(simulatorEngine, isWhite, currentDepth, deadline, localAlpha, localBeta);
-                    if (moveAndScore == null) {
-                        break;
-                    }
-
-                    double score = moveAndScore.score;
-                    if (score <= localAlpha) {
-                        localAlpha = score - ASPIRATION_WINDOW;
-                    } else if (score >= localBeta) {
-                        localBeta = score + ASPIRATION_WINDOW;
-                    } else {
-                        alpha = score - ASPIRATION_WINDOW;
-                        beta = score + ASPIRATION_WINDOW;
-                        break;
-                    }
-                }
-
-                if (moveAndScore == null) {
-                    break;
-                }
-
-                if (isNewBestMove(moveAndScore, bestScore, isWhite)) {
-                    bestScore = moveAndScore.score;
-                    bestMove = moveAndScore.move;
-                    updateTranspositionTable(boardStateHash, moveAndScore, currentDepth);
-                }
-            }
-        } finally {
-            // In very rare cases the search may exit without assigning a best move
-            // (for example when the time limit is hit before any move is
-            // evaluated). Provide a fallback so the engine always responds with a
-            // legal move instead of timing out.
-            if (bestMove == -1) {
-                MoveList legalMoves = simulatorEngine.getAllLegalMoves();
-                if (legalMoves.size() > 0) {
-                    bestMove = legalMoves.getMove(0);
-                }
+        for (int depth = 1; depth <= maxDepth; depth++) {
+            if (shouldStopCalculating(deadline)) {
+                break;
             }
 
-            currentBestMove = bestMove;
-            fillCalculatedLine(simulatorEngine); // Ensure this is always called at the end
+            MoveAndScore ms = getBestMove(pos, isWhite, depth, deadline, alpha, beta);
+            if (ms == null) {
+                break;
+            }
+
+            bestMove = ms.move;
+            bestScore = ms.score;
+            updateTranspositionTable(pos.hash(), ms, depth);
+
+            alpha = ms.score - ASPIRATION_WINDOW;
+            beta  = ms.score + ASPIRATION_WINDOW;
         }
+
+        if (bestMove == -1) {
+            MoveList ml = pos.pseudoMoves();
+            if (ml.size() > 0) {
+                bestMove = ml.getMove(0);
+            }
+        }
+        currentBestMove = bestMove;
+        fillCalculatedLineFromTT(pos);
     }
 
     private boolean shouldStopCalculating(long deadline) {
         return positionChanged() || timeLimitExceeded(deadline) || Thread.currentThread().isInterrupted();
     }
 
-    private void fillCalculatedLine(Engine simulation) {
-        long currentBoardHash = simulation.getBoardStateHash();
+    private void fillCalculatedLineFromTT(SearchPosition pos) {
+        long currentHash = pos.hash();
         List<MoveAndScore> newCalculatedLine = new LinkedList<>();
-        Set<Long> seenBoardHashes = new HashSet<>();
-        int movesPerformed = 0; // Counter for the number of moves performed
+        Set<Long> seen = new HashSet<>();
+        List<Integer> performed = new ArrayList<>();
 
         TranspositionTableEntry entry;
-        while ((entry = transpositionTable.get(currentBoardHash)) != null) {
-            if (entry.bestMove == -1 || !seenBoardHashes.add(currentBoardHash)) {
-                // Exit if no best move is found or repetition is detected
+        while ((entry = transpositionTable.get(currentHash)) != null) {
+            if (entry.bestMove == -1 || !seen.add(currentHash)) {
                 break;
             }
-
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] hash exists and move: {}", currentBoardHash, entry);
-            }
             newCalculatedLine.add(new MoveAndScore(entry.bestMove, entry.score));
-
-            // Perform the move and increment the counter
-            simulation.performMove(entry.bestMove);
-            movesPerformed++;
-            currentBoardHash = simulation.getBoardStateHash();
+            pos.make(entry.bestMove);
+            performed.add(entry.bestMove);
+            currentHash = pos.hash();
         }
 
-        // Undo the moves in reverse order
-        for (int i = 0; i < movesPerformed; i++) {
-            simulation.undoLastMove();
+        for (int i = performed.size() - 1; i >= 0; i--) {
+            pos.undo(performed.get(i));
         }
 
         this.calculatedLine = new ArrayList<>(newCalculatedLine);
-
-        if (log.isDebugEnabled()) {
-            log.debug("Move Line: {}", newCalculatedLine.stream()
-                    .map(m -> Move.convertIntToMove(m.move).toString())
-                    .collect(Collectors.joining(", ")));
-            log.debug("");
-        }
     }
 
-
-    private MoveAndScore getBestMove(Engine simulatorEngine, boolean isWhitesTurn, int depth, long deadline,
+    private MoveAndScore getBestMove(SearchPosition pos, boolean isWhite, int depth, long deadline,
                                      double alpha, double beta) {
-        int bestMove = -1; // Use an integer to represent the best move
-        double bestScore = isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+        int bestMove = -1;
+        double bestScore = isWhite ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
 
-        ArrayList<Integer> sortedMoves = sortMovesByEfficiency(simulatorEngine.getAllLegalMoves(), depth,
-                simulatorEngine.getBoardStateHash());
+        long hash = pos.hash();
+        ArrayList<Integer> ordered = sortMovesByEfficiency(pos.pseudoMoves(), depth, hash);
 
-        for (int moveInt : sortedMoves) {
-
-            // Exit early if the search was cancelled or the position changed
+        for (int move : ordered) {
             if (Thread.currentThread().isInterrupted() || positionChanged() || System.nanoTime() > deadline) {
                 break;
             }
 
-            simulatorEngine.performMove(moveInt); // Perform move using its integer representation
-            double score;
-
-            if (simulatorEngine.getGameState().isInStateCheckMate()) {
-                score = isWhitesTurn ? (CHECKMATE - depth) : -(CHECKMATE - depth);
-            } else if (simulatorEngine.getGameState().isInStateDraw()) {
-                // FIX: keep draw policy consistent (use same static evaluation as elsewhere)
-                score = evaluateStaticPosition(simulatorEngine.getGameState(), !isWhitesTurn, depth);
-            } else {
-                score = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline);
-                // Check for time limit exceeded after alphaBeta call
-                if (score == EXIT_FLAG || positionChanged()) {
-                    simulatorEngine.undoLastMove(); // Undo move using its integer representation
-                    break;
-                }
+            pos.make(move);
+            if (pos.inCheck(isWhite)) {
+                pos.undo(move);
+                continue;
             }
 
-            simulatorEngine.undoLastMove(); // Undo move using its integer representation
+            double score = alphaBeta(pos, depth - 1, alpha, beta, !isWhite, deadline);
+            pos.undo(move);
+            if (score == EXIT_FLAG) {
+                return null;
+            }
 
-            // Check if the current move leads to a better score
-            if (isBetterScore(isWhitesTurn, score, bestScore)) {
+            if (isWhite ? score > bestScore : score < bestScore) {
                 bestScore = score;
-                bestMove = moveInt; // Store the best move as an integer
+                bestMove = move;
             }
-
-            if (isWhitesTurn) {
+            if (isWhite) {
                 alpha = Math.max(alpha, score);
             } else {
                 beta = Math.min(beta, score);
             }
-
             if (alpha >= beta) {
+                updateKillerMoves(depth, move);
+                incrementHistory(move, depth);
                 break;
             }
         }
-
-        return bestMove != -1 ? new MoveAndScore(bestMove, bestScore) : null; // Return the best move and score
+        return bestMove != -1 ? new MoveAndScore(bestMove, bestScore) : null;
     }
 
-    /**
-     * *
-     * 5rkr/pp2Rp2/1b1p1Pb1/3P2Q1/2n3P1/2p5/P4P2/4R1K1 w - - 1 0
-     * *
-     */
-    private double alphaBeta(Engine simulatorEngine, int depth, double alpha, double beta, boolean isWhite, long deadline) {
+    private double alphaBeta(SearchPosition pos, int depth, double alpha, double beta,
+                             boolean isWhite, long deadline) {
         nodesVisited++;
-        // Stop if the search was cancelled, the position changed, or time ran out
         if (Thread.currentThread().isInterrupted() || positionChanged() || System.nanoTime() > deadline) {
             return EXIT_FLAG;
         }
 
-        long boardHash = simulatorEngine.getBoardStateHash();
-
-        // FIX: consistent draw handling (use same policy everywhere)
-        if (simulatorEngine.getGameState().isInStateDraw()) {
-            return evaluateStaticPosition(simulatorEngine.getGameState(), isWhite, depth);
+        long key = pos.hash();
+        TranspositionTableEntry tt = transpositionTable.get(key);
+        if (tt != null && tt.depth >= depth) {
+            if (tt.nodeType == NodeType.EXACT) return tt.score;
+            if (tt.nodeType == NodeType.LOWERBOUND) alpha = Math.max(alpha, tt.score);
+            if (tt.nodeType == NodeType.UPPERBOUND) beta  = Math.min(beta,  tt.score);
+            if (alpha >= beta) return tt.score;
         }
 
-        if (depth == 0 || simulatorEngine.getGameState().isGameOver()) {
-            double eval = evaluateBoard(simulatorEngine, isWhite, deadline);
-            if (eval == EXIT_FLAG) { // FIX: propagate qsearch timeout
-                return EXIT_FLAG;
-            }
-            log.trace("eval {}, alpha {}, beta {}, depth: {}, isWhite {}", eval, alpha, beta, depth, isWhite);
-            if (!isWhite) {
-                eval = -eval;
-            }
-            return eval;
+        if (depth == 0) {
+            double eval = evaluateBoard(pos, isWhite, deadline);
+            return eval == EXIT_FLAG ? EXIT_FLAG : eval;
         }
 
-        TranspositionTableEntry entry = transpositionTable.get(boardHash);
-
-        // FIX: accept entries with depth >= current depth
-        if (entry != null && entry.depth >= depth) {
-            if (entry.nodeType == NodeType.EXACT) {
-                return entry.score;
-            }
-            if (entry.nodeType == NodeType.LOWERBOUND && entry.score > alpha) {
-                alpha = entry.score;
-            } else if (entry.nodeType == NodeType.UPPERBOUND && entry.score < beta) {
-                beta = entry.score;
-            }
-            if (alpha >= beta) {
-                return entry.score;
-            }
-        }
-
-        if (useNullMovePruning && depth >= 3 && !isSideInCheck(simulatorEngine, isWhite) && !simulatorEngine.isEndgame()) {
-            int ep = simulatorEngine.doNullMove();
+        if (useNullMovePruning && depth >= 3 && !pos.inCheck(isWhite) && !pos.isEndgame()) {
+            int ep = pos.doNullMove();
             nullMoveCount++;
-            double nullScore = alphaBeta(simulatorEngine, depth - 1 - 2, alpha, beta, !isWhite, deadline);
-            simulatorEngine.undoNullMove(ep);
-
-            if (nullScore == EXIT_FLAG) { // propagate timeout
-                return EXIT_FLAG;
-            }
-
-            if (isWhite && nullScore >= beta) {
-                return beta;
-            } else if (!isWhite && nullScore <= alpha) {
-                return alpha;
-            }
+            double nullScore = alphaBeta(pos, depth - 1 - 2, alpha, beta, !isWhite, deadline);
+            pos.undoNullMove(ep);
+            if (nullScore == EXIT_FLAG) return EXIT_FLAG;
+            if (isWhite && nullScore >= beta) return beta;
+            if (!isWhite && nullScore <= alpha) return alpha;
         }
 
-        double alphaOriginal = alpha; // Store the original alpha value
-        double betaOriginal = beta;   // Store the original beta value
+        double best = isWhite ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+        MoveList ml = pos.pseudoMoves();
+        ArrayList<Integer> ordered = sortMovesByEfficiency(ml, depth, key);
 
-        MoveList moves = simulatorEngine.getAllLegalMoves();
+        double alpha0 = alpha, beta0 = beta;
+        int bestMove = -1;
 
-        if (isWhite) {
-            return maximizer(simulatorEngine, depth, alpha, beta, isWhite, boardHash, alphaOriginal, moves, deadline);
-        } else {
-            return minimizer(simulatorEngine, depth, alpha, beta, isWhite, boardHash, betaOriginal, moves, deadline);
-        }
-    }
-
-    private boolean isSideInCheck(Engine engine, boolean isWhite) {
-        GameStateEnum state = engine.getGameState().getState();
-        return (isWhite && state == GameStateEnum.WHITE_IN_CHECK) || (!isWhite && state == GameStateEnum.BLACK_IN_CHECK);
-    }
-
-    private double maximizer(Engine simulatorEngine, int depth, double alpha, double beta, boolean isWhite, long boardHash, double alphaOriginal, MoveList moves, long deadline) {
-        long start = log.isDebugEnabled() ? System.nanoTime() : 0L; // Start timing only for debugging
-        double maxEval = Double.NEGATIVE_INFINITY;
-        int bestMoveAtThisNode = -1; // Variable to track the best move at this node
-
-        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth, boardHash);
-        for (int index = 0; index < orderedMoves.size(); index++) {
-            if (Thread.currentThread().isInterrupted() || positionChanged() || System.nanoTime() > deadline) {
-                return EXIT_FLAG;
+        for (int idx = 0; idx < ordered.size(); idx++) {
+            int move = ordered.get(idx);
+            pos.make(move);
+            if (pos.inCheck(isWhite)) {
+                pos.undo(move);
+                continue;
             }
-            int move = orderedMoves.get(index);
-            simulatorEngine.performMove(move);
-            long newBoardHash = simulatorEngine.getBoardStateHash();
 
-            double eval;
-            TranspositionTableEntry entry = transpositionTable.get(newBoardHash);
-
-            if (entry != null && entry.depth >= depth) {
-                eval = entry.score; // Use the score from the transposition table
+            int newDepth = depth - 1;
+            double score;
+            boolean reduced = false;
+            if (useLateMoveReductions && depth >= LMR_MIN_DEPTH && idx >= LMR_MOVE_INDEX_THRESHOLD) {
+                score = alphaBeta(pos, newDepth - LMR_DEPTH_REDUCTION, alpha, beta, !isWhite, deadline);
+                reduced = true;
             } else {
-                int nextDepth = depth - 1;
-                boolean reduced = false;
-                if (useLateMoveReductions && depth >= LMR_MIN_DEPTH && index >= LMR_MOVE_INDEX_THRESHOLD
-                        && !MoveHelper.isCapture(move) && !isKillerMove(depth, move)) {
-                    nextDepth = depth - 1 - LMR_DEPTH_REDUCTION;
-                    reduced = true;
-                }
-
-                boolean usePvs = index > 0 && alpha != Double.NEGATIVE_INFINITY && beta != Double.POSITIVE_INFINITY;
-                double pAlpha = alpha;
-                double pBeta = beta;
-                if (usePvs) {
-                    pBeta = alpha + 1;
-                }
-
-                eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline);
-
-                if (eval == EXIT_FLAG || positionChanged()) {
-                    simulatorEngine.undoLastMove();
-                    return EXIT_FLAG;
-                }
-
-                if (usePvs && eval > alpha && eval < beta) {
-                    eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline);
-                    if (eval == EXIT_FLAG || positionChanged()) {
-                        simulatorEngine.undoLastMove();
-                        return EXIT_FLAG;
-                    }
-                }
-
-                if (reduced && eval > alpha) {
-                    eval = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhite, deadline);
-                    if (eval == EXIT_FLAG || positionChanged()) {
-                        simulatorEngine.undoLastMove();
-                        return EXIT_FLAG;
-                    }
-                }
+                score = alphaBeta(pos, newDepth, alpha, beta, !isWhite, deadline);
             }
 
-            if (log.isDebugEnabled()) {
-                long endTime = System.nanoTime();
-                log.debug("DEPTH: {} --- {}", depth, Move.convertIntToMove(move));
-                log.debug("DEPTH: {}", depth);
-                log.debug("--> [+] Time taken for maximizer: {} ms", (endTime - start) / 1e6);
+            if (reduced && score != EXIT_FLAG &&
+                    ((isWhite && score > alpha) || (!isWhite && score < beta))) {
+                score = alphaBeta(pos, newDepth, alpha, beta, !isWhite, deadline);
             }
 
-            simulatorEngine.undoLastMove();
+            pos.undo(move);
+            if (score == EXIT_FLAG) return EXIT_FLAG;
 
-            if (eval > maxEval) { // Found a better evaluation
-                maxEval = eval;
-                bestMoveAtThisNode = move; // Update the best move
-            }
-
-            alpha = Math.max(alpha, eval);
-            if (beta <= alpha) {
-                updateKillerMoves(depth, move);
-                incrementHistory(move, depth);
-                if (log.isDebugEnabled()) {
-                    log.debug(" Maxi New Killer Move is {}", Move.convertIntToMove(move));
-                }
-                break; // Alpha-beta pruning
-            }
-        }
-
-        // After the for loop, update the transposition table with the best move
-        TranspositionTableEntry existingEntry = transpositionTable.get(boardHash);
-        boolean shouldUpdate = existingEntry == null || existingEntry.depth < depth;
-
-        if (maxEval <= alphaOriginal && shouldUpdate) {
-            transpositionTable.put(boardHash, new TranspositionTableEntry(maxEval, depth, NodeType.UPPERBOUND, bestMoveAtThisNode));
-        } else if (maxEval >= beta && shouldUpdate) {
-            transpositionTable.put(boardHash, new TranspositionTableEntry(maxEval, depth, NodeType.LOWERBOUND, bestMoveAtThisNode));
-        } else if (shouldUpdate) {
-            transpositionTable.put(boardHash, new TranspositionTableEntry(maxEval, depth, NodeType.EXACT, bestMoveAtThisNode));
-        }
-
-        return maxEval;
-    }
-
-
-    private double minimizer(Engine simulatorEngine, int depth, double alpha, double beta,
-                             boolean isWhite, long boardHash,
-                             double betaOriginal, MoveList moves, long deadline) {
-        long start = log.isDebugEnabled() ? System.nanoTime() : 0L; // Start timing only for debugging
-        double minEval = Double.POSITIVE_INFINITY;
-        int bestMoveAtThisNode = -1; // Track the best move at this node
-
-        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth, boardHash);
-        for (int index = 0; index < orderedMoves.size(); index++) {
-            if (Thread.currentThread().isInterrupted() || positionChanged() || System.nanoTime() > deadline) {
-                return EXIT_FLAG;
-            }
-            int move = orderedMoves.get(index);
-            simulatorEngine.performMove(move);
-            long newBoardHash = simulatorEngine.getBoardStateHash();
-            double eval;
-            TranspositionTableEntry entry = transpositionTable.get(newBoardHash);
-
-            if (entry != null && entry.depth >= depth) {
-                eval = entry.score;
+            if (isWhite) {
+                if (score > best) { best = score; bestMove = move; }
+                alpha = Math.max(alpha, score);
             } else {
-                int nextDepth = depth - 1;
-                boolean reduced = false;
-                if (useLateMoveReductions && depth >= LMR_MIN_DEPTH && index >= LMR_MOVE_INDEX_THRESHOLD
-                        && !MoveHelper.isCapture(move) && !isKillerMove(depth, move)) {
-                    nextDepth = depth - 1 - LMR_DEPTH_REDUCTION;
-                    reduced = true;
-                }
-
-                boolean usePvs = index > 0 && alpha != Double.NEGATIVE_INFINITY && beta != Double.POSITIVE_INFINITY;
-                double pAlpha = alpha;
-                double pBeta = beta;
-                if (usePvs) {
-                    pAlpha = beta - 1;
-                }
-
-                eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline);
-
-                if (eval == EXIT_FLAG || positionChanged()) {
-                    simulatorEngine.undoLastMove();
-                    return EXIT_FLAG;
-                }
-
-                if (usePvs && eval > alpha && eval < beta) {
-                    eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline);
-                    if (eval == EXIT_FLAG || positionChanged()) {
-                        simulatorEngine.undoLastMove();
-                        return EXIT_FLAG;
-                    }
-                }
-
-                if (reduced && eval < beta) {
-                    eval = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhite, deadline);
-                    if (eval == EXIT_FLAG || positionChanged()) {
-                        simulatorEngine.undoLastMove();
-                        return EXIT_FLAG;
-                    }
-                }
+                if (score < best) { best = score; bestMove = move; }
+                beta = Math.min(beta, score);
             }
 
-            if (log.isDebugEnabled()) {
-                long endTime = System.nanoTime();
-                log.debug("DEPTH: {} --- {}", depth, Move.convertIntToMove(move));
-                log.debug("<-- [-] Time taken for minimizer: {} ms", (endTime - start) / 1e6);
-            }
-
-            simulatorEngine.undoLastMove();
-
-            if (eval < minEval) {
-                minEval = eval;
-                bestMoveAtThisNode = move; // Update the best move at this node
-            }
-
-            beta = Math.min(beta, eval);
             if (alpha >= beta) {
                 updateKillerMoves(depth, move);
                 incrementHistory(move, depth);
-                if (log.isDebugEnabled()) {
-                    log.debug("Mini New Killer Move is {}", Move.convertIntToMove(move));
-                }
                 break;
             }
         }
 
-        TranspositionTableEntry existingEntry = transpositionTable.get(boardHash);
-        boolean shouldUpdate = existingEntry == null || existingEntry.depth < depth;
-
-        if (minEval >= betaOriginal && shouldUpdate) {
-            transpositionTable.put(boardHash, new TranspositionTableEntry(minEval, depth, NodeType.LOWERBOUND, bestMoveAtThisNode));
-        } else if (minEval <= alpha && shouldUpdate) {
-            transpositionTable.put(boardHash, new TranspositionTableEntry(minEval, depth, NodeType.UPPERBOUND, bestMoveAtThisNode));
-        } else if (shouldUpdate) {
-            transpositionTable.put(boardHash, new TranspositionTableEntry(minEval, depth, NodeType.EXACT, bestMoveAtThisNode));
+        if (bestMove == -1) {
+            return pos.inCheck(isWhite) ? (isWhite ? -CHECKMATE + depth : CHECKMATE - depth) : DRAW;
         }
 
-        return minEval;
+        NodeType type = (best <= alpha0) ? NodeType.UPPERBOUND : (best >= beta0) ? NodeType.LOWERBOUND : NodeType.EXACT;
+        transpositionTable.put(key, new TranspositionTableEntry(best, depth, type, bestMove));
+        return best;
     }
 
+    private double evaluateBoard(SearchPosition pos, boolean isWhitesTurn, long deadline) {
+        long boardHash = pos.hash();
+        CaptureTranspositionTableEntry entry = captureTranspositionTable.get(boardHash);
+        if (entry != null && entry.isWhite() == isWhitesTurn) {
+            return entry.getScore();
+        }
+
+        double score = quiescenceSearch(pos, isWhitesTurn,
+                Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, deadline, 0);
+
+        if (score != EXIT_FLAG) {
+            captureTranspositionTable.put(boardHash, new CaptureTranspositionTableEntry(score, isWhitesTurn));
+        }
+        return score;
+    }
+
+    private double quiescenceSearch(SearchPosition pos, boolean isWhitesTurn,
+                                    double alpha, double beta, long deadline, int depth) {
+        if (Thread.currentThread().isInterrupted() || positionChanged() || System.nanoTime() > deadline) {
+            return EXIT_FLAG;
+        }
+
+        boolean inCheck = pos.inCheck(isWhitesTurn);
+        double standPat = staticEval(pos, isWhitesTurn, depth);
+
+        if (!inCheck) {
+            if (standPat >= beta) return beta;
+            if (standPat > alpha) alpha = standPat;
+        }
+
+        MoveList moves = inCheck ? pos.pseudoMoves() : pos.capturesAndPromotions();
+        ArrayList<Integer> ordered = sortMovesByEfficiency(moves, depth, pos.hash());
+        if (ordered.isEmpty()) {
+            return inCheck ? (isWhitesTurn ? -CHECKMATE + depth : CHECKMATE - depth) : DRAW;
+        }
+
+        for (int move : ordered) {
+            pos.make(move);
+            if (pos.inCheck(isWhitesTurn)) {
+                pos.undo(move);
+                continue;
+            }
+            double score = -quiescenceSearch(pos, !isWhitesTurn, -beta, -alpha, deadline, depth + 1);
+            pos.undo(move);
+            if (score == EXIT_FLAG) return EXIT_FLAG;
+            if (score >= beta) return beta;
+            if (score > alpha) alpha = score;
+        }
+        return alpha;
+    }
+
+    private double staticEval(SearchPosition pos, boolean isWhite, int depth) {
+        Score s = new Score();
+        s.initializeScore(pos.view());
+        double v = s.getScoreDifference();
+        return isWhite ? v : -v;
+    }
 
     ArrayList<Integer> sortMovesByEfficiency(MoveList moves, int currentDepth, long boardHash) {
         final int size = moves.size();
@@ -832,147 +635,6 @@ public class AI {
 
         return sortedMoveList;
     }
-
-
-    public double evaluateBoard(Engine simulatorEngine, boolean isWhitesTurn, long deadline) {
-        if (simulatorEngine.getGameState().isInStateCheckMate()) {
-            return CHECKMATE;
-        }
-
-        if (simulatorEngine.getGameState().isInStateDraw()) {
-            double scoreDiff = simulatorEngine.getGameState().getScore().getScoreDifference();
-            if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
-                return DRAW - 1; // discourage draws when ahead
-            } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {
-                return DRAW + 1; // prefer draws when behind
-            }
-            return DRAW;
-        }
-
-        double alpha = Double.NEGATIVE_INFINITY;
-        double beta = Double.POSITIVE_INFINITY;
-
-        long boardStateHash = simulatorEngine.getBoardStateHash();
-        CaptureTranspositionTableEntry entry = captureTranspositionTable.get(boardStateHash);
-
-        // Check if the entry exists and is relevant for the current search
-        if (entry != null && entry.isWhite() == isWhitesTurn) {
-            return entry.getScore();
-        }
-
-        double score = quiescenceSearch(simulatorEngine, isWhitesTurn, alpha, beta, deadline, 0);
-
-        // FIX: don't cache timeouts in the capture TT (qsearch TT)
-        if (score != EXIT_FLAG) {
-            captureTranspositionTable.put(boardStateHash, new CaptureTranspositionTableEntry(score, isWhitesTurn));
-        }
-
-        return score;
-    }
-
-    private double quiescenceSearch(Engine simulatorEngine, boolean isWhitesTurn,
-                                    double alpha, double beta, long deadline, int depth) {
-        // FIX: early stop conditions (mirror main search)
-        if (Thread.currentThread().isInterrupted() || positionChanged() || System.nanoTime() > deadline) {
-            if (log.isDebugEnabled()) log.debug("qsearch stop (timeout/interrupt/positionChanged)");
-            return AI.EXIT_FLAG; // Timeout / cancelled
-        }
-
-        // If side to move is in check, search all legal evasions (not only captures)
-        boolean inCheck = isSideInCheck(simulatorEngine, isWhitesTurn);
-
-        double standPat = evaluateStaticPosition(simulatorEngine.getGameState(), isWhitesTurn, depth);
-        if (!inCheck) {
-            if (standPat >= beta) {
-                return beta; // fail-hard beta
-            }
-            if (alpha < standPat) {
-                alpha = standPat; // raise alpha via stand-pat
-            }
-
-            // Simple delta/futility-like guard: if even a big swing cannot beat alpha, cut
-            // Keeps it conservative to avoid tactical blindness
-            final int BIG_DELTA = 1000; // ~queen
-            if (standPat + BIG_DELTA < alpha) {
-                return alpha;
-            }
-        }
-
-        // Generate moves: evasions if in check, else captures/promotions
-        MoveList moves = inCheck ? simulatorEngine.getAllLegalMoves() : getPossibleCapturesOrPromotions(simulatorEngine);
-
-        // Order them (captures first via MVV-LVA/promotion bonus, killers/history still help)
-        ArrayList<Integer> ordered = sortMovesByEfficiency(moves, 0, simulatorEngine.getBoardStateHash());
-
-        for (int m : ordered) {
-            simulatorEngine.performMove(m);
-            // FIX: propagate timeout BEFORE negation
-            double child = quiescenceSearch(simulatorEngine, !isWhitesTurn, -beta, -alpha, deadline, depth + 1);
-            simulatorEngine.undoLastMove();
-
-            if (child == EXIT_FLAG) return EXIT_FLAG;
-
-            double score = -child;
-
-            if (score >= beta) {
-                return beta;
-            }
-            if (score > alpha) {
-                alpha = score;
-            }
-        }
-        return alpha;
-    }
-
-    private double evaluateStaticPosition(GameState gameState, boolean isWhitesTurn, int depth) {
-
-        if (gameState.isInStateCheckMate()) {
-            if (log.isDebugEnabled()) {
-                log.debug("Checkmate found");
-            }
-            return CHECKMATE - depth; // -depth to allow faster checkmates
-        }
-        if (gameState.isInStateDraw()) {
-            if (log.isDebugEnabled()) {
-                log.debug("DRAW");
-            }
-            double scoreDiff = gameState.getScore().getScoreDifference();
-            if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
-                return DRAW - 1; // avoid draws when ahead
-            } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {
-                return DRAW + 1; // accept draws when behind
-            }
-            return DRAW;
-        }
-        double scoreDifference = gameState.getScore().getScoreDifference();
-
-        if (log.isDebugEnabled()) {
-            log.debug("Evaluate static position score {}, {} ",
-                    isWhitesTurn ? scoreDifference : -scoreDifference,
-                    isWhitesTurn ? "WHITE" : "BLACK");
-        }
-        return isWhitesTurn ? scoreDifference : -scoreDifference;
-    }
-
-    private MoveList getPossibleCapturesOrPromotions(Engine simulatorEngine) {
-        MoveList allLegalMoves = simulatorEngine.getAllLegalMoves();
-        MoveList capturesAndPromotions = new MoveList();
-        for (int i = 0; i < allLegalMoves.size(); i++) {
-            int m = allLegalMoves.getMove(i);
-            if (MoveHelper.isCapture(m) || MoveHelper.isPawnPromotionMove(m)) {
-                capturesAndPromotions.add(m);
-            }
-        }
-
-        return capturesAndPromotions;
-    }
-
-
-    private boolean isNewBestMove(MoveAndScore moveAndScore, double currentBestScore, boolean isWhite) {
-        double score = moveAndScore.score;
-        return moveAndScore.move != -1 && (isWhite ? score > currentBestScore : score < currentBestScore);
-    }
-
     private boolean timeLimitExceeded(long deadline) {
         return System.nanoTime() > deadline;
     }
@@ -991,10 +653,6 @@ public class AI {
     /**
      * Checks if the current score is better than the best score based on the player's color.
      */
-    private boolean isBetterScore(boolean isWhite, double score, double bestScore) {
-        return isWhite ? score > bestScore : score < bestScore;
-    }
-
     public void updateBoardStateHash() {
         currentBoardState = mainEngine.getBoardStateHash();
         synchronized (calculationLock) {

--- a/src/main/java/julius/game/chessengine/ai/SearchPosition.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchPosition.java
@@ -72,14 +72,18 @@ public final class SearchPosition {
      */
     public int doNullMove() {
         int prev = board.getLastMoveDoubleStepPawnIndex();
+        if (prev != 0) board.xorEnPassantForSearch(prev);
         board.setLastMoveDoubleStepPawnIndex(0);
         board.whitesTurn = !board.whitesTurn;
+        board.xorSideToMoveForSearch();
         return prev;
     }
 
     public void undoNullMove(int prevEp) {
         board.whitesTurn = !board.whitesTurn;
+        board.xorSideToMoveForSearch();
         board.setLastMoveDoubleStepPawnIndex(prevEp);
+        if (prevEp != 0) board.xorEnPassantForSearch(prevEp);
     }
 
     /**

--- a/src/main/java/julius/game/chessengine/ai/SearchPosition.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchPosition.java
@@ -1,0 +1,92 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.board.MoveList;
+
+/**
+ * Lightweight wrapper around {@link BitBoard} used exclusively for search.
+ * Generates pseudo-legal moves and checks legality only after making a move.
+ */
+public final class SearchPosition {
+    private final BitBoard board;
+
+    // small reusable buffer for capture generation in quiescence search
+    private final MoveList capsBuf = new MoveList();
+
+    public SearchPosition(BitBoard start) {
+        this.board = new BitBoard(start); // deep copy
+    }
+
+    public long hash() {
+        return board.getBoardStateHash();
+    }
+
+    public boolean whiteToMove() {
+        return board.whitesTurn;
+    }
+
+    public boolean inCheck(boolean white) {
+        return board.isInCheck(white);
+    }
+
+    public boolean isEndgame() {
+        return board.isEndgame();
+    }
+
+    /**
+     * Generates pseudo-legal moves for the side to move. The returned list
+     * should be used immediately and not cached.
+     */
+    public MoveList pseudoMoves() {
+        return board.generateAllPossibleMoves(board.whitesTurn);
+    }
+
+    /**
+     * Returns only captures and promotions for quiescence search.
+     */
+    public MoveList capturesAndPromotions() {
+        MoveList all = board.generateAllPossibleMoves(board.whitesTurn);
+        capsBuf.clear();
+        for (int i = 0; i < all.size(); i++) {
+            int m = all.getMove(i);
+            if (MoveHelper.isCapture(m) || MoveHelper.isPawnPromotionMove(m)) {
+                capsBuf.add(m);
+            }
+        }
+        return capsBuf;
+    }
+
+    public void make(int move) {
+        board.performMove(move);
+    }
+
+    public void undo(int move) {
+        board.undoMove(move);
+    }
+
+    /**
+     * Executes a null move used for null-move pruning.
+     *
+     * @return previous en-passant square index so it can be restored
+     */
+    public int doNullMove() {
+        int prev = board.getLastMoveDoubleStepPawnIndex();
+        board.setLastMoveDoubleStepPawnIndex(0);
+        board.whitesTurn = !board.whitesTurn;
+        return prev;
+    }
+
+    public void undoNullMove(int prevEp) {
+        board.whitesTurn = !board.whitesTurn;
+        board.setLastMoveDoubleStepPawnIndex(prevEp);
+    }
+
+    /**
+     * Exposes the underlying bitboard for evaluation purposes.
+     */
+    public BitBoard view() {
+        return board;
+    }
+}
+

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -52,6 +52,9 @@ public class BitBoard {
     private boolean blackAttackDirty = true;
     private PieceType[] pieceBoard = new PieceType[64];
 
+    @Getter
+    private long zobrist = 0L;
+
     // Reusable buffer for move generation to avoid frequent allocations.
     private final MoveList moveGenerationBuffer = new MoveList();
 
@@ -102,6 +105,7 @@ public class BitBoard {
         initPieceBoardFromBitboards();
         recomputeWhiteAttackMap();
         recomputeBlackAttackMap();
+        rebuildZobrist();
     }
 
     public BitBoard() {
@@ -151,6 +155,7 @@ public class BitBoard {
         this.blackAttackDirty = other.blackAttackDirty;
 
         this.pieceBoard = Arrays.copyOf(other.pieceBoard, other.pieceBoard.length);
+        this.zobrist = other.zobrist;
     }
 
     public void setLastMoveDoubleStepPawnIndex(int index) {
@@ -220,6 +225,7 @@ public class BitBoard {
         initPieceBoardFromBitboards();
         recomputeWhiteAttackMap();
         recomputeBlackAttackMap();
+        rebuildZobrist();
     }
 
     private void initPieceBoardFromBitboards() {
@@ -247,6 +253,69 @@ public class BitBoard {
             pieceBoard[index] = type;
             bitboard &= bitboard - 1;
         }
+    }
+
+    private void xorPieceSquare(PieceType pt, boolean white, int sq) {
+        if (pt == null) return;
+        int pieceIndex = getPieceIndex(pt, white ? Color.WHITE : Color.BLACK);
+        zobrist ^= ZobristTable.getPieceSquareHash(pieceIndex, sq);
+    }
+
+    private void xorEnPassantIfAny(int epIndex) {
+        if (epIndex != 0) {
+            zobrist ^= ZobristTable.getEnPassantSquareHash(epIndex);
+        }
+    }
+
+    /** bit0=WK, bit1=WQ, bit2=BK, bit3=BQ (only when right actually exists) */
+    private int castleMask() {
+        int m = 0;
+        if (!whiteKingMoved && !whiteRookH1Moved && isRookAtIndex(7)) m |= 1;
+        if (!whiteKingMoved && !whiteRookA1Moved && isRookAtIndex(0)) m |= 2;
+        if (!blackKingMoved && !blackRookH8Moved && isRookAtIndex(63)) m |= 4;
+        if (!blackKingMoved && !blackRookA8Moved && isRookAtIndex(56)) m |= 8;
+        return m;
+    }
+
+    private void xorCastleDelta(int oldMask, int newMask) {
+        int d = oldMask ^ newMask;
+        if ((d & 1) != 0) zobrist ^= ZobristTable.getCastlingRightsHash(0);
+        if ((d & 2) != 0) zobrist ^= ZobristTable.getCastlingRightsHash(1);
+        if ((d & 4) != 0) zobrist ^= ZobristTable.getCastlingRightsHash(2);
+        if ((d & 8) != 0) zobrist ^= ZobristTable.getCastlingRightsHash(3);
+    }
+
+    public void xorSideToMoveForSearch() {
+        zobrist ^= ZobristTable.getBlackTurnHash();
+    }
+
+    public void xorEnPassantForSearch(int epIndex) {
+        if (epIndex != 0) zobrist ^= ZobristTable.getEnPassantSquareHash(epIndex);
+    }
+
+    public void rebuildZobrist() {
+        long z = 0L;
+        for (int sq = 0; sq < 64; sq++) {
+            PieceType pt = pieceBoard[sq];
+            if (pt != null) {
+                Color c = getPieceColorAtIndex(sq);
+                int idx = getPieceIndex(pt, c);
+                z ^= ZobristTable.getPieceSquareHash(idx, sq);
+            }
+        }
+        int cm = castleMask();
+        if ((cm & 1) != 0) z ^= ZobristTable.getCastlingRightsHash(0);
+        if ((cm & 2) != 0) z ^= ZobristTable.getCastlingRightsHash(1);
+        if ((cm & 4) != 0) z ^= ZobristTable.getCastlingRightsHash(2);
+        if ((cm & 8) != 0) z ^= ZobristTable.getCastlingRightsHash(3);
+
+        if (lastMoveDoubleStepPawnIndex != 0) {
+            z ^= ZobristTable.getEnPassantSquareHash(lastMoveDoubleStepPawnIndex);
+        }
+        if (whitesTurn) {
+            z ^= ZobristTable.getBlackTurnHash();
+        }
+        this.zobrist = z;
     }
 
     // Method to get the bitboard for a specific piece type and color
@@ -821,9 +890,14 @@ public class BitBoard {
         long fromMask = 1L << fromIndex;
         long toMask   = 1L << toIndex;
 
+        xorEnPassantIfAny(lastMoveDoubleStepPawnIndex);
+        int oldCastle = castleMask();
+
         // ---- 1) Captures (fast, no aggregates yet)
         if (isCapture) {
             int capIndex = isEnPassant ? (isWhite ? toIndex - 8 : toIndex + 8) : toIndex;
+            PieceType capType = pieceBoard[capIndex];
+            xorPieceSquare(capType, !isWhite, capIndex);
             long capMask = 1L << capIndex;
 
             if (isWhite) {
@@ -852,6 +926,9 @@ public class BitBoard {
             long rfMask  = 1L << rookFrom;
             long rtMask  = 1L << rookTo;
 
+            xorPieceSquare(PieceType.ROOK, isWhite, rookFrom);
+            xorPieceSquare(PieceType.ROOK, isWhite, rookTo);
+
             if (isWhite) {
                 whiteRooks &= ~rfMask;
                 whiteRooks |=  rtMask;
@@ -866,6 +943,8 @@ public class BitBoard {
 
         // ---- 3) Move the piece (fast)
         PieceType movingPiece = pieceTypeFromBits(pieceBits);
+
+        xorPieceSquare(movingPiece, isWhite, fromIndex);
 
         // remove from 'from'
         switch (pieceBits) {
@@ -889,8 +968,10 @@ public class BitBoard {
                 case 6 -> { if (isWhite) whiteKing    |= toMask; else blackKing    |= toMask; }
             }
             pieceBoard[toIndex] = movingPiece;
+            xorPieceSquare(movingPiece, isWhite, toIndex);
         } else {
             // Promotion: place promoted piece instead of pawn
+            PieceType promoPiece = pieceTypeFromBits(promoBits);
             switch (promoBits) {
                 case 2 -> { if (isWhite) whiteKnights |= toMask; else blackKnights |= toMask; pieceBoard[toIndex] = PieceType.KNIGHT; }
                 case 3 -> { if (isWhite) whiteBishops |= toMask; else blackBishops |= toMask; pieceBoard[toIndex] = PieceType.BISHOP; }
@@ -898,6 +979,7 @@ public class BitBoard {
                 case 5 -> { if (isWhite) whiteQueens  |= toMask; else blackQueens  |= toMask; pieceBoard[toIndex] = PieceType.QUEEN; }
                 default -> throw new IllegalArgumentException("Invalid promotion piece bits: " + promoBits);
             }
+            xorPieceSquare(promoPiece, isWhite, toIndex);
         }
 
         // board mirror for 'from'
@@ -921,6 +1003,7 @@ public class BitBoard {
         } else {
             lastMoveDoubleStepPawnIndex = 0;
         }
+        xorEnPassantIfAny(lastMoveDoubleStepPawnIndex);
 
         // ---- 5) Finalize once
         updateAggregatedBitboards();
@@ -929,7 +1012,10 @@ public class BitBoard {
         whiteAttackDirty = true;
         blackAttackDirty = true;
 
+        xorCastleDelta(oldCastle, castleMask());
+
         whitesTurn = !whitesTurn;
+        xorSideToMoveForSearch();
     }
 
 
@@ -1093,6 +1179,33 @@ public class BitBoard {
         boolean isRookFirstMove = MoveHelper.isRookFirstMove(move);
         int doubleStepPawnIndex = MoveHelper.deriveLastMoveDoubleStepPawnIndex(move);
 
+        xorEnPassantIfAny(lastMoveDoubleStepPawnIndex);
+        int oldCastle = castleMask();
+
+        int capIndex = isEnPassantMove ? (isWhite ? toIndex - 8 : toIndex + 8) : toIndex;
+        if (isCapture) {
+            PieceType capType = pieceTypeFromBits(capturedPieceTypeBits);
+            xorPieceSquare(capType, !isWhite, capIndex);
+        }
+
+        PieceType mover = pieceTypeFromBits(pieceTypeBits);
+        if (promotionPieceTypeBits != 0) {
+            PieceType promo = pieceTypeFromBits(promotionPieceTypeBits);
+            xorPieceSquare(promo, isWhite, toIndex);
+            xorPieceSquare(PieceType.PAWN, isWhite, fromIndex);
+        } else {
+            xorPieceSquare(mover, isWhite, toIndex);
+            xorPieceSquare(mover, isWhite, fromIndex);
+        }
+
+        if (isCastlingMove) {
+            boolean kingside = toIndex > fromIndex;
+            int rookFrom = isWhite ? (kingside ? 7 : 0) : (kingside ? 63 : 56);
+            int rookTo   = kingside ? (rookFrom - 2) : (rookFrom + 3);
+            xorPieceSquare(PieceType.ROOK, isWhite, rookTo);
+            xorPieceSquare(PieceType.ROOK, isWhite, rookFrom);
+        }
+
         // 1) restore captured piece (bitboards + pieceBoard)
         undoCapture(toIndex, capturedPieceTypeBits, isCapture, isWhite, isEnPassantMove);
 
@@ -1115,13 +1228,17 @@ public class BitBoard {
 
         // 7) restore state flags + ep index
         undoGameState(fromIndex, toIndex, pieceTypeBits, isKingFirstMove, isRookFirstMove, isWhite, doubleStepPawnIndex);
+        xorEnPassantIfAny(lastMoveDoubleStepPawnIndex);
 
         // 8) finalize aggregates once; mark attacks dirty (lazy recompute)
         updateAggregatedBitboards();
         whiteAttackDirty = true;
         blackAttackDirty = true;
 
+        xorCastleDelta(oldCastle, castleMask());
+
         whitesTurn = !whitesTurn;
+        xorSideToMoveForSearch();
     }
 
     private void undoGameState(int fromIndex, int toIndex, int pieceTypeBits, boolean isKingFirstMove, boolean isRookFirstMove, boolean isWhite, int doubleStepPawnIndex) {
@@ -1308,46 +1425,7 @@ public class BitBoard {
     }
 
     public long getBoardStateHash() {
-        long hash = 0;
-
-        // Iterate over all squares and XOR the hash with the piece hash values
-        for (int square = 0; square < 64; square++) {
-            PieceType pieceType = getPieceTypeAtSquare(square);
-            Color pieceColor = getPieceColorAtSquare(square);
-            if (pieceType != null && pieceColor != null) {
-                int pieceIndex = getPieceIndex(pieceType, pieceColor); // You need to implement this method
-                hash ^= ZobristTable.getPieceSquareHash(pieceIndex, square);
-            }
-        }
-
-        // Include castling rights in the hash
-        if (!whiteKingMoved) {
-            if (!whiteRookH1Moved) {
-                hash ^= ZobristTable.getCastlingRightsHash(0); // White Kingside
-            }
-            if (!whiteRookA1Moved) {
-                hash ^= ZobristTable.getCastlingRightsHash(1); // White Queenside
-            }
-        }
-        if (!blackKingMoved) {
-            if (!blackRookH8Moved) {
-                hash ^= ZobristTable.getCastlingRightsHash(2); // Black Kingside
-            }
-            if (!blackRookA8Moved) {
-                hash ^= ZobristTable.getCastlingRightsHash(3); // Black Queenside
-            }
-        }
-
-        if (lastMoveDoubleStepPawnIndex != 0) {
-            hash ^= ZobristTable.getEnPassantSquareHash(lastMoveDoubleStepPawnIndex);
-        }
-
-        // Include the player's turn in the hash
-        if (whitesTurn) {
-            hash ^= ZobristTable.getBlackTurnHash(); // XOR with blackTurnHash means it's white's turn
-        }
-
-        return hash;
+        return zobrist;
     }
 
 }

--- a/src/main/java/julius/game/chessengine/board/FEN.java
+++ b/src/main/java/julius/game/chessengine/board/FEN.java
@@ -138,7 +138,9 @@ public class FEN {
         }
 
         // Pass these inferred values to the BitBoard constructor
-        return new BitBoard(whitesTurn, whitePawns, blackPawns, whiteKnights, blackKnights, whiteBishops, blackBishops, whiteRooks, blackRooks, whiteQueens, blackQueens, whiteKing, blackKing, whitePieces, blackPieces, allPieces, lastMoveDoubleStepPawnIndex, whiteKingMoved, blackKingMoved, whiteRookA1Moved, whiteRookH1Moved, blackRookA8Moved, blackRookH8Moved, whiteKingHasCastled, blackKingHasCastled);
+        BitBoard board = new BitBoard(whitesTurn, whitePawns, blackPawns, whiteKnights, blackKnights, whiteBishops, blackBishops, whiteRooks, blackRooks, whiteQueens, blackQueens, whiteKing, blackKing, whitePieces, blackPieces, allPieces, lastMoveDoubleStepPawnIndex, whiteKingMoved, blackKingMoved, whiteRookA1Moved, whiteRookH1Moved, blackRookA8Moved, blackRookH8Moved, whiteKingHasCastled, blackKingHasCastled);
+        board.rebuildZobrist();
+        return board;
     }
 
 }

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -89,6 +89,15 @@ public class Engine {
         return new Engine(this);
     }
 
+    /**
+     * Creates a deep copy of the underlying {@link BitBoard}. This is used by
+     * the search to obtain a lightweight snapshot of the current position
+     * without any of the GUI or game state overhead.
+     */
+    public BitBoard cloneBitBoard() {
+        return new BitBoard(this.bitBoard);
+    }
+
     public void startNewGame() {
         bitBoard = new BitBoard();
         gameState = new GameState(bitBoard);

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -3,6 +3,8 @@ package julius.game.chessengine.board;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.utils.Color;
 import julius.game.chessengine.figures.PieceType;
+import julius.game.chessengine.ai.SearchPosition;
+import julius.game.chessengine.board.MoveList;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Test;
 
@@ -47,6 +49,28 @@ public class BitBoardTest {
         b.logBoard();
 
         assertEquals(a.getBoardStateHash(), b.getBoardStateHash());
+    }
+
+    @Test
+    public void testMakeUndoHashIdentity() {
+        BitBoard b = new BitBoard();
+        long h0 = b.getBoardStateHash();
+        MoveList ml = b.generateAllPossibleMoves(true);
+        for (int i = 0; i < ml.size(); i++) {
+            int m = ml.getMove(i);
+            b.performMove(m);
+            b.undoMove(m);
+            assertEquals(h0, b.getBoardStateHash(), "hash mismatch after make/undo");
+        }
+    }
+
+    @Test
+    public void testNullMoveHashIdentity() {
+        SearchPosition sp = new SearchPosition(new BitBoard());
+        long h0 = sp.hash();
+        int ep = sp.doNullMove();
+        sp.undoNullMove(ep);
+        assertEquals(h0, sp.hash(), "hash mismatch after null/undo");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Introduce `SearchPosition` wrapper over `BitBoard` for pseudo-legal move generation and efficient make/undo
- Expose `cloneBitBoard` in `Engine` to provide snapshots for search
- Rewrite `AI` search to operate on `SearchPosition`, checking legality post-move and avoiding `Engine` overhead

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM – network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c3104e72f4832aaf7a287f58bc3d22