### PR TITLE
Handle draw adjudication during state recompute

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -87,6 +87,8 @@ public class GameState {
             }
         } else if (isDraw(bitBoard, legalMoves)) {
             state = GameStateEnum.DRAW;
+        } else if (isFiftyMoveRule() || isThreefoldRepetition()) {
+            state = GameStateEnum.DRAW;
         } else {
             if(isOpeningMove) {
                 state = GameStateEnum.PLAY_OPENING;


### PR DESCRIPTION
## Summary
- check the fifty-move rule and threefold repetition when recomputing the game state after board updates

## Testing
- mvn -q test *(fails: unable to resolve parent POM while offline)*

------
https://chatgpt.com/codex/tasks/task_e_68c94c61ce28832aba0f32eca18c5746