### PR TITLE
Add UCI protocol integration and options tests

### DIFF
--- a/src/test/java/julius/game/chessengine/uci/UciOptionsTest.java
+++ b/src/test/java/julius/game/chessengine/uci/UciOptionsTest.java
@@ -1,0 +1,54 @@
+package julius.game.chessengine.uci;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for UCI option handling.
+ */
+public class UciOptionsTest {
+
+    @Test
+    void testSetOptionsAffectEngine() throws Exception {
+        UciHandler handler = new UciHandler();
+
+        // send option commands
+        assertTrue(handler.handle("setoption name Threads value 2"));
+        assertTrue(handler.handle("setoption name Hash value 32"));
+        assertTrue(handler.handle("setoption name Move Overhead value 150"));
+
+        // access AI via reflection
+        Field aiField = UciHandler.class.getDeclaredField("ai");
+        aiField.setAccessible(true);
+        Object aiObj = aiField.get(handler);
+        Class<?> aiClass = aiObj.getClass();
+
+        Field searchThreadsField = aiClass.getDeclaredField("searchThreads");
+        searchThreadsField.setAccessible(true);
+        assertEquals(2, searchThreadsField.getInt(aiObj));
+
+        Field hashField = aiClass.getDeclaredField("hashSizeMb");
+        hashField.setAccessible(true);
+        assertEquals(32, hashField.getInt(aiObj));
+
+        Field overheadField = UciHandler.class.getDeclaredField("moveOverheadMs");
+        overheadField.setAccessible(true);
+        assertEquals(150, overheadField.getInt(handler));
+
+        // ensure engine still answers readyok
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        try {
+            System.setOut(new PrintStream(out, true));
+            handler.handle("isready");
+        } finally {
+            System.setOut(originalOut);
+        }
+        assertTrue(out.toString().contains("readyok"));
+    }
+}

--- a/src/test/java/julius/game/chessengine/uci/UciProtocolTest.java
+++ b/src/test/java/julius/game/chessengine/uci/UciProtocolTest.java
@@ -1,0 +1,62 @@
+package julius.game.chessengine.uci;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration style tests verifying basic UCI command exchanges over
+ * standard input/output.
+ */
+public class UciProtocolTest {
+
+    @Test
+    void testUciIsreadyPositionGoQuit() throws Exception {
+        String commands = String.join("\n",
+                "uci",
+                "isready",
+                "position startpos",
+                "go movetime 200",
+                "isready",
+                "quit") + "\n";
+
+        InputStream originalIn = System.in;
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            System.setIn(new ByteArrayInputStream(commands.getBytes(StandardCharsets.UTF_8)));
+            System.setOut(new PrintStream(out, true));
+
+            UciMain.main(new String[0]);
+
+            // wait until bestmove is printed or timeout after ~2s
+            for (int i = 0; i < 40; i++) {
+                if (out.toString().contains("bestmove")) {
+                    break;
+                }
+                Thread.sleep(50);
+            }
+        } finally {
+            System.setIn(originalIn);
+            System.setOut(originalOut);
+        }
+
+        String output = out.toString();
+        assertTrue(output.contains("id name JuliusChessEngine"), output);
+        assertTrue(output.contains("uciok"), output);
+        assertTrue(output.contains("readyok"), output);
+        assertTrue(output.contains("bestmove"), output);
+    }
+
+    @Test
+    void testQuitReturnsFalse() {
+        UciHandler handler = new UciHandler();
+        assertFalse(handler.handle("quit"));
+    }
+}


### PR DESCRIPTION
## Summary
- add integration test simulating UCI stdin/stdout exchanges and verifying bestmove/readyok handling
- add regression test for setoption commands updating engine configuration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ee638874832ab6ad56b7949b8b2e