### PR TITLE
Refactor move ordering hash lookup

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -495,18 +495,22 @@ public class AI {
                         return scoreCache.get(moveInt);
                     }
 
-                    // If not a killer move, proceed with existing scoring method
-                    Long boardStateHash = simulatorEngine.getBoardStateHashAfterMove(moveInt);
-                    TranspositionTableEntry entry = transpositionTable.get(boardStateHash);
-                    if (entry != null && entry.depth >= currentDepth) {
-                        return isWhite ? entry.score : -entry.score;
-                    } else {
-                        simulatorEngine.performMove(moveInt);
-                        double score = evaluateBoard(simulatorEngine, isWhite, startTime, timeLimit);
+                    double score;
+                    simulatorEngine.performMove(moveInt);
+                    try {
+                        long boardStateHash = simulatorEngine.getBoardStateHash();
+                        TranspositionTableEntry entry = transpositionTable.get(boardStateHash);
+                        if (entry != null && entry.depth >= currentDepth) {
+                            score = isWhite ? entry.score : -entry.score;
+                        } else {
+                            score = evaluateBoard(simulatorEngine, isWhite, startTime, timeLimit);
+                        }
+                    } finally {
                         simulatorEngine.undoLastMove();
-                        scoreCache.put(moveInt, score);
-                        return score;
                     }
+
+                    scoreCache.put(moveInt, score);
+                    return score;
                 }).reversed()
         );
 

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -280,17 +280,6 @@ public class Engine {
         return FEN.translateBoardToFEN(bitBoard);
     }
 
-    public Long getBoardStateHashAfterMove(int move) {
-        // Step 1: Create a deep copy of the current board state
-        BitBoard boardCopy = new BitBoard(this.bitBoard);
-
-        // Step 2: Simulate the move on the copied board
-        boardCopy.performMove(move); // Assuming 'false' means no need to update the score
-
-        // Step 3: Return the computed hash
-        return boardCopy.getBoardStateHash();
-    }
-
     public boolean isEndgame() {
         return bitBoard.isEndgame();
     }


### PR DESCRIPTION
## Summary
- refactor `AI.sortMovesByEfficiency` to simulate moves directly when checking transposition-table entries, removing the deep-copy hash helper
- drop the now-unused `Engine.getBoardStateHashAfterMove` method

## Testing
- `mvn test` *(fails: unable to download org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c9eda32e60832aa3aec999427e62bd