### PR TITLE
Improve mate extensions and add regression tests

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -449,7 +449,7 @@ public class AI {
         } else if (simulatorEngine.getGameState().isInStateDraw()) {
             firstScore = evaluateStaticPosition(simulatorEngine.getGameState(), !isWhitesTurn, depth);
         } else {
-            firstScore = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, firstMove);
+            firstScore = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, firstMove, 1);
             if (firstScore == EXIT_FLAG || positionChanged()) {
                 simulatorEngine.undoLastMove();
                 return null;
@@ -519,7 +519,7 @@ public class AI {
                 } else if (e.getGameState().isInStateDraw()) {
                     probe = evaluateStaticPosition(e.getGameState(), !isWhitesTurn, depth);
                 } else {
-                    probe = alphaBeta(e, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline, moveInt);
+                    probe = alphaBeta(e, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline, moveInt, 1);
                     if (probe == EXIT_FLAG) return null;
                 }
 
@@ -542,7 +542,7 @@ public class AI {
                             double aNow = alphaRef.get();
                             double bNow = betaRef.get();
 
-                            double full = alphaBeta(e, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt);
+                            double full = alphaBeta(e, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt, 1);
                             if (full != EXIT_FLAG) {
                                 finalScore = full;
                                 // Tighten bounds + update best
@@ -739,7 +739,7 @@ public class AI {
                 // keep draw policy consistent
                 score = evaluateStaticPosition(simulatorEngine.getGameState(), !isWhitesTurn, depth);
             } else {
-                score = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, moveInt);
+                score = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, moveInt, 1);
                 // Check for time limit exceeded after alphaBeta call
                 if (score == EXIT_FLAG || positionChanged()) {
                     simulatorEngine.undoLastMove(); // Undo move using its integer representation
@@ -776,7 +776,7 @@ public class AI {
      */
     // AI.java
     private double alphaBeta(Engine simulatorEngine, int depth, double alpha, double beta,
-                             boolean isWhite, long deadline, int prevMove) {
+                             boolean isWhite, long deadline, int prevMove, int plyFromRoot) {
         nodesVisited++;
 
         // stop conditions
@@ -784,8 +784,11 @@ public class AI {
             return EXIT_FLAG;
         }
 
-        // ply-from-root for distance-to-mate normalization
-        final int plyFromRoot = Math.max(0, rootDepthForMateScoring - Math.max(0, depth));
+        boolean inCheck = isSideInCheck(simulatorEngine, isWhite);
+        int depthRemaining = depth;
+        if (inCheck) {
+            depthRemaining++;
+        }
 
         // Terminal states first, with distance-to-mate
         if (simulatorEngine.getGameState().isInStateCheckMate()) {
@@ -799,7 +802,7 @@ public class AI {
 
         long boardHash = simulatorEngine.getBoardStateHash();
 
-        if (depth == 0) {
+        if (depthRemaining <= 0) {
             // Quiescence returns white-oriented score; flip for black-to-move
             double eval = evaluateBoard(simulatorEngine, isWhite, deadline);
             if (eval == EXIT_FLAG) { // propagate qsearch timeout
@@ -810,6 +813,8 @@ public class AI {
             }
             return eval;
         }
+
+        depth = depthRemaining;
 
         // Transposition table lookup
         TranspositionTableEntry entry = transpositionTable.get(boardHash);
@@ -831,8 +836,8 @@ public class AI {
         // Workflow: perform a reduced-depth null search, verify apparent fail-highs
         // with a second (depth - 1) search, and only prune when both agree. This
         // dramatically reduces the risk of zugzwangs or other tactical misses.
-        boolean inCheck = isSideInCheck(simulatorEngine, isWhite);
-        int mobility = simulatorEngine.getAllLegalMoves().size(); // guard against zugzwang-like nodes
+        MoveList moves = simulatorEngine.getAllLegalMoves();
+        int mobility = moves.size(); // guard against zugzwang-like nodes
         boolean allowNullMove = useNullMovePruning
                 && depth >= 4
                 && !inCheck
@@ -841,9 +846,16 @@ public class AI {
                 && mobility >= 8;     // mobility guard
 
         if (allowNullMove) {
+            double mateThreatScore = CHECKMATE - (plyFromRoot + 1);
+            if ((isWhite && beta >= mateThreatScore) || (!isWhite && alpha <= -mateThreatScore)) {
+                allowNullMove = false;
+            }
+        }
+
+        if (allowNullMove) {
             int savedEp = simulatorEngine.doNullMoveForSearch(); // O(1) flip side + clear EP
             nullMoveCount++;
-            double nullScore = alphaBeta(simulatorEngine, depth - 1 - 2, alpha, beta, !isWhite, deadline, -1);
+            double nullScore = alphaBeta(simulatorEngine, depth - 1 - 2, alpha, beta, !isWhite, deadline, -1, plyFromRoot + 1);
             simulatorEngine.undoNullMoveForSearch(savedEp); // O(1) restore
 
             if (nullScore == EXIT_FLAG) { // propagate timeout
@@ -852,11 +864,15 @@ public class AI {
 
             boolean nullFailHigh = isWhite ? nullScore >= beta : nullScore <= alpha;
             if (nullFailHigh) {
-                double verificationScore = alphaBeta(simulatorEngine, depth - 1, alpha, beta, isWhite, deadline, prevMove);
+                double verificationScore = alphaBeta(simulatorEngine, depth - 1, alpha, beta, isWhite, deadline, prevMove, plyFromRoot);
                 if (verificationScore == EXIT_FLAG) {
                     return EXIT_FLAG;
                 }
-                nullFailHigh = isWhite ? verificationScore >= beta : verificationScore <= alpha;
+                if (Math.abs(verificationScore) >= CHECKMATE - (plyFromRoot + 1)) {
+                    nullFailHigh = false;
+                } else {
+                    nullFailHigh = isWhite ? verificationScore >= beta : verificationScore <= alpha;
+                }
             }
 
             if (nullFailHigh) {
@@ -868,12 +884,10 @@ public class AI {
         double alphaOriginal = alpha; // Store the original alpha value
         double betaOriginal = beta;   // Store the original beta value
 
-        MoveList moves = simulatorEngine.getAllLegalMoves();
-
         if (isWhite) {
-            return maximizer(simulatorEngine, depth, alpha, beta, isWhite, boardHash, alphaOriginal, moves, deadline, prevMove);
+            return maximizer(simulatorEngine, depth, alpha, beta, isWhite, boardHash, alphaOriginal, moves, deadline, prevMove, plyFromRoot);
         } else {
-            return minimizer(simulatorEngine, depth, alpha, beta, isWhite, boardHash, betaOriginal, moves, deadline, prevMove);
+            return minimizer(simulatorEngine, depth, alpha, beta, isWhite, boardHash, betaOriginal, moves, deadline, prevMove, plyFromRoot);
         }
     }
 
@@ -942,7 +956,7 @@ public class AI {
 
     private double maximizer(Engine simulatorEngine, int depth, double alpha, double beta,
                              boolean isWhite, long boardHash, double alphaOriginal,
-                             MoveList moves, long deadline, int prevMove) {
+                             MoveList moves, long deadline, int prevMove, int plyFromRoot) {
 
         long start = log.isDebugEnabled() ? System.nanoTime() : 0L;
         double maxEval = Double.NEGATIVE_INFINITY;
@@ -1049,7 +1063,7 @@ public class AI {
 
                 if (canReduce) {
                     int reduced = Math.max(1, nextDepth - reduction);
-                    eval = alphaBeta(simulatorEngine, reduced, pAlpha, pBeta, !isWhite, deadline, move);
+                    eval = alphaBeta(simulatorEngine, reduced, pAlpha, pBeta, !isWhite, deadline, move, plyFromRoot + 1);
                     if (eval == EXIT_FLAG || positionChanged()) {
                         simulatorEngine.undoLastMove();
                         return EXIT_FLAG;
@@ -1057,7 +1071,7 @@ public class AI {
 
                     boolean promising = eval > alpha;
                     if (promising) {
-                        eval = alphaBeta(simulatorEngine, nextDepth, usePvs ? alpha : pAlpha, usePvs ? beta : pBeta, !isWhite, deadline, move);
+                        eval = alphaBeta(simulatorEngine, nextDepth, usePvs ? alpha : pAlpha, usePvs ? beta : pBeta, !isWhite, deadline, move, plyFromRoot + 1);
                         if (eval == EXIT_FLAG || positionChanged()) {
                             simulatorEngine.undoLastMove();
                             return EXIT_FLAG;
@@ -1065,13 +1079,13 @@ public class AI {
                     }
                 } else {
                     // No reduction for checks/queen-threats/tacticals
-                    eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline, move);
+                    eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline, move, plyFromRoot + 1);
                     if (eval == EXIT_FLAG || positionChanged()) {
                         simulatorEngine.undoLastMove();
                         return EXIT_FLAG;
                     }
                     if (usePvs && eval > alpha && eval < beta) {
-                        eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline, move);
+                        eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline, move, plyFromRoot + 1);
                         if (eval == EXIT_FLAG || positionChanged()) {
                             simulatorEngine.undoLastMove();
                             return EXIT_FLAG;
@@ -1123,7 +1137,7 @@ public class AI {
 
     private double minimizer(Engine simulatorEngine, int depth, double alpha, double beta,
                              boolean isWhite, long boardHash, double betaOriginal,
-                             MoveList moves, long deadline, int prevMove) {
+                             MoveList moves, long deadline, int prevMove, int plyFromRoot) {
 
         long start = log.isDebugEnabled() ? System.nanoTime() : 0L;
         double minEval = Double.POSITIVE_INFINITY;
@@ -1220,7 +1234,7 @@ public class AI {
                 if (canReduce) {
                     int reduced = Math.max(1, nextDepth - reduction);
 
-                    eval = alphaBeta(simulatorEngine, reduced, pAlpha, pBeta, !isWhite, deadline, move);
+                    eval = alphaBeta(simulatorEngine, reduced, pAlpha, pBeta, !isWhite, deadline, move, plyFromRoot + 1);
                     if (eval == EXIT_FLAG || positionChanged()) {
                         simulatorEngine.undoLastMove();
                         return EXIT_FLAG;
@@ -1228,21 +1242,21 @@ public class AI {
 
                     boolean promising = eval < beta;
                     if (promising) {
-                        eval = alphaBeta(simulatorEngine, nextDepth, usePvs ? alpha : pAlpha, usePvs ? beta : pBeta, !isWhite, deadline, move);
+                        eval = alphaBeta(simulatorEngine, nextDepth, usePvs ? alpha : pAlpha, usePvs ? beta : pBeta, !isWhite, deadline, move, plyFromRoot + 1);
                         if (eval == EXIT_FLAG || positionChanged()) {
                             simulatorEngine.undoLastMove();
                             return EXIT_FLAG;
                         }
                     }
                 } else {
-                    eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline, move);
+                    eval = alphaBeta(simulatorEngine, nextDepth, pAlpha, pBeta, !isWhite, deadline, move, plyFromRoot + 1);
                     if (eval == EXIT_FLAG || positionChanged()) {
                         simulatorEngine.undoLastMove();
                         return EXIT_FLAG;
                     }
 
                     if (usePvs && eval > alpha && eval < beta) {
-                        eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline, move);
+                        eval = alphaBeta(simulatorEngine, nextDepth, alpha, beta, !isWhite, deadline, move, plyFromRoot + 1);
                         if (eval == EXIT_FLAG || positionChanged()) {
                             simulatorEngine.undoLastMove();
                             return EXIT_FLAG;

--- a/src/test/java/julius/game/chessengine/ai/MateInThreeToSevenTest.java
+++ b/src/test/java/julius/game/chessengine/ai/MateInThreeToSevenTest.java
@@ -1,0 +1,98 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.engine.GameState;
+import julius.game.chessengine.engine.GameStateEnum;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+/**
+ * Focused regression covering deeper forced mates (N = 3..7).
+ *
+ * <p>The existing {@link MateSearchTest} already verifies a broad mix of
+ * puzzles and time budgets. This suite narrows in on the tricky range where
+ * check extensions and mate-distance propagation are most critical. Each FEN
+ * encodes a known mate in N and we simply assert that the engine reaches the
+ * expected game termination within {@code 2N-1} plies while driving both
+ * colours via {@link AI#startAutoPlay(boolean, boolean)}.</p>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MateInThreeToSevenTest {
+
+    private Stream<Object[]> matePuzzles() {
+        return Stream.of(
+                // mate in 3 -> BLACK_WON
+                new Object[]{"2r3k1/p4p2/3Rp2p/1p2P1pK/8/1P4P1/P3Q2P/1q6 b - - 0 1", 3, GameStateEnum.BLACK_WON},
+
+                // mate in 4 -> WHITE_WON
+                new Object[]{"4k2r/1R3R2/p3p1pp/4b3/1BnNr3/8/P1P5/5K2 w - - 1 0", 4, GameStateEnum.WHITE_WON},
+
+                // mate in 5 -> WHITE_WON
+                new Object[]{"2q1nk1r/4Rp2/1ppp1P2/6Pp/3p1B2/3P3P/PPP1Q3/6K1 w - - 0 1", 5, GameStateEnum.WHITE_WON},
+
+                // mate in 6 -> WHITE_WON
+                new Object[]{"8/8/p1p2p1p/k1P2Pp1/P5P1/1K5P/8/8 w - - 1 0", 6, GameStateEnum.WHITE_WON},
+
+                // mate in 7 -> WHITE_WON
+                new Object[]{"8/8/p1p2ppp/k1P2P2/P5P1/1K5P/8/8 w - - 0 1", 7, GameStateEnum.WHITE_WON}
+        );
+    }
+
+    @ParameterizedTest(name = "Mate in {1} for FEN {0}")
+    @MethodSource("matePuzzles")
+    void detectsMateInRange(String fen, int mateInMoves, GameStateEnum expectedWinner) {
+        Engine engine = new Engine();
+        engine.importBoardFromFen(fen);
+
+        AI ai = new AI(engine);
+        final long timeLimitMs = 1000L;
+        ai.setTimeLimit(timeLimitMs);
+
+        // Drive both colours with the engine so it follows the forced line
+        ai.startAutoPlay(true, true);
+
+        final int maxPlies = Math.max(1, 2 * mateInMoves - 1);
+        final long slackMs = 250L;
+        final long perPlyBudgetMs = timeLimitMs + slackMs;
+        final long absoluteDeadlineMs = System.currentTimeMillis() + perPlyBudgetMs * maxPlies;
+
+        int observedPlies = 0;
+        long lastHash = engine.getBoardStateHash();
+
+        while (System.currentTimeMillis() < absoluteDeadlineMs
+                && observedPlies < maxPlies
+                && !engine.getGameState().isGameOver()) {
+
+            try {
+                TimeUnit.MILLISECONDS.sleep(10L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+
+            long currentHash = engine.getBoardStateHash();
+            if (currentHash != lastHash) {
+                lastHash = currentHash;
+                observedPlies++;
+                ai.updateBoardStateHash();
+            }
+        }
+
+        ai.stopCalculation();
+
+        GameState state = engine.getGameState();
+        String failInfo = String.format(
+                "FEN='%s', mateIn=%d, plies=%d/%d, expected=%s, actual=%s",
+                fen, mateInMoves, observedPlies, maxPlies, expectedWinner, state.getState()
+        );
+
+        Assertions.assertEquals(expectedWinner, state.getState(), failInfo);
+        Assertions.assertTrue(observedPlies <= maxPlies, "Exceeded ply cap: " + failInfo);
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend the alpha-beta search one ply when the side to move is in check and track ply-from-root explicitly so mate scores propagate correctly
- gate null-move pruning near mating scores and keep verification searches from discarding winning continuations
- add a focused mate-in-3 through mate-in-7 regression to ensure the engine solves deeper forced mates

## Testing
- `./mvnw -q -o test` *(fails: wrapper cannot download Maven because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c9139c794c832aa6ea023b0dc4c379