### PR TITLE
Guard legal move cache with synchronization

### DIFF
--- a/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
+++ b/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
@@ -3,13 +3,17 @@ package julius.game.chessengine.cache;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 
 /**
- * A lightweight, unsynchronized LRU cache with optional time-based eviction.
- * Keys are primitives and timestamps are stored alongside values to avoid
- * a secondary map. The cache is not thread safe; any required synchronization
- * should happen at a higher level.
+ * A lightweight LRU cache with optional time-based eviction. Keys are
+ * primitives and timestamps are stored alongside values to avoid a secondary
+ * map. Basic thread-safety is provided via an internal lock so callers can
+ * access the cache concurrently without additional synchronization.
  *
  * <p>Notes:</p>
  * <ul>
@@ -39,6 +43,7 @@ public class TimedLRUCache<V> {
     private final Long2ObjectOpenHashMap<Entry<V>> map = new Long2ObjectOpenHashMap<>();
     private final LongArrayFIFOQueue keyQueue = new LongArrayFIFOQueue();
     private final LongArrayFIFOQueue timeQueue = new LongArrayFIFOQueue();
+    private final Object lock = new Object();
 
     /**
      * @param maxSize maximum number of entries to retain (LRU when exceeded)
@@ -54,44 +59,56 @@ public class TimedLRUCache<V> {
     }
 
     public V get(long key) {
-        Entry<V> entry = map.get(key);
-        if (entry == null) {
-            return null;
+        synchronized (lock) {
+            Entry<V> entry = map.get(key);
+            if (entry == null) {
+                return null;
+            }
+            long now = System.currentTimeMillis();
+            entry.time = now;               // touch (refresh recency)
+            keyQueue.enqueue(key);
+            timeQueue.enqueue(now);
+            evictLocked(now);
+            return entry.value;
         }
-        long now = System.currentTimeMillis();
-        entry.time = now;               // touch (refresh recency)
-        keyQueue.enqueue(key);
-        timeQueue.enqueue(now);
-        evict(now);
-        return entry.value;
     }
 
     public void put(long key, V value) {
         long now = System.currentTimeMillis();
-        map.put(key, new Entry<>(value, now));
-        keyQueue.enqueue(key);
-        timeQueue.enqueue(now);
-        evict(now);
+        synchronized (lock) {
+            map.put(key, new Entry<>(value, now));
+            keyQueue.enqueue(key);
+            timeQueue.enqueue(now);
+            evictLocked(now);
+        }
     }
 
     public boolean containsKey(long key) {
-        return map.containsKey(key);
+        synchronized (lock) {
+            return map.containsKey(key);
+        }
     }
 
     public int size() {
-        return map.size();
+        synchronized (lock) {
+            return map.size();
+        }
     }
 
     /** Manually trigger eviction pass (e.g., on timers in higher layers). */
     public void cleanup() {
-        evict(System.currentTimeMillis());
+        synchronized (lock) {
+            evictLocked(System.currentTimeMillis());
+        }
     }
 
     /** Remove all entries. */
     public void clear() {
-        map.clear();
-        keyQueue.clear();
-        timeQueue.clear();
+        synchronized (lock) {
+            map.clear();
+            keyQueue.clear();
+            timeQueue.clear();
+        }
     }
 
     public int getMaxSize() {
@@ -102,7 +119,7 @@ public class TimedLRUCache<V> {
         return maxAgeMs;
     }
 
-    private void evict(long now) {
+    private void evictLocked(long now) {
         // Ensure both queues contain data before accessing their heads to avoid
         // NoSuchElementException when they become unsynchronized.
         while (!keyQueue.isEmpty() && !timeQueue.isEmpty()) {
@@ -138,6 +155,15 @@ public class TimedLRUCache<V> {
     }
 
     public void forEach(BiConsumer<Long, V> action) {
-        map.long2ObjectEntrySet().forEach(e -> action.accept(e.getLongKey(), e.getValue().value));
+        Objects.requireNonNull(action, "action");
+        List<AbstractMap.SimpleEntry<Long, V>> snapshot = new ArrayList<>();
+        synchronized (lock) {
+            map.long2ObjectEntrySet().fastForEach(e ->
+                    snapshot.add(new AbstractMap.SimpleEntry<>(e.getLongKey(), e.getValue().value))
+            );
+        }
+        for (AbstractMap.SimpleEntry<Long, V> entry : snapshot) {
+            action.accept(entry.getKey(), entry.getValue());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- serialize access to the TimedLRUCache so the underlying fastutil map cannot be corrupted by concurrent reads and writes
- refresh the class documentation and take a snapshot during forEach to preserve thread-safety when invoking callbacks

## Testing
- `mvn test` *(fails: unable to download Spring Boot parent due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c878af5b18832a812777bd68a979b3