### PR TITLE
Improve bullet time handling in UCI go command

### DIFF
--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -208,6 +208,51 @@ public class UciHandler {
         return from + to;
     }
 
+    static long estimateMovesToGo(long timeLeft, long increment) {
+        if (timeLeft <= 0) {
+            return 1;
+        }
+        if (increment <= 0 && timeLeft <= 75_000) {
+            // Bullet-style controls burn through many moves with little time
+            return 60;
+        }
+        if (timeLeft <= 300_000) {
+            // Rapid/blitz without an explicit movestogo hint
+            return 40;
+        }
+        return 30;
+    }
+
+    static long computeTimeLimit(long timeLeft, long increment, long movetime, int movestogo, int overheadMs) {
+        if (movetime > 0) {
+            long adjusted = movetime - overheadMs;
+            if (timeLeft > overheadMs) {
+                long maxAvailable = timeLeft - overheadMs;
+                if (adjusted > maxAvailable) {
+                    adjusted = maxAvailable;
+                }
+            }
+            return Math.max(adjusted, 1);
+        }
+
+        long movesToGo = movestogo > 0 ? movestogo : estimateMovesToGo(timeLeft, increment);
+        if (movesToGo <= 0) {
+            movesToGo = 1;
+        }
+
+        long share = timeLeft > 0 ? timeLeft / movesToGo : 0;
+        long limit = share + increment - overheadMs;
+
+        if (timeLeft > overheadMs) {
+            long maxAvailable = timeLeft - overheadMs;
+            if (limit > maxAvailable) {
+                limit = maxAvailable;
+            }
+        }
+
+        return Math.max(limit, 1);
+    }
+
     private void go(String[] tokens) {
         // Stop any previous search thread
         stop();
@@ -235,10 +280,7 @@ public class UciHandler {
         boolean whitesTurn = engine.whitesTurn();
         long timeLeft = whitesTurn ? wtime : btime;
         long inc = whitesTurn ? winc : binc;
-        long movesToGo = (movestogo > 0 ? movestogo : 30);
-        long limit = (movetime > 0 ? movetime :
-                (timeLeft / movesToGo) + inc - moveOverheadMs);
-        limit = Math.max(limit, 1);
+        long limit = computeTimeLimit(timeLeft, inc, movetime, movestogo, moveOverheadMs);
         ai.setTimeLimit(limit);
 
         searchThread = new Thread(() -> {

--- a/src/test/java/julius/game/chessengine/uci/UciTimeManagementTest.java
+++ b/src/test/java/julius/game/chessengine/uci/UciTimeManagementTest.java
@@ -1,0 +1,39 @@
+package julius.game.chessengine.uci;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UciTimeManagementTest {
+
+    @Test
+    void estimateMovesToGoPrefersLongerHorizonForBullet() {
+        assertEquals(60L, UciHandler.estimateMovesToGo(60_000L, 0L));
+        assertEquals(40L, UciHandler.estimateMovesToGo(180_000L, 0L));
+        assertEquals(30L, UciHandler.estimateMovesToGo(600_000L, 0L));
+    }
+
+    @Test
+    void computeTimeLimitUsesEstimateWhenMovestogoMissing() {
+        long limit = UciHandler.computeTimeLimit(60_000L, 0L, 0L, 0, 0);
+        assertEquals(1_000L, limit);
+    }
+
+    @Test
+    void computeTimeLimitRespectsMoveOverheadForMovetime() {
+        long limit = UciHandler.computeTimeLimit(0L, 0L, 500L, 0, 75);
+        assertEquals(425L, limit);
+    }
+
+    @Test
+    void computeTimeLimitCapsMovetimeToRemainingTime() {
+        long limit = UciHandler.computeTimeLimit(200L, 0L, 500L, 0, 0);
+        assertEquals(200L, limit);
+    }
+
+    @Test
+    void computeTimeLimitDoesNotExceedRemainingTime() {
+        long limit = UciHandler.computeTimeLimit(300L, 5_000L, 0L, 0, 0);
+        assertEquals(300L, limit);
+    }
+}


### PR DESCRIPTION
## Summary
- derive a reusable helper in `UciHandler` to estimate moves-to-go and compute safer per-move limits
- clamp per-move limits to the remaining clock time and honour configured move overheads
- cover the new time allocation logic with focused unit tests

## Testing
- `mvn test` *(fails: Network is unreachable while resolving Maven parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c967107844832a896111ba570f71d4