### PR TITLE
Handle king recaptures in SEE

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -413,6 +413,14 @@ public class BitBoard {
             else if (attBishops != 0) { fromBB = attBishops; attBits = 3; }
             else if (attRooks != 0)   { fromBB = attRooks;   attBits = 4; }
             else if (attQueens != 0)  { fromBB = attQueens;  attBits = 5; }
+            else if (attKing != 0) {
+                int kingFrom = Long.numberOfTrailingZeros(attKing);
+                if (!isKingCaptureLegal(sideWhite, kingFrom, to, W, B, occ, toPieceWhite, toPieceBits)) {
+                    break;
+                }
+                fromBB = 1L << kingFrom;
+                attBits = 6;
+            }
             else break; // no more recaptures
 
             int attFrom = Long.numberOfTrailingZeros(fromBB);
@@ -476,9 +484,69 @@ public class BitBoard {
 
         // Resolve swaps back (fail-soft)
         for (int i = d - 1; i >= 0; i--) {
-            gain[i] = Math.max(-gain[i + 1], gain[i]);
+            gain[i] = -Math.max(-gain[i], gain[i + 1]);
         }
         return gain[0];
+    }
+
+    private boolean isKingCaptureLegal(boolean kingIsWhite, int kingFrom, int target,
+                                       long[] whiteByType, long[] blackByType, long occ,
+                                       boolean toPieceWhite, int toPieceBits) {
+        long[] wCopy = whiteByType.clone();
+        long[] bCopy = blackByType.clone();
+        long occCopy = occ;
+
+        long toMask = 1L << target;
+        long fromMask = 1L << kingFrom;
+
+        if (toPieceBits >= 1 && toPieceBits <= 6) {
+            if (toPieceWhite) {
+                wCopy[toPieceBits] &= ~toMask;
+            } else {
+                bCopy[toPieceBits] &= ~toMask;
+            }
+        }
+
+        if (kingIsWhite) {
+            wCopy[6] &= ~fromMask;
+            wCopy[6] |= toMask;
+        } else {
+            bCopy[6] &= ~fromMask;
+            bCopy[6] |= toMask;
+        }
+
+        occCopy &= ~fromMask;
+
+        return !isSquareAttackedInSee(target, !kingIsWhite, wCopy, bCopy, occCopy);
+    }
+
+    private boolean isSquareAttackedInSee(int square, boolean attackerWhite,
+                                          long[] whiteByType, long[] blackByType, long occ) {
+        if (pawnAttackersToSquare(square, attackerWhite, whiteByType[1], blackByType[1]) != 0) {
+            return true;
+        }
+
+        long knights = attackerWhite ? whiteByType[2] : blackByType[2];
+        if ((KnightHelper.knightMoveTable[square] & knights) != 0) {
+            return true;
+        }
+
+        long bishops = attackerWhite ? whiteByType[3] : blackByType[3];
+        long rooks = attackerWhite ? whiteByType[4] : blackByType[4];
+        long queens = attackerWhite ? whiteByType[5] : blackByType[5];
+        long king = attackerWhite ? whiteByType[6] : blackByType[6];
+
+        long bishopRays = bishopAttacksFromWithOcc(square, occ);
+        if ((bishopRays & (bishops | queens)) != 0) {
+            return true;
+        }
+
+        long rookRays = rookAttacksFromWithOcc(square, occ);
+        if ((rookRays & (rooks | queens)) != 0) {
+            return true;
+        }
+
+        return (KING_ATTACKS[square] & king) != 0;
     }
 
 

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -88,6 +88,24 @@ public class BitBoardTest {
     }
 
     @Test
+    void seeConsidersKingRecaptureOnCheckingCapture() {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("6k1/5p2/4Q3/8/8/8/6P1/6K1 w - - 0 1");
+
+        int from = convertStringToIndex("e6");
+        int to = convertStringToIndex("f7");
+        PieceType captured = engine.getBitBoard().getPieceTypeAtIndex(to);
+
+        int move = MoveHelper.createMoveInt(from, to, PieceType.QUEEN, true,
+                true, false, false, null, captured, false, false,
+                engine.getBitBoard().getLastMoveDoubleStepPawnIndex());
+
+        int see = engine.see(move);
+
+        assertTrue(see < 0, "King recapture after checking capture should be evaluated");
+    }
+
+    @Test
     public void PERFT() {
         long startTime = System.nanoTime(); // Start timing
 


### PR DESCRIPTION
## Summary
- extend the static exchange evaluation to consider king recaptures by selecting the king as an attacker only when the recapture is legal
- propagate SEE gains using the fail-soft negative max formulation so losing recaptures (such as king takes) reduce the score correctly
- add helper routines to detect attacks in the SEE simulation and a regression test that covers a checking capture followed by a king recapture

## Testing
- `mvn test` *(fails: unable to download parent POM because the build container has no network access)*

------
https://chatgpt.com/codex/tasks/task_e_68c873355120832ab2117a107487cce6