### PR TITLE
Allow AI killer move heuristics to grow with max depth

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -92,7 +92,8 @@ public class AI {
      */
     private final TranspositionTable<CaptureTranspositionTableEntry> captureTranspositionTable;
 
-    private final int[][] killerMoves; // 2D array for killer moves, initialized in the constructor
+    private static final int NUM_KILLER_MOVES = 2;
+    private volatile int[][] killerMoves; // 2D array for killer moves, initialized in the constructor
 
     /**
      * History heuristic table. Indexed by from and to square (0-63), it stores a
@@ -148,13 +149,7 @@ public class AI {
         this.timeLimit = 50;
 
         // Initialize killer moves etc...
-        int numKillerMoves = 2;
-        this.killerMoves = new int[maxDepth][numKillerMoves];
-        for (int i = 0; i < maxDepth; i++) {
-            for (int j = 0; j < numKillerMoves; j++) {
-                killerMoves[i][j] = -1;
-            }
-        }
+        this.killerMoves = allocateKillerMoves(maxDepth);
         this.historyTable = new int[64][64];
         this.counterMove = new int[64][64];
         for (int f = 0; f < 64; f++) Arrays.fill(counterMove[f], -1);
@@ -179,11 +174,32 @@ public class AI {
     }
 
     /**
-     * Override the maximum depth for iterative deepening. Depth values greater than
-     * the preallocated tables are clamped.
+     * Override the maximum depth for iterative deepening. The killer-move table is
+     * grown on demand so deeper searches can proceed without being clamped by the
+     * previous allocation. The requested depth is always respected (minimum 1).
      */
-    public void setMaxDepth(int depth) {
-        this.maxDepth = Math.max(1, Math.min(depth, killerMoves.length));
+    public synchronized void setMaxDepth(int depth) {
+        int requestedDepth = Math.max(1, depth);
+        if (requestedDepth > killerMoves.length) {
+            killerMoves = resizeKillerMoves(killerMoves, requestedDepth);
+        }
+        this.maxDepth = requestedDepth;
+    }
+
+    private static int[][] allocateKillerMoves(int depth) {
+        int[][] table = new int[depth][NUM_KILLER_MOVES];
+        for (int i = 0; i < depth; i++) {
+            Arrays.fill(table[i], -1);
+        }
+        return table;
+    }
+
+    private static int[][] resizeKillerMoves(int[][] current, int newDepth) {
+        int[][] expanded = allocateKillerMoves(newDepth);
+        for (int i = 0; i < current.length; i++) {
+            System.arraycopy(current[i], 0, expanded[i], 0, current[i].length);
+        }
+        return expanded;
     }
 
 
@@ -307,7 +323,7 @@ public class AI {
         }
     }
 
-    private MoveAndScore searchRootMoves(Engine sim, SearchTask task, int depth, double alpha, double beta, SplittableRandom rng) {
+    protected MoveAndScore searchRootMoves(Engine sim, SearchTask task, int depth, double alpha, double beta, SplittableRandom rng) {
         if (searchThreads > 1) {
             return getBestMoveParallel(sim, task.isWhiteToMove(), depth, task.getDeadline(), alpha, beta, rng);
         }

--- a/src/test/java/julius/game/chessengine/ai/IterativeDeepeningMaxDepthTest.java
+++ b/src/test/java/julius/game/chessengine/ai/IterativeDeepeningMaxDepthTest.java
@@ -1,0 +1,83 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.engine.Engine;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IterativeDeepeningMaxDepthTest {
+
+    @Test
+    void setMaxDepthResizesKillerMovesAndAllowsThirtyPlies() throws Exception {
+        Engine engine = new Engine();
+        TestAI ai = new TestAI(engine);
+
+        int initialCapacity = extractKillerMoves(ai).length;
+
+        ai.setMaxDepth(30);
+
+        assertEquals(30, ai.getMaxDepth(), "maxDepth should be set to the requested value");
+
+        int[][] killerMoves = extractKillerMoves(ai);
+        assertTrue(killerMoves.length >= 30, "killer move table must accommodate the requested depth");
+
+        if (killerMoves.length > initialCapacity) {
+            for (int depth = initialCapacity; depth < killerMoves.length; depth++) {
+                for (int slot = 0; slot < killerMoves[depth].length; slot++) {
+                    assertEquals(-1, killerMoves[depth][slot], "new killer move slots should be initialised to -1");
+                }
+            }
+        }
+
+        long boardHash = engine.getBoardStateHash();
+        setLongField(ai, "currentBoardState", boardHash);
+        setLongField(ai, "beforeCalculationBoardState", boardHash);
+
+        SearchTask task = new SearchTask(1L, boardHash, engine.whitesTurn(),
+                System.nanoTime() + TimeUnit.SECONDS.toNanos(1), 1);
+
+        Method iterativeDeepening = AI.class.getDeclaredMethod(
+                "iterativeDeepening", SearchTask.class, Engine.class, SplittableRandom.class);
+        iterativeDeepening.setAccessible(true);
+        iterativeDeepening.invoke(ai, task, engine, null);
+
+        assertEquals(30, ai.getDeepestRequestedDepth(),
+                "iterative deepening should reach the configured depth");
+    }
+
+    private static int[][] extractKillerMoves(AI ai) throws Exception {
+        Field field = AI.class.getDeclaredField("killerMoves");
+        field.setAccessible(true);
+        return (int[][]) field.get(ai);
+    }
+
+    private static void setLongField(AI ai, String fieldName, long value) throws Exception {
+        Field field = AI.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.setLong(ai, value);
+    }
+
+    private static final class TestAI extends AI {
+        private int deepestRequestedDepth = 0;
+
+        private TestAI(Engine engine) {
+            super(engine);
+        }
+
+        @Override
+        protected MoveAndScore searchRootMoves(Engine sim, SearchTask task, int depth,
+                                               double alpha, double beta, SplittableRandom rng) {
+            deepestRequestedDepth = Math.max(deepestRequestedDepth, depth);
+            return new MoveAndScore(0, 0.0);
+        }
+
+        int getDeepestRequestedDepth() {
+            return deepestRequestedDepth;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- grow the killer-move heuristic table when increasing the configured search depth so new rows are initialised and the request is honoured
- expose the root move search hook for testing and add a regression test proving iterative deepening can reach 30 plies after calling `setMaxDepth(30)`

## Testing
- mvn test *(fails: network is unreachable while resolving Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c41be660832a90fef4bdefdef9c5