### PR TITLE
Optimize attack map access with caching helper

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -951,7 +951,7 @@ public class AI {
         BitBoard bb = e.getBitBoard();
         long enemyQueen = moverIsWhite ? bb.getBlackQueens() : bb.getWhiteQueens();
         if (enemyQueen == 0) return false;
-        long myAttacks = bb.generateAttackBitboard(moverIsWhite);
+        long myAttacks = bb.getAttackBitboard(moverIsWhite);
         return (myAttacks & enemyQueen) != 0L;
     }
 
@@ -963,7 +963,7 @@ public class AI {
         }
         int kingIndex = Long.numberOfTrailingZeros(enemyKing);
         long kingZone = KING_ATTACKS[kingIndex];
-        long myAttacks = bb.generateAttackBitboard(moverIsWhite);
+        long myAttacks = bb.getAttackBitboard(moverIsWhite);
         return (myAttacks & kingZone) != 0L;
     }
 

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -737,6 +737,25 @@ public class BitBoard {
         return attacks;
     }
 
+    /**
+     * Returns the cached attack bitboard for the given side, recomputing it only when
+     * marked dirty. This avoids rebuilding the entire attack map multiple times for the
+     * same position.
+     */
+    public long getAttackBitboard(boolean colorWhite) {
+        if (colorWhite) {
+            if (whiteAttackDirty) {
+                recomputeWhiteAttackMap();
+            }
+            return whiteAttackMap;
+        } else {
+            if (blackAttackDirty) {
+                recomputeBlackAttackMap();
+            }
+            return blackAttackMap;
+        }
+    }
+
     // Method to set the bitboard for a specific piece type and color
     void updateAggregatedBitboards() {
         whitePieces = whitePawns | whiteKnights | whiteBishops | whiteRooks | whiteQueens | whiteKing;

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -342,8 +342,8 @@ public class Score {
         long whiteKing = bitBoard.getWhiteKing();
         long blackKing = bitBoard.getBlackKing();
         long allPieces = bitBoard.getAllPieces();
-        long whiteAttacks = bitBoard.generateAttackBitboard(true);
-        long blackAttacks = bitBoard.generateAttackBitboard(false);
+        long whiteAttacks = bitBoard.getAttackBitboard(true);
+        long blackAttacks = bitBoard.getAttackBitboard(false);
         int phase = bitBoard.getPhase();
 
         updateCenterPawnBonusWhite(whitePawns);
@@ -1232,8 +1232,8 @@ public class Score {
         long whitePawns = bitBoard.getWhitePawns();
         long blackPawns = bitBoard.getBlackPawns();
 
-        long whiteAttacks = bitBoard.generateAttackBitboard(true);
-        long blackAttacks = bitBoard.generateAttackBitboard(false);
+        long whiteAttacks = bitBoard.getAttackBitboard(true);
+        long blackAttacks = bitBoard.getAttackBitboard(false);
         long allPieces = bitBoard.getAllPieces();
         long whiteKnights = bitBoard.getWhiteKnights();
         long whiteBishops = bitBoard.getWhiteBishops();
@@ -1484,7 +1484,7 @@ public class Score {
         long whitePawns = bitBoard.getWhitePawns();
         long blackPawns = bitBoard.getBlackPawns();
         long allPieces = bitBoard.getAllPieces();
-        long blackAttacks = bitBoard.generateAttackBitboard(false);
+        long blackAttacks = bitBoard.getAttackBitboard(false);
         long whiteKing = bitBoard.getWhiteKing();
         int phase = bitBoard.getPhase();
 
@@ -1522,7 +1522,7 @@ public class Score {
         long blackPawns = bitBoard.getBlackPawns();
         long whitePawns = bitBoard.getWhitePawns();
         long allPieces = bitBoard.getAllPieces();
-        long whiteAttacks = bitBoard.generateAttackBitboard(true);
+        long whiteAttacks = bitBoard.getAttackBitboard(true);
         long blackKing = bitBoard.getBlackKing();
         int phase = bitBoard.getPhase();
 


### PR DESCRIPTION
## Summary
- add a cached attack-map accessor on `BitBoard` that lazily rebuilds white/black attack maps only when needed
- switch `Score` evaluation helpers to reuse the cached attack maps for pawn and king-safety heuristics
- update AI heuristics that only need the current attack map to call the cached accessor while keeping the eager generator available

## Testing
- `./mvnw -q test` *(fails: Maven wrapper cannot download dependencies because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e3b54878832a815b0da4719093a6