### PR TITLE
Handle quiet checking moves in quiescence search

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -846,11 +846,23 @@ public class AI {
             }
         }
 
-        // Generate moves: evasions if in check, else captures/promotions
-        MoveList moves = inCheck ? simulatorEngine.getAllLegalMoves() : getPossibleCapturesOrPromotions(simulatorEngine);
+        ArrayList<Integer> ordered;
+        if (inCheck) {
+            // When in check, search all legal evasions
+            MoveList moves = simulatorEngine.getAllLegalMoves();
+            ordered = sortMovesByEfficiency(moves, 0, simulatorEngine.getBoardStateHash());
+        } else {
+            // Otherwise consider captures/promotions and quiet checking moves
+            MoveList captures = getPossibleCapturesOrPromotions(simulatorEngine);
+            MoveList checks = getCheckingMoves(simulatorEngine, isWhitesTurn);
 
-        // Order them (captures first via MVV-LVA/promotion bonus, killers/history still help)
-        ArrayList<Integer> ordered = sortMovesByEfficiency(moves, 0, simulatorEngine.getBoardStateHash());
+            ArrayList<Integer> orderedCaptures = sortMovesByEfficiency(captures, 0, simulatorEngine.getBoardStateHash());
+            ArrayList<Integer> orderedChecks = sortMovesByEfficiency(checks, 0, simulatorEngine.getBoardStateHash());
+
+            ordered = new ArrayList<>(orderedCaptures.size() + orderedChecks.size());
+            ordered.addAll(orderedCaptures); // captures/promotions first
+            ordered.addAll(orderedChecks);   // quiet checks afterwards
+        }
 
         for (int m : ordered) {
             simulatorEngine.performMove(m);
@@ -913,6 +925,28 @@ public class AI {
         }
 
         return capturesAndPromotions;
+    }
+
+    /**
+     * Generate quiet moves that deliver check to the opponent.
+     * These are appended after captures/promotions in quiescence search
+     * to catch simple mating threats without incurring large overhead.
+     */
+    private MoveList getCheckingMoves(Engine simulatorEngine, boolean isWhitesTurn) {
+        MoveList allLegalMoves = simulatorEngine.getAllLegalMoves();
+        MoveList checkingMoves = new MoveList();
+        for (int i = 0; i < allLegalMoves.size(); i++) {
+            int m = allLegalMoves.getMove(i);
+            if (MoveHelper.isCapture(m) || MoveHelper.isPawnPromotionMove(m)) {
+                continue; // only quiet moves
+            }
+            simulatorEngine.performMove(m);
+            if (isSideInCheck(simulatorEngine, !isWhitesTurn)) {
+                checkingMoves.add(m);
+            }
+            simulatorEngine.undoLastMove();
+        }
+        return checkingMoves;
     }
 
 

--- a/src/test/java/julius/game/chessengine/ai/QuiescenceSearchCheckTest.java
+++ b/src/test/java/julius/game/chessengine/ai/QuiescenceSearchCheckTest.java
@@ -5,16 +5,21 @@ import julius.game.chessengine.board.MoveList;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.utils.Score;
 import org.junit.jupiter.api.Test;
+import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class QuiescenceSearchCheckTest {
 
     @Test
-    void engineAvoidsAllowingImmediateMate() {
+    void engineAvoidsAllowingImmediateMate() throws Exception {
         Engine engine = new Engine();
         AI ai = new AI(engine);
         engine.importBoardFromFen("7k/7p/4N3/5Q1/8/4q3/4R3/6K1 b - - 0 1");
+
+        Method alphaBeta = AI.class.getDeclaredMethod("alphaBeta", Engine.class, int.class,
+                double.class, double.class, boolean.class, long.class);
+        alphaBeta.setAccessible(true);
 
         MoveList legal = engine.getAllLegalMoves();
         int losingMove = -1;
@@ -25,7 +30,9 @@ public class QuiescenceSearchCheckTest {
             Move decoded = Move.convertIntToMove(m);
 
             engine.performMove(m);
-            double score = ai.evaluateBoard(engine, engine.whitesTurn(), System.nanoTime() + 1_000_000_000L);
+            long deadline = System.nanoTime() + 1_000_000_000L;
+            double score = (double) alphaBeta.invoke(ai, engine, 0, Double.NEGATIVE_INFINITY,
+                    Double.POSITIVE_INFINITY, engine.whitesTurn(), deadline);
             engine.undoLastMove();
             double blackScore = -score;
 

--- a/src/test/java/julius/game/chessengine/ai/QuiescenceSearchCheckTest.java
+++ b/src/test/java/julius/game/chessengine/ai/QuiescenceSearchCheckTest.java
@@ -1,0 +1,43 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.board.Move;
+import julius.game.chessengine.board.MoveList;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.utils.Score;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class QuiescenceSearchCheckTest {
+
+    @Test
+    void engineAvoidsAllowingImmediateMate() {
+        Engine engine = new Engine();
+        AI ai = new AI(engine);
+        engine.importBoardFromFen("7k/7p/4N3/5Q1/8/4q3/4R3/6K1 b - - 0 1");
+
+        MoveList legal = engine.getAllLegalMoves();
+        int losingMove = -1;
+        double bestScore = Double.NEGATIVE_INFINITY;
+        int bestMove = -1;
+        for (int i = 0; i < legal.size(); i++) {
+            int m = legal.getMove(i);
+            Move decoded = Move.convertIntToMove(m);
+
+            engine.performMove(m);
+            double score = ai.evaluateBoard(engine, engine.whitesTurn(), System.nanoTime() + 1_000_000_000L);
+            engine.undoLastMove();
+            double blackScore = -score;
+
+            if ("Qxe2".equals(decoded.toString())) {
+                losingMove = m;
+                assertTrue(score >= Score.CHECKMATE - 1);
+            }
+            if (blackScore > bestScore) {
+                bestScore = blackScore;
+                bestMove = m;
+            }
+        }
+        assertNotEquals(losingMove, bestMove);
+    }
+}


### PR DESCRIPTION
## Summary
- Extend quiescence search to include quiet checking moves, appending them after captures/promotions
- Add helper to generate quiet checks and corresponding unit test covering mate threat after …Qxe2??

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM – network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e62fc9a0832a88166ea508181503