### PR TITLE
Package UCI engine as executable jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Chess Engine
+
+This project builds a UCI-compatible chess engine. The build now produces an
+executable JAR that bundles all dependencies and specifies
+`julius.game.chessengine.uci.UciMain` as the manifest `Main-Class`.
+
+## Building
+
+```bash
+./mvnw package
+```
+
+The command above creates
+`target/chess-engine-<version>-uci.jar`.
+
+## Running
+
+Launch the engine without adding anything to the classpath:
+
+```bash
+java -jar target/chess-engine-<version>-uci.jar
+```
+
+The process listens on standard input and speaks the UCI protocol on standard
+output.
+

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,17 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>uci</classifier>
+                            <mainClass>julius.game.chessengine.uci.UciMain</mainClass>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <!-- Guardrails: fail on version drift and wrong toolchains -->


### PR DESCRIPTION
## Summary
- Configure Spring Boot repackage goal with a `uci` classifier and `julius.game.chessengine.uci.UciMain` main class
- Document how to build and run the new UCI executable jar

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central: Network is unreachable)*
- `java -jar target/chess-engine-3.0.9-uci.jar` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f6452028832a8b1f0a219c1d889f