### PR TITLE
Handle terminal draw states on FEN import

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -222,8 +222,31 @@ public class Engine {
         synchronized (boardLock) {
             this.bitBoard = FEN.translateFENtoBitBoard(fen);
             this.gameState = new GameState(bitBoard);
-            generateLegalMoves();
-            gameState.updateState(bitBoard, legalMoves, false);
+
+            // Ensure the imported state reflects the parsed halfmove/fullmove counters and
+            // repetition baseline.  The constructor copies the counters from the bitboard, but
+            // we explicitly reset the historical bookkeeping so future updates start from this
+            // root position.
+            gameState.setHalfmoveClock(bitBoard.getHalfmoveClock());
+            gameState.setFullmoveNumber(bitBoard.getFullmoveNumber());
+            gameState.getHashHistory().clear();
+            gameState.getRepetition().clear();
+            gameState.recordHash(getBoardStateHash());
+
+            // For terminal draw states (e.g., fifty-move rule) skip move generation entirely so
+            // callers observe an empty legal move list.
+            if (gameState.isFiftyMoveRule() || gameState.isThreefoldRepetition()) {
+                if (legalMoves == null) {
+                    legalMoves = new MoveList();
+                } else {
+                    legalMoves.clear();
+                }
+                legalMovesNeedUpdate = false;
+                gameState.setState(GameStateEnum.DRAW);
+            } else {
+                generateLegalMoves();
+                gameState.updateState(bitBoard, legalMoves, false);
+            }
             notifyPositionChanged();
         }
     }

--- a/src/test/java/julius/game/chessengine/engine/EngineFenImportTest.java
+++ b/src/test/java/julius/game/chessengine/engine/EngineFenImportTest.java
@@ -1,0 +1,21 @@
+package julius.game.chessengine.engine;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EngineFenImportTest {
+
+    @Test
+    void importingFenWithFiftyMoveDrawMarksGameOver() {
+        Engine engine = new Engine();
+
+        engine.importBoardFromFen("4k3/8/8/8/8/8/8/4K3 w - - 100 1");
+
+        GameState gameState = engine.getGameState();
+        assertTrue(gameState.isGameOver());
+        assertEquals(GameStateEnum.DRAW, gameState.getState());
+        assertEquals(0, engine.getAllLegalMoves().size());
+    }
+}


### PR DESCRIPTION
## Summary
- reset the imported game state to use the parsed halfmove/fullmove counters and fresh repetition history
- short-circuit draw adjudication during FEN import so terminal positions expose empty move lists
- add a regression test that imports a halfmove=100 FEN and asserts the game is over as a draw

## Testing
- `./mvnw test` *(fails: network unreachable while downloading wrapper distribution)*
- `mvn test` *(fails: network unreachable while resolving Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c94d8660ec832ab099aac6de35c5d9