### PR TITLE
Stop double bestmove output

### DIFF
--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -244,8 +244,7 @@ public class UciHandler {
                 while (!Thread.currentThread().isInterrupted()) {
                     Integer bm = ai.getCurrentBestMoveInt();
                     if (bm != null && bm != -1) {
-                        System.out.println("bestmove " + toUci(bm));
-                        return;
+                        break;
                     }
                     Thread.sleep(50);
                 }


### PR DESCRIPTION
## Summary
- prevent UCI handler from printing best move twice by breaking search loop and relying on finally block to emit move

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7db6e5160832a8b8fc06c2620fb53