### PR TITLE
Prevent stale best moves from new games

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -188,7 +188,17 @@ public class AI {
 
 
     public Integer getCurrentBestMoveInt() {
-        return currentBestMove;
+        int move = currentBestMove;
+        if (move == -1) {
+            return -1;
+        }
+
+        long currentHash = mainEngine.getBoardStateHash();
+        if (currentHash != bestMoveForHash) {
+            return -1;
+        }
+
+        return move;
     }
 
     private void startCalculationThread() {
@@ -308,6 +318,7 @@ public class AI {
     public void reset() {
         stopCalculation();
         currentBestMove = -1;
+        bestMoveForHash = -1;
         currentBoardState = -1;
         beforeCalculationBoardState = -2;
         calculatedLine = Collections.synchronizedList(new ArrayList<>());


### PR DESCRIPTION
## Summary
- avoid returning a cached best move when the stored hash does not match the current board position
- clear the cached hash when resetting the AI for a new game

## Testing
- ./mvnw -q -DskipTests package *(fails: network is unreachable for Maven wrapper download)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ae61db40832a9dc39bc5589d8c5a