### PR TITLE
Log thread configuration at bot startup

### DIFF
--- a/src/main/resources/py/lichess_bot.py
+++ b/src/main/resources/py/lichess_bot.py
@@ -902,4 +902,13 @@ def run_bot():
 if __name__ == "__main__":
     if platform.system().lower() == "windows":
         import msvcrt  # noqa: F401
+    cpu_count = os.cpu_count()
+    cpu_display = cpu_count if cpu_count is not None else "unknown"
+    print(f"[+] Detected logical CPU cores: {cpu_display}")
+    print(f"[+] Python active threads at startup: {threading.active_count()}")
+    configured_threads = str(SEARCH_THREADS).strip()
+    print(
+        "[+] Configured engine search threads (CHESSENGINE_THREADS/NUMBER_OF_PROCESSORS):"
+        f" {configured_threads}"
+    )
     run_bot()


### PR DESCRIPTION
## Summary
- log detected CPU cores, active Python threads, and configured engine threads when the bot starts

## Testing
- python3 -m py_compile src/main/resources/py/lichess_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68c87ed383a0832ab59d49c96388ce8c