### PR TITLE
Add repetition tracking, 50-move draw, and counter-move pruning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,113 +1,116 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<!-- Align everything to a coherent Spring Boot release train -->
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
-		<relativePath/>
-	</parent>
+    <!-- Align everything to a coherent Spring Boot release train -->
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.5</version>
+        <relativePath/>
+    </parent>
 
-	<groupId>julius.game</groupId>
-	<artifactId>chess-engine</artifactId>
-	<version>3.0.7</version>
-	<name>chess-engine</name>
-	<description>ChessEngine</description>
+    <groupId>julius.game</groupId>
+    <artifactId>chess-engine</artifactId>
+    <version>3.0.8</version>
+    <name>chess-engine</name>
+    <description>ChessEngine</description>
 
-	<properties>
-		<!-- Boot uses this to set the compiler release -->
-		<java.version>21</java.version>
-	</properties>
+    <properties>
+        <!-- Boot uses this to set the compiler release -->
+        <java.version>21</java.version>
+    </properties>
 
-	<dependencies>
-		<!-- MVC + embedded Tomcat (no WebFlux, no direct spring-webmvc pinning) -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+    <dependencies>
+        <!-- MVC + embedded Tomcat (no WebFlux, no direct spring-webmvc pinning) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
 
-		<!-- Health endpoint for your readiness probe (/actuator/health) -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
+        <!-- Health endpoint for your readiness probe (/actuator/health) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
 
-		<!-- Lombok (compile-time only) -->
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.40</version>
-			<scope>provided</scope>
-		</dependency>
+        <!-- Lombok (compile-time only) -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.40</version>
+            <scope>provided</scope>
+        </dependency>
 
-		<!-- Test stack -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<!-- Spock on Groovy 4 works with Java 21 -->
-		<dependency>
-			<groupId>org.spockframework</groupId>
-			<artifactId>spock-core</artifactId>
-			<version>2.3-groovy-4.0</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.spockframework</groupId>
-			<artifactId>spock-spring</artifactId>
-			<version>2.3-groovy-4.0</version>
-			<scope>test</scope>
-		</dependency>
-                <dependency>
-                        <groupId>org.apache.groovy</groupId>
-                        <artifactId>groovy</artifactId>
-                        <version>4.0.28</version>
-                        <scope>test</scope>
-                </dependency>
-                <dependency>
-                        <groupId>it.unimi.dsi</groupId>
-                        <artifactId>fastutil</artifactId>
-                        <version>8.5.13</version>
-                </dependency>
-        </dependencies>
+        <!-- Test stack -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Spock on Groovy 4 works with Java 21 -->
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+            <version>2.3-groovy-4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-spring</artifactId>
+            <version>2.3-groovy-4.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>4.0.28</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/it.unimi.dsi/fastutil -->
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <version>8.5.16</version>
+        </dependency>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<!-- Boot manages plugin versions; this adds the repackage goal -->
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
+    <build>
+        <plugins>
+            <!-- Boot manages plugin versions; this adds the repackage goal -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
 
-			<!-- Guardrails: fail on version drift and wrong toolchains -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.6.1</version>
-				<executions>
-					<execution>
-						<id>enforce</id>
-						<goals><goal>enforce</goal></goals>
-						<configuration>
-							<fail>true</fail>
-							<rules>
-								<requireMavenVersion>
-									<version>[3.6.3,)</version>
-								</requireMavenVersion>
-								<requireJavaVersion>
-									<version>[17,)</version>
-								</requireJavaVersion>
-								<dependencyConvergence/>
-							</rules>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+            <!-- Guardrails: fail on version drift and wrong toolchains -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <fail>true</fail>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.6.3,)</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>[17,)</version>
+                                </requireJavaVersion>
+                                <dependencyConvergence/>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -891,7 +891,6 @@ public class AI {
                 double pBeta  = usePvs ? (alpha + 1) : beta;
 
                 // ---- LMR: reduce late quiets when we’re not in check at this node ----
-                boolean isTactical = MoveHelper.isCapture(move) || MoveHelper.isPawnPromotionMove(move);
                 boolean canReduce = !inCheckAtNode && !isTactical && nextDepth >= 2 && index >= 3;
 
                 if (canReduce) {

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -81,6 +81,7 @@ public class AI {
      * scores mean the move should be ordered earlier in the move list.
      */
     private final int[][] historyTable; // [from][to]
+    private final int[][] counterMove; // [prevFrom][prevTo] -> reply move
 
     // Buffers used for move ordering. Reused across calls to avoid repeated
     // allocations when ordering moves.
@@ -136,6 +137,8 @@ public class AI {
             }
         }
         this.historyTable = new int[64][64];
+        this.counterMove = new int[64][64];
+        for (int f = 0; f < 64; f++) Arrays.fill(counterMove[f], -1);
 
         // NEW: create a fixed-size pool only when useful
         this.searchPool = SEARCH_THREADS > 1
@@ -396,7 +399,7 @@ public class AI {
 
         // Order root moves once
         MoveList legal = simulatorEngine.getAllLegalMoves();
-        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(legal, depth, simulatorEngine.getBoardStateHash());
+        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(legal, depth, simulatorEngine.getBoardStateHash(), -1);
         if (orderedMoves.isEmpty()) return null;
 
         //Quick, human-friendly banner so you can grep logs and *see* parallel tasks:
@@ -423,7 +426,7 @@ public class AI {
         } else if (simulatorEngine.getGameState().isInStateDraw()) {
             firstScore = evaluateStaticPosition(simulatorEngine.getGameState(), !isWhitesTurn, depth);
         } else {
-            firstScore = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline);
+            firstScore = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, firstMove);
             if (firstScore == EXIT_FLAG || positionChanged()) {
                 simulatorEngine.undoLastMove();
                 return null;
@@ -493,7 +496,7 @@ public class AI {
                 } else if (e.getGameState().isInStateDraw()) {
                     probe = evaluateStaticPosition(e.getGameState(), !isWhitesTurn, depth);
                 } else {
-                    probe = alphaBeta(e, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline);
+            probe = alphaBeta(e, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline, moveInt);
                     if (probe == EXIT_FLAG) return null;
                 }
 
@@ -516,7 +519,7 @@ public class AI {
                             double aNow = alphaRef.get();
                             double bNow = betaRef.get();
 
-                            double full = alphaBeta(e, depth - 1, aNow, bNow, !isWhitesTurn, deadline);
+                            double full = alphaBeta(e, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt);
                             if (full != EXIT_FLAG) {
                                 finalScore = full;
                                 // Tighten bounds + update best
@@ -703,7 +706,7 @@ public class AI {
         double bestScore = isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
 
         ArrayList<Integer> sortedMoves = sortMovesByEfficiency(simulatorEngine.getAllLegalMoves(), depth,
-                simulatorEngine.getBoardStateHash());
+                simulatorEngine.getBoardStateHash(), -1);
 
         for (int moveInt : sortedMoves) {
 
@@ -721,7 +724,7 @@ public class AI {
                 // FIX: keep draw policy consistent (use same static evaluation as elsewhere)
                 score = evaluateStaticPosition(simulatorEngine.getGameState(), !isWhitesTurn, depth);
             } else {
-                score = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline);
+                score = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, moveInt);
                 // Check for time limit exceeded after alphaBeta call
                 if (score == EXIT_FLAG || positionChanged()) {
                     simulatorEngine.undoLastMove(); // Undo move using its integer representation
@@ -757,7 +760,7 @@ public class AI {
      * *
      */
 // AI.java
-    private double alphaBeta(Engine simulatorEngine, int depth, double alpha, double beta, boolean isWhite, long deadline) {
+    private double alphaBeta(Engine simulatorEngine, int depth, double alpha, double beta, boolean isWhite, long deadline, int prevMove) {
         nodesVisited++;
         // Stop if the search was cancelled, the position changed, or time ran out
         if (Thread.currentThread().isInterrupted() || positionChanged() || System.nanoTime() > deadline) {
@@ -804,7 +807,7 @@ public class AI {
         if (useNullMovePruning && depth >= 3 && !isSideInCheck(simulatorEngine, isWhite) && !simulatorEngine.isEndgame()) {
             int savedEp = simulatorEngine.doNullMoveForSearch(); // O(1) flip side + clear EP
             nullMoveCount++;
-            double nullScore = alphaBeta(simulatorEngine, depth - 1 - 2, alpha, beta, !isWhite, deadline);
+            double nullScore = alphaBeta(simulatorEngine, depth - 1 - 2, alpha, beta, !isWhite, deadline, -1);
             simulatorEngine.undoNullMoveForSearch(savedEp); // O(1) restore
 
             if (nullScore == EXIT_FLAG) { // propagate timeout
@@ -826,9 +829,9 @@ public class AI {
         MoveList moves = simulatorEngine.getAllLegalMoves();
 
         if (isWhite) {
-            return maximizer(simulatorEngine, depth, alpha, beta, isWhite, boardHash, alphaOriginal, moves, deadline);
+            return maximizer(simulatorEngine, depth, alpha, beta, isWhite, boardHash, alphaOriginal, moves, deadline, prevMove);
         } else {
-            return minimizer(simulatorEngine, depth, alpha, beta, isWhite, boardHash, betaOriginal, moves, deadline);
+            return minimizer(simulatorEngine, depth, alpha, beta, isWhite, boardHash, betaOriginal, moves, deadline, prevMove);
         }
     }
 
@@ -849,7 +852,7 @@ public class AI {
 
     private double maximizer(Engine simulatorEngine, int depth, double alpha, double beta,
                              boolean isWhite, long boardHash, double alphaOriginal,
-                             MoveList moves, long deadline) {
+                             MoveList moves, long deadline, int prevMove) {
 
         long start = log.isDebugEnabled() ? System.nanoTime() : 0L;
         double maxEval = Double.NEGATIVE_INFINITY;
@@ -857,13 +860,20 @@ public class AI {
 
         final boolean inCheckAtNode = isSideInCheck(simulatorEngine, isWhite);
 
-        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth, boardHash);
+        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove);
         for (int index = 0; index < orderedMoves.size(); index++) {
             if (Thread.currentThread().isInterrupted() || positionChanged() || System.nanoTime() > deadline) {
                 return EXIT_FLAG;
             }
 
             int move = orderedMoves.get(index);
+
+            boolean isTactical = MoveHelper.isCapture(move) || MoveHelper.isPawnPromotionMove(move);
+            int lmpThreshold = 8 + depth * 2;
+            if (!inCheckAtNode && !isTactical && depth <= 3 && index > lmpThreshold) {
+                continue;
+            }
+
             simulatorEngine.performMove(move);
             long newBoardHash = simulatorEngine.getBoardStateHash();
 
@@ -888,26 +898,26 @@ public class AI {
                     int r = lmrReduction(nextDepth, index);
                     int reduced = Math.max(1, nextDepth - r);
 
-                    eval = alphaBeta(simulatorEngine, reduced, pAlpha, pBeta, !isWhite, deadline);
+                    eval = alphaBeta(simulatorEngine, reduced, pAlpha, pBeta, !isWhite, deadline, move);
                     if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
 
                     // If the reduced result looks promising, re-search deeper (PVS/full as needed)
                     boolean promising = eval > alpha;
                     if (promising) {
                         if (usePvs && eval > alpha && eval < beta) {
-                            eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline);
+                            eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline, move);
                         } else {
-                            eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline);
+                            eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline, move);
                         }
                         if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
                     }
                 } else {
                     // Normal PVS
-                    eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline);
+                    eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline, move);
                     if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
 
                     if (usePvs && eval > alpha && eval < beta) {
-                        eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline);
+                        eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline, move);
                         if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
                     }
                 }
@@ -930,6 +940,10 @@ public class AI {
             if (beta <= alpha) {
                 updateKillerMoves(depth, move);
                 incrementHistory(move, depth);
+                if (prevMove >= 0) {
+                    int pf = prevMove & 0x3F, pt = (prevMove >>> 6) & 0x3F;
+                    counterMove[pf][pt] = move;
+                }
                 if (log.isDebugEnabled()) log.debug(" Maxi New Killer Move is {}", Move.convertIntToMove(move));
                 break;
             }
@@ -952,7 +966,7 @@ public class AI {
 
     private double minimizer(Engine simulatorEngine, int depth, double alpha, double beta,
                              boolean isWhite, long boardHash, double betaOriginal,
-                             MoveList moves, long deadline) {
+                             MoveList moves, long deadline, int prevMove) {
 
         long start = log.isDebugEnabled() ? System.nanoTime() : 0L;
         double minEval = Double.POSITIVE_INFINITY;
@@ -960,7 +974,7 @@ public class AI {
 
         final boolean inCheckAtNode = isSideInCheck(simulatorEngine, isWhite);
 
-        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth, boardHash);
+        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove);
         for (int index = 0; index < orderedMoves.size(); index++) {
             if (Thread.currentThread().isInterrupted() || positionChanged() || System.nanoTime() > deadline) {
                 return EXIT_FLAG;
@@ -989,24 +1003,24 @@ public class AI {
                     int r = lmrReduction(nextDepth, index);
                     int reduced = Math.max(1, nextDepth - r);
 
-                    eval = alphaBeta(simulatorEngine, reduced, pAlpha, pBeta, !isWhite, deadline);
+                    eval = alphaBeta(simulatorEngine, reduced, pAlpha, pBeta, !isWhite, deadline, move);
                     if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
 
                     boolean promising = eval < beta;
                     if (promising) {
                         if (usePvs && eval > alpha && eval < beta) {
-                            eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline);
+                            eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline, move);
                         } else {
-                            eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline);
+                            eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline, move);
                         }
                         if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
                     }
                 } else {
-                    eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline);
+                    eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline, move);
                     if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
 
                     if (usePvs && eval > alpha && eval < beta) {
-                        eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline);
+                        eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline, move);
                         if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
                     }
                 }
@@ -1029,6 +1043,10 @@ public class AI {
             if (alpha >= beta) {
                 updateKillerMoves(depth, move);
                 incrementHistory(move, depth);
+                if (prevMove >= 0) {
+                    int pf = prevMove & 0x3F, pt = (prevMove >>> 6) & 0x3F;
+                    counterMove[pf][pt] = move;
+                }
                 if (log.isDebugEnabled()) log.debug("Mini New Killer Move is {}", Move.convertIntToMove(move));
                 break;
             }
@@ -1050,7 +1068,7 @@ public class AI {
 
 
 
-    ArrayList<Integer> sortMovesByEfficiency(MoveList moves, int currentDepth, long boardHash) {
+    ArrayList<Integer> sortMovesByEfficiency(MoveList moves, int currentDepth, long boardHash, int prevMove) {
         final int size = moves.size();
         final int depthIndex = Math.max(0, Math.min(currentDepth, killerMoves.length - 1));
 
@@ -1073,6 +1091,11 @@ public class AI {
         // Pre-fetch killers for this depth
         final int k0 = killerMoves[depthIndex][0];
         final int k1 = killerMoves[depthIndex][1];
+
+        final int prevFrom = (prevMove >= 0) ? (prevMove & 0x3F) : -1;
+        final int prevTo   = (prevMove >= 0) ? ((prevMove >>> 6) & 0x3F) : -1;
+        final int cm = (prevFrom >= 0) ? counterMove[prevFrom][prevTo] : -1;
+        final int COUNTER_MOVE_BONUS = 400;
 
 
         final long[] sortKeys = new long[size];
@@ -1125,6 +1148,7 @@ public class AI {
                 final int to = (moveInt >>> 6) & 0x3F;
                 category = CAT_QUIET;
                 score = historyTable[from][to]; // butterfly history
+                if (moveInt == cm) score += COUNTER_MOVE_BONUS;
             }
 
             // Persist (kept for compatibility with your buffers)
@@ -1238,7 +1262,7 @@ public class AI {
         MoveList moves = inCheck ? simulatorEngine.getAllLegalMoves() : getPossibleCapturesOrPromotions(simulatorEngine);
 
         // Order them (captures first via MVV-LVA/promotion bonus, killers/history still help)
-        ArrayList<Integer> ordered = sortMovesByEfficiency(moves, 0, simulatorEngine.getBoardStateHash());
+        ArrayList<Integer> ordered = sortMovesByEfficiency(moves, 0, simulatorEngine.getBoardStateHash(), -1);
 
         for (int m : ordered) {
             // --- SEE pruning: drop clearly losing captures (keeps promotions) ---

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -194,6 +194,7 @@ public class Engine {
                 isOpeningMove = true;
             }
             generateLegalMoves();
+            gameState.pushHalfmoveClock();
             gameState.update(bitBoard, legalMoves, move, isOpeningMove);
             line.add(move);
             notifyPositionChanged();
@@ -410,6 +411,7 @@ public class Engine {
 
         // 2) Recompute legal moves
         generateLegalMoves();
+        gameState.popHalfmoveClock();
         gameState.updateState(bitBoard, legalMoves, false);
         gameState.updateScore(bitBoard, undoMove);
 

--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -1,18 +1,18 @@
 package julius.game.chessengine.engine;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.MoveList;
 import julius.game.chessengine.utils.Score;
 import lombok.Data;
+import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
 
-import it.unimi.dsi.fastutil.ints.IntArrayDeque;
-import it.unimi.dsi.fastutil.ints.IntDeque;
 
 @Data
 @Log4j2
@@ -20,12 +20,13 @@ public class GameState {
 
     private final Deque<Long> hashHistory = new ArrayDeque<>(256);
     private final HashMap<Long, Integer> repetition = new HashMap<>();
-    private final IntDeque halfmoveStack = new IntArrayDeque();
+    private final IntArrayList halfmoveStack = new IntArrayList();
 
     private GameStateEnum state;
 
     private Score score;
 
+    @Getter
     private int halfmoveClock = 0;          // resets on pawn move or capture
     private long lastZobrist = 0L;          // last committed root hash
 
@@ -260,7 +261,6 @@ public class GameState {
         return repetition.getOrDefault(lastZobrist, 0) >= 3;
     }
 
-    public int getHalfmoveClock() { return halfmoveClock; }
     public void resetHalfmoveClock() { halfmoveClock = 0; }
     public void incHalfmoveClock() { halfmoveClock++; }
     public boolean isFiftyMoveRule() { return halfmoveClock >= 100; }
@@ -270,13 +270,12 @@ public class GameState {
 
     @Override
     public String toString() {
-        String sb = "GameState {" +
+        return "GameState {" +
                 "\n  State: " + state +
                 "\n  White Score: " + score.calculateTotalWhiteScore() +
                 "\n  Black Score: " + score.calculateTotalBlackScore() +
                 "\n  Score Difference: " + score.getScoreDifference() +
                 "\n  Repetition Count: " + repetition +
                 "\n}";
-        return sb;
     }
 }

--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -7,20 +7,29 @@ import julius.game.chessengine.utils.Score;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 
-import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+
+import it.unimi.dsi.fastutil.ints.IntArrayDeque;
+import it.unimi.dsi.fastutil.ints.IntDeque;
 
 @Data
 @Log4j2
 public class GameState {
 
-    private Long2IntOpenHashMap repetitionCounter;
+    private final Deque<Long> hashHistory = new ArrayDeque<>(256);
+    private final HashMap<Long, Integer> repetition = new HashMap<>();
+    private final IntDeque halfmoveStack = new IntArrayDeque();
 
     private GameStateEnum state;
 
     private Score score;
 
+    private int halfmoveClock = 0;          // resets on pawn move or capture
+    private long lastZobrist = 0L;          // last committed root hash
+
     public GameState(BitBoard bitBoard) {
-        repetitionCounter = new Long2IntOpenHashMap();
         state = GameStateEnum.PLAY;
         score = new Score();
         initializeScore(bitBoard);
@@ -28,9 +37,13 @@ public class GameState {
     }
 
     public GameState(GameState other) {
-        this.repetitionCounter = new Long2IntOpenHashMap(other.repetitionCounter); // Deep copy of the map
         this.state = other.state; // Enum, so a direct copy is fine
         this.score = new Score(other.score);
+        this.halfmoveClock = other.halfmoveClock;
+        this.lastZobrist = other.lastZobrist;
+        this.hashHistory.addAll(other.hashHistory);
+        this.repetition.putAll(other.repetition);
+        this.halfmoveStack.addAll(other.halfmoveStack);
     }
 
 
@@ -40,6 +53,18 @@ public class GameState {
 
     public void update(BitBoard bitBoard, MoveList legalMoves, int move, boolean isOpeningMove) {
         updateState(bitBoard, legalMoves, isOpeningMove);
+
+        // 50-move clock maintenance
+        boolean isCapture = MoveHelper.isCapture(move);
+        boolean isPawnMove = (MoveHelper.derivePieceTypeBits(move) == 1);
+        if (isCapture || isPawnMove) resetHalfmoveClock();
+        else incHalfmoveClock();
+
+        // Threefold / 50-move adjudication
+        if (isThreefoldRepetition() || isFiftyMoveRule()) {
+            this.state = GameStateEnum.DRAW;
+        }
+
         updateScore(bitBoard, move);
     }
 
@@ -207,30 +232,41 @@ public class GameState {
 
     private boolean isDraw(BitBoard bitBoard, MoveList legalMoves) {
         boolean insufficientMaterial = bitBoard.hasInsufficientMaterial();
-        boolean isThreeFoldRepetition = isThreeFoldRepetition(bitBoard.getBoardStateHash());
-        return legalMoves.size() == 0 || insufficientMaterial || isThreeFoldRepetition;
+        return legalMoves.size() == 0 || insufficientMaterial;
     }
 
     /**
      * Threefold Repetition Logic
      */
-    public void recordHash(long hash) {
-        repetitionCounter.addTo(hash, 1);
+    public void recordHash(long zKey) {
+        hashHistory.addLast(zKey);
+        repetition.merge(zKey, 1, Integer::sum);
+        lastZobrist = zKey;
     }
 
-    public void removeHash(long hash) {
-        int count = repetitionCounter.get(hash);
-        if (count <= 1) {
-            repetitionCounter.remove(hash);
-        } else {
-            repetitionCounter.put(hash, count - 1);
+    public void removeHash(long zKey) {
+        // Called on undo at the current head
+        Integer c = repetition.get(zKey);
+        if (c != null) {
+            if (c <= 1) repetition.remove(zKey);
+            else repetition.put(zKey, c - 1);
         }
-        state = GameStateEnum.PLAY;
+        // We only ever remove the most recent
+        if (!hashHistory.isEmpty()) hashHistory.removeLast();
+        lastZobrist = hashHistory.isEmpty() ? 0L : hashHistory.getLast();
     }
 
-    private boolean isThreeFoldRepetition(long hash) {
-        return repetitionCounter.getOrDefault(hash, 0) >= 3;
+    public boolean isThreefoldRepetition() {
+        return repetition.getOrDefault(lastZobrist, 0) >= 3;
     }
+
+    public int getHalfmoveClock() { return halfmoveClock; }
+    public void resetHalfmoveClock() { halfmoveClock = 0; }
+    public void incHalfmoveClock() { halfmoveClock++; }
+    public boolean isFiftyMoveRule() { return halfmoveClock >= 100; }
+
+    public void pushHalfmoveClock() { halfmoveStack.addLast(halfmoveClock); }
+    public void popHalfmoveClock()  { if (!halfmoveStack.isEmpty()) halfmoveClock = halfmoveStack.removeLast(); }
 
     @Override
     public String toString() {
@@ -239,7 +275,7 @@ public class GameState {
                 "\n  White Score: " + score.calculateTotalWhiteScore() +
                 "\n  Black Score: " + score.calculateTotalBlackScore() +
                 "\n  Score Difference: " + score.getScoreDifference() +
-                "\n  Repetition Count: " + repetitionCounter +
+                "\n  Repetition Count: " + repetition +
                 "\n}";
         return sb;
     }


### PR DESCRIPTION
## Summary
- track hash history and half-move clock to detect threefold repetition and fifty-move draws
- maintain half-move clock across moves and undos
- integrate counter-move heuristic and late-move pruning into search ordering

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c57b1eb840832aa440a7ec1d22118b