### PR TITLE
Handle queen threats in search and evaluation

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1,5 +1,6 @@
 package julius.game.chessengine.ai;
 
+import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.Move;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.MoveList;
@@ -868,6 +869,14 @@ public class AI {
         return (isWhite && state == GameStateEnum.WHITE_IN_CHECK) || (!isWhite && state == GameStateEnum.BLACK_IN_CHECK);
     }
 
+    private boolean attacksOpponentQueenNow(Engine e, boolean moverIsWhite) {
+        BitBoard bb = e.getBitBoard();
+        long enemyQueen = moverIsWhite ? bb.getBlackQueens() : bb.getWhiteQueens();
+        if (enemyQueen == 0) return false;
+        long myAttacks = bb.generateAttackBitboard(moverIsWhite);
+        return (myAttacks & enemyQueen) != 0L;
+    }
+
     /**
      * LMR reduction: larger for deeper plies and later moves; tuned to be safe.
      */
@@ -904,15 +913,20 @@ public class AI {
             // Skip obviously losing captures based on SEE, unless the move gives check or is a promotion
             if (!inCheckAtNode && isCapture && !isPromotion) {
                 int see = simulatorEngine.see(move);
-                if (see < 0) {
-                    continue;
-                }
+                if (see < 0) continue;
+                // tiny margin helps drop "equal on paper but terrible" grabs
+                if (see == 0 && Score.getPieceValue(MoveHelper.derivePieceTypeBits(move)) > 2) continue;
             }
 
             boolean isTactical = isCapture || isPromotion;
             int lmpThreshold = 8 + depth * 2;
             if (!inCheckAtNode && !isTactical && depth <= 3 && index > lmpThreshold) {
-                continue;
+                // But don't prune moves that give check or create an immediate queen threat
+                simulatorEngine.performMove(move);
+                boolean givesCheck = isSideInCheck(simulatorEngine, !isWhite);
+                boolean attacksQueen = attacksOpponentQueenNow(simulatorEngine, isWhite);
+                simulatorEngine.undoLastMove();
+                if (!givesCheck && !attacksQueen) continue;
             }
 
             simulatorEngine.performMove(move);
@@ -924,53 +938,45 @@ public class AI {
             if (entry != null && entry.depth >= depth) {
                 eval = entry.score;
             } else {
-                int nextDepth = depth - 1;
+                // Compute extension/gating signals AFTER making the move
+                boolean givesCheck = isSideInCheck(simulatorEngine, !isWhite);
+                boolean attacksQueen = attacksOpponentQueenNow(simulatorEngine, isWhite);
 
-                // PVS window for non-first moves
+                // depth for child
+                int nextDepth = depth - 1;
+                if (givesCheck || attacksQueen) nextDepth = Math.min(nextDepth + 1, depth);
+
+                // Decide if we can reduce this move
+                boolean canReduce = !inCheckAtNode
+                        && !isTactical
+                        && !givesCheck
+                        && !attacksQueen
+                        && nextDepth >= 2
+                        && index >= 3;
+
+                // PVS windows as you had them
                 boolean usePvs = index > 0 && alpha != Double.NEGATIVE_INFINITY && beta != Double.POSITIVE_INFINITY;
                 double pAlpha = alpha;
-                double pBeta = usePvs ? (alpha + 1) : beta;
-
-                // ---- LMR: reduce late quiets when we’re not in check at this node ----
-                boolean canReduce = !inCheckAtNode && !isTactical && nextDepth >= 2 && index >= 3;
+                double pBeta  = usePvs ? (alpha + 1) : beta;
 
                 if (canReduce) {
                     int r = lmrReduction(nextDepth, index);
                     int reduced = Math.max(1, nextDepth - r);
-
                     eval = alphaBeta(simulatorEngine, reduced, pAlpha, pBeta, !isWhite, deadline, move);
-                    if (eval == EXIT_FLAG || positionChanged()) {
-                        simulatorEngine.undoLastMove();
-                        return EXIT_FLAG;
-                    }
+                    if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
 
-                    // If the reduced result looks promising, re-search deeper (PVS/full as needed)
                     boolean promising = eval > alpha;
                     if (promising) {
-                        if (usePvs && eval > alpha && eval < beta) {
-                            eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline, move);
-                        } else {
-                            eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline, move);
-                        }
-                        if (eval == EXIT_FLAG || positionChanged()) {
-                            simulatorEngine.undoLastMove();
-                            return EXIT_FLAG;
-                        }
+                        eval = alphaBeta(simulatorEngine, nextDepth, usePvs ? alpha : pAlpha, usePvs ? beta : pBeta, !isWhite, deadline, move);
+                        if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
                     }
                 } else {
-                    // Normal PVS
+                    // No reduction for checks/queen-threats/tacticals
                     eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline, move);
-                    if (eval == EXIT_FLAG || positionChanged()) {
-                        simulatorEngine.undoLastMove();
-                        return EXIT_FLAG;
-                    }
-
+                    if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
                     if (usePvs && eval > alpha && eval < beta) {
                         eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline, move);
-                        if (eval == EXIT_FLAG || positionChanged()) {
-                            simulatorEngine.undoLastMove();
-                            return EXIT_FLAG;
-                        }
+                        if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
                     }
                 }
             }
@@ -1039,9 +1045,8 @@ public class AI {
 
             if (!inCheckAtNode && isCapture && !isPromotion) {
                 int see = simulatorEngine.see(move);
-                if (see < 0) {
-                    continue;
-                }
+                if (see < 0) continue;
+                if (see == 0 && Score.getPieceValue(MoveHelper.derivePieceTypeBits(move)) > 2) continue;
             }
 
             simulatorEngine.performMove(move);
@@ -1053,50 +1058,44 @@ public class AI {
             if (entry != null && entry.depth >= depth) {
                 eval = entry.score;
             } else {
+                // Compute extension/gating signals AFTER making the move
+                boolean givesCheck = isSideInCheck(simulatorEngine, !isWhite);
+                boolean attacksQueen = attacksOpponentQueenNow(simulatorEngine, isWhite);
+
                 int nextDepth = depth - 1;
+                if (givesCheck || attacksQueen) nextDepth = Math.min(nextDepth + 1, depth);
+
+                boolean isTactical = isCapture || isPromotion;
+                boolean canReduce = !inCheckAtNode
+                        && !isTactical
+                        && !givesCheck
+                        && !attacksQueen
+                        && nextDepth >= 2
+                        && index >= 3;
 
                 boolean usePvs = index > 0 && alpha != Double.NEGATIVE_INFINITY && beta != Double.POSITIVE_INFINITY;
                 double pAlpha = usePvs ? (beta - 1) : alpha;
                 double pBeta = beta;
-
-                boolean isTactical = isCapture || isPromotion;
-                boolean canReduce = !inCheckAtNode && !isTactical && nextDepth >= 2 && index >= 3;
 
                 if (canReduce) {
                     int r = lmrReduction(nextDepth, index);
                     int reduced = Math.max(1, nextDepth - r);
 
                     eval = alphaBeta(simulatorEngine, reduced, pAlpha, pBeta, !isWhite, deadline, move);
-                    if (eval == EXIT_FLAG || positionChanged()) {
-                        simulatorEngine.undoLastMove();
-                        return EXIT_FLAG;
-                    }
+                    if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
 
                     boolean promising = eval < beta;
                     if (promising) {
-                        if (usePvs && eval > alpha && eval < beta) {
-                            eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline, move);
-                        } else {
-                            eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline, move);
-                        }
-                        if (eval == EXIT_FLAG || positionChanged()) {
-                            simulatorEngine.undoLastMove();
-                            return EXIT_FLAG;
-                        }
+                        eval = alphaBeta(simulatorEngine, nextDepth, usePvs ? alpha : pAlpha, usePvs ? beta : pBeta, !isWhite, deadline, move);
+                        if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
                     }
                 } else {
                     eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline, move);
-                    if (eval == EXIT_FLAG || positionChanged()) {
-                        simulatorEngine.undoLastMove();
-                        return EXIT_FLAG;
-                    }
+                    if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
 
                     if (usePvs && eval > alpha && eval < beta) {
                         eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline, move);
-                        if (eval == EXIT_FLAG || positionChanged()) {
-                            simulatorEngine.undoLastMove();
-                            return EXIT_FLAG;
-                        }
+                        if (eval == EXIT_FLAG || positionChanged()) { simulatorEngine.undoLastMove(); return EXIT_FLAG; }
                     }
                 }
             }

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -166,6 +166,10 @@ public class Engine {
         return bitBoard.see(move);
     }
 
+    public BitBoard getBitBoard() {
+        return bitBoard;
+    }
+
     public MoveList getAllLegalMoves() {
         if (gameState.isGameOver()) {
             if (legalMoves == null) {

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -87,6 +87,7 @@ public class Score {
     private static final int ROOK_ATTACK_PENALTY = -15;
     private static final int QUEEN_ATTACK_PENALTY = -20;
     private static final int DEFENDER_BONUS = 5;
+    private static final int QUEEN_ATTACKED_PENALTY = -80; // small but noticeable
     public static final int BISHOP_PAIR_BONUS = 40;
     private static final int KNIGHT_OUTPOST_BONUS = 30;
     private static final int KNIGHT_OUTPOST_DEFENDED_BONUS = 10;
@@ -115,6 +116,8 @@ public class Score {
     // King safety
     private int whiteKingSafetyScore = 0;
     private int blackKingSafetyScore = 0;
+    private int whiteQueenSafetyScore = 0;
+    private int blackQueenSafetyScore = 0;
 
     // Initialize bonuses and penalties
     private int whiteCenterPawnBonus = 0;
@@ -242,6 +245,8 @@ public class Score {
         this.blackMobilityScore = other.blackMobilityScore;
         this.whiteKingSafetyScore = other.whiteKingSafetyScore;
         this.blackKingSafetyScore = other.blackKingSafetyScore;
+        this.whiteQueenSafetyScore = other.whiteQueenSafetyScore;
+        this.blackQueenSafetyScore = other.blackQueenSafetyScore;
 
         this.whiteCenterPawnBonus = other.whiteCenterPawnBonus;
         this.blackCenterPawnBonus = other.blackCenterPawnBonus;
@@ -426,6 +431,7 @@ public class Score {
 
         totalWhiteScore += whiteMobilityScore;
         totalWhiteScore += whiteKingSafetyScore;
+        totalWhiteScore += whiteQueenSafetyScore;
 
         totalWhiteScore += whiteStateBonus;
 
@@ -471,6 +477,7 @@ public class Score {
 
         totalBlackScore += blackMobilityScore;
         totalBlackScore += blackKingSafetyScore;
+        totalBlackScore += blackQueenSafetyScore;
 
         totalBlackScore += blackStateBonus;
 
@@ -937,6 +944,12 @@ public class Score {
         return true;
     }
 
+    private int evaluateQueenSafety(long queenBits, long enemyAttacks) {
+        if (queenBits == 0) return 0;
+        int qSq = Long.numberOfTrailingZeros(queenBits);
+        return ((enemyAttacks & (1L << qSq)) != 0) ? QUEEN_ATTACKED_PENALTY : 0;
+    }
+
     public void updateKingSafety(BitBoard bitBoard) {
         boolean isEndgame = bitBoard.isEndgame();
         long whiteKing = bitBoard.getWhiteKing();
@@ -972,6 +985,10 @@ public class Score {
                 allPieces,
                 false,
                 isEndgame);
+
+        // --- NEW: queen safety (simple "queen is attacked" penalty) ---
+        whiteQueenSafetyScore = evaluateQueenSafety(bitBoard.getWhiteQueens(), blackAttacks);
+        blackQueenSafetyScore = evaluateQueenSafety(bitBoard.getBlackQueens(), whiteAttacks);
     }
 
     private int evaluateKingSafety(long king, long friendlyPawns, long enemyPawns,


### PR DESCRIPTION
## Summary
- Penalize positions where the queen is attacked, tracking new queen safety scores in evaluation.
- Treat quiet moves that threaten the enemy queen as tactical: prevent late-move pruning/reduction and slightly extend search, with stricter SEE pruning.
- Expose BitBoard from Engine for threat detection.

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c80c54c258832a9013c51c67475eee