### PR TITLE
Parse movestogo UCI token and refine time management

### DIFF
--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -211,6 +211,7 @@ public class UciHandler {
 
         long wtime = 0, btime = 0, winc = 0, binc = 0, movetime = 0;
         int depth = 0;
+        int movestogo = 0;
         for (int i = 1; i < tokens.length; i++) {
             switch (tokens[i]) {
                 case "wtime" -> wtime = Long.parseLong(tokens[++i]);
@@ -219,6 +220,7 @@ public class UciHandler {
                 case "binc" -> binc = Long.parseLong(tokens[++i]);
                 case "movetime" -> movetime = Long.parseLong(tokens[++i]);
                 case "depth" -> depth = Integer.parseInt(tokens[++i]);
+                case "movestogo" -> movestogo = Integer.parseInt(tokens[++i]);
                 default -> { /* ignore */ }
             }
         }
@@ -227,22 +229,13 @@ public class UciHandler {
             ai.setMaxDepth(depth);
         }
 
-        long limit = movetime;
-        if (limit == 0) {
-            if (engine.whitesTurn()) {
-                limit = wtime;
-                if (winc > 0) limit += winc;
-            } else {
-                limit = btime;
-                if (binc > 0) limit += binc;
-            }
-        }
-        if (limit <= 0) {
-            limit = 1000; // default 1 second
-        }
-        if (limit > moveOverheadMs) {
-            limit -= moveOverheadMs;
-        }
+        boolean whitesTurn = engine.whitesTurn();
+        long timeLeft = whitesTurn ? wtime : btime;
+        long inc = whitesTurn ? winc : binc;
+        long movesToGo = (movestogo > 0 ? movestogo : 30);
+        long limit = (movetime > 0 ? movetime :
+                (timeLeft / movesToGo) + inc - moveOverheadMs);
+        limit = Math.max(limit, 1);
         ai.setTimeLimit(limit);
 
         searchThread = new Thread(() -> {


### PR DESCRIPTION
## Summary
- Parse optional `movestogo` in `go` command
- Rework time allocation to use remaining moves and increments with move-overhead adjustment

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f9fd9a20832a8550e022023b8e39