### PR TITLE
Use composite pawn structure cache key

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -201,7 +201,10 @@ public class Score {
 
 
     // Cache for pawn structure evaluations to avoid recomputation
-    private static final ConcurrentMap<Long, PawnStructure> pawnStructureCache = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<PawnStructureKey, PawnStructure> pawnStructureCache = new ConcurrentHashMap<>();
+
+    private static record PawnStructureKey(long whitePawns, long blackPawns) {
+    }
 
     private static final class PawnStructure {
         private final int whiteCenterPawnBonus;
@@ -229,12 +232,8 @@ public class Score {
         }
     }
 
-    private static long pawnHash(long whitePawns, long blackPawns) {
-        return whitePawns ^ (blackPawns << 1);
-    }
-
     private static PawnStructure getPawnStructure(long whitePawns, long blackPawns) {
-        long key = pawnHash(whitePawns, blackPawns);
+        PawnStructureKey key = new PawnStructureKey(whitePawns, blackPawns);
         return pawnStructureCache.computeIfAbsent(key, k -> new PawnStructure(whitePawns, blackPawns));
     }
 


### PR DESCRIPTION
## Summary
- replace the pawn structure cache key in `Score` with a `PawnStructureKey` record that captures both pawn bitboards
- update `getPawnStructure` to use the composite key instead of hashing longs

## Testing
- ./mvnw -q test *(fails: Network is unreachable while downloading Maven wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e2fd0eec832aac6470702cf26e50