### PR TITLE
feat: implement clock-aware time management

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -117,8 +117,19 @@ public class AI {
     private int maxDepth = 18; // Adjust the level of depth according to your requirements
 
     @Getter
-    @Setter
     private long timeLimit; // milliseconds
+
+    // Remaining clock times (milliseconds)
+    private long whiteTimeMs;
+    private long blackTimeMs;
+    private long whiteIncrementMs;
+    private long blackIncrementMs;
+
+    // Optional explicit override for the search time of the next move
+    private long explicitTimeLimit = 50; // default used for REST/autoplay
+
+    // Additional buffer to account for UI/communication delay
+    private long moveOverheadMs = 0;
 
     private boolean useNullMovePruning = Boolean.parseBoolean(
             System.getProperty("chessengine.nullMove", "true")
@@ -133,6 +144,10 @@ public class AI {
     public AI(Engine mainEngine) {
         this.mainEngine = mainEngine;
         this.timeLimit = 50;
+        this.whiteTimeMs = 0L;
+        this.blackTimeMs = 0L;
+        this.whiteIncrementMs = 0L;
+        this.blackIncrementMs = 0L;
 
         // Initialize killer moves etc...
         this.killerMoves = new int[maxDepth][numKillerMoves];
@@ -173,6 +188,69 @@ public class AI {
         this.maxDepth = Math.max(1, Math.min(depth, killerMoves.length));
     }
 
+    /**
+     * Set an explicit search time for the next move. Used by REST and when a
+     * "movetime" is supplied via UCI. Passing a value here overrides any
+     * time-management heuristics until {@link #clearTimeLimitOverride()} is
+     * called.
+     */
+    public void setTimeLimit(long millis) {
+        this.explicitTimeLimit = millis;
+        this.timeLimit = millis;
+    }
+
+    /**
+     * Remove any previously set explicit search time so the engine will compute
+     * a time budget from the remaining clocks instead.
+     */
+    public void clearTimeLimitOverride() {
+        this.explicitTimeLimit = -1;
+    }
+
+    /**
+     * Update internal clock information (all values in milliseconds).
+     */
+    public void setClock(long wtime, long btime, long winc, long binc) {
+        this.whiteTimeMs = wtime;
+        this.blackTimeMs = btime;
+        this.whiteIncrementMs = winc;
+        this.blackIncrementMs = binc;
+    }
+
+    public void setMoveOverhead(long overheadMs) {
+        this.moveOverheadMs = overheadMs;
+    }
+
+    /**
+     * Compute the search time for the current move. If an explicit time limit
+     * has been set it is used directly; otherwise we allocate time based on the
+     * remaining clock and a crude game phase heuristic.
+     */
+    private void updateTimeLimit() {
+        if (explicitTimeLimit > 0) {
+            this.timeLimit = explicitTimeLimit;
+            return;
+        }
+
+        boolean whitesTurn = mainEngine.whitesTurn();
+        long remaining = whitesTurn ? whiteTimeMs : blackTimeMs;
+        remaining = Math.max(0, remaining - moveOverheadMs);
+        long inc = whitesTurn ? whiteIncrementMs : blackIncrementMs;
+
+        int moveNumber = mainEngine.getLine().size() / 2 + 1;
+        int movesToGo;
+        if (moveNumber <= 20) {
+            movesToGo = 30; // opening
+        } else if (moveNumber <= 40) {
+            movesToGo = 20; // middlegame
+        } else {
+            movesToGo = 10; // endgame
+        }
+
+        long limit = remaining / Math.max(1, movesToGo) + inc;
+        this.timeLimit = Math.max(1L, limit);
+    }
+
 
     public Integer getCurrentBestMoveInt() {
         return currentBestMove;
@@ -193,6 +271,9 @@ public class AI {
         calculatedLine = Collections.synchronizedList(new ArrayList<>());
         mainEngine.startNewGame();
         clearHistoryTable();
+        explicitTimeLimit = 50;
+        timeLimit = 50;
+        whiteTimeMs = blackTimeMs = whiteIncrementMs = blackIncrementMs = 0L;
     }
 
     public void stopCalculation() {
@@ -288,6 +369,7 @@ public class AI {
         log.debug(" --- TranspositionTable[{}] --- ", transpositionTable.size());
         decayHistoryTable();
         try {
+            updateTimeLimit();
             Engine simulatorEngine = mainEngine.createSimulation();
             long boardStateHash = simulatorEngine.getBoardStateHash();
             log.debug("boardStateBeforeCalculation {}, currentBoardState {}", beforeCalculationBoardState, currentBoardState);

--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -211,7 +211,6 @@ public class UciHandler {
 
         long wtime = 0, btime = 0, winc = 0, binc = 0, movetime = 0;
         int depth = 0;
-        int movestogo = 0;
         for (int i = 1; i < tokens.length; i++) {
             switch (tokens[i]) {
                 case "wtime" -> wtime = Long.parseLong(tokens[++i]);
@@ -220,7 +219,6 @@ public class UciHandler {
                 case "binc" -> binc = Long.parseLong(tokens[++i]);
                 case "movetime" -> movetime = Long.parseLong(tokens[++i]);
                 case "depth" -> depth = Integer.parseInt(tokens[++i]);
-                case "movestogo" -> movestogo = Integer.parseInt(tokens[++i]);
                 default -> { /* ignore */ }
             }
         }
@@ -229,14 +227,13 @@ public class UciHandler {
             ai.setMaxDepth(depth);
         }
 
-        boolean whitesTurn = engine.whitesTurn();
-        long timeLeft = whitesTurn ? wtime : btime;
-        long inc = whitesTurn ? winc : binc;
-        long movesToGo = (movestogo > 0 ? movestogo : 30);
-        long limit = (movetime > 0 ? movetime :
-                (timeLeft / movesToGo) + inc - moveOverheadMs);
-        limit = Math.max(limit, 1);
-        ai.setTimeLimit(limit);
+        ai.setClock(wtime, btime, winc, binc);
+        ai.setMoveOverhead(moveOverheadMs);
+        if (movetime > 0) {
+            ai.setTimeLimit(movetime);
+        } else {
+            ai.clearTimeLimitOverride();
+        }
 
         searchThread = new Thread(() -> {
             ai.startAutoPlay(false, false); // start calculation without auto-move

--- a/src/main/resources/py/lichess_bot.py
+++ b/src/main/resources/py/lichess_bot.py
@@ -227,7 +227,7 @@ def is_my_turn(board: chess.Board, my_color_is_white: bool) -> bool:
     return (board.turn is chess.WHITE) == my_color_is_white
 
 
-def calc_move_time(state: dict, my_color_is_white: bool) -> float:
+def calc_move_time(state: dict, board: chess.Board, my_color_is_white: bool) -> float:
     key_time = "wtime" if my_color_is_white else "btime"
     key_inc = "winc" if my_color_is_white else "binc"
     time_ms = state.get(key_time)
@@ -246,7 +246,15 @@ def calc_move_time(state: dict, my_color_is_white: bool) -> float:
     else:
         increment = float(inc_ms) / 1000.0 if inc_ms else 0.0
 
-    think = remaining / 100.0 + 0.8 * increment
+    move_no = board.fullmove_number
+    if move_no <= 20:
+        divisor = 30.0
+    elif move_no <= 40:
+        divisor = 20.0
+    else:
+        divisor = 10.0
+
+    think = remaining / divisor + 0.8 * increment
     return max(MOVE_TIME, min(think, max(0.2, remaining - 0.1)))
 
 
@@ -320,8 +328,19 @@ def play_game(client: berserk.Client, engine: chess.engine.SimpleEngine, game_id
                     board.push_uci(mv)
 
             if is_my_turn(board, my_color_is_white) and not board.is_game_over():
-                think_time = calc_move_time(state, my_color_is_white)
-                result = engine.play(board, chess.engine.Limit(time=think_time), ponder=True)
+                think_time = calc_move_time(state, board, my_color_is_white)
+                wtime = state.get("wtime")
+                btime = state.get("btime")
+                winc = state.get("winc", 0)
+                binc = state.get("binc", 0)
+                limit = chess.engine.Limit(
+                    time=think_time,
+                    white_clock=float(wtime) / 1000.0 if wtime is not None else None,
+                    black_clock=float(btime) / 1000.0 if btime is not None else None,
+                    white_inc=float(winc) / 1000.0 if winc else 0.0,
+                    black_inc=float(binc) / 1000.0 if binc else 0.0,
+                )
+                result = engine.play(board, limit, ponder=True)
                 ponder_move = result.ponder
                 safe_make_move(client, game_id, result.move.uci())
 
@@ -355,8 +374,19 @@ def play_game(client: berserk.Client, engine: chess.engine.SimpleEngine, game_id
                         pass
                     ponder_move = None
 
-                think_time = calc_move_time(state, my_color_is_white)
-                result = engine.play(board, chess.engine.Limit(time=think_time), ponder=True)
+                think_time = calc_move_time(state, board, my_color_is_white)
+                wtime = state.get("wtime")
+                btime = state.get("btime")
+                winc = state.get("winc", 0)
+                binc = state.get("binc", 0)
+                limit = chess.engine.Limit(
+                    time=think_time,
+                    white_clock=float(wtime) / 1000.0 if wtime is not None else None,
+                    black_clock=float(btime) / 1000.0 if btime is not None else None,
+                    white_inc=float(winc) / 1000.0 if winc else 0.0,
+                    black_inc=float(binc) / 1000.0 if binc else 0.0,
+                )
+                result = engine.play(board, limit, ponder=True)
                 ponder_move = result.ponder
                 safe_make_move(client, game_id, result.move.uci())
 


### PR DESCRIPTION
## Summary
- expose remaining clock time to AI and compute per-move limits based on game phase
- forward clock data via UCI handler and Lichess bot
- let bot send clock and increment info with each move

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c721b6dc70832a84c5dc5f7001cb9e