### PR TITLE
Add best move tests for select FEN positions

### DIFF
--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -1,0 +1,75 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.board.Move;
+import julius.game.chessengine.engine.Engine;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+/**
+ * Verifies that the AI selects the expected best move from a set of FEN
+ * positions within a small time budget. Similar in spirit to
+ * {@link MateSearchTest} but checks the single move chosen by the engine
+ * instead of the game result.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class BestMoveSearchTest {
+
+    /**
+     * Test matrix: (fen, expected moves in algebraic notation). Some positions
+     * have multiple acceptable best moves, so we keep a list.
+     */
+    private Stream<Object[]> fenMatrix() {
+        return Stream.of(
+                new Object[]{
+                        "r1b1kbnr/ppp1p1pp/3q4/2N2p2/1n1pP3/5N2/P1PP1PPP/R1BQKB1R w KQkq - 0 7",
+                        List.of("c3")
+                },
+                new Object[]{
+                        "4k3/1bp1bp1p/p3p3/1r1qN3/3P1p1r/2B5/PPP2PP1/R3RQK1 w - - 0 19",
+                        List.of("a3", "f3")
+                },
+                new Object[]{
+                        "r1bqkb1r/pppppppp/2n2n2/1P6/8/8/PBPPPPPP/RN1QKBNR b KQkq - 0 3",
+                        List.of("Na5")
+                },
+                new Object[]{
+                        "r1b2rk1/ppp2p2/2n2n2/P6p/2P1P1p1/4P1K1/1B1N4/R5NR b - - 1 20",
+                        List.of("Ne8", "Nh7")
+                }
+        );
+    }
+
+    @ParameterizedTest(name = "Best move {1} for FEN {0}")
+    @MethodSource("fenMatrix")
+    void testBestMove(String fen, List<String> expectedMoves) throws InterruptedException {
+        Engine engine = new Engine();
+        engine.importBoardFromFen(fen);
+
+        AI ai = new AI(engine);
+        ai.setTimeLimit(1000L); // milliseconds
+
+        boolean whiteToMove = fen.split(" ")[1].equals("w");
+        ai.startAutoPlay(whiteToMove, !whiteToMove);
+
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(5);
+        int lastMove = -1;
+        while (System.currentTimeMillis() < deadline) {
+            lastMove = engine.getLastMove();
+            if (lastMove != -1) break;
+            TimeUnit.MILLISECONDS.sleep(50);
+        }
+
+        ai.stopCalculation();
+
+        Assertions.assertNotEquals(-1, lastMove, "Engine failed to make a move for FEN: " + fen);
+        String moveString = Move.convertIntToMove(lastMove).toString();
+        Assertions.assertTrue(expectedMoves.contains(moveString),
+                "Expected one of " + expectedMoves + " but got " + moveString + " for FEN: " + fen);
+    }
+}


### PR DESCRIPTION
## Summary
- add BestMoveSearchTest verifying the AI picks expected moves from four FEN positions

## Testing
- `mvn -q -o test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b6c41798832a96135982d87cfe20