### PR TITLE
Include full state in exported FEN

### DIFF
--- a/src/main/java/julius/game/chessengine/board/FEN.java
+++ b/src/main/java/julius/game/chessengine/board/FEN.java
@@ -1,16 +1,24 @@
 package julius.game.chessengine.board;
 
+import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.utils.Color;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Objects;
+
+import static julius.game.chessengine.board.MoveHelper.convertIndexToString;
 
 @Data
 @RequiredArgsConstructor
 public class FEN {
     private final String renderBoard;
 
-    public static FEN translateBoardToFEN(BitBoard board) {
+    public static FEN translateBoardToFEN(BitBoard board, GameState gameState) {
+        Objects.requireNonNull(board, "board");
+        Objects.requireNonNull(gameState, "gameState");
+
         StringBuilder fenBuilder = new StringBuilder();
         for (int rank = 8; rank >= 1; rank--) {
             int emptyCount = 0;
@@ -37,9 +45,76 @@ public class FEN {
                 fenBuilder.append('/');
             }
         }
-        // You would add the active color, castling availability, en passant target square,
-        // halfmove clock, and fullmove number after this
+        fenBuilder.append(' ');
+        fenBuilder.append(board.isWhitesTurn() ? 'w' : 'b');
+        fenBuilder.append(' ');
+
+        String castlingAvailability = buildCastlingAvailability(board);
+        fenBuilder.append(castlingAvailability.isEmpty() ? "-" : castlingAvailability);
+        fenBuilder.append(' ');
+
+        int enPassantIndex = board.getEnPassantTargetIndex();
+        fenBuilder.append(enPassantIndex == -1 ? "-" : convertIndexToString(enPassantIndex));
+        fenBuilder.append(' ');
+        fenBuilder.append(gameState.getHalfmoveClock());
+        fenBuilder.append(' ');
+        fenBuilder.append(gameState.getFullmoveNumber());
+
         return new FEN(fenBuilder.toString());
+    }
+
+    private static String buildCastlingAvailability(BitBoard board) {
+        StringBuilder castling = new StringBuilder();
+
+        if (canCastleKingSide(board, true)) {
+            castling.append('K');
+        }
+        if (canCastleQueenSide(board, true)) {
+            castling.append('Q');
+        }
+        if (canCastleKingSide(board, false)) {
+            castling.append('k');
+        }
+        if (canCastleQueenSide(board, false)) {
+            castling.append('q');
+        }
+
+        return castling.toString();
+    }
+
+    private static boolean canCastleKingSide(BitBoard board, boolean white) {
+        if (white) {
+            return !board.isWhiteKingMoved()
+                    && !board.isWhiteRookH1Moved()
+                    && hasHomeKingAndRook(board, 4, 7, Color.WHITE);
+        }
+        return !board.isBlackKingMoved()
+                && !board.isBlackRookH8Moved()
+                && hasHomeKingAndRook(board, 60, 63, Color.BLACK);
+    }
+
+    private static boolean canCastleQueenSide(BitBoard board, boolean white) {
+        if (white) {
+            return !board.isWhiteKingMoved()
+                    && !board.isWhiteRookA1Moved()
+                    && hasHomeKingAndRook(board, 4, 0, Color.WHITE);
+        }
+        return !board.isBlackKingMoved()
+                && !board.isBlackRookA8Moved()
+                && hasHomeKingAndRook(board, 60, 56, Color.BLACK);
+    }
+
+    private static boolean hasHomeKingAndRook(BitBoard board, int kingIndex, int rookIndex,
+                                              Color color) {
+        PieceType kingPiece = board.getPieceTypeAtIndex(kingIndex);
+        Color kingColor = board.getPieceColorAtIndex(kingIndex);
+        PieceType rookPiece = board.getPieceTypeAtIndex(rookIndex);
+        Color rookColor = board.getPieceColorAtIndex(rookIndex);
+
+        return kingPiece == PieceType.KING
+                && kingColor == color
+                && rookPiece == PieceType.ROOK
+                && rookColor == color;
     }
 
     private static char getFenCharacter(PieceType pieceType, Color color) {

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -506,7 +506,7 @@ public class Engine {
 
     public FEN translateBoardToFen() {
         synchronized (boardLock) {
-            return FEN.translateBoardToFEN(bitBoard);
+            return FEN.translateBoardToFEN(bitBoard, gameState);
         }
     }
 

--- a/src/test/java/julius/game/chessengine/board/FENExportTest.java
+++ b/src/test/java/julius/game/chessengine/board/FENExportTest.java
@@ -1,0 +1,21 @@
+package julius.game.chessengine.board;
+
+import julius.game.chessengine.engine.Engine;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FENExportTest {
+
+    @Test
+    void exportFenReflectsCompleteGameState() {
+        Engine engine = new Engine();
+        String expectedFen = "r3k2r/pppb1ppp/2n1bn2/2Pp4/3P4/2N1PN2/PPPB1PPP/R3K2R w KQkq d6 7 12";
+
+        engine.importBoardFromFen(expectedFen);
+
+        FEN exportedFen = engine.translateBoardToFen();
+
+        assertEquals(expectedFen, exportedFen.getRenderBoard());
+    }
+}


### PR DESCRIPTION
## Summary
- extend the FEN exporter to append the active color, castling rights, en-passant square, halfmove clock, and fullmove number derived from the current bitboard and game state
- update the engine to pass the live GameState when building a FEN string
- add a regression test that verifies a complex position is exported to the expected FEN representation

## Testing
- ./mvnw test *(fails: Network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c9501bb7dc832aaf6ac2641b384fe9