### PR TITLE
Refine move ordering buffers

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -107,14 +107,8 @@ public class AI {
     // allocations when ordering moves.
     private static final int MAX_MOVE_LIST_SIZE = 218; // maximum legal moves
 
-    private static final class SortBuffers {
-        final int[] moveBuffer = new int[MAX_MOVE_LIST_SIZE];
-        final int[] scoreBuffer = new int[MAX_MOVE_LIST_SIZE];
-        final long[] sortKeyBuffer = new long[MAX_MOVE_LIST_SIZE];
-    }
-
     private final ThreadLocal<SortBuffers> sortBuffers =
-            ThreadLocal.withInitial(SortBuffers::new);
+            ThreadLocal.withInitial(() -> new SortBuffers(MAX_MOVE_LIST_SIZE));
     private final ThreadLocal<Map<Integer, Integer>> seeCacheThreadLocal =
             ThreadLocal.withInitial(() -> new HashMap<>(64));
 

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -106,9 +106,15 @@ public class AI {
     // Buffers used for move ordering. Reused across calls to avoid repeated
     // allocations when ordering moves.
     private static final int MAX_MOVE_LIST_SIZE = 218; // maximum legal moves
-    private final int[] moveBuffer = new int[MAX_MOVE_LIST_SIZE];
-    private final int[] scoreBuffer = new int[MAX_MOVE_LIST_SIZE];
-    private final long[] sortKeyBuffer = new long[MAX_MOVE_LIST_SIZE];
+
+    private static final class SortBuffers {
+        final int[] moveBuffer = new int[MAX_MOVE_LIST_SIZE];
+        final int[] scoreBuffer = new int[MAX_MOVE_LIST_SIZE];
+        final long[] sortKeyBuffer = new long[MAX_MOVE_LIST_SIZE];
+    }
+
+    private final ThreadLocal<SortBuffers> sortBuffers =
+            ThreadLocal.withInitial(SortBuffers::new);
     private final ThreadLocal<Map<Integer, Integer>> seeCacheThreadLocal =
             ThreadLocal.withInitial(() -> new HashMap<>(64));
 
@@ -1328,6 +1334,11 @@ public class AI {
             return moves;
         }
 
+        final SortBuffers buffers = sortBuffers.get();
+        final int[] moveBuffer = buffers.moveBuffer;
+        final int[] scoreBuffer = buffers.scoreBuffer;
+        final long[] sortKeys = buffers.sortKeyBuffer;
+
         final int depthIndex = Math.max(0, Math.min(currentDepth, killerMoves.length - 1));
 
         // Category encoding (higher is earlier):
@@ -1354,8 +1365,6 @@ public class AI {
         final int prevTo = (prevMove >= 0) ? ((prevMove >>> 6) & 0x3F) : -1;
         final int cm = (prevFrom >= 0) ? counterMove[prevFrom][prevTo] : -1;
         final int COUNTER_MOVE_BONUS = 400;
-
-        final long[] sortKeys = sortKeyBuffer;
 
         for (int i = 0; i < size; i++) {
             final int moveInt = moves.getMove(i);

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -108,6 +108,9 @@ public class AI {
     private static final int MAX_MOVE_LIST_SIZE = 218; // maximum legal moves
     private final int[] moveBuffer = new int[MAX_MOVE_LIST_SIZE];
     private final int[] scoreBuffer = new int[MAX_MOVE_LIST_SIZE];
+    private final long[] sortKeyBuffer = new long[MAX_MOVE_LIST_SIZE];
+    private final ThreadLocal<Map<Integer, Integer>> seeCacheThreadLocal =
+            ThreadLocal.withInitial(() -> new HashMap<>(64));
 
     private ScheduledExecutorService scheduler;
 
@@ -530,12 +533,36 @@ public class AI {
         fillCalculatedLine(simulatorEngine);
     }
 
-    private void maybeRotateRootMoves(List<Integer> moves, SplittableRandom rng) {
-        if (rng == null || moves.isEmpty()) return;
-        int bound = Math.min(moves.size(), 4);
+    private void maybeRotateRootMoves(MoveList moves, SplittableRandom rng) {
+        if (rng == null) return;
+        int size = moves.size();
+        if (size == 0) return;
+
+        int bound = Math.min(size, 4);
         if (bound <= 1) return;
+
         int rotation = rng.nextInt(bound);
-        if (rotation != 0) Collections.rotate(moves, -rotation);
+        if (rotation == 0) return;
+
+        rotateMoveListLeft(moves, rotation);
+    }
+
+    private void rotateMoveListLeft(MoveList moves, int distance) {
+        int size = moves.size();
+        if (size <= 1) return;
+
+        int shift = distance % size;
+        if (shift < 0) shift += size;
+        if (shift == 0) return;
+
+        for (int r = 0; r < shift; r++) {
+            int first = moves.getMove(0);
+            for (int i = 0; i < size - 1; i++) {
+                int next = moves.getMove(i + 1);
+                moves.setMove(i, next);
+            }
+            moves.setMove(size - 1, first);
+        }
     }
 
     private boolean abortRequested(long deadline) {
@@ -558,11 +585,11 @@ public class AI {
         }
 
         MoveList legal = simulatorEngine.getAllLegalMoves();
-        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(legal, depth, simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
-        if (orderedMoves.isEmpty()) return null;
+        MoveList orderedMoves = sortMovesByEfficiency(legal, depth, simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
+        if (orderedMoves.size() == 0) return null;
         maybeRotateRootMoves(orderedMoves, rng);
 
-        int firstMove = orderedMoves.get(0);
+        int firstMove = orderedMoves.getMove(0);
         int bestMove = -1;
         double bestScore = isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
 
@@ -605,7 +632,7 @@ public class AI {
         final java.util.concurrent.locks.ReentrantLock fullResLock = new java.util.concurrent.locks.ReentrantLock();
 
         for (int i = 1; i <= fanout; i++) {
-            final int moveInt = orderedMoves.get(i);
+            final int moveInt = orderedMoves.getMove(i);
             futures.add(ecs.submit(() -> {
                 if (stopRef.get() || abortRequested(deadline)) return null;
 
@@ -785,11 +812,12 @@ public class AI {
         int bestMove = -1;
         double bestScore = isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
 
-        ArrayList<Integer> sortedMoves = sortMovesByEfficiency(simulatorEngine.getAllLegalMoves(), depth,
+        MoveList sortedMoves = sortMovesByEfficiency(simulatorEngine.getAllLegalMoves(), depth,
                 simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
         maybeRotateRootMoves(sortedMoves, rng);
 
-        for (int moveInt : sortedMoves) {
+        for (int idx = 0; idx < sortedMoves.size(); idx++) {
+            int moveInt = sortedMoves.getMove(idx);
             if (abortRequested(deadline)) break;
 
             simulatorEngine.performMove(moveInt);
@@ -987,10 +1015,10 @@ public class AI {
 
         final boolean inCheckAtNode = isSideInCheck(simulatorEngine, isWhite);
 
-        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove, simulatorEngine);
+        MoveList orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove, simulatorEngine);
         for (int index = 0; index < orderedMoves.size(); index++) {
             if (abortRequested(deadline)) { return EXIT_FLAG; }
-            int move = orderedMoves.get(index);
+            int move = orderedMoves.getMove(index);
 
             int from = MoveHelper.deriveFromIndex(move);
             int to   = MoveHelper.deriveToIndex(move);
@@ -1142,13 +1170,13 @@ public class AI {
 
         final boolean inCheckAtNode = isSideInCheck(simulatorEngine, isWhite);
 
-        ArrayList<Integer> orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove, simulatorEngine);
+        MoveList orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove, simulatorEngine);
         for (int index = 0; index < orderedMoves.size(); index++) {
             if (Thread.currentThread().isInterrupted() || positionChanged() || System.nanoTime() > deadline) {
                 return EXIT_FLAG;
             }
 
-            int move = orderedMoves.get(index);
+            int move = orderedMoves.getMove(index);
 
             int from = MoveHelper.deriveFromIndex(move);
             int to   = MoveHelper.deriveToIndex(move);
@@ -1290,9 +1318,16 @@ public class AI {
      * their capture bucket. Results are cached per move within this ordering
      * pass so repeated SEE queries are avoided.
      */
-    ArrayList<Integer> sortMovesByEfficiency(MoveList moves, int currentDepth, long boardHash, int prevMove,
-                                             Engine simulatorEngine) {
+    MoveList sortMovesByEfficiency(MoveList moves, int currentDepth, long boardHash, int prevMove,
+                                   Engine simulatorEngine) {
         final int size = moves.size();
+        final Map<Integer, Integer> seeCache = seeCacheThreadLocal.get();
+        seeCache.clear();
+
+        if (size == 0) {
+            return moves;
+        }
+
         final int depthIndex = Math.max(0, Math.min(currentDepth, killerMoves.length - 1));
 
         // Category encoding (higher is earlier):
@@ -1320,9 +1355,7 @@ public class AI {
         final int cm = (prevFrom >= 0) ? counterMove[prevFrom][prevTo] : -1;
         final int COUNTER_MOVE_BONUS = 400;
 
-
-        final long[] sortKeys = new long[size];
-        final Map<Integer, Integer> seeCache = new HashMap<>();
+        final long[] sortKeys = sortKeyBuffer;
 
         for (int i = 0; i < size; i++) {
             final int moveInt = moves.getMove(i);
@@ -1416,20 +1449,23 @@ public class AI {
         Arrays.sort(sortKeys, sortStart, size); // ascending by key
 
         // Build result in descending order (bigger category/score first)
-        ArrayList<Integer> sortedMoveList = new ArrayList<>(size);
+        int outIndex = 0;
         if (ttIndex != -1) {
-            // TT already at index 0
-            sortedMoveList.add((int) (sortKeys[0] & 0xFFFFFFFFL));
+            moveBuffer[outIndex++] = (int) (sortKeys[0] & 0xFFFFFFFFL);
             for (int i = size - 1; i >= 1; i--) {
-                sortedMoveList.add((int) (sortKeys[i] & 0xFFFFFFFFL));
+                moveBuffer[outIndex++] = (int) (sortKeys[i] & 0xFFFFFFFFL);
             }
         } else {
             for (int i = size - 1; i >= 0; i--) {
-                sortedMoveList.add((int) (sortKeys[i] & 0xFFFFFFFFL));
+                moveBuffer[outIndex++] = (int) (sortKeys[i] & 0xFFFFFFFFL);
             }
         }
 
-        return sortedMoveList;
+        for (int i = 0; i < size; i++) {
+            moves.setMove(i, moveBuffer[i]);
+        }
+
+        return moves;
     }
 
 
@@ -1502,10 +1538,11 @@ public class AI {
         MoveList moves = inCheck ? simulatorEngine.getAllLegalMoves() : getPossibleCapturesOrPromotions(simulatorEngine);
 
         // Order them (captures first via MVV-LVA/promotion bonus, killers/history still help)
-        ArrayList<Integer> ordered = sortMovesByEfficiency(moves, 0, simulatorEngine.getBoardStateHash(), -1,
+        MoveList ordered = sortMovesByEfficiency(moves, 0, simulatorEngine.getBoardStateHash(), -1,
                 simulatorEngine);
 
-        for (int m : ordered) {
+        for (int i = 0; i < ordered.size(); i++) {
+            int m = ordered.getMove(i);
             boolean isCapture = MoveHelper.isCapture(m);
             boolean isPromotion = MoveHelper.isPawnPromotionMove(m);
             boolean isQuiet = !isCapture && !isPromotion;

--- a/src/main/java/julius/game/chessengine/ai/SortBuffers.java
+++ b/src/main/java/julius/game/chessengine/ai/SortBuffers.java
@@ -1,0 +1,14 @@
+package julius.game.chessengine.ai;
+
+final class SortBuffers {
+
+    final int[] moveBuffer;
+    final int[] scoreBuffer;
+    final long[] sortKeyBuffer;
+
+    SortBuffers(int maxMoveListSize) {
+        this.moveBuffer = new int[maxMoveListSize];
+        this.scoreBuffer = new int[maxMoveListSize];
+        this.sortKeyBuffer = new long[maxMoveListSize];
+    }
+}

--- a/src/test/java/julius/game/chessengine/ai/SortMovesByEfficiencyTest.java
+++ b/src/test/java/julius/game/chessengine/ai/SortMovesByEfficiencyTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -48,7 +47,7 @@ class SortMovesByEfficiencyTest {
         MoveList moves = engine.getAllLegalMoves();
         long hash = engine.getBoardStateHash();
 
-        ArrayList<Integer> ordered = ai.sortMovesByEfficiency(moves, 0, hash, -1, engine);
+        MoveList ordered = ai.sortMovesByEfficiency(moves, 0, hash, -1, engine);
 
         Set<Integer> captureMoves = new HashSet<>();
         for (int i = 0; i < moves.size(); i++) {
@@ -74,7 +73,7 @@ class SortMovesByEfficiencyTest {
         int firstCaptureIndex = -1;
         int firstCaptureMove = -1;
         for (int i = 0; i < ordered.size(); i++) {
-            int move = ordered.get(i);
+            int move = ordered.getMove(i);
             if (seeByMove.containsKey(move)) {
                 firstCaptureIndex = i;
                 firstCaptureMove = move;
@@ -86,7 +85,7 @@ class SortMovesByEfficiencyTest {
 
         int worstCaptureIndex = -1;
         for (int i = ordered.size() - 1; i >= 0; i--) {
-            int move = ordered.get(i);
+            int move = ordered.getMove(i);
             if (seeByMove.containsKey(move) && seeByMove.get(move) == worstSee) {
                 worstCaptureIndex = i;
                 break;


### PR DESCRIPTION
## Summary
* Reworked `sortMovesByEfficiency` to reuse a thread-local SEE cache and a preallocated key buffer while sorting directly on the provided `MoveList`, eliminating per-call list allocations and the transient long-array churn.【F:src/main/java/julius/game/chessengine/ai/AI.java†L1321-L1468】【F:src/main/java/julius/game/chessengine/ai/AI.java†L109-L113】
* Added helpers to rotate root move lists in place and adjusted all callers to operate on `MoveList` instead of `ArrayList`, keeping ordering logic consistent without extra objects.【F:src/main/java/julius/game/chessengine/ai/AI.java†L536-L635】
* Updated the move-ordering unit test to use the in-place `MoveList` ordering while preserving SEE-based assertions.【F:src/test/java/julius/game/chessengine/ai/SortMovesByEfficiencyTest.java†L47-L94】

## Testing
* `mvn -Dtest=SortMovesByEfficiencyTest#positiveSeeCapturesArePrioritisedAndLosingTradesAreDeferred test` *(fails: parent POM unavailable because the Maven central repository is unreachable in this environment)*【02aa84†L1-L21】

------
https://chatgpt.com/codex/tasks/task_e_68c9c737c4a0832a83056014187d7957