### PR TITLE
Handle checkmate vs draw correctly in GameState

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -233,7 +233,9 @@ public class GameState {
 
     private boolean isDraw(BitBoard bitBoard, MoveList legalMoves) {
         boolean insufficientMaterial = bitBoard.hasInsufficientMaterial();
-        return legalMoves.size() == 0 || insufficientMaterial;
+        boolean noLegalMoves = legalMoves.size() == 0;
+        boolean inCheck = bitBoard.isInCheck(bitBoard.isWhitesTurn());
+        return (noLegalMoves && !inCheck) || insufficientMaterial;
     }
 
     /**

--- a/src/test/java/julius/game/chessengine/engine/GameStateCheckmateTest.java
+++ b/src/test/java/julius/game/chessengine/engine/GameStateCheckmateTest.java
@@ -1,0 +1,33 @@
+package julius.game.chessengine.engine;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.board.MoveList;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GameStateCheckmateTest {
+
+    @Test
+    void blackCheckmatedSetsWhiteWon() {
+        BitBoard board = FEN.translateFENtoBitBoard("7k/6Q1/6K1/8/8/8/8/8 b - - 0 1");
+        MoveList legalMoves = board.generateAllPossibleMoves(board.isWhitesTurn());
+        GameState gameState = new GameState(board);
+        gameState.updateState(board, legalMoves, false);
+        assertEquals(0, legalMoves.size());
+        assertEquals(GameStateEnum.WHITE_WON, gameState.getState());
+        assertNotEquals(GameStateEnum.DRAW, gameState.getState());
+    }
+
+    @Test
+    void whiteCheckmatedSetsBlackWon() {
+        BitBoard board = FEN.translateFENtoBitBoard("8/8/8/8/8/6k1/6q1/7K w - - 0 1");
+        MoveList legalMoves = board.generateAllPossibleMoves(board.isWhitesTurn());
+        GameState gameState = new GameState(board);
+        gameState.updateState(board, legalMoves, false);
+        assertEquals(0, legalMoves.size());
+        assertEquals(GameStateEnum.BLACK_WON, gameState.getState());
+        assertNotEquals(GameStateEnum.DRAW, gameState.getState());
+    }
+}


### PR DESCRIPTION
## Summary
- Prevent draw when side to move is in check by ensuring `isDraw` only returns true for stalemates or insufficient material
- Add unit tests verifying that checkmated positions set `WHITE_WON` or `BLACK_WON` instead of `DRAW`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c720a3d228832aa39767c89eac0f4f