### PR TITLE
Normalize draw handling for white perspective

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -558,6 +558,9 @@ public class AI {
             firstScore = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
         } else if (simulatorEngine.getGameState().isInStateDraw()) {
             firstScore = evaluateStaticPosition(simulatorEngine.getGameState(), !isWhitesTurn, depth);
+            if (isWhitesTurn) {
+                firstScore = -firstScore;
+            }
         } else {
             firstScore = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, firstMove, 1);
             if (firstScore == EXIT_FLAG || abortRequested(deadline)) {
@@ -604,6 +607,9 @@ public class AI {
                     probe = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
                 } else if (e.getGameState().isInStateDraw()) {
                     probe = evaluateStaticPosition(e.getGameState(), !isWhitesTurn, depth);
+                    if (isWhitesTurn) {
+                        probe = -probe;
+                    }
                 } else {
                     probe = alphaBeta(e, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline, moveInt, 1);
                     if (probe == EXIT_FLAG || abortRequested(deadline)) return null;
@@ -776,6 +782,9 @@ public class AI {
                 score = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
             } else if (simulatorEngine.getGameState().isInStateDraw()) {
                 score = evaluateStaticPosition(simulatorEngine.getGameState(), !isWhitesTurn, depth);
+                if (isWhitesTurn) {
+                    score = -score;
+                }
             } else {
                 score = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, moveInt, 1);
                 if (score == EXIT_FLAG || abortRequested(deadline)) {

--- a/src/test/java/julius/game/chessengine/ai/AvoidRepetitionDrawTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AvoidRepetitionDrawTest.java
@@ -1,0 +1,76 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.board.Move;
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.board.MoveList;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.engine.GameState;
+import julius.game.chessengine.engine.GameStateEnum;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+class AvoidRepetitionDrawTest {
+
+    private static final String WINNING_FEN = "7k/p6B/5K1Q/8/8/8/8/8 w - - 0 1";
+
+    @Test
+    void whiteDoesNotRepeatWhenWinning() throws InterruptedException {
+        Engine engine = new Engine();
+        engine.importBoardFromFen(WINNING_FEN);
+
+        int drawMove = findMove(engine, "h6", "g6");
+
+        Engine repetitionProbe = engine.createSimulation();
+        repetitionProbe.performMove(drawMove);
+        long drawHash = repetitionProbe.getBoardStateHash();
+
+        GameState gameState = engine.getGameState();
+        gameState.getRepetition().put(drawHash, 2);
+
+        AI ai = new AI(engine);
+        ai.setTimeLimit(200L);
+        ai.startAutoPlay(true, false);
+
+        int observedMove = waitForMove(engine);
+
+        ai.stopCalculation();
+
+        Assertions.assertNotEquals(drawMove, observedMove,
+                () -> "Expected engine to avoid repetition draw, but it played "
+                        + Move.convertIntToMove(observedMove));
+        Assertions.assertNotEquals(GameStateEnum.DRAW, engine.getGameState().getState(),
+                "Engine incorrectly accepted a repetition draw from a winning position.");
+        Assertions.assertEquals(GameStateEnum.WHITE_WON, engine.getGameState().getState(),
+                "Engine should convert the advantage instead of repeating for a draw.");
+    }
+
+    private int findMove(Engine engine, String from, String to) {
+        int fromIndex = MoveHelper.convertStringToIndex(from);
+        int toIndex = MoveHelper.convertStringToIndex(to);
+        MoveList legalMoves = engine.getAllLegalMoves();
+        for (int i = 0; i < legalMoves.size(); i++) {
+            int move = legalMoves.getMove(i);
+            if (MoveHelper.deriveFromIndex(move) == fromIndex
+                    && MoveHelper.deriveToIndex(move) == toIndex) {
+                return move;
+            }
+        }
+        throw new IllegalStateException("Move " + from + " -> " + to + " not found");
+    }
+
+    private int waitForMove(Engine engine) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(5);
+        int lastMove = -1;
+        while (System.currentTimeMillis() < deadline) {
+            lastMove = engine.getLastMove();
+            if (lastMove != -1) {
+                break;
+            }
+            TimeUnit.MILLISECONDS.sleep(50);
+        }
+        Assertions.assertNotEquals(-1, lastMove, "Engine failed to make a move in time");
+        return lastMove;
+    }
+}


### PR DESCRIPTION
## Summary
- negate immediate draw scores when white is the root mover in both serial and parallel search paths so evaluations stay white-oriented
- add an integration test that seeds a repeated position and ensures the engine converts a winning position instead of repeating for a draw

## Testing
- mvn test *(fails: unable to download parent POM because the build environment cannot reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c016dcfc832a978befd90e83384f