### PR TITLE
Refactor score initialization for thread safety

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -32,8 +32,7 @@ public class GameState {
 
     public GameState(BitBoard bitBoard) {
         state = GameStateEnum.PLAY;
-        score = new Score();
-        initializeScore(bitBoard);
+        score = Score.initializeScore(bitBoard);
         recordHash(bitBoard.getBoardStateHash());
     }
 
@@ -46,12 +45,6 @@ public class GameState {
         this.repetition.putAll(other.repetition);
         this.halfmoveStack.addAll(other.halfmoveStack);
     }
-
-
-    private void initializeScore(BitBoard bitBoard) {
-        score.initializeScore(bitBoard);
-    }
-
     public void update(BitBoard bitBoard, MoveList legalMoves, int move, boolean isOpeningMove) {
         updateState(bitBoard, legalMoves, isOpeningMove);
 

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -103,8 +103,6 @@ public class Score {
 
     private static final long[] EMPTY_LONG_ARRAY = new long[0];
 
-    private Double cachedScoreDifference = null;
-
     private int whiteScore;
     private int blackScore;
 
@@ -320,17 +318,19 @@ public class Score {
 
         this.whiteStateBonus = other.whiteStateBonus;
         this.blackStateBonus = other.blackStateBonus;
-
-        this.cachedScoreDifference = other.cachedScoreDifference;
     }
 
 
     /**
      * Score mechanisms of the Game
      */
-    public void initializeScore(BitBoard bitBoard) {
-        cachedScoreDifference = null;
+    public static Score initializeScore(BitBoard bitBoard) {
+        Score score = new Score();
+        score.initializeFrom(bitBoard);
+        return score;
+    }
 
+    private void initializeFrom(BitBoard bitBoard) {
         long whitePawns = bitBoard.getWhitePawns();
         long blackPawns = bitBoard.getBlackPawns();
         long allPawns = whitePawns | blackPawns;
@@ -421,11 +421,7 @@ public class Score {
 
 
     public double getScoreDifference() {
-        if (cachedScoreDifference == null) {
-            cachedScoreDifference = (calculateTotalWhiteScore() - calculateTotalBlackScore()) / 100.0;
-        }
-
-        return cachedScoreDifference;
+        return (calculateTotalWhiteScore() - calculateTotalBlackScore()) / 100.0;
     }
 
     public int calculateTotalWhiteScore() {
@@ -1753,7 +1749,6 @@ public class Score {
     }
 
     public void applyMove(BitBoard bitBoard, int move, GameStateEnum state) {
-        resetCachedScoreDifference();
         boolean isWhite = MoveHelper.isWhitesMove(move);
         int pieceTypeBits = MoveHelper.derivePieceTypeBits(move);
         int capturedPieceTypeBits = MoveHelper.deriveCapturedPieceTypeBits(move);
@@ -1871,10 +1866,6 @@ public class Score {
         } else {
             blackStateBonus = 0;
         }
-    }
-
-    public void resetCachedScoreDifference() {
-        this.cachedScoreDifference = null;
     }
 
     public static int getPieceValue(int pieceTypeBits) {

--- a/src/test/java/julius/game/chessengine/utils/BishopPairBonusTest.java
+++ b/src/test/java/julius/game/chessengine/utils/BishopPairBonusTest.java
@@ -11,8 +11,7 @@ public class BishopPairBonusTest {
     @Test
     void whiteBishopsPairGetsBonus() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/8/2B1KB2 w - - 0 1");
-        Score score = new Score();
-        score.initializeScore(board);
+        Score score = Score.initializeScore(board);
         assertEquals(Score.BISHOP_PAIR_BONUS, score.getWhiteBishopPairBonus());
         assertEquals(0, score.getBlackBishopPairBonus());
     }
@@ -20,8 +19,7 @@ public class BishopPairBonusTest {
     @Test
     void blackBishopsPairGetsBonus() {
         BitBoard board = FEN.translateFENtoBitBoard("2b1kb2/8/8/8/8/8/8/4K3 w - - 0 1");
-        Score score = new Score();
-        score.initializeScore(board);
+        Score score = Score.initializeScore(board);
         assertEquals(Score.BISHOP_PAIR_BONUS, score.getBlackBishopPairBonus());
         assertEquals(0, score.getWhiteBishopPairBonus());
     }

--- a/src/test/java/julius/game/chessengine/utils/DevelopmentEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/utils/DevelopmentEvaluationTest.java
@@ -11,12 +11,10 @@ public class DevelopmentEvaluationTest {
     @Test
     void undevelopedBlackMinorsArePenalizedAfterOpening() {
         BitBoard undeveloped = FEN.translateFENtoBitBoard("rnb1kbnr/pppppppp/8/8/2B2B2/2N2N2/PPPPPPPP/R3K2R w KQkq - 0 1");
-        Score undevelopedScore = new Score();
-        undevelopedScore.initializeScore(undeveloped);
+        Score undevelopedScore = Score.initializeScore(undeveloped);
 
         BitBoard developed = FEN.translateFENtoBitBoard("r3k2r/pppbbppp/2n2n2/8/2B2B2/2N2N2/PPPPPPPP/R3K2R w KQkq - 0 1");
-        Score developedScore = new Score();
-        developedScore.initializeScore(developed);
+        Score developedScore = Score.initializeScore(developed);
 
         assertTrue(undevelopedScore.getBlackMinorDevelopmentPenalty() < 0,
                 "Black should be penalized for leaving minors on their home squares after the opening");
@@ -29,12 +27,10 @@ public class DevelopmentEvaluationTest {
     @Test
     void earlyQueenDevelopmentIsDiscouraged() {
         BitBoard queenHome = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
-        Score queenHomeScore = new Score();
-        queenHomeScore.initializeScore(queenHome);
+        Score queenHomeScore = Score.initializeScore(queenHome);
 
         BitBoard queenAdventure = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/7Q/8/8/PPPPPPPP/RNB1KBNR w KQkq - 0 3");
-        Score queenAdventureScore = new Score();
-        queenAdventureScore.initializeScore(queenAdventure);
+        Score queenAdventureScore = Score.initializeScore(queenAdventure);
 
         assertEquals(0, queenHomeScore.getWhiteQueenDevelopmentPenalty(),
                 "Keeping the queen at home should avoid any penalty");

--- a/src/test/java/julius/game/chessengine/utils/NotCastledPenaltyTest.java
+++ b/src/test/java/julius/game/chessengine/utils/NotCastledPenaltyTest.java
@@ -11,12 +11,10 @@ public class NotCastledPenaltyTest {
     @Test
     void penaltySkippedWhenShielded() {
         BitBoard baseline = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
-        Score scoreBaseline = new Score();
-        scoreBaseline.initializeScore(baseline);
+        Score scoreBaseline = Score.initializeScore(baseline);
 
         BitBoard noRights = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1");
-        Score scoreNoRights = new Score();
-        scoreNoRights.initializeScore(noRights);
+        Score scoreNoRights = Score.initializeScore(noRights);
 
         assertEquals(scoreBaseline.getWhiteKingsPosition(), scoreNoRights.getWhiteKingsPosition());
     }
@@ -24,12 +22,10 @@ public class NotCastledPenaltyTest {
     @Test
     void penaltyAppliedWhenOpenFile() {
         BitBoard shield = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1");
-        Score scoreShield = new Score();
-        scoreShield.initializeScore(shield);
+        Score scoreShield = Score.initializeScore(shield);
 
         BitBoard openFile = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPP1PPP/RNBQKBNR w - - 0 1");
-        Score scoreOpen = new Score();
-        scoreOpen.initializeScore(openFile);
+        Score scoreOpen = Score.initializeScore(openFile);
 
         assertTrue(scoreOpen.getWhiteKingsPosition() < scoreShield.getWhiteKingsPosition());
     }
@@ -37,12 +33,10 @@ public class NotCastledPenaltyTest {
     @Test
     void penaltyReducedWhenBehindMaterial() {
         BitBoard openFile = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPP1PPP/RNBQKBNR w - - 0 1");
-        Score evenScore = new Score();
-        evenScore.initializeScore(openFile);
+        Score evenScore = Score.initializeScore(openFile);
 
         BitBoard openFileWhiteDown = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPP1PPP/RNBQKB1R w - - 0 1");
-        Score downScore = new Score();
-        downScore.initializeScore(openFileWhiteDown);
+        Score downScore = Score.initializeScore(openFileWhiteDown);
 
         assertTrue(downScore.getWhiteKingsPosition() > evenScore.getWhiteKingsPosition());
     }

--- a/src/test/java/julius/game/chessengine/utils/PassedPawnScoreTest.java
+++ b/src/test/java/julius/game/chessengine/utils/PassedPawnScoreTest.java
@@ -11,8 +11,7 @@ public class PassedPawnScoreTest {
     @Test
     void whitePassedPawnGetsBonus() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/4P3/8/8/8/4K3 w - - 0 1");
-        Score score = new Score();
-        score.initializeScore(board);
+        Score score = Score.initializeScore(board);
         assertEquals(Score.PASSED_PAWN_BONUS * 4, score.getWhitePassedPawnBonus());
         assertEquals(0, score.getBlackPassedPawnBonus());
     }
@@ -20,8 +19,7 @@ public class PassedPawnScoreTest {
     @Test
     void blackPassedPawnGetsBonus() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/3p4/8/8/4K3 w - - 0 1");
-        Score score = new Score();
-        score.initializeScore(board);
+        Score score = Score.initializeScore(board);
         assertEquals(Score.PASSED_PAWN_BONUS * 4, score.getBlackPassedPawnBonus());
         assertEquals(0, score.getWhitePassedPawnBonus());
     }

--- a/src/test/java/julius/game/chessengine/utils/RookOpenFileBonusTest.java
+++ b/src/test/java/julius/game/chessengine/utils/RookOpenFileBonusTest.java
@@ -11,12 +11,10 @@ public class RookOpenFileBonusTest {
     @Test
     void rooksOnOpenFilesScoreHigherThanHalfOpen() {
         BitBoard openFile = FEN.translateFENtoBitBoard("4k3/p7/8/8/8/8/8/1R2K3 w - - 0 1");
-        Score openScore = new Score();
-        openScore.initializeScore(openFile);
+        Score openScore = Score.initializeScore(openFile);
 
         BitBoard halfOpenFile = FEN.translateFENtoBitBoard("4k3/p7/8/8/8/8/8/R3K3 w - - 0 1");
-        Score halfScore = new Score();
-        halfScore.initializeScore(halfOpenFile);
+        Score halfScore = Score.initializeScore(halfOpenFile);
 
         assertTrue(openScore.getWhiteRooksOpenFileBonus() > halfScore.getWhiteRooksHalfOpenFileBonus());
         assertTrue(openScore.getScoreDifference() > halfScore.getScoreDifference());

--- a/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
@@ -11,12 +11,10 @@ public class ScoreEvaluationTest {
     @Test
     void stalemateHasLowestMobility() {
         BitBoard stalemate = FEN.translateFENtoBitBoard("7k/5Q2/6K1/8/8/8/8/8 b - - 0 1");
-        Score scoreStalemate = new Score();
-        scoreStalemate.initializeScore(stalemate);
+        Score scoreStalemate = Score.initializeScore(stalemate);
 
         BitBoard active = FEN.translateFENtoBitBoard("7k/4Q3/6K1/8/8/8/8/8 b - - 0 1");
-        Score scoreActive = new Score();
-        scoreActive.initializeScore(active);
+        Score scoreActive = Score.initializeScore(active);
 
         assertTrue(scoreStalemate.getBlackMobilityScore() <= scoreActive.getBlackMobilityScore());
         assertTrue(scoreActive.getBlackMobilityScore() > 0);
@@ -26,12 +24,10 @@ public class ScoreEvaluationTest {
     @Test
     void exposedKingIsPenalized() {
         BitBoard safe = FEN.translateFENtoBitBoard("6k1/6pp/8/8/8/8/6PP/6K1 w - - 0 1");
-        Score scoreSafe = new Score();
-        scoreSafe.initializeScore(safe);
+        Score scoreSafe = Score.initializeScore(safe);
 
         BitBoard exposed = FEN.translateFENtoBitBoard("6k1/8/8/6pp/8/8/6PP/6K1 w - - 0 1");
-        Score scoreExposed = new Score();
-        scoreExposed.initializeScore(exposed);
+        Score scoreExposed = Score.initializeScore(exposed);
 
         assertTrue(scoreExposed.getBlackKingSafetyScore() < scoreSafe.getBlackKingSafetyScore());
         assertTrue(scoreExposed.getScoreDifference() > scoreSafe.getScoreDifference());
@@ -40,8 +36,7 @@ public class ScoreEvaluationTest {
     @Test
     void centerPawnsGrantBonusToWhite() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/4P3/8/8/4K3 w - - 0 1");
-        Score score = new Score();
-        score.initializeScore(board);
+        Score score = Score.initializeScore(board);
 
         assertEquals(Score.CENTER_PAWN_BONUS, score.getWhiteCenterPawnBonus());
         assertEquals(0, score.getBlackCenterPawnBonus());
@@ -50,8 +45,7 @@ public class ScoreEvaluationTest {
     @Test
     void centerPawnsGrantBonusToBlack() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/4p3/8/8/8/4K3 w - - 0 1");
-        Score score = new Score();
-        score.initializeScore(board);
+        Score score = Score.initializeScore(board);
 
         assertEquals(0, score.getWhiteCenterPawnBonus());
         assertEquals(Score.CENTER_PAWN_BONUS, score.getBlackCenterPawnBonus());

--- a/src/test/java/julius/game/chessengine/utils/StartingSquarePenaltyTest.java
+++ b/src/test/java/julius/game/chessengine/utils/StartingSquarePenaltyTest.java
@@ -11,24 +11,21 @@ public class StartingSquarePenaltyTest {
     @Test
     void noPenaltyWhenOnlyKnightsOnStartingSquares() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/R1B2B1R/1N2K1N1 w - - 0 1");
-        Score score = new Score();
-        score.initializeScore(board);
+        Score score = Score.initializeScore(board);
         assertEquals(0, score.getWhiteStartingSquarePenalty());
     }
 
     @Test
     void noPenaltyWhenOnlyBishopsOnStartingSquares() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/2N2N2/R6R/2B1KB2 w - - 0 1");
-        Score score = new Score();
-        score.initializeScore(board);
+        Score score = Score.initializeScore(board);
         assertEquals(0, score.getWhiteStartingSquarePenalty());
     }
 
     @Test
     void noPenaltyWhenOnlyRooksOnStartingSquares() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/2B2B2/2N2N2/8/R3K2R w - - 0 1");
-        Score score = new Score();
-        score.initializeScore(board);
+        Score score = Score.initializeScore(board);
         assertEquals(0, score.getWhiteStartingSquarePenalty());
     }
 }


### PR DESCRIPTION
## Summary
- return a freshly constructed `Score` from `Score.initializeScore` so callers never mutate shared state
- remove the cached score difference field and update `GameState` plus tests to use the new initialization flow

## Testing
- `mvn test` *(fails: unable to download parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c928154dc8832a868d4fe3d1cd08ed