### PR TITLE
Perform move in engine when reporting bestmove

### DIFF
--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -298,11 +298,14 @@ public class UciHandler {
             } finally {
                 Integer bm = ai.getCurrentBestMoveInt();
                 if (bm != null && bm != -1) {
+                    engine.performMove(bm);
                     System.out.println("bestmove " + toUci(bm));
                 } else {
                     MoveList legal = engine.getAllLegalMoves();
                     if (legal.size() > 0) {
-                        System.out.println("bestmove " + toUci(legal.getMove(0)));
+                        int move = legal.getMove(0);
+                        engine.performMove(move);
+                        System.out.println("bestmove " + toUci(move));
                     } else {
                         System.out.println("bestmove (none)");
                     }


### PR DESCRIPTION
## Summary
- call `engine.performMove` when a best move is found before emitting the UCI response
- update the fallback move selection to apply the move on the engine before reporting it

## Testing
- mvn test *(fails: unable to resolve parent POM because the Maven Central repository is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a16ecb44832aad77efc11cb1bc08