### PR TITLE
Introduce evaluation pipeline abstraction

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationContext.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationContext.java
@@ -1,0 +1,68 @@
+package julius.game.chessengine.evaluation;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.engine.GameStateEnum;
+
+import java.util.Objects;
+
+/**
+ * Immutable snapshot of the current evaluation inputs.  Modules receive a context instance during
+ * initialization and whenever the board state changes so they can derive any expensive features
+ * lazily.
+ */
+public final class EvaluationContext {
+
+    private final BitBoard board;
+    private final GameStateEnum gameState;
+    private final int phase;
+    private final long whiteAttackMap;
+    private final long blackAttackMap;
+    private final boolean whiteToMove;
+
+    private EvaluationContext(BitBoard board, GameStateEnum gameState, int phase,
+                              long whiteAttackMap, long blackAttackMap, boolean whiteToMove) {
+        this.board = Objects.requireNonNull(board, "board");
+        this.gameState = gameState;
+        this.phase = phase;
+        this.whiteAttackMap = whiteAttackMap;
+        this.blackAttackMap = blackAttackMap;
+        this.whiteToMove = whiteToMove;
+    }
+
+    public static EvaluationContext from(BitBoard bitBoard, GameStateEnum gameState) {
+        Objects.requireNonNull(bitBoard, "bitBoard");
+        BitBoard snapshot = new BitBoard(bitBoard);
+        long whiteAttacks = bitBoard.getAttackBitboard(true);
+        long blackAttacks = bitBoard.getAttackBitboard(false);
+        return new EvaluationContext(snapshot, gameState, bitBoard.getPhase(), whiteAttacks, blackAttacks,
+                bitBoard.isWhitesTurn());
+    }
+
+    public BitBoard getBoard() {
+        return board;
+    }
+
+    public GameStateEnum getGameState() {
+        return gameState;
+    }
+
+    public int getPhase() {
+        return phase;
+    }
+
+    public long getWhiteAttackMap() {
+        return whiteAttackMap;
+    }
+
+    public long getBlackAttackMap() {
+        return blackAttackMap;
+    }
+
+    public boolean isWhiteToMove() {
+        return whiteToMove;
+    }
+
+    public EvaluationContext copy() {
+        return new EvaluationContext(new BitBoard(board), gameState, phase, whiteAttackMap, blackAttackMap, whiteToMove);
+    }
+}

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationModule.java
@@ -1,0 +1,45 @@
+package julius.game.chessengine.evaluation;
+
+/**
+ * A pluggable evaluation component.  Modules may maintain incremental state and only recompute
+ * their contribution when marked dirty by the pipeline or by themselves.
+ */
+public interface EvaluationModule {
+
+    /**
+     * Called once when the pipeline is initialized or when a module needs to rebuild its state from
+     * scratch.
+     */
+    void initialize(EvaluationContext context);
+
+    /**
+     * Recompute the module's internal caches if {@link #isDirty()} returns {@code true}.
+     */
+    void evaluate(EvaluationContext context);
+
+    /**
+     * Apply an incremental move update.  Modules that cannot handle incremental updates may simply
+     * mark themselves dirty and defer recomputation to {@link #evaluate(EvaluationContext)}.
+     */
+    void applyMove(MoveContext moveContext);
+
+    /**
+     * Undo a move.  The default implementation is to delegate to {@link #applyMove(MoveContext)},
+     * but modules may override when they have directional state.
+     */
+    void undoMove(MoveContext moveContext);
+
+    int getMidgameScore();
+
+    int getEndgameScore();
+
+    /**
+     * Indicates whether the cached scores need to be recomputed.
+     */
+    boolean isDirty();
+
+    /**
+     * Mark the module as dirty so its contribution is refreshed on the next evaluation cycle.
+     */
+    void markDirty();
+}

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
@@ -1,0 +1,159 @@
+package julius.game.chessengine.evaluation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Coordinates a set of {@link EvaluationModule modules} and provides tapered evaluation blending.
+ * Each module can signal when its cached contribution is stale so that the pipeline avoids
+ * recomputing unrelated features.
+ */
+public final class EvaluationPipeline {
+
+    private static final int BLEND_SCALE = 256;
+
+    private static final class ModuleState {
+        private final EvaluationModule module;
+        private int midgameCache;
+        private int endgameCache;
+
+        private ModuleState(EvaluationModule module) {
+            this.module = module;
+            this.module.markDirty();
+        }
+    }
+
+    private final List<ModuleState> modules;
+    private EvaluationContext context;
+    private boolean initialized;
+    private boolean aggregateDirty = true;
+    private int midgameTotal;
+    private int endgameTotal;
+
+    public EvaluationPipeline(List<? extends EvaluationModule> modules) {
+        if (modules == null || modules.isEmpty()) {
+            throw new IllegalArgumentException("At least one evaluation module is required");
+        }
+        List<ModuleState> moduleStates = new ArrayList<>(modules.size());
+        for (EvaluationModule module : modules) {
+            moduleStates.add(new ModuleState(module));
+        }
+        this.modules = Collections.unmodifiableList(moduleStates);
+    }
+
+    public void initialize(EvaluationContext context) {
+        this.context = Objects.requireNonNull(context, "context");
+        for (ModuleState state : modules) {
+            state.module.initialize(context);
+            state.module.markDirty();
+        }
+        initialized = true;
+        aggregateDirty = true;
+        refreshTotals();
+    }
+
+    public void updateContext(EvaluationContext context) {
+        if (!initialized) {
+            initialize(context);
+            return;
+        }
+        this.context = Objects.requireNonNull(context, "context");
+        markAllDirty();
+    }
+
+    public void applyMove(MoveContext moveContext) {
+        ensureInitialized();
+        for (ModuleState state : modules) {
+            state.module.applyMove(moveContext);
+        }
+        aggregateDirty = true;
+    }
+
+    public void undoMove(MoveContext moveContext) {
+        ensureInitialized();
+        for (ModuleState state : modules) {
+            state.module.undoMove(moveContext);
+        }
+        aggregateDirty = true;
+    }
+
+    public int getMidgameScore() {
+        refreshTotals();
+        return midgameTotal;
+    }
+
+    public int getEndgameScore() {
+        refreshTotals();
+        return endgameTotal;
+    }
+
+    public int getBlendedScore() {
+        refreshTotals();
+        if (context == null) {
+            return 0;
+        }
+        int phase = clamp(context.getPhase());
+        int midgameWeight = BLEND_SCALE - phase;
+        int endgameWeight = phase;
+        long blended = (long) midgameTotal * midgameWeight + (long) endgameTotal * endgameWeight;
+        return (int) (blended / BLEND_SCALE);
+    }
+
+    public double getScoreDifference() {
+        return getBlendedScore() / 100.0;
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    public EvaluationContext getContext() {
+        return context;
+    }
+
+    private void refreshTotals() {
+        ensureInitialized();
+        if (!aggregateDirty) {
+            return;
+        }
+        int midgame = 0;
+        int endgame = 0;
+        for (ModuleState state : modules) {
+            if (state.module.isDirty()) {
+                state.module.evaluate(context);
+            }
+            state.midgameCache = state.module.getMidgameScore();
+            state.endgameCache = state.module.getEndgameScore();
+            midgame += state.midgameCache;
+            endgame += state.endgameCache;
+        }
+        midgameTotal = midgame;
+        endgameTotal = endgame;
+        aggregateDirty = false;
+    }
+
+    private void ensureInitialized() {
+        if (!initialized) {
+            throw new IllegalStateException("Pipeline has not been initialized yet");
+        }
+    }
+
+    private void markAllDirty() {
+        for (ModuleState state : modules) {
+            state.module.markDirty();
+        }
+        aggregateDirty = true;
+    }
+
+    private static int clamp(int phase) {
+        if (phase < 0) {
+            return 0;
+        }
+        if (phase > BLEND_SCALE) {
+            return BLEND_SCALE;
+        }
+        return phase;
+    }
+}

--- a/src/main/java/julius/game/chessengine/evaluation/MoveContext.java
+++ b/src/main/java/julius/game/chessengine/evaluation/MoveContext.java
@@ -1,0 +1,31 @@
+package julius.game.chessengine.evaluation;
+
+import java.util.Objects;
+
+/**
+ * Carries the information required to update evaluation modules when a move is made.
+ */
+public final class MoveContext {
+
+    private final int move;
+    private final EvaluationContext previousContext;
+    private final EvaluationContext currentContext;
+
+    public MoveContext(int move, EvaluationContext previousContext, EvaluationContext currentContext) {
+        this.move = move;
+        this.previousContext = previousContext;
+        this.currentContext = Objects.requireNonNull(currentContext, "currentContext");
+    }
+
+    public int getMove() {
+        return move;
+    }
+
+    public EvaluationContext getPreviousContext() {
+        return previousContext;
+    }
+
+    public EvaluationContext getCurrentContext() {
+        return currentContext;
+    }
+}

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -4,10 +4,15 @@ import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveList;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.evaluation.EvaluationContext;
+import julius.game.chessengine.evaluation.EvaluationModule;
+import julius.game.chessengine.evaluation.EvaluationPipeline;
+import julius.game.chessengine.evaluation.MoveContext;
 import julius.game.chessengine.helper.BishopHelper;
 import julius.game.chessengine.helper.RookHelper;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -103,6 +108,10 @@ public class Score {
 
     private int whiteScore;
     private int blackScore;
+
+    private final EvaluationPipeline evaluationPipeline;
+    private EvaluationContext evaluationContext;
+    private boolean pipelineInitialized;
 
     //initialize number of pieces bonus
     private int whitePawnsAmountScore = 0;
@@ -239,11 +248,17 @@ public class Score {
 
 
     public Score() {
+        this.evaluationPipeline = createPipeline();
+        this.evaluationContext = null;
+        this.pipelineInitialized = false;
         this.whiteScore = 0;
         this.blackScore = 0;
     }
 
     public Score(Score other) {
+        this.evaluationPipeline = createPipeline();
+        this.pipelineInitialized = false;
+        this.evaluationContext = other.evaluationContext != null ? other.evaluationContext.copy() : null;
         this.whiteScore = other.whiteScore;
         this.blackScore = other.blackScore;
 
@@ -315,6 +330,77 @@ public class Score {
 
         this.whiteStateBonus = other.whiteStateBonus;
         this.blackStateBonus = other.blackStateBonus;
+
+        if (other.pipelineInitialized && this.evaluationContext != null) {
+            syncPipeline(this.evaluationContext);
+        }
+    }
+
+
+    private EvaluationPipeline createPipeline() {
+        EvaluationModule module = new LegacyEvaluationModule();
+        return new EvaluationPipeline(List.of(module));
+    }
+
+    private void syncPipeline(EvaluationContext context) {
+        if (context == null) {
+            return;
+        }
+        if (!pipelineInitialized) {
+            evaluationPipeline.initialize(context);
+            pipelineInitialized = true;
+        } else {
+            evaluationPipeline.updateContext(context);
+        }
+    }
+
+    private final class LegacyEvaluationModule implements EvaluationModule {
+
+        private int midgameScoreCache;
+        private int endgameScoreCache;
+        private boolean dirty = true;
+
+        @Override
+        public void initialize(EvaluationContext context) {
+            markDirty();
+        }
+
+        @Override
+        public void evaluate(EvaluationContext context) {
+            midgameScoreCache = calculateTotalWhiteScore() - calculateTotalBlackScore();
+            endgameScoreCache = midgameScoreCache;
+            dirty = false;
+        }
+
+        @Override
+        public void applyMove(MoveContext moveContext) {
+            markDirty();
+        }
+
+        @Override
+        public void undoMove(MoveContext moveContext) {
+            markDirty();
+        }
+
+        @Override
+        public int getMidgameScore() {
+            return midgameScoreCache;
+        }
+
+        @Override
+        public int getEndgameScore() {
+            return endgameScoreCache;
+        }
+
+        @Override
+        public boolean isDirty() {
+            return dirty;
+        }
+
+        @Override
+        public void markDirty() {
+            dirty = true;
+        }
     }
 
 
@@ -414,10 +500,17 @@ public class Score {
 
         calculateTotalWhiteScore();
         calculateTotalBlackScore();
+
+        EvaluationContext context = EvaluationContext.from(bitBoard, null);
+        this.evaluationContext = context;
+        syncPipeline(context);
     }
 
 
     public double getScoreDifference() {
+        if (pipelineInitialized) {
+            return evaluationPipeline.getScoreDifference();
+        }
         return (calculateTotalWhiteScore() - calculateTotalBlackScore()) / 100.0;
     }
 
@@ -1715,6 +1808,13 @@ public class Score {
 
         updateMobilityScores(bitBoard);
         updateKingSafety(bitBoard);
+
+        EvaluationContext previousContext = this.evaluationContext;
+        EvaluationContext updatedContext = EvaluationContext.from(bitBoard, state);
+        this.evaluationContext = updatedContext;
+        syncPipeline(updatedContext);
+        MoveContext moveContext = new MoveContext(move, previousContext, updatedContext);
+        evaluationPipeline.applyMove(moveContext);
     }
 
     public void undoMove(BitBoard bitBoard, int move, GameStateEnum state) {


### PR DESCRIPTION
## Summary
- add an evaluation package with context, module, move context, and pipeline classes to support tapered scoring and lazy recomputation
- adapt Score to own an evaluation pipeline, keep a legacy adapter module, and synchronize pipeline state on initialization and move updates

## Testing
- `./mvnw -q test` *(fails: network is unreachable while downloading Maven Wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ca85929c30832a90a4921d64fa465e