### PR TITLE
Refactor pawn structure evaluation into dedicated module

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -35,6 +35,7 @@ public class GameState {
 
     private void initializeScore(BitBoard bitBoard) {
         score.initializeScore(bitBoard);
+        score.getPawnStructureModule().initialize(bitBoard);
     }
 
     public void update(BitBoard bitBoard, MoveList legalMoves, int move, boolean isOpeningMove) {
@@ -83,6 +84,8 @@ public class GameState {
         if (promotionPieceTypeBits != 0) {
             updatePromotionPieceValues(isWhite, promotionPieceTypeBits, bitBoard);
         }
+
+        score.getPawnStructureModule().refresh(bitBoard);
 
         log.debug("Piecetype: {}, CapturedType: {}, ScoreWhite: {}, ScoreBlack: {}",
                 pieceTypeBits, capturedPieceTypeBits, score.calculateTotalWhiteScore(), score.calculateTotalBlackScore());

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -2,13 +2,13 @@ package julius.game.chessengine.utils;
 
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.utils.eval.PawnStructureModule;
 import lombok.Data;
 import lombok.extern.log4j.Log4j2;
 
 import static julius.game.chessengine.helper.BishopHelper.BISHOP_POSITIONAL_VALUES;
 import static julius.game.chessengine.helper.KingHelper.*;
 import static julius.game.chessengine.helper.KnightHelper.KNIGHT_POSITIONAL_VALUES;
-import static julius.game.chessengine.helper.PawnHelper.*;
 import static julius.game.chessengine.helper.QueenHelper.QUEEN_POSITIONAL_VALUES;
 import static julius.game.chessengine.helper.RookHelper.*;
 
@@ -27,6 +27,8 @@ public class Score {
     private int whiteScore;
     private int blackScore;
 
+    private final PawnStructureModule pawnStructureModule;
+
     //initialize number of pieces bonus
     private int whitePawnsAmountScore = 0;
     private int blackPawnsAmountScore = 0;
@@ -43,21 +45,7 @@ public class Score {
     private int agilityWhite = 0;
     private int agilityBlack = 0;
 
-    // Initialize bonuses and penalties
-    private int whiteCenterPawnBonus = 0;
-    private int blackCenterPawnBonus = 0;
-    private int whiteDoubledPawnPenalty = 0;
-    private int blackDoubledPawnPenalty = 0;
-    private int whiteIsolatedPawnPenalty = 0;
-    private int blackIsolatedPawnPenalty = 0;
-    private int whiteRooksHalfOpenFileBonus = 0;
-    private int blackRooksHalfOpenFileBonus = 0;
-    private int whiteRooksOpenFileBonus = 0;
-    private int blackRooksOpenFileBonus = 0;
-
     // Initialize positional values
-    private int whitePawnsPosition = 0;
-    private int blackPawnsPosition = 0;
     private int whiteKnightsPosition = 0;
     private int blackKnightsPosition = 0;
     private int whiteBishopsPosition = 0;
@@ -83,18 +71,10 @@ public class Score {
     public static final int ROOK_VALUE = 5000;   // Rooks are worth 5 points
     public static final int QUEEN_VALUE = 9000;  // Queens are worth 9 points
 
-    // Pawn bonuses and penalties
-    private static final int DOUBLED_PAWN_PENALTY = -20; // Example penalty value for doubled pawns
-    private static final int ISOLATED_PAWN_PENALTY = -10; // Penalty for isolated pawns
-    private static final int PASSED_PAWN_BONUS = 60;     // Bonus for passed pawns
-
     // Other bonuses and penalties
     private static final int NOT_CASTLED_AND_ROOK_MOVE_PENALTY = -50;
     private static final int START_POSITION_PENALTY = -50; // Define the penalty value for starting position
     private static final int CASTLING_BONUS = 75;
-
-    private static final int ROOK_HALF_OPEN_FILE_BONUS = 25;
-    private static final int ROOK_OPEN_FILE_BONUS = 12;
 
     // Constants for the initial positions of each piece type
     private static final long INITIAL_WHITE_KNIGHT_POSITION = 0x0000000000000042L; // Knights on b1 and g1
@@ -108,11 +88,13 @@ public class Score {
     public Score() {
         this.whiteScore = 0;
         this.blackScore = 0;
+        this.pawnStructureModule = new PawnStructureModule();
     }
 
     public Score(Score other) {
         this.whiteScore = other.whiteScore;
         this.blackScore = other.blackScore;
+        this.pawnStructureModule = new PawnStructureModule(other.pawnStructureModule);
 
         this.whitePawnsAmountScore = other.whitePawnsAmountScore;
         this.blackPawnsAmountScore = other.blackPawnsAmountScore;
@@ -127,20 +109,6 @@ public class Score {
 
         this.agilityWhite = other.agilityWhite;
         this.agilityBlack = other.agilityBlack;
-
-        this.whiteCenterPawnBonus = other.whiteCenterPawnBonus;
-        this.blackCenterPawnBonus = other.blackCenterPawnBonus;
-        this.whiteDoubledPawnPenalty = other.whiteDoubledPawnPenalty;
-        this.blackDoubledPawnPenalty = other.blackDoubledPawnPenalty;
-        this.whiteIsolatedPawnPenalty = other.whiteIsolatedPawnPenalty;
-        this.blackIsolatedPawnPenalty = other.blackIsolatedPawnPenalty;
-        this.whiteRooksHalfOpenFileBonus = other.whiteRooksHalfOpenFileBonus;
-        this.blackRooksHalfOpenFileBonus = other.blackRooksHalfOpenFileBonus;
-        this.whiteRooksOpenFileBonus = other.whiteRooksOpenFileBonus;
-        this.blackRooksOpenFileBonus = other.blackRooksOpenFileBonus;
-
-        this.whitePawnsPosition = other.whitePawnsPosition;
-        this.blackPawnsPosition = other.blackPawnsPosition;
         this.whiteKnightsPosition = other.whiteKnightsPosition;
         this.blackKnightsPosition = other.blackKnightsPosition;
         this.whiteBishopsPosition = other.whiteBishopsPosition;
@@ -170,7 +138,6 @@ public class Score {
 
         long whitePawns = bitBoard.getWhitePawns();
         long blackPawns = bitBoard.getBlackPawns();
-        long allPawns = whitePawns | blackPawns;
         long whiteKnights = bitBoard.getWhiteKnights();
         long blackKnights = bitBoard.getBlackKnights();
         long whiteBishops = bitBoard.getWhiteBishops();
@@ -187,20 +154,6 @@ public class Score {
         initializeBishopScore(whiteBishops, blackBishops);
         initializeRookScore(whiteRooks, blackRooks);
         initializeQueenScore(whiteQueens, blackQueens);
-
-        updateDoubledPawnPenaltyWhite(whitePawns);
-        updateDoubledPawnPenaltyBlack(blackPawns);
-        updateIsolatedPawnPenaltyWhite(whitePawns);
-        updateIsolatedPawnPenaltyBlack(blackPawns);
-
-        updateRookHalfOpenFileBonusWhite(whiteRooks, whitePawns, blackPawns);
-        updateRookHalfOpenFileBonusBlack(blackRooks, blackPawns, whitePawns);
-        updateRookOpenFileBonusWhite(whiteRooks, allPawns);
-        updateRookOpenFileBonusBlack(blackRooks, allPawns);
-
-        // Apply positional values to the pawns
-        updatePawnsPositionBonusWhite(whitePawns);
-        updatePawnsPositionBonusBlack(blackPawns);
 
         updateKnightsPositionBonusWhite(whiteKnights);
         updateKnightsPositionBonusBlack(blackKnights);
@@ -244,14 +197,8 @@ public class Score {
         totalWhiteScore += whiteRooksAmountScore;
         totalWhiteScore += whiteQueensAmountScore;
 
-        totalWhiteScore += whiteCenterPawnBonus;
-        totalWhiteScore += whiteDoubledPawnPenalty;
-        totalWhiteScore += whiteIsolatedPawnPenalty;
+        totalWhiteScore += pawnStructureModule.getMidgameContribution(Color.WHITE);
 
-        totalWhiteScore += whiteRooksHalfOpenFileBonus;
-        totalWhiteScore += whiteRooksOpenFileBonus;
-
-        totalWhiteScore += whitePawnsPosition;
         totalWhiteScore += whiteKnightsPosition;
         totalWhiteScore += whiteBishopsPosition;
         totalWhiteScore += whiteRooksPosition;
@@ -278,14 +225,8 @@ public class Score {
         totalBlackScore += blackRooksAmountScore;
         totalBlackScore += blackQueensAmountScore;
 
-        totalBlackScore += blackCenterPawnBonus;
-        totalBlackScore += blackDoubledPawnPenalty;
-        totalBlackScore += blackIsolatedPawnPenalty;
+        totalBlackScore += pawnStructureModule.getMidgameContribution(Color.BLACK);
 
-        totalBlackScore += blackRooksHalfOpenFileBonus;
-        totalBlackScore += blackRooksOpenFileBonus;
-
-        totalBlackScore += blackPawnsPosition;
         totalBlackScore += blackKnightsPosition;
         totalBlackScore += blackBishopsPosition;
         totalBlackScore += blackRooksPosition;
@@ -325,56 +266,6 @@ public class Score {
     public void initializePawnScore(long whitePawns, long blackPawns) {
         this.whitePawnsAmountScore = Long.bitCount(whitePawns) * PAWN_VALUE;
         this.blackPawnsAmountScore = Long.bitCount(blackPawns) * PAWN_VALUE;
-    }
-
-    /**
-     * Bonuses and Penalties
-     */
-
-    // Method to add penalty for doubled pawns
-    public void updateDoubledPawnPenaltyWhite(long whitePawns) {
-        whiteDoubledPawnPenalty = countDoubledPawns(whitePawns) * DOUBLED_PAWN_PENALTY;
-    }
-
-    public void updateDoubledPawnPenaltyBlack(long blackPawns) {
-        blackDoubledPawnPenalty = countDoubledPawns(blackPawns) * DOUBLED_PAWN_PENALTY;
-    }
-
-    // Method to add penalty for isolated pawns
-    public void updateIsolatedPawnPenaltyWhite(long whitePawns) {
-        whiteIsolatedPawnPenalty = countIsolatedPawns(whitePawns) * ISOLATED_PAWN_PENALTY;
-    }
-
-    public void updateIsolatedPawnPenaltyBlack(long blackPawns) {
-        blackIsolatedPawnPenalty = countIsolatedPawns(blackPawns) * ISOLATED_PAWN_PENALTY;
-    }
-
-    public void updateRookHalfOpenFileBonusWhite(long whiteRooks, long whitePawns, long blackPawns) {
-        whiteRooksHalfOpenFileBonus = countRooksOnHalfOpenFiles(whiteRooks, whitePawns, blackPawns) * ROOK_HALF_OPEN_FILE_BONUS;
-    }
-
-    public void updateRookHalfOpenFileBonusBlack(long blackRooks, long blackPawns, long whitePawns) {
-        blackRooksHalfOpenFileBonus = countRooksOnHalfOpenFiles(blackRooks, blackPawns, whitePawns) * ROOK_HALF_OPEN_FILE_BONUS;
-    }
-
-    public void updateRookOpenFileBonusWhite(long whiteRooks, long allPawns) {
-        whiteRooksOpenFileBonus = countRooksOnOpenFiles(whiteRooks, allPawns) * ROOK_OPEN_FILE_BONUS;
-    }
-
-    public void updateRookOpenFileBonusBlack(long blackRooks, long allPawns) {
-        blackRooksOpenFileBonus = countRooksOnOpenFiles(blackRooks, allPawns) * ROOK_OPEN_FILE_BONUS;
-    }
-
-    /**
-     * Positional Bonuses
-     */
-
-    public void updatePawnsPositionBonusWhite(long whitePawns) {
-        whitePawnsPosition = applyPositionalValues(whitePawns, WHITE_PAWN_POSITIONAL_VALUES);
-    }
-
-    public void updatePawnsPositionBonusBlack(long blackPawns) {
-        blackPawnsPosition = applyPositionalValues(blackPawns, BLACK_PAWN_POSITIONAL_VALUES);
     }
 
     public void updateKnightsPositionBonusWhite(long whiteKnights) {
@@ -500,26 +391,12 @@ public class Score {
         long whitePawns = bitBoard.getWhitePawns();
 
         this.whitePawnsAmountScore = Long.bitCount(whitePawns) * PAWN_VALUE;
-        updateIsolatedPawnPenaltyWhite(whitePawns);
-        updateDoubledPawnPenaltyWhite(whitePawns);
-        updatePawnsPositionBonusWhite(whitePawns);
-
-        //check if Rook is now on an HalfOpen/Open File
-        updateBlackRookValues(bitBoard);
-        updateWhiteRookValues(bitBoard);
     }
 
     public void updateBlackPawnValues(BitBoard bitBoard) {
         long blackPawns = bitBoard.getBlackPawns();
 
         this.blackPawnsAmountScore = Long.bitCount(blackPawns) * PAWN_VALUE;
-        updateIsolatedPawnPenaltyBlack(blackPawns);
-        updateDoubledPawnPenaltyBlack(blackPawns);
-        updatePawnsPositionBonusBlack(blackPawns);
-
-        //check if Rook is now on an HalfOpen/Open File
-        updateBlackRookValues(bitBoard);
-        updateWhiteRookValues(bitBoard);
     }
 
     public void updateWhiteKnightValues(long whiteKnights, long whiteBishops, long whiteRooks) {
@@ -547,9 +424,6 @@ public class Score {
     }
 
     public void updateWhiteRookValues(BitBoard bitBoard) {
-
-        long whitePawns = bitBoard.getWhitePawns();
-        long blackPawns = bitBoard.getBlackPawns();
         long whiteKing = bitBoard.getWhiteKing();
 
         long whiteKnights = bitBoard.getWhiteKnights();
@@ -562,21 +436,15 @@ public class Score {
         boolean rookH1Moved = bitBoard.isWhiteRookH1Moved();
         boolean isEndgame = bitBoard.isEndgame();
 
-
         this.whiteRooksAmountScore = Long.bitCount(whiteRooks) * ROOK_VALUE;
 
         updateRooksPositionBonusWhite(whiteRooks);
-
-        updateRookHalfOpenFileBonusWhite(whiteRooks, whitePawns, blackPawns);
-        updateRookOpenFileBonusWhite(whiteRooks, whitePawns | blackPawns);
 
         updateStartingSquarePenaltyWhite(whiteKnights, whiteBishops, whiteRooks);
         updateKingValuesWhite(whiteKing, isCastled, isWhiteKingHasMoved, rookA1Moved, rookH1Moved, isEndgame);
     }
 
     public void updateBlackRookValues(BitBoard bitBoard) {
-        long blackPawns = bitBoard.getBlackPawns();
-        long whitePawns = bitBoard.getWhitePawns();
         long blackKing = bitBoard.getBlackKing();
 
         long blackKnights = bitBoard.getBlackKnights();
@@ -592,9 +460,6 @@ public class Score {
         this.blackRooksAmountScore = Long.bitCount(blackRooks) * ROOK_VALUE;
 
         updateRooksPositionBonusBlack(blackRooks);
-
-        updateRookHalfOpenFileBonusBlack(blackRooks, blackPawns, whitePawns);
-        updateRookOpenFileBonusBlack(blackRooks, whitePawns | blackPawns);
 
         updateStartingSquarePenaltyBlack(blackKnights, blackBishops, blackRooks);
         updateKingValuesBlack(blackKing, isCastled, isBlackKingMoved, rookA8Moved, rookH8Moved, isEndgame);

--- a/src/main/java/julius/game/chessengine/utils/eval/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/utils/eval/PawnStructureModule.java
@@ -1,0 +1,178 @@
+package julius.game.chessengine.utils.eval;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.helper.BitHelper;
+import julius.game.chessengine.helper.PawnHelper;
+import julius.game.chessengine.helper.RookHelper;
+import julius.game.chessengine.utils.Color;
+
+import java.util.EnumMap;
+
+import static julius.game.chessengine.helper.PawnHelper.BLACK_PAWN_POSITIONAL_VALUES;
+import static julius.game.chessengine.helper.PawnHelper.WHITE_PAWN_POSITIONAL_VALUES;
+
+/**
+ * Maintains pawn structure evaluation caches for both colours.
+ */
+public class PawnStructureModule {
+
+    static final int DOUBLED_PAWN_PENALTY = -20;
+    static final int ISOLATED_PAWN_PENALTY = -10;
+    static final int CENTER_PAWN_BONUS = 20;
+    static final int PASSED_PAWN_MIDGAME_BONUS = 60;
+    static final int PASSED_PAWN_ENDGAME_BONUS = 120;
+    static final int ROOK_HALF_OPEN_FILE_BONUS = 25;
+    static final int ROOK_OPEN_FILE_BONUS = 12;
+
+    private final EnumMap<Color, PhaseScore> cachedScores;
+
+    public PawnStructureModule() {
+        this.cachedScores = new EnumMap<>(Color.class);
+        reset();
+    }
+
+    public PawnStructureModule(PawnStructureModule other) {
+        this();
+        for (Color color : Color.values()) {
+            PhaseScore otherScore = other.cachedScores.get(color);
+            cachedScores.put(color, otherScore == null ? new PhaseScore(0, 0)
+                    : new PhaseScore(otherScore.midgame(), otherScore.endgame()));
+        }
+    }
+
+    /**
+     * Clears all cached values.
+     */
+    public void reset() {
+        for (Color color : Color.values()) {
+            cachedScores.put(color, new PhaseScore(0, 0));
+        }
+    }
+
+    /**
+     * Initialises the module from scratch for the supplied board position.
+     */
+    public void initialize(BitBoard bitBoard) {
+        refresh(bitBoard);
+    }
+
+    /**
+     * Recomputes the cached values using the current board state.
+     */
+    public void refresh(BitBoard bitBoard) {
+        cachedScores.put(Color.WHITE, computeScore(bitBoard, Color.WHITE));
+        cachedScores.put(Color.BLACK, computeScore(bitBoard, Color.BLACK));
+    }
+
+    public int getMidgameContribution(Color color) {
+        return cachedScores.get(color).midgame();
+    }
+
+    public int getEndgameContribution(Color color) {
+        return cachedScores.get(color).endgame();
+    }
+
+    private PhaseScore computeScore(BitBoard bitBoard, Color color) {
+        long pawns = color == Color.WHITE ? bitBoard.getWhitePawns() : bitBoard.getBlackPawns();
+        long opponentPawns = color == Color.WHITE ? bitBoard.getBlackPawns() : bitBoard.getWhitePawns();
+        long rooks = color == Color.WHITE ? bitBoard.getWhiteRooks() : bitBoard.getBlackRooks();
+        long allPawns = bitBoard.getWhitePawns() | bitBoard.getBlackPawns();
+
+        int midgame = 0;
+        int endgame = 0;
+
+        int centerControl = PawnHelper.countCenterPawns(pawns) * CENTER_PAWN_BONUS;
+        midgame += centerControl;
+        endgame += centerControl;
+
+        int doubledPenalty = PawnHelper.countDoubledPawns(pawns) * DOUBLED_PAWN_PENALTY;
+        midgame += doubledPenalty;
+        endgame += doubledPenalty;
+
+        int isolatedPenalty = PawnHelper.countIsolatedPawns(pawns) * ISOLATED_PAWN_PENALTY;
+        midgame += isolatedPenalty;
+        endgame += isolatedPenalty;
+
+        int positional = applyPositionalValues(pawns,
+                color == Color.WHITE ? WHITE_PAWN_POSITIONAL_VALUES : BLACK_PAWN_POSITIONAL_VALUES);
+        midgame += positional;
+        endgame += positional;
+
+        int halfOpenFileBonus = RookHelper.countRooksOnHalfOpenFiles(rooks, pawns, opponentPawns)
+                * ROOK_HALF_OPEN_FILE_BONUS;
+        midgame += halfOpenFileBonus;
+        endgame += halfOpenFileBonus;
+
+        int openFileBonus = RookHelper.countRooksOnOpenFiles(rooks, allPawns) * ROOK_OPEN_FILE_BONUS;
+        midgame += openFileBonus;
+        endgame += openFileBonus;
+
+        int passedPawns = countPassedPawns(pawns, opponentPawns, color);
+        midgame += passedPawns * PASSED_PAWN_MIDGAME_BONUS;
+        endgame += passedPawns * PASSED_PAWN_ENDGAME_BONUS;
+
+        return new PhaseScore(midgame, endgame);
+    }
+
+    private int applyPositionalValues(long bitboard, int[] positionalValues) {
+        if (bitboard == 0L) {
+            return 0;
+        }
+
+        int score = 0;
+        int start = Long.numberOfTrailingZeros(bitboard);
+        int end = 64 - Long.numberOfLeadingZeros(bitboard);
+        for (int i = start; i < end; i++) {
+            long mask = 1L << i;
+            if ((bitboard & mask) != 0) {
+                score += positionalValues[i];
+            }
+        }
+        return score;
+    }
+
+    private int countPassedPawns(long pawns, long opponentPawns, Color color) {
+        int passed = 0;
+        long remaining = pawns;
+        while (remaining != 0) {
+            int square = Long.numberOfTrailingZeros(remaining);
+            remaining &= remaining - 1;
+            if (isPassedPawn(square, opponentPawns, color)) {
+                passed++;
+            }
+        }
+        return passed;
+    }
+
+    private boolean isPassedPawn(int square, long opponentPawns, Color color) {
+        int file = square % 8;
+        int rank = square / 8;
+        long mask = 0L;
+
+        if (color == Color.WHITE) {
+            for (int r = rank + 1; r < 8; r++) {
+                mask |= BitHelper.RankMasks[r] & BitHelper.FileMasks[file];
+                if (file > 0) {
+                    mask |= BitHelper.RankMasks[r] & BitHelper.FileMasks[file - 1];
+                }
+                if (file < 7) {
+                    mask |= BitHelper.RankMasks[r] & BitHelper.FileMasks[file + 1];
+                }
+            }
+        } else {
+            for (int r = rank - 1; r >= 0; r--) {
+                mask |= BitHelper.RankMasks[r] & BitHelper.FileMasks[file];
+                if (file > 0) {
+                    mask |= BitHelper.RankMasks[r] & BitHelper.FileMasks[file - 1];
+                }
+                if (file < 7) {
+                    mask |= BitHelper.RankMasks[r] & BitHelper.FileMasks[file + 1];
+                }
+            }
+        }
+
+        return (opponentPawns & mask) == 0;
+    }
+
+    public record PhaseScore(int midgame, int endgame) { }
+}

--- a/src/test/java/julius/game/chessengine/utils/ScoreTest.java
+++ b/src/test/java/julius/game/chessengine/utils/ScoreTest.java
@@ -1,0 +1,66 @@
+package julius.game.chessengine.utils;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.helper.BitHelper;
+import julius.game.chessengine.utils.Color;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ScoreTest {
+
+    @Test
+    void calculateTotalScoreIncludesPawnStructureContribution() {
+        BitBoard bitBoard = createBoardWithSinglePawn();
+
+        Score score = new Score();
+        score.initializePawnScore(bitBoard.getWhitePawns(), bitBoard.getBlackPawns());
+        score.getPawnStructureModule().initialize(bitBoard);
+
+        int expectedWhite = score.getWhitePawnsAmountScore()
+                + score.getPawnStructureModule().getMidgameContribution(Color.WHITE);
+        int expectedBlack = score.getBlackPawnsAmountScore()
+                + score.getPawnStructureModule().getMidgameContribution(Color.BLACK);
+
+        assertEquals(expectedWhite, score.calculateTotalWhiteScore());
+        assertEquals(expectedBlack, score.calculateTotalBlackScore());
+    }
+
+    private BitBoard createBoardWithSinglePawn() {
+        long whitePawn = 1L << BitHelper.bitIndex('e', 4);
+        long blackPawn = 1L << BitHelper.bitIndex('d', 5);
+        long whiteKing = 1L << BitHelper.bitIndex('e', 1);
+        long blackKing = 1L << BitHelper.bitIndex('e', 8);
+
+        long whitePieces = whitePawn | whiteKing;
+        long blackPieces = blackPawn | blackKing;
+
+        return new BitBoard(
+                true,
+                whitePawn,
+                blackPawn,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                whiteKing,
+                blackKing,
+                whitePieces,
+                blackPieces,
+                whitePieces | blackPieces,
+                0,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+        );
+    }
+}

--- a/src/test/java/julius/game/chessengine/utils/eval/PawnStructureModuleTest.java
+++ b/src/test/java/julius/game/chessengine/utils/eval/PawnStructureModuleTest.java
@@ -1,0 +1,178 @@
+package julius.game.chessengine.utils.eval;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.helper.BitHelper;
+import julius.game.chessengine.helper.PawnHelper;
+import julius.game.chessengine.helper.RookHelper;
+import julius.game.chessengine.utils.Color;
+import org.junit.jupiter.api.Test;
+
+import static julius.game.chessengine.helper.PawnHelper.BLACK_PAWN_POSITIONAL_VALUES;
+import static julius.game.chessengine.helper.PawnHelper.WHITE_PAWN_POSITIONAL_VALUES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PawnStructureModuleTest {
+
+    @Test
+    void shouldMatchLegacyTotalsForInitialPosition() {
+        BitBoard bitBoard = new BitBoard();
+        PawnStructureModule module = new PawnStructureModule();
+        module.initialize(bitBoard);
+
+        assertEquals(expectedMidgame(bitBoard, Color.WHITE), module.getMidgameContribution(Color.WHITE));
+        assertEquals(expectedEndgame(bitBoard, Color.WHITE), module.getEndgameContribution(Color.WHITE));
+
+        assertEquals(expectedMidgame(bitBoard, Color.BLACK), module.getMidgameContribution(Color.BLACK));
+        assertEquals(expectedEndgame(bitBoard, Color.BLACK), module.getEndgameContribution(Color.BLACK));
+    }
+
+    @Test
+    void shouldScalePassedPawnsPerPhase() {
+        BitBoard bitBoard = createBoardWithWhitePassedPawn();
+        PawnStructureModule module = new PawnStructureModule();
+        module.initialize(bitBoard);
+
+        int expectedMidgame = expectedMidgame(bitBoard, Color.WHITE);
+        int expectedEndgame = expectedEndgame(bitBoard, Color.WHITE);
+
+        assertEquals(expectedMidgame, module.getMidgameContribution(Color.WHITE));
+        assertEquals(expectedEndgame, module.getEndgameContribution(Color.WHITE));
+
+        int expectedDifference = PawnStructureModule.PASSED_PAWN_ENDGAME_BONUS
+                - PawnStructureModule.PASSED_PAWN_MIDGAME_BONUS;
+        assertEquals(expectedDifference,
+                module.getEndgameContribution(Color.WHITE) - module.getMidgameContribution(Color.WHITE));
+    }
+
+    private BitBoard createBoardWithWhitePassedPawn() {
+        long whitePawn = 1L << BitHelper.bitIndex('e', 5);
+        long whiteKing = 1L << BitHelper.bitIndex('e', 1);
+        long blackKing = 1L << BitHelper.bitIndex('e', 8);
+
+        long whitePieces = whitePawn | whiteKing;
+        long blackPieces = blackKing;
+
+        return new BitBoard(
+                true,
+                whitePawn,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                whiteKing,
+                blackKing,
+                whitePieces,
+                blackPieces,
+                whitePieces | blackPieces,
+                0,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false
+        );
+    }
+
+    private int expectedMidgame(BitBoard bitBoard, Color color) {
+        PhaseExpectation expectation = expectation(bitBoard, color);
+        return expectation.midgame();
+    }
+
+    private int expectedEndgame(BitBoard bitBoard, Color color) {
+        PhaseExpectation expectation = expectation(bitBoard, color);
+        return expectation.endgame();
+    }
+
+    private PhaseExpectation expectation(BitBoard bitBoard, Color color) {
+        long pawns = color == Color.WHITE ? bitBoard.getWhitePawns() : bitBoard.getBlackPawns();
+        long opponentPawns = color == Color.WHITE ? bitBoard.getBlackPawns() : bitBoard.getWhitePawns();
+        long rooks = color == Color.WHITE ? bitBoard.getWhiteRooks() : bitBoard.getBlackRooks();
+        long allPawns = bitBoard.getWhitePawns() | bitBoard.getBlackPawns();
+
+        int center = PawnHelper.countCenterPawns(pawns) * PawnStructureModule.CENTER_PAWN_BONUS;
+        int doubled = PawnHelper.countDoubledPawns(pawns) * PawnStructureModule.DOUBLED_PAWN_PENALTY;
+        int isolated = PawnHelper.countIsolatedPawns(pawns) * PawnStructureModule.ISOLATED_PAWN_PENALTY;
+        int positional = applyPositionalValues(pawns,
+                color == Color.WHITE ? WHITE_PAWN_POSITIONAL_VALUES : BLACK_PAWN_POSITIONAL_VALUES);
+        int halfOpen = RookHelper.countRooksOnHalfOpenFiles(rooks, pawns, opponentPawns)
+                * PawnStructureModule.ROOK_HALF_OPEN_FILE_BONUS;
+        int open = RookHelper.countRooksOnOpenFiles(rooks, allPawns)
+                * PawnStructureModule.ROOK_OPEN_FILE_BONUS;
+        int passed = countPassedPawns(pawns, opponentPawns, color);
+
+        int midgame = center + doubled + isolated + positional + halfOpen + open
+                + passed * PawnStructureModule.PASSED_PAWN_MIDGAME_BONUS;
+        int endgame = center + doubled + isolated + positional + halfOpen + open
+                + passed * PawnStructureModule.PASSED_PAWN_ENDGAME_BONUS;
+        return new PhaseExpectation(midgame, endgame);
+    }
+
+    private int applyPositionalValues(long bitboard, int[] positionalValues) {
+        if (bitboard == 0L) {
+            return 0;
+        }
+        int score = 0;
+        int start = Long.numberOfTrailingZeros(bitboard);
+        int end = 64 - Long.numberOfLeadingZeros(bitboard);
+        for (int i = start; i < end; i++) {
+            long mask = 1L << i;
+            if ((bitboard & mask) != 0) {
+                score += positionalValues[i];
+            }
+        }
+        return score;
+    }
+
+    private int countPassedPawns(long pawns, long opponentPawns, Color color) {
+        int passed = 0;
+        long remaining = pawns;
+        while (remaining != 0) {
+            int square = Long.numberOfTrailingZeros(remaining);
+            remaining &= remaining - 1;
+            if (isPassedPawn(square, opponentPawns, color)) {
+                passed++;
+            }
+        }
+        return passed;
+    }
+
+    private boolean isPassedPawn(int square, long opponentPawns, Color color) {
+        int file = square % 8;
+        int rank = square / 8;
+        long mask = 0L;
+
+        if (color == Color.WHITE) {
+            for (int r = rank + 1; r < 8; r++) {
+                mask |= BitHelper.RankMasks[r] & BitHelper.FileMasks[file];
+                if (file > 0) {
+                    mask |= BitHelper.RankMasks[r] & BitHelper.FileMasks[file - 1];
+                }
+                if (file < 7) {
+                    mask |= BitHelper.RankMasks[r] & BitHelper.FileMasks[file + 1];
+                }
+            }
+        } else {
+            for (int r = rank - 1; r >= 0; r--) {
+                mask |= BitHelper.RankMasks[r] & BitHelper.FileMasks[file];
+                if (file > 0) {
+                    mask |= BitHelper.RankMasks[r] & BitHelper.FileMasks[file - 1];
+                }
+                if (file < 7) {
+                    mask |= BitHelper.RankMasks[r] & BitHelper.FileMasks[file + 1];
+                }
+            }
+        }
+
+        return (opponentPawns & mask) == 0;
+    }
+
+    private record PhaseExpectation(int midgame, int endgame) { }
+}


### PR DESCRIPTION
## Summary
- Added a `PawnStructureModule` that caches pawn-structure features for both phases, including passed pawn scaling and rook file bonuses, so consumers can read midgame/endgame contributions directly.【F:src/main/java/julius/game/chessengine/utils/eval/PawnStructureModule.java†L17-L177】
- Refactored `Score` to own a `PawnStructureModule`, delegate pawn refreshes, and include the module’s cached values when calculating totals.【F:src/main/java/julius/game/chessengine/utils/Score.java†L30-L206】
- Updated `GameState` to initialise and refresh the pawn-structure module as part of score maintenance and added regression tests for the new module and score integration.【F:src/main/java/julius/game/chessengine/engine/GameState.java†L36-L92】【F:src/test/java/julius/game/chessengine/utils/eval/PawnStructureModuleTest.java†L14-L178】【F:src/test/java/julius/game/chessengine/utils/ScoreTest.java†L10-L65】

## Testing
- `mvn test` *(fails: missing parent POM because the build cannot reach Maven Central in this environment)*【d6618f†L1-L23】

------
https://chatgpt.com/codex/tasks/task_e_68ca8f336968832abf9f2df82f851d65