### PR TITLE
Limit castling penalties to exposed kings

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -358,10 +358,10 @@ public class Score {
         updateQueensPositionBonusWhite(whiteQueens, phase);
         updateQueensPositionBonusBlack(blackQueens, phase);
 
-        updateWhiteKingsPositionBonus(whiteKing, bitBoard.isWhiteKingHasCastled(), bitBoard.isWhiteKingMoved(),
-                bitBoard.isWhiteRookA1Moved(), bitBoard.isWhiteRookH1Moved(), phase);
-        updateBlackKingsPositionBonus(blackKing, bitBoard.isBlackKingHasCastled(), bitBoard.isBlackKingMoved(),
-                bitBoard.isBlackRookA8Moved(), bitBoard.isBlackRookH8Moved(), phase);
+        updateWhiteKingsPositionBonus(whiteKing, whitePawns, blackPawns, bitBoard.isWhiteKingHasCastled(),
+                bitBoard.isWhiteKingMoved(), bitBoard.isWhiteRookA1Moved(), bitBoard.isWhiteRookH1Moved(), phase);
+        updateBlackKingsPositionBonus(blackKing, blackPawns, whitePawns, bitBoard.isBlackKingHasCastled(),
+                bitBoard.isBlackKingMoved(), bitBoard.isBlackRookA8Moved(), bitBoard.isBlackRookH8Moved(), phase);
 
         updateStartingSquarePenaltyWhite(whiteKnights, whiteBishops, whiteRooks);
         updateStartingSquarePenaltyBlack(blackKnights, blackBishops, blackRooks);
@@ -725,13 +725,42 @@ public class Score {
         blackQueensPosition = applyPositionalValues(blackQueens, QUEEN_MIDGAME_POSITIONAL_VALUES, QUEEN_ENDGAME_POSITIONAL_VALUES, phase);
     }
 
-    public void updateWhiteKingsPositionBonus(long whiteKing, boolean isCastled, boolean isWhiteKingMoved, boolean rookA1Moved, boolean rookH1Moved, int phase) {
-        whiteKingsPosition = applyPositionalValues(whiteKing, WHITE_KING_POSITIONAL_VALUES, KING_ENDGAME_POSITIONAL_VALUES, phase);
+    public void updateWhiteKingsPositionBonus(long whiteKing, long whitePawns, long blackPawns,
+                                              boolean isCastled, boolean isWhiteKingMoved,
+                                              boolean rookA1Moved, boolean rookH1Moved, int phase) {
+        whiteKingsPosition = applyPositionalValues(whiteKing, WHITE_KING_POSITIONAL_VALUES,
+                KING_ENDGAME_POSITIONAL_VALUES, phase);
+
         int castlingBonus = CASTLING_BONUS * (256 - phase) / 256;
         int rookMovePenalty = NOT_CASTLED_AND_ROOK_MOVE_PENALTY * (256 - phase) / 256;
+
+        int materialBalance = (whitePawnsAmountScore + whiteKnightsAmountScore + whiteBishopsAmountScore
+                + whiteRooksAmountScore + whiteQueensAmountScore)
+                - (blackPawnsAmountScore + blackKnightsAmountScore + blackBishopsAmountScore
+                + blackRooksAmountScore + blackQueensAmountScore);
+        if (materialBalance < 0) {
+            rookMovePenalty /= 2;
+        }
+
+        boolean applyPenalty = false;
+        if (!isCastled) {
+            int kingIndex = Long.numberOfTrailingZeros(whiteKing);
+            long forwardMask = (whiteKing << 8);
+            if ((whiteKing & NOT_A_FILE) != 0) forwardMask |= (whiteKing << 7);
+            if ((whiteKing & NOT_H_FILE) != 0) forwardMask |= (whiteKing << 9);
+
+            boolean missingShield = Long.bitCount(whitePawns & forwardMask) < 3;
+
+            int fileIndex = kingIndex % 8;
+            long fileMask = FileMasks[fileIndex];
+            boolean openOrHalfOpen = (whitePawns & fileMask) == 0;
+
+            applyPenalty = missingShield || openOrHalfOpen;
+        }
+
         if (isCastled) {
             whiteKingsPosition += castlingBonus;
-        } else {
+        } else if (applyPenalty) {
             if (rookA1Moved) {
                 whiteKingsPosition += rookMovePenalty;
             }
@@ -744,13 +773,42 @@ public class Score {
         }
     }
 
-    public void updateBlackKingsPositionBonus(long blackKing, boolean isCastled, boolean isBlackKingMoved, boolean rookA8Moved, boolean rookH8Moved, int phase) {
-        blackKingsPosition = applyPositionalValues(blackKing, BLACK_KING_POSITIONAL_VALUES, KING_ENDGAME_POSITIONAL_VALUES, phase);
+    public void updateBlackKingsPositionBonus(long blackKing, long blackPawns, long whitePawns,
+                                              boolean isCastled, boolean isBlackKingMoved,
+                                              boolean rookA8Moved, boolean rookH8Moved, int phase) {
+        blackKingsPosition = applyPositionalValues(blackKing, BLACK_KING_POSITIONAL_VALUES,
+                KING_ENDGAME_POSITIONAL_VALUES, phase);
+
         int castlingBonus = CASTLING_BONUS * (256 - phase) / 256;
         int rookMovePenalty = NOT_CASTLED_AND_ROOK_MOVE_PENALTY * (256 - phase) / 256;
+
+        int materialBalance = (whitePawnsAmountScore + whiteKnightsAmountScore + whiteBishopsAmountScore
+                + whiteRooksAmountScore + whiteQueensAmountScore)
+                - (blackPawnsAmountScore + blackKnightsAmountScore + blackBishopsAmountScore
+                + blackRooksAmountScore + blackQueensAmountScore);
+        if (materialBalance > 0) {
+            rookMovePenalty /= 2;
+        }
+
+        boolean applyPenalty = false;
+        if (!isCastled) {
+            int kingIndex = Long.numberOfTrailingZeros(blackKing);
+            long forwardMask = (blackKing >>> 8);
+            if ((blackKing & NOT_A_FILE) != 0) forwardMask |= (blackKing >>> 9);
+            if ((blackKing & NOT_H_FILE) != 0) forwardMask |= (blackKing >>> 7);
+
+            boolean missingShield = Long.bitCount(blackPawns & forwardMask) < 3;
+
+            int fileIndex = kingIndex % 8;
+            long fileMask = FileMasks[fileIndex];
+            boolean openOrHalfOpen = (blackPawns & fileMask) == 0;
+
+            applyPenalty = missingShield || openOrHalfOpen;
+        }
+
         if (isCastled) {
             blackKingsPosition += castlingBonus;
-        } else {
+        } else if (applyPenalty) {
             if (rookA8Moved) {
                 blackKingsPosition += rookMovePenalty;
             }
@@ -1148,7 +1206,7 @@ public class Score {
         updateRookOpenFileBonusWhite(whiteRooks, whitePawns | blackPawns);
 
         updateStartingSquarePenaltyWhite(whiteKnights, whiteBishops, whiteRooks);
-        updateKingValuesWhite(whiteKing, isCastled, isWhiteKingHasMoved, rookA1Moved, rookH1Moved, phase);
+        updateKingValuesWhite(whiteKing, whitePawns, blackPawns, isCastled, isWhiteKingHasMoved, rookA1Moved, rookH1Moved, phase);
     }
 
     public void updateBlackRookValues(BitBoard bitBoard) {
@@ -1174,7 +1232,7 @@ public class Score {
         updateRookOpenFileBonusBlack(blackRooks, whitePawns | blackPawns);
 
         updateStartingSquarePenaltyBlack(blackKnights, blackBishops, blackRooks);
-        updateKingValuesBlack(blackKing, isCastled, isBlackKingMoved, rookA8Moved, rookH8Moved, phase);
+        updateKingValuesBlack(blackKing, blackPawns, whitePawns, isCastled, isBlackKingMoved, rookA8Moved, rookH8Moved, phase);
     }
 
     public void updateWhiteQueenValues(BitBoard bitBoard) {
@@ -1234,8 +1292,9 @@ public class Score {
             case 3 -> updateWhiteBishopValues(bitBoard);
             case 4 -> updateWhiteRookValues(bitBoard);
             case 5 -> updateWhiteQueenValues(bitBoard);
-            case 6 -> updateKingValuesWhite(bitBoard.getWhiteKing(), bitBoard.isWhiteKingHasCastled(),
-                    bitBoard.isWhiteKingMoved(), bitBoard.isWhiteRookA1Moved(), bitBoard.isWhiteRookH1Moved(), phase);
+            case 6 -> updateKingValuesWhite(bitBoard.getWhiteKing(), bitBoard.getWhitePawns(),
+                    bitBoard.getBlackPawns(), bitBoard.isWhiteKingHasCastled(), bitBoard.isWhiteKingMoved(),
+                    bitBoard.isWhiteRookA1Moved(), bitBoard.isWhiteRookH1Moved(), phase);
             default -> {
             }
         }
@@ -1249,8 +1308,9 @@ public class Score {
             case 3 -> updateBlackBishopValues(bitBoard);
             case 4 -> updateBlackRookValues(bitBoard);
             case 5 -> updateBlackQueenValues(bitBoard);
-            case 6 -> updateKingValuesBlack(bitBoard.getBlackKing(), bitBoard.isBlackKingHasCastled(),
-                    bitBoard.isBlackKingMoved(), bitBoard.isBlackRookA8Moved(), bitBoard.isBlackRookH8Moved(), phase);
+            case 6 -> updateKingValuesBlack(bitBoard.getBlackKing(), bitBoard.getBlackPawns(),
+                    bitBoard.getWhitePawns(), bitBoard.isBlackKingHasCastled(), bitBoard.isBlackKingMoved(),
+                    bitBoard.isBlackRookA8Moved(), bitBoard.isBlackRookH8Moved(), phase);
             default -> {
             }
         }
@@ -1272,12 +1332,26 @@ public class Score {
         }
     }
 
-    public void updateKingValuesWhite(long whiteKing, boolean isCastled, boolean isWhiteKingMoved, boolean rookA1Moved, boolean rookH1Moved, int phase) {
-        updateWhiteKingsPositionBonus(whiteKing, isCastled, isWhiteKingMoved, rookA1Moved, rookH1Moved, phase);
+    public void updateKingValuesWhite(long whiteKing, long whitePawns, long blackPawns,
+                                     boolean isCastled, boolean isWhiteKingMoved,
+                                     boolean rookA1Moved, boolean rookH1Moved, int phase) {
+        updateWhiteKingsPositionBonus(whiteKing, whitePawns, blackPawns, isCastled,
+                isWhiteKingMoved, rookA1Moved, rookH1Moved, phase);
     }
 
-    public void updateKingValuesBlack(long blackKing, boolean isCastled, boolean isBlackKingMoved, boolean rookA8Moved, boolean rookH8Moved, int phase) {
-        updateBlackKingsPositionBonus(blackKing, isCastled, isBlackKingMoved, rookA8Moved, rookH8Moved, phase);
+    public void updateKingValuesBlack(long blackKing, long blackPawns, long whitePawns,
+                                     boolean isCastled, boolean isBlackKingMoved,
+                                     boolean rookA8Moved, boolean rookH8Moved, int phase) {
+        updateBlackKingsPositionBonus(blackKing, blackPawns, whitePawns, isCastled,
+                isBlackKingMoved, rookA8Moved, rookH8Moved, phase);
+    }
+
+    public int getWhiteKingsPosition() {
+        return whiteKingsPosition;
+    }
+
+    public int getBlackKingsPosition() {
+        return blackKingsPosition;
     }
 
     public void updateStateValuesWhite(GameStateEnum state) {

--- a/src/test/java/julius/game/chessengine/utils/NotCastledPenaltyTest.java
+++ b/src/test/java/julius/game/chessengine/utils/NotCastledPenaltyTest.java
@@ -1,0 +1,49 @@
+package julius.game.chessengine.utils;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NotCastledPenaltyTest {
+
+    @Test
+    void penaltySkippedWhenShielded() {
+        BitBoard baseline = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+        Score scoreBaseline = new Score();
+        scoreBaseline.initializeScore(baseline);
+
+        BitBoard noRights = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1");
+        Score scoreNoRights = new Score();
+        scoreNoRights.initializeScore(noRights);
+
+        assertEquals(scoreBaseline.getWhiteKingsPosition(), scoreNoRights.getWhiteKingsPosition());
+    }
+
+    @Test
+    void penaltyAppliedWhenOpenFile() {
+        BitBoard shield = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1");
+        Score scoreShield = new Score();
+        scoreShield.initializeScore(shield);
+
+        BitBoard openFile = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPP1PPP/RNBQKBNR w - - 0 1");
+        Score scoreOpen = new Score();
+        scoreOpen.initializeScore(openFile);
+
+        assertTrue(scoreOpen.getWhiteKingsPosition() < scoreShield.getWhiteKingsPosition());
+    }
+
+    @Test
+    void penaltyReducedWhenBehindMaterial() {
+        BitBoard openFile = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPP1PPP/RNBQKBNR w - - 0 1");
+        Score evenScore = new Score();
+        evenScore.initializeScore(openFile);
+
+        BitBoard openFileWhiteDown = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPP1PPP/RNBQKB1R w - - 0 1");
+        Score downScore = new Score();
+        downScore.initializeScore(openFileWhiteDown);
+
+        assertTrue(downScore.getWhiteKingsPosition() > evenScore.getWhiteKingsPosition());
+    }
+}


### PR DESCRIPTION
## Summary
- Only apply rook-move castling penalties when the king lacks a pawn shield or sits on an open/half-open file
- Diminish the penalty when the opponent already leads in material to discourage needless sacrifices
- Add tests validating shielded kings avoid the penalty and disadvantaged sides receive a reduced hit

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ee0d45f8832aa6e351737e5a0e8a