### PR TITLE
Fix en passant undo ghost pawn on target square

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -1589,8 +1589,8 @@ public class BitBoard {
         // 3) move mover back on bitboards
         undoPieceMove(pieceTypeBits, fromIndex, toIndex, isWhite);
 
-        // 4) clear landing square on simple non-capture, non-promotion, non-ep
-        if (!isCapture && promotionPieceTypeBits == 0 && !isEnPassantMove) {
+        // 4) clear landing square when nothing should remain there (quiet moves or en passant)
+        if (isEnPassantMove || (!isCapture && promotionPieceTypeBits == 0)) {
             pieceBoard[toIndex] = null;
         }
 


### PR DESCRIPTION
## Summary
- ensure undoing an en passant capture clears the destination square so no phantom pawn remains
- update the undoMove comment to reflect that the square is cleared for quiet moves and en passant captures

## Testing
- `mvn -q -Dtest=FENExportTest test -o` *(fails: parent Spring Boot BOM unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c953ec38e0832ab2b9f2246df526c2