### PR TITLE
Stop ongoing search on isready

### DIFF
--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -40,7 +40,10 @@ public class UciHandler {
         String cmd = tokens[0];
         switch (cmd) {
             case "uci" -> sendId();
-            case "isready" -> System.out.println("readyok");
+            case "isready" -> {
+                stop();
+                System.out.println("readyok");
+            }
             case "ucinewgame" -> newGame();
             case "position" -> setPosition(tokens);
             case "go" -> go(tokens);

--- a/src/test/java/julius/game/chessengine/uci/UciProtocolTest.java
+++ b/src/test/java/julius/game/chessengine/uci/UciProtocolTest.java
@@ -59,4 +59,33 @@ public class UciProtocolTest {
         UciHandler handler = new UciHandler();
         assertFalse(handler.handle("quit"));
     }
+
+    @Test
+    void testIsreadyStopsOngoingSearch() throws Exception {
+        String commands = String.join("\n",
+                "uci",
+                "position startpos",
+                "go movetime 1000",
+                "isready",
+                "quit") + "\n";
+
+        InputStream originalIn = System.in;
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            System.setIn(new ByteArrayInputStream(commands.getBytes(StandardCharsets.UTF_8)));
+            System.setOut(new PrintStream(out, true));
+
+            UciMain.main(new String[0]);
+        } finally {
+            System.setIn(originalIn);
+            System.setOut(originalOut);
+        }
+
+        String output = out.toString();
+        long bestmoveCount = output.lines().filter(l -> l.startsWith("bestmove")).count();
+        assertEquals(1, bestmoveCount, output);
+        assertTrue(output.contains("readyok"), output);
+        assertTrue(output.indexOf("bestmove") < output.indexOf("readyok"), output);
+    }
 }


### PR DESCRIPTION
## Summary
- Stop the current search thread when `isready` is received and only then reply `readyok`
- Add regression test ensuring `isready` waits for the search to finish and prints exactly one `bestmove`

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d74294e4832a9f46ab27989b4362