### PR TITLE
Display version and thread count in UI

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -152,6 +152,13 @@ public class AI {
         return currentBestMove;
     }
 
+    /**
+     * Expose the number of search threads configured for the engine.
+     */
+    public int getSearchThreads() {
+        return SEARCH_THREADS;
+    }
+
     private void startCalculationThread() {
         keepCalculating = true;
         calculationThread = new Thread(this::calculateLine);

--- a/src/main/java/julius/game/chessengine/controller/ChessController.java
+++ b/src/main/java/julius/game/chessengine/controller/ChessController.java
@@ -9,6 +9,7 @@ import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.pgn.PGN;
 import julius.game.chessengine.pgn.PgnParser;
 import julius.game.chessengine.utils.Score;
+import julius.game.chessengine.utils.VersionInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +33,15 @@ public class ChessController {
 
     private final AI ai;
     private final OpeningBook openingBook;
+
+    @GetMapping(value = "/info")
+    public ResponseEntity<Map<String, Object>> info() {
+        Map<String, Object> info = Map.of(
+                "version", VersionInfo.getVersion(),
+                "threads", ai.getSearchThreads()
+        );
+        return ResponseEntity.ok(info);
+    }
 
     @GetMapping(value = "/score")
     public ResponseEntity<Score> getScore() {

--- a/src/main/java/julius/game/chessengine/utils/VersionInfo.java
+++ b/src/main/java/julius/game/chessengine/utils/VersionInfo.java
@@ -2,27 +2,56 @@ package julius.game.chessengine.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Properties;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 /**
  * Utility to expose the application version from the generated pom.properties.
  */
 public final class VersionInfo {
 
-    private static final String POM_PATH = "/META-INF/maven/julius.game/chess-engine/pom.properties";
+    private static final String POM_PROPERTIES = "/META-INF/maven/julius.game/chess-engine/pom.properties";
     private static final String UNKNOWN = "unknown";
+    private static final Path LOCAL_POM = Path.of("pom.xml");
 
     private VersionInfo() {
     }
 
     public static String getVersion() {
-        try (InputStream is = VersionInfo.class.getResourceAsStream(POM_PATH)) {
+        String fromProps = readFromPomProperties();
+        return UNKNOWN.equals(fromProps) ? readFromPomXml() : fromProps;
+    }
+
+    private static String readFromPomProperties() {
+        try (InputStream is = VersionInfo.class.getResourceAsStream(POM_PROPERTIES)) {
             if (is != null) {
                 Properties props = new Properties();
                 props.load(is);
                 return props.getProperty("version", UNKNOWN);
             }
         } catch (IOException ignored) {
+        }
+        return UNKNOWN;
+    }
+
+    private static String readFromPomXml() {
+        if (!Files.exists(LOCAL_POM)) {
+            return UNKNOWN;
+        }
+        try (InputStream is = Files.newInputStream(LOCAL_POM)) {
+            Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+            Node project = doc.getDocumentElement();
+            for (int i = 0; i < project.getChildNodes().getLength(); i++) {
+                Node node = project.getChildNodes().item(i);
+                if (node.getNodeType() == Node.ELEMENT_NODE && "version".equals(node.getNodeName())) {
+                    return node.getTextContent();
+                }
+            }
+        } catch (Exception ignored) {
         }
         return UNKNOWN;
     }

--- a/src/main/java/julius/game/chessengine/utils/VersionInfo.java
+++ b/src/main/java/julius/game/chessengine/utils/VersionInfo.java
@@ -1,0 +1,29 @@
+package julius.game.chessengine.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Utility to expose the application version from the generated pom.properties.
+ */
+public final class VersionInfo {
+
+    private static final String POM_PATH = "/META-INF/maven/julius.game/chess-engine/pom.properties";
+    private static final String UNKNOWN = "unknown";
+
+    private VersionInfo() {
+    }
+
+    public static String getVersion() {
+        try (InputStream is = VersionInfo.class.getResourceAsStream(POM_PATH)) {
+            if (is != null) {
+                Properties props = new Properties();
+                props.load(is);
+                return props.getProperty("version", UNKNOWN);
+            }
+        } catch (IOException ignored) {
+        }
+        return UNKNOWN;
+    }
+}

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -189,6 +189,11 @@ body {
 }
 
 /* Top Bar Styles */
+.top-bar {
+    background: linear-gradient(90deg, #003366, #006400);
+    padding: 10px 0;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+}
 .top-bar ul {
     list-style: none; /* Removes default list styling */
     padding: 0;
@@ -201,6 +206,16 @@ body {
 
 .top-bar li {
     margin: 0 5px; /* Adjust spacing between menu items */
+}
+
+#infoBar {
+    text-align: center;
+    color: #32CD32;
+    background-color: rgba(0, 0, 0, 0.6);
+    font-family: 'Orbitron', sans-serif;
+    padding: 5px 0;
+    box-shadow: 0 0 10px #00eeff;
+    margin-bottom: 15px;
 }
 
 /* Button Styles */

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -26,9 +26,11 @@
             </ul>
         </nav>
 
+        <div id="infoBar">Loading...</div>
+
         <section id="section1">
             <div>
-                <h1 id="header">ALIEKNEK 1.0</h1>
+                <h1 id="header">ALIEKNEK</h1>
             </div>
         </section>
 

--- a/src/main/resources/static/js/chess-data-fetching.js
+++ b/src/main/resources/static/js/chess-data-fetching.js
@@ -21,6 +21,19 @@ const makeRequest = async (method, url, callback) => {
     }
 };
 
+// Load version and thread information for the info bar
+const loadInfoBar = () => {
+    fetch(`${apiBaseUrl}/chess/info`)
+        .then(r => r.json())
+        .then(data => {
+            const infoBar = document.getElementById('infoBar');
+            if (infoBar) {
+                infoBar.textContent = `Version: v${data.version} | Threads: ${data.threads}`;
+            }
+        })
+        .catch(err => console.error('Failed to load app info', err));
+};
+
 // Update the calculated line and game details
 const updateCalculatedLine = () => {
     makeRequest('GET', '/chess/state', (data) => {
@@ -340,4 +353,5 @@ const startAutoRefresh = (intervalMs) => {
 $(document).ready(function () {
     initBoard(); // Initialize the board when the document is ready
     startAutoRefresh(300); // Start auto-refresh
+    loadInfoBar();
 });


### PR DESCRIPTION
## Summary
- expose search thread count from AI
- add `/chess/info` endpoint returning version and thread count using new `VersionInfo`
- show version and active threads in a styled info bar on the main page

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c52b828d40832a8c314d1c837c2625