### PR TITLE
Implement incremental Zobrist hashing and repetition tracking

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -7,7 +7,6 @@ import julius.game.chessengine.helper.RookHelper;
 import julius.game.chessengine.helper.ZobristTable;
 import julius.game.chessengine.utils.Color;
 import julius.game.chessengine.board.MoveHelper;
-import julius.game.chessengine.utils.Score;
 
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
@@ -46,6 +45,7 @@ public class BitBoard {
     private long whitePieces = 0L;
     private long blackPieces = 0L;
     private long allPieces = 0L;
+    private long zKey = 0L;
     /**
      * Bitboards caching the squares attacked by each side.
      */
@@ -74,6 +74,46 @@ public class BitBoard {
     //I just need those values to give the Engine a better score if it castles
     private boolean whiteKingHasCastled = false;
     private boolean blackKingHasCastled = false;
+
+    private void xorPiece(Color color, PieceType type, int square) {
+        zKey ^= ZobristTable.getPieceSquareHash(getPieceIndex(type, color), square);
+    }
+
+    private void xorCastlingRight(int index) {
+        zKey ^= ZobristTable.getCastlingRightsHash(index);
+    }
+
+    private void xorEp(int squareIndex) {
+        zKey ^= ZobristTable.getEnPassantSquareHash(squareIndex);
+    }
+
+    private void xorSide() {
+        zKey ^= ZobristTable.getBlackTurnHash();
+    }
+
+    private void recomputeZobristKey() {
+        zKey = 0;
+        if (whitesTurn) {
+            xorSide();
+        }
+        for (int sq = 0; sq < 64; sq++) {
+            PieceType pt = pieceBoard[sq];
+            if (pt != null) {
+                Color c = getPieceColorAtIndex(sq);
+                xorPiece(c, pt, sq);
+            }
+        }
+        if (!whiteKingMoved) {
+            if (!whiteRookH1Moved) xorCastlingRight(0);
+            if (!whiteRookA1Moved) xorCastlingRight(1);
+        }
+        if (!blackKingMoved) {
+            if (!blackRookH8Moved) xorCastlingRight(2);
+            if (!blackRookA8Moved) xorCastlingRight(3);
+        }
+        int ep = getEnPassantTargetIndex();
+        if (ep != -1) xorEp(ep);
+    }
 
     public BitBoard(boolean whitesTurn, long whitePawns, long blackPawns, long whiteKnights, long blackKnights, long whiteBishops, long blackBishops, long whiteRooks, long blackRooks, long whiteQueens, long blackQueens, long whiteKing, long blackKing, long whitePieces, long blackPieces, long allPieces, int lastMoveDoubleStepPawnIndex, boolean whiteKingMoved, boolean blackKingMoved, boolean whiteRookA1Moved, boolean whiteRookH1Moved, boolean blackRookA8Moved, boolean blackRookH8Moved, boolean whiteKingHasCastled, boolean blackKingHasCastled) {
         this.whitesTurn = whitesTurn;
@@ -104,6 +144,7 @@ public class BitBoard {
         initPieceBoardFromBitboards();
         recomputeWhiteAttackMap();
         recomputeBlackAttackMap();
+        recomputeZobristKey();
     }
 
     public BitBoard() {
@@ -151,12 +192,20 @@ public class BitBoard {
         this.blackAttackMap = other.blackAttackMap;
         this.whiteAttackDirty = other.whiteAttackDirty;
         this.blackAttackDirty = other.blackAttackDirty;
-
+        this.zKey = other.zKey;
         this.pieceBoard = Arrays.copyOf(other.pieceBoard, other.pieceBoard.length);
     }
-
     public void setLastMoveDoubleStepPawnIndex(int index) {
+        int oldEp = getEnPassantTargetIndex();
         this.lastMoveDoubleStepPawnIndex = index;
+        int newEp = getEnPassantTargetIndex();
+        if (oldEp != -1) xorEp(oldEp);
+        if (newEp != -1) xorEp(newEp);
+    }
+
+    public void flipSideToMove() {
+        whitesTurn = !whitesTurn;
+        xorSide();
     }
 
 
@@ -222,6 +271,7 @@ public class BitBoard {
         initPieceBoardFromBitboards();
         recomputeWhiteAttackMap();
         recomputeBlackAttackMap();
+        recomputeZobristKey();
     }
 
     private void initPieceBoardFromBitboards() {
@@ -1018,9 +1068,24 @@ public class BitBoard {
         long fromMask = 1L << fromIndex;
         long toMask = 1L << toIndex;
 
+        int oldEp = getEnPassantTargetIndex();
+        boolean oldWK = !whiteKingMoved && !whiteRookH1Moved;
+        boolean oldWQ = !whiteKingMoved && !whiteRookA1Moved;
+        boolean oldBK = !blackKingMoved && !blackRookH8Moved;
+        boolean oldBQ = !blackKingMoved && !blackRookA8Moved;
+
+        PieceType movingPiece = pieceTypeFromBits(pieceBits);
+        Color moverColor = isWhite ? Color.WHITE : Color.BLACK;
+        xorPiece(moverColor, movingPiece, fromIndex);
+        PieceType placedPiece = promoBits == 0 ? movingPiece : pieceTypeFromBits(promoBits);
+        xorPiece(moverColor, placedPiece, toIndex);
+
         // ---- 1) Captures (fast, no aggregates yet)
         if (isCapture) {
             int capIndex = isEnPassant ? (isWhite ? toIndex - 8 : toIndex + 8) : toIndex;
+            PieceType capType = pieceBoard[capIndex];
+            Color capColor = isWhite ? Color.BLACK : Color.WHITE;
+            xorPiece(capColor, capType, capIndex);
             long capMask = 1L << capIndex;
 
             if (isWhite) {
@@ -1067,6 +1132,8 @@ public class BitBoard {
             boolean kingside = toIndex > fromIndex;
             int rookFrom = isWhite ? (kingside ? 7 : 0) : (kingside ? 63 : 56);
             int rookTo = kingside ? (rookFrom - 2) : (rookFrom + 3);
+            xorPiece(moverColor, PieceType.ROOK, rookFrom);
+            xorPiece(moverColor, PieceType.ROOK, rookTo);
             long rfMask = 1L << rookFrom;
             long rtMask = 1L << rookTo;
 
@@ -1083,8 +1150,7 @@ public class BitBoard {
         }
 
         // ---- 3) Move the piece (fast)
-        PieceType movingPiece = pieceTypeFromBits(pieceBits);
-
+        
         // remove from 'from'
         switch (pieceBits) {
             case 1 -> {
@@ -1192,6 +1258,19 @@ public class BitBoard {
             lastMoveDoubleStepPawnIndex = 0;
         }
 
+        int newEp = (lastMoveDoubleStepPawnIndex != 0) ? ((isWhite ? 2 : 5) * 8 + (lastMoveDoubleStepPawnIndex & 7)) : -1;
+        if (oldEp != -1) xorEp(oldEp);
+        if (newEp != -1) xorEp(newEp);
+
+        boolean newWK = !whiteKingMoved && !whiteRookH1Moved;
+        boolean newWQ = !whiteKingMoved && !whiteRookA1Moved;
+        boolean newBK = !blackKingMoved && !blackRookH8Moved;
+        boolean newBQ = !blackKingMoved && !blackRookA8Moved;
+        if (oldWK != newWK) xorCastlingRight(0);
+        if (oldWQ != newWQ) xorCastlingRight(1);
+        if (oldBK != newBK) xorCastlingRight(2);
+        if (oldBQ != newBQ) xorCastlingRight(3);
+
         // ---- 5) Finalize once
         updateAggregatedBitboards();
 
@@ -1199,7 +1278,7 @@ public class BitBoard {
         whiteAttackDirty = true;
         blackAttackDirty = true;
 
-        whitesTurn = !whitesTurn;
+        flipSideToMove();
     }
 
 
@@ -1363,6 +1442,33 @@ public class BitBoard {
         boolean isRookFirstMove = MoveHelper.isRookFirstMove(move);
         int doubleStepPawnIndex = MoveHelper.deriveLastMoveDoubleStepPawnIndex(move);
 
+        int oldEp = getEnPassantTargetIndex();
+        boolean oldWK = !whiteKingMoved && !whiteRookH1Moved;
+        boolean oldWQ = !whiteKingMoved && !whiteRookA1Moved;
+        boolean oldBK = !blackKingMoved && !blackRookH8Moved;
+        boolean oldBQ = !blackKingMoved && !blackRookA8Moved;
+
+        PieceType movingPiece = pieceTypeFromBits(pieceTypeBits);
+        Color moverColor = isWhite ? Color.WHITE : Color.BLACK;
+        PieceType toPiece = promotionPieceTypeBits == 0 ? movingPiece : pieceTypeFromBits(promotionPieceTypeBits);
+        xorPiece(moverColor, toPiece, toIndex);
+        xorPiece(moverColor, movingPiece, fromIndex);
+
+        if (isCapture) {
+            int capIndex = isEnPassantMove ? (isWhite ? toIndex - 8 : toIndex + 8) : toIndex;
+            PieceType capType = pieceTypeFromBits(capturedPieceTypeBits);
+            Color capColor = isWhite ? Color.BLACK : Color.WHITE;
+            xorPiece(capColor, capType, capIndex);
+        }
+
+        if (isCastlingMove) {
+            boolean kingside = toIndex > fromIndex;
+            int rookFrom = isWhite ? (kingside ? 7 : 0) : (kingside ? 63 : 56);
+            int rookTo = kingside ? (rookFrom - 2) : (rookFrom + 3);
+            xorPiece(moverColor, PieceType.ROOK, rookFrom);
+            xorPiece(moverColor, PieceType.ROOK, rookTo);
+        }
+
         // 1) restore captured piece (bitboards + pieceBoard)
         undoCapture(toIndex, capturedPieceTypeBits, isCapture, isWhite, isEnPassantMove);
 
@@ -1386,12 +1492,25 @@ public class BitBoard {
         // 7) restore state flags + ep index
         undoGameState(fromIndex, toIndex, pieceTypeBits, isKingFirstMove, isRookFirstMove, isWhite, doubleStepPawnIndex);
 
+        int newEp = (lastMoveDoubleStepPawnIndex != 0) ? ((isWhite ? 5 : 2) * 8 + (lastMoveDoubleStepPawnIndex & 7)) : -1;
+        if (oldEp != -1) xorEp(oldEp);
+        if (newEp != -1) xorEp(newEp);
+
+        boolean newWK = !whiteKingMoved && !whiteRookH1Moved;
+        boolean newWQ = !whiteKingMoved && !whiteRookA1Moved;
+        boolean newBK = !blackKingMoved && !blackRookH8Moved;
+        boolean newBQ = !blackKingMoved && !blackRookA8Moved;
+        if (oldWK != newWK) xorCastlingRight(0);
+        if (oldWQ != newWQ) xorCastlingRight(1);
+        if (oldBK != newBK) xorCastlingRight(2);
+        if (oldBQ != newBQ) xorCastlingRight(3);
+
         // 8) finalize aggregates once; mark attacks dirty (lazy recompute)
         updateAggregatedBitboards();
         whiteAttackDirty = true;
         blackAttackDirty = true;
 
-        whitesTurn = !whitesTurn;
+        flipSideToMove();
     }
 
     private void undoGameState(int fromIndex, int toIndex, int pieceTypeBits, boolean isKingFirstMove, boolean isRookFirstMove, boolean isWhite, int doubleStepPawnIndex) {
@@ -1610,47 +1729,7 @@ public class BitBoard {
     }
 
     public long getBoardStateHash() {
-        long hash = 0;
-
-        // Iterate over all squares and XOR the hash with the piece hash values
-        for (int square = 0; square < 64; square++) {
-            PieceType pieceType = getPieceTypeAtSquare(square);
-            Color pieceColor = getPieceColorAtSquare(square);
-            if (pieceType != null && pieceColor != null) {
-                int pieceIndex = getPieceIndex(pieceType, pieceColor); // You need to implement this method
-                hash ^= ZobristTable.getPieceSquareHash(pieceIndex, square);
-            }
-        }
-
-        // Include castling rights in the hash
-        if (!whiteKingMoved) {
-            if (!whiteRookH1Moved) {
-                hash ^= ZobristTable.getCastlingRightsHash(0); // White Kingside
-            }
-            if (!whiteRookA1Moved) {
-                hash ^= ZobristTable.getCastlingRightsHash(1); // White Queenside
-            }
-        }
-        if (!blackKingMoved) {
-            if (!blackRookH8Moved) {
-                hash ^= ZobristTable.getCastlingRightsHash(2); // Black Kingside
-            }
-            if (!blackRookA8Moved) {
-                hash ^= ZobristTable.getCastlingRightsHash(3); // Black Queenside
-            }
-        }
-
-        int ep = getEnPassantTargetIndex();
-        if (ep != -1) {
-            hash ^= ZobristTable.getEnPassantSquareHash(ep);
-        }
-
-        // Include the player's turn in the hash
-        if (whitesTurn) {
-            hash ^= ZobristTable.getBlackTurnHash(); // XOR with blackTurnHash means it's white's turn
-        }
-
-        return hash;
+        return zKey;
     }
 
 }

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -8,6 +8,7 @@ import julius.game.chessengine.helper.ZobristTable;
 import julius.game.chessengine.utils.Color;
 import julius.game.chessengine.board.MoveHelper;
 
+import julius.game.chessengine.utils.Score;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -188,6 +188,8 @@ public class Engine {
         if (!gameState.isGameOver()) {
             long boardStateHashBeforeMove = getBoardStateHash();
             bitBoard.performMove(move);
+            long newHash = getBoardStateHash();
+            gameState.recordHash(newHash);
             if (openingBook.containsMoveAndBoardStateHash(boardStateHashBeforeMove, move)) {
                 isOpeningMove = true;
             }
@@ -371,11 +373,11 @@ public class Engine {
         // Save current en-passant target (0 means none in your codebase)
         int previousDoubleStep = bitBoard.getLastMoveDoubleStepPawnIndex();
 
-        // EP is not valid across a null move: clear it (no move-gen)
+        // EP is not valid across a null move: clear it
         bitBoard.setLastMoveDoubleStepPawnIndex(0);
 
-        // Flip side to move (no legalMoves recompute, no GameState updates)
-        bitBoard.whitesTurn = !bitBoard.whitesTurn;
+        // Flip side to move
+        bitBoard.flipSideToMove();
 
         // Mark move list stale so the next search ply regenerates for the new side.
         legalMovesNeedUpdate = true;
@@ -385,8 +387,8 @@ public class Engine {
 
     // Engine.java
     public void undoNullMoveForSearch(int previousDoubleStep) {
-        // Flip side back (still no move-gen / GameState work)
-        bitBoard.whitesTurn = !bitBoard.whitesTurn;
+        // Flip side back
+        bitBoard.flipSideToMove();
 
         // Restore EP target
         bitBoard.setLastMoveDoubleStepPawnIndex(previousDoubleStep);
@@ -400,18 +402,18 @@ public class Engine {
 
         Integer undoMove = line.getLast();
 
-        // 1) Undo on the board first
+        long currentHash = getBoardStateHash();
+        gameState.removeHash(currentHash);
+
+        // 1) Undo on the board
         this.bitBoard.undoMove(undoMove);
 
-        // 2) Recompute legal moves and the *new* hash
+        // 2) Recompute legal moves
         generateLegalMoves();
-        long newHash = bitBoard.getBoardStateHash();
-
-        // 3) Let GameState see the correct, post-undo position
-        gameState.undo(newHash);
+        gameState.updateState(bitBoard, legalMoves, false);
         gameState.updateScore(bitBoard, undoMove);
 
-        // 4) Bookkeeping
+        // 3) Bookkeeping
         redoLine.add(undoMove);
         line.removeLast();
         notifyPositionChanged();

--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -7,27 +7,28 @@ import julius.game.chessengine.utils.Score;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 
-import java.util.concurrent.ConcurrentHashMap;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 
 @Data
 @Log4j2
 public class GameState {
 
-    private ConcurrentHashMap<Long, Integer> repetitionCounter;
+    private Long2IntOpenHashMap repetitionCounter;
 
     private GameStateEnum state;
 
     private Score score;
 
     public GameState(BitBoard bitBoard) {
-        repetitionCounter = new ConcurrentHashMap<>();
+        repetitionCounter = new Long2IntOpenHashMap();
         state = GameStateEnum.PLAY;
         score = new Score();
         initializeScore(bitBoard);
+        recordHash(bitBoard.getBoardStateHash());
     }
 
     public GameState(GameState other) {
-        this.repetitionCounter = new ConcurrentHashMap<>(other.repetitionCounter); // Deep copy of the map
+        this.repetitionCounter = new Long2IntOpenHashMap(other.repetitionCounter); // Deep copy of the map
         this.state = other.state; // Enum, so a direct copy is fine
         this.score = new Score(other.score);
     }
@@ -62,7 +63,6 @@ public class GameState {
             else {
                 state = GameStateEnum.PLAY;
             }
-            incrementHashCount(bitBoard.getBoardStateHash());
         }
     }
 
@@ -214,36 +214,22 @@ public class GameState {
     /**
      * Threefold Repetition Logic
      */
-    private void incrementHashCount(long hash) {
-        repetitionCounter.put(hash, repetitionCounter.getOrDefault(hash, 0) + 1);
+    public void recordHash(long hash) {
+        repetitionCounter.addTo(hash, 1);
     }
 
-    private void decrementHashCount(long hash) {
-        // Check if the hash exists in the map
-        if (repetitionCounter.containsKey(hash)) {
-            int count = repetitionCounter.get(hash);
-
-            // Decrement the count
-            if (count > 1) {
-                repetitionCounter.put(hash, count - 1);
-            } else {
-                // If the count reaches zero, remove the hash from the map
-                repetitionCounter.remove(hash);
-            }
+    public void removeHash(long hash) {
+        int count = repetitionCounter.get(hash);
+        if (count <= 1) {
+            repetitionCounter.remove(hash);
+        } else {
+            repetitionCounter.put(hash, count - 1);
         }
+        state = GameStateEnum.PLAY;
     }
 
     private boolean isThreeFoldRepetition(long hash) {
-        int repCount = repetitionCounter.getOrDefault(hash, 0);
-        if (repCount > 3) {
-            throw new IllegalStateException(String.format("Repetition count can't be higher then 3, was %s", repCount));
-        }
-        return repCount == 3;
-    }
-
-    public void undo(long hash) {
-        decrementHashCount(hash);
-        state = GameStateEnum.PLAY;
+        return repetitionCounter.getOrDefault(hash, 0) >= 3;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Maintain an incremental Zobrist key on the bitboard and update it for piece moves, captures, castling, en-passant changes, and side-to-move flips.
- Track position repetitions with a lightweight Long2IntOpenHashMap and expose helpers to record/remove hashes.
- Ensure engine methods update the repetition table and Zobrist key on moves, undos, and null moves.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c570e41174832a99cb41ce00703f16