### PR TITLE
Refine transposition table clustering and aging

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -440,6 +440,13 @@ public class AI {
         for (int currentDepth = 1; currentDepth <= maxDepth; currentDepth++) {
             if (shouldStopCalculating(task.getDeadline())) break;
 
+            if (transpositionTable != null) {
+                transpositionTable.advanceAge();
+            }
+            if (captureTranspositionTable != null) {
+                captureTranspositionTable.advanceAge();
+            }
+
             /**
              * Ply hint for distance-to-mate normalization (set per ID iteration).
              */
@@ -1369,11 +1376,11 @@ public class AI {
         boolean shouldUpdate = existingEntry == null || existingEntry.depth < depth;
 
         if (maxEval <= alphaOriginal && shouldUpdate) {
-            transpositionTable.put(boardHash, new TranspositionTableEntry(maxEval, depth, NodeType.UPPERBOUND, bestMoveAtThisNode));
+            transpositionTable.put(boardHash, new TranspositionTableEntry(maxEval, depth, NodeType.UPPERBOUND, bestMoveAtThisNode), depth);
         } else if (maxEval >= beta && shouldUpdate) {
-            transpositionTable.put(boardHash, new TranspositionTableEntry(maxEval, depth, NodeType.LOWERBOUND, bestMoveAtThisNode));
+            transpositionTable.put(boardHash, new TranspositionTableEntry(maxEval, depth, NodeType.LOWERBOUND, bestMoveAtThisNode), depth);
         } else if (shouldUpdate) {
-            transpositionTable.put(boardHash, new TranspositionTableEntry(maxEval, depth, NodeType.EXACT, bestMoveAtThisNode));
+            transpositionTable.put(boardHash, new TranspositionTableEntry(maxEval, depth, NodeType.EXACT, bestMoveAtThisNode), depth);
         }
 
         return maxEval;
@@ -1531,11 +1538,11 @@ public class AI {
         boolean shouldUpdate = existingEntry == null || existingEntry.depth < depth;
 
         if (minEval >= betaOriginal && shouldUpdate) {
-            transpositionTable.put(boardHash, new TranspositionTableEntry(minEval, depth, NodeType.LOWERBOUND, bestMoveAtThisNode));
+            transpositionTable.put(boardHash, new TranspositionTableEntry(minEval, depth, NodeType.LOWERBOUND, bestMoveAtThisNode), depth);
         } else if (minEval <= alpha && shouldUpdate) {
-            transpositionTable.put(boardHash, new TranspositionTableEntry(minEval, depth, NodeType.UPPERBOUND, bestMoveAtThisNode));
+            transpositionTable.put(boardHash, new TranspositionTableEntry(minEval, depth, NodeType.UPPERBOUND, bestMoveAtThisNode), depth);
         } else if (shouldUpdate) {
-            transpositionTable.put(boardHash, new TranspositionTableEntry(minEval, depth, NodeType.EXACT, bestMoveAtThisNode));
+            transpositionTable.put(boardHash, new TranspositionTableEntry(minEval, depth, NodeType.EXACT, bestMoveAtThisNode), depth);
         }
 
         return minEval;
@@ -1739,7 +1746,7 @@ public class AI {
 
         // don't cache timeouts in the capture TT (qsearch TT)
         if (score != EXIT_FLAG) {
-            captureTranspositionTable.put(boardStateHash, new CaptureTranspositionTableEntry(score, isWhitesTurn));
+            captureTranspositionTable.put(boardStateHash, new CaptureTranspositionTableEntry(score, isWhitesTurn), 0);
         }
 
         return score;

--- a/src/main/java/julius/game/chessengine/ai/FixedSizeTranspositionTable.java
+++ b/src/main/java/julius/game/chessengine/ai/FixedSizeTranspositionTable.java
@@ -4,81 +4,125 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
- * Simple fixed-size hash table with open addressing. The table uses linear
- * probing and overwrites old entries when the table is full. The implementation
- * is thread-safe using atomic operations which makes it usable in concurrent
- * search scenarios without additional locking. Keys are {@code long} hashes
- * representing board states.
+ * Fixed-size hash table that stores a small cluster of entries for each hashed
+ * index. Clusters improve replacement decisions under contention by allowing
+ * the search to keep multiple candidates per bucket. The implementation relies
+ * on atomic operations and is therefore safe to use from concurrent search
+ * threads without additional locking.
  *
  * @param <V> type of value stored in the table
  */
 public class FixedSizeTranspositionTable<V> implements TranspositionTable<V> {
 
+    private static final int CLUSTER_SIZE = 4;
+
     private static final class Entry<V> {
         final long key;
         final V value;
+        final int depth;
+        final int age;
 
-        Entry(long key, V value) {
+        Entry(long key, V value, int depth, int age) {
             this.key = key;
             this.value = value;
+            this.depth = depth;
+            this.age = age;
         }
     }
 
     private final AtomicReferenceArray<Entry<V>> table;
-    private final int mask; // table.length - 1 (power of two size)
+    private final int clusterMask;
     private final AtomicInteger size = new AtomicInteger();
+    private final AtomicInteger currentAge = new AtomicInteger();
 
     public FixedSizeTranspositionTable(int capacity) {
-        int n = 1;
-        while (n < capacity) {
-            n <<= 1;
+        int clusters = 1;
+        int minClusters = Math.max(1, (capacity + CLUSTER_SIZE - 1) / CLUSTER_SIZE);
+        while (clusters < minClusters) {
+            clusters <<= 1;
         }
-        this.table = new AtomicReferenceArray<>(n);
-        this.mask = n - 1;
+        this.table = new AtomicReferenceArray<>(clusters * CLUSTER_SIZE);
+        this.clusterMask = clusters - 1;
     }
 
-    private int index(long key) {
-        return (int) (key) & mask;
+    private int clusterIndex(long key) {
+        return (int) key & clusterMask;
     }
 
     @Override
     public V get(long key) {
-        int idx = index(key);
-        for (int i = 0; i < table.length(); i++) {
-            Entry<V> e = table.get(idx);
-            if (e == null) {
+        int cluster = clusterIndex(key);
+        int base = cluster * CLUSTER_SIZE;
+        for (int i = 0; i < CLUSTER_SIZE; i++) {
+            Entry<V> entry = table.get(base + i);
+            if (entry == null) {
                 return null;
             }
-            if (e.key == key) {
-                return e.value;
+            if (entry.key == key) {
+                return entry.value;
             }
-            idx = (idx + 1) & mask;
         }
         return null;
     }
 
     @Override
-    public void put(long key, V value) {
-        int idx = index(key);
-        Entry<V> newEntry = new Entry<>(key, value);
-        for (int i = 0; i < table.length(); i++) {
-            Entry<V> cur = table.get(idx);
-            if (cur == null) {
-                if (table.compareAndSet(idx, null, newEntry)) {
-                    size.incrementAndGet();
-                    return;
-                } else {
-                    continue; // CAS failed, retry same slot
+    public void put(long key, V value, int depth) {
+        retry:
+        while (true) {
+            int cluster = clusterIndex(key);
+            int base = cluster * CLUSTER_SIZE;
+            Entry<V> shallowEntry = null;
+            int shallowSlot = -1;
+            Entry<V> oldestEntry = null;
+            int oldestSlot = -1;
+
+            for (int i = 0; i < CLUSTER_SIZE; i++) {
+                int slot = base + i;
+                Entry<V> current = table.get(slot);
+                if (current == null) {
+                    Entry<V> newEntry = new Entry<>(key, value, depth, currentAge.get());
+                    if (table.compareAndSet(slot, null, newEntry)) {
+                        size.incrementAndGet();
+                        return;
+                    } else {
+                        // slot filled concurrently, restart
+                        continue retry;
+                    }
                 }
-            } else if (cur.key == key) {
-                table.set(idx, newEntry);
-                return;
-            } else {
-                idx = (idx + 1) & mask;
+                if (current.key == key) {
+                    Entry<V> newEntry = new Entry<>(key, value, depth, currentAge.get());
+                    if (table.compareAndSet(slot, current, newEntry)) {
+                        return;
+                    } else {
+                        continue retry; // retry whole cluster
+                    }
+                }
+                if (shallowEntry == null || current.depth < shallowEntry.depth) {
+                    shallowEntry = current;
+                    shallowSlot = slot;
+                }
+                if (oldestEntry == null || current.age < oldestEntry.age) {
+                    oldestEntry = current;
+                    oldestSlot = slot;
+                }
+            }
+
+            if (shallowEntry != null && shallowEntry.depth < depth) {
+                Entry<V> newEntry = new Entry<>(key, value, depth, currentAge.get());
+                if (table.compareAndSet(shallowSlot, shallowEntry, newEntry)) {
+                    return;
+                }
+                continue retry;
+            }
+
+            if (oldestEntry != null) {
+                Entry<V> newEntry = new Entry<>(key, value, depth, currentAge.get());
+                if (table.compareAndSet(oldestSlot, oldestEntry, newEntry)) {
+                    return;
+                }
+                continue retry;
             }
         }
-        // table full, overwrite the initial slot
-        table.set(idx, newEntry);
     }
 
     @Override
@@ -87,10 +131,16 @@ public class FixedSizeTranspositionTable<V> implements TranspositionTable<V> {
             table.set(i, null);
         }
         size.set(0);
+        currentAge.set(0);
     }
 
     @Override
     public int size() {
         return size.get();
+    }
+
+    @Override
+    public void advanceAge() {
+        currentAge.incrementAndGet();
     }
 }

--- a/src/main/java/julius/game/chessengine/ai/PlainFixedSizeTranspositionTable.java
+++ b/src/main/java/julius/game/chessengine/ai/PlainFixedSizeTranspositionTable.java
@@ -1,83 +1,123 @@
 package julius.game.chessengine.ai;
 
-import java.lang.reflect.Array;
-import java.util.Arrays;
-
 /**
  * Fixed-size transposition table implementation for single-threaded search.
- * It uses plain arrays and does not perform any atomic operations.
+ * Each hashed index owns a small cluster of entries so the search can keep
+ * several candidates per bucket and make informed replacement decisions.
  *
  * @param <V> value type stored in the table
  */
 public class PlainFixedSizeTranspositionTable<V> implements TranspositionTable<V> {
 
-    private final long[] keys;
-    private final V[] values;
-    private final int mask; // table.length - 1 (power of two size)
+    private static final int CLUSTER_SIZE = 4;
+
+    private static final class Entry<V> {
+        final long key;
+        final V value;
+        final int depth;
+        final int age;
+
+        Entry(long key, V value, int depth, int age) {
+            this.key = key;
+            this.value = value;
+            this.depth = depth;
+            this.age = age;
+        }
+    }
+
+    private final Entry<V>[] table;
+    private final int clusterMask; // number of clusters - 1
     private int size;
+    private int currentAge;
 
     @SuppressWarnings("unchecked")
     public PlainFixedSizeTranspositionTable(int capacity, Class<V> valueClass) {
-        int n = 1;
-        while (n < capacity) {
-            n <<= 1;
+        int clusters = 1;
+        int minClusters = Math.max(1, (capacity + CLUSTER_SIZE - 1) / CLUSTER_SIZE);
+        while (clusters < minClusters) {
+            clusters <<= 1;
         }
-        this.keys = new long[n];
-        this.values = (V[]) Array.newInstance(valueClass, n);
-        this.mask = n - 1;
+        this.table = (Entry<V>[]) new Entry[clusters * CLUSTER_SIZE];
+        this.clusterMask = clusters - 1;
     }
 
     private int index(long key) {
-        return (int) key & mask;
+        return (int) key & clusterMask;
     }
 
     @Override
     public V get(long key) {
-        int idx = index(key);
-        for (int i = 0; i < values.length; i++) {
-            V v = values[idx];
-            if (v == null) {
+        int cluster = index(key);
+        int base = cluster * CLUSTER_SIZE;
+        for (int i = 0; i < CLUSTER_SIZE; i++) {
+            Entry<V> entry = table[base + i];
+            if (entry == null) {
                 return null;
             }
-            if (keys[idx] == key) {
-                return v;
+            if (entry.key == key) {
+                return entry.value;
             }
-            idx = (idx + 1) & mask;
         }
         return null;
     }
 
     @Override
-    public void put(long key, V value) {
-        int idx = index(key);
-        for (int i = 0; i < values.length; i++) {
-            V v = values[idx];
-            if (v == null) {
-                keys[idx] = key;
-                values[idx] = value;
+    public void put(long key, V value, int depth) {
+        int cluster = index(key);
+        int base = cluster * CLUSTER_SIZE;
+        Entry<V> shallowEntry = null;
+        int shallowSlot = -1;
+        Entry<V> oldestEntry = null;
+        int oldestSlot = -1;
+
+        for (int i = 0; i < CLUSTER_SIZE; i++) {
+            int slot = base + i;
+            Entry<V> current = table[slot];
+            if (current == null) {
+                table[slot] = new Entry<>(key, value, depth, currentAge);
                 size++;
                 return;
-            } else if (keys[idx] == key) {
-                values[idx] = value;
+            }
+            if (current.key == key) {
+                table[slot] = new Entry<>(key, value, depth, currentAge);
                 return;
-            } else {
-                idx = (idx + 1) & mask;
+            }
+            if (shallowEntry == null || current.depth < shallowEntry.depth) {
+                shallowEntry = current;
+                shallowSlot = slot;
+            }
+            if (oldestEntry == null || current.age < oldestEntry.age) {
+                oldestEntry = current;
+                oldestSlot = slot;
             }
         }
-        // table full, overwrite the initial slot
-        keys[idx] = key;
-        values[idx] = value;
+
+        if (shallowEntry != null && shallowEntry.depth < depth) {
+            table[shallowSlot] = new Entry<>(key, value, depth, currentAge);
+            return;
+        }
+
+        if (oldestSlot != -1) {
+            table[oldestSlot] = new Entry<>(key, value, depth, currentAge);
+        }
     }
 
     @Override
     public void clear() {
-        Arrays.fill(values, null);
-        Arrays.fill(keys, 0L);
+        for (int i = 0; i < table.length; i++) {
+            table[i] = null;
+        }
         size = 0;
+        currentAge = 0;
     }
 
     @Override
     public int size() {
         return size;
+    }
+
+    @Override
+    public void advanceAge() {
+        currentAge++;
     }
 }

--- a/src/main/java/julius/game/chessengine/ai/TranspositionTable.java
+++ b/src/main/java/julius/game/chessengine/ai/TranspositionTable.java
@@ -6,7 +6,8 @@ package julius.game.chessengine.ai;
  */
 public interface TranspositionTable<V> {
     V get(long key);
-    void put(long key, V value);
+    void put(long key, V value, int depth);
     void clear();
     int size();
+    void advanceAge();
 }


### PR DESCRIPTION
## Summary
- redesign the concurrent transposition table to manage per-bucket clusters with depth and age metadata
- mirror the clustered layout in the single-threaded table and expose depth-aware put plus age advancement on the shared interface
- bump table ages on each iterative deepening pass so newer entries outlive stale data during replacement

## Testing
- `./mvnw -q test` *(fails: network unreachable while downloading Maven Wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68ca75651df4832aa9535913885fcf23