### PR TITLE
Remove unused sort buffer from AI move ordering

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -95,7 +95,6 @@ public class AI {
     private static final int MAX_MOVE_LIST_SIZE = 218; // maximum legal moves
     private final int[] moveBuffer = new int[MAX_MOVE_LIST_SIZE];
     private final int[] scoreBuffer = new int[MAX_MOVE_LIST_SIZE];
-    private final long[] sortBuffer = new long[MAX_MOVE_LIST_SIZE];
 
     private ScheduledExecutorService scheduler;
     private Thread calculationThread;


### PR DESCRIPTION
## Summary
- remove the unused `sortBuffer` array from the AI move ordering buffers

## Testing
- mvn -q compile *(fails: unable to download parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c91d4d7eb4832a8961f36fe7c79750