### PR TITLE
Refactor score to pipeline outputs

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -194,8 +194,9 @@ public class GameState {
     public String toString() {
         return "GameState {" +
                 "\n  State: " + state +
-                "\n  White Score: " + score.calculateTotalWhiteScore() +
-                "\n  Black Score: " + score.calculateTotalBlackScore() +
+                "\n  Midgame Score: " + score.getMidgameScore() +
+                "\n  Endgame Score: " + score.getEndgameScore() +
+                "\n  Blended Score: " + score.getBlendedScore() +
                 "\n  Score Difference: " + score.getScoreDifference() +
                 "\n  Repetition Count: " + repetition +
                 "\n}";

--- a/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
@@ -5,13 +5,18 @@ import java.util.Arrays;
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.figures.PieceType;
-import julius.game.chessengine.utils.Score;
-
 /**
  * Tracks per-side material using incremental updates so the evaluation pipeline can
  * access midgame and endgame material totals without rescanning the board.
  */
 public final class MaterialModule implements EvaluationModule {
+
+    public static final int PAWN_VALUE = 100;
+    public static final int KNIGHT_VALUE = 320;  // was 300
+    public static final int BISHOP_VALUE = 330;  // ok
+    public static final int ROOK_VALUE = 500;    // ok
+    public static final int QUEEN_VALUE = 900;   // ok
+    public static final int BISHOP_PAIR_BONUS = 40;
 
     public interface PawnChangeListener {
         void onPawnAdded(boolean isWhite, int squareIndex);
@@ -32,17 +37,17 @@ public final class MaterialModule implements EvaluationModule {
     private static final int[] ENDGAME_VALUES = new int[7];
 
     static {
-        MIDGAME_VALUES[PAWN] = Score.PAWN_VALUE;
-        MIDGAME_VALUES[KNIGHT] = Score.KNIGHT_VALUE;
-        MIDGAME_VALUES[BISHOP] = Score.BISHOP_VALUE;
-        MIDGAME_VALUES[ROOK] = Score.ROOK_VALUE;
-        MIDGAME_VALUES[QUEEN] = Score.QUEEN_VALUE;
+        MIDGAME_VALUES[PAWN] = PAWN_VALUE;
+        MIDGAME_VALUES[KNIGHT] = KNIGHT_VALUE;
+        MIDGAME_VALUES[BISHOP] = BISHOP_VALUE;
+        MIDGAME_VALUES[ROOK] = ROOK_VALUE;
+        MIDGAME_VALUES[QUEEN] = QUEEN_VALUE;
 
-        ENDGAME_VALUES[PAWN] = Score.PAWN_VALUE;
-        ENDGAME_VALUES[KNIGHT] = Score.KNIGHT_VALUE;
-        ENDGAME_VALUES[BISHOP] = Score.BISHOP_VALUE;
-        ENDGAME_VALUES[ROOK] = Score.ROOK_VALUE;
-        ENDGAME_VALUES[QUEEN] = Score.QUEEN_VALUE;
+        ENDGAME_VALUES[PAWN] = PAWN_VALUE;
+        ENDGAME_VALUES[KNIGHT] = KNIGHT_VALUE;
+        ENDGAME_VALUES[BISHOP] = BISHOP_VALUE;
+        ENDGAME_VALUES[ROOK] = ROOK_VALUE;
+        ENDGAME_VALUES[QUEEN] = QUEEN_VALUE;
     }
 
     private final int[] midgameMaterial = new int[2];
@@ -184,8 +189,8 @@ public final class MaterialModule implements EvaluationModule {
             int previous = bishopCounts[colorIndex];
             bishopCounts[colorIndex] = previous + count;
             if (previous < 2 && bishopCounts[colorIndex] >= 2) {
-                midgameMaterial[colorIndex] += Score.BISHOP_PAIR_BONUS;
-                endgameMaterial[colorIndex] += Score.BISHOP_PAIR_BONUS;
+                midgameMaterial[colorIndex] += BISHOP_PAIR_BONUS;
+                endgameMaterial[colorIndex] += BISHOP_PAIR_BONUS;
             }
         }
     }
@@ -200,8 +205,8 @@ public final class MaterialModule implements EvaluationModule {
             int previous = bishopCounts[colorIndex];
             bishopCounts[colorIndex] = previous + 1;
             if (previous == 1) {
-                midgameMaterial[colorIndex] += Score.BISHOP_PAIR_BONUS;
-                endgameMaterial[colorIndex] += Score.BISHOP_PAIR_BONUS;
+                midgameMaterial[colorIndex] += BISHOP_PAIR_BONUS;
+                endgameMaterial[colorIndex] += BISHOP_PAIR_BONUS;
             }
         }
     }
@@ -216,8 +221,8 @@ public final class MaterialModule implements EvaluationModule {
             int previous = bishopCounts[colorIndex];
             bishopCounts[colorIndex] = previous - 1;
             if (previous == 2) {
-                midgameMaterial[colorIndex] -= Score.BISHOP_PAIR_BONUS;
-                endgameMaterial[colorIndex] -= Score.BISHOP_PAIR_BONUS;
+                midgameMaterial[colorIndex] -= BISHOP_PAIR_BONUS;
+                endgameMaterial[colorIndex] -= BISHOP_PAIR_BONUS;
             }
         }
     }

--- a/src/main/java/julius/game/chessengine/evaluation/PieceSquareModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PieceSquareModule.java
@@ -184,6 +184,10 @@ public final class PieceSquareModule implements EvaluationModule {
         return endgameTotal;
     }
 
+    public int getDevelopmentContribution() {
+        return developmentContribution;
+    }
+
     @Override
     public boolean isDirty() {
         return dirty;

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -1,335 +1,65 @@
 package julius.game.chessengine.utils;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import julius.game.chessengine.board.BitBoard;
-import julius.game.chessengine.board.MoveList;
-import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.evaluation.ActivityModule;
 import julius.game.chessengine.evaluation.EvaluationContext;
-import julius.game.chessengine.evaluation.EvaluationModule;
 import julius.game.chessengine.evaluation.EvaluationPipeline;
-import julius.game.chessengine.evaluation.MoveContext;
 import julius.game.chessengine.evaluation.KingSafetyModule;
 import julius.game.chessengine.evaluation.MaterialModule;
+import julius.game.chessengine.evaluation.MoveContext;
 import julius.game.chessengine.evaluation.PawnStructureModule;
 import julius.game.chessengine.evaluation.PieceSquareModule;
-import julius.game.chessengine.helper.BishopHelper;
-import julius.game.chessengine.helper.RookHelper;
-import lombok.Data;
-import lombok.extern.log4j.Log4j2;
+
 import java.util.List;
+import java.util.Objects;
 
-import static julius.game.chessengine.helper.KingHelper.*;
-import static julius.game.chessengine.helper.KnightHelper.knightMoveTable;
-import static julius.game.chessengine.helper.PawnMoveTables.PAWN_ATTACKS;
-import static julius.game.chessengine.helper.BitHelper.FileMasks;
-import static julius.game.chessengine.helper.BitHelper.RankMasks;
-import static julius.game.chessengine.helper.BitHelper.bitIndex;
-
-@Data
-@Log4j2
+/**
+ * Central entry point for the evaluation pipeline.  The legacy score bookkeeping previously
+ * maintained in this class has been replaced by incremental evaluation modules coordinated by the
+ * {@link EvaluationPipeline}.  The public API now exposes only tapered totals that originate from
+ * the pipeline itself.
+ */
 public class Score {
 
     public static final int CHECKMATE = 100000;
     public static final int CHECK = 0;
     public static final int DRAW = 0;
-
     public static final int KILLER_MOVE_SCORE = 10000;
-
-    // --- Material (centipawns) ---
-    public static final int PAWN_VALUE   = 100;
-    public static final int KNIGHT_VALUE = 320;  // was 300
-    public static final int BISHOP_VALUE = 330;  // ok
-    public static final int ROOK_VALUE   = 500;  // ok
-    public static final int QUEEN_VALUE  = 900;  // ok
-
-    public  static final int PASSED_PAWN_BONUS     = PawnStructureModule.PASSED_PAWN_BONUS;
-    public  static final int CENTER_PAWN_BONUS     = PawnStructureModule.CENTER_PAWN_BONUS;
-
-    // Other bonuses and penalties
-    private static final int NOT_CASTLED_AND_ROOK_MOVE_PENALTY = -10; // further reduced
-    private static final int CASTLING_BONUS                    = 20;  // further reduced
-
-    private static final int ROOK_HALF_OPEN_FILE_BONUS = 15; // was 25
-    private static final int ROOK_OPEN_FILE_BONUS      = 25; // was 35
-
-    // Piece-specific mobility weights
-    private static final int KNIGHT_MOBILITY_BONUS = 2;
-    private static final int BISHOP_MOBILITY_BONUS = 4;
-    private static final int ROOK_MOBILITY_BONUS   = 2;
-    private static final int QUEEN_MOBILITY_BONUS  = 1;
-
-    // Bonus for moves that reach or control central squares (d4, e4, d5, e5)
-    private static final int CENTER_CONTROL_BONUS = 3;
-    private static final long CENTRAL_SQUARES =
-            (1L << bitIndex('d', 4)) | (1L << bitIndex('e', 4)) |
-            (1L << bitIndex('d', 5)) | (1L << bitIndex('e', 5));
-    private static final int MISSING_PAWN_SHIELD_PENALTY = -15;
-    private static final int HALF_OPEN_FILE_PENALTY = -15;
-    private static final int OPEN_FILE_PENALTY = -25;
-    private static final int PAWN_ATTACK_PENALTY = -5;
-    private static final int KNIGHT_ATTACK_PENALTY = -10;
-    private static final int BISHOP_ATTACK_PENALTY = -10;
-    private static final int ROOK_ATTACK_PENALTY = -15;
-    private static final int QUEEN_ATTACK_PENALTY = -20;
-    private static final int DEFENDER_BONUS = 5;
-    private static final int QUEEN_ATTACKED_PENALTY = -135;
-    private static final int MINOR_PIECE_ATTACK_PENALTY = -12;
-    private static final int MINOR_PIECE_PAWN_ATTACK_PENALTY = -15;
-    public static final int BISHOP_PAIR_BONUS = 40;
-    private static final int KNIGHT_OUTPOST_BONUS = 15;
-    private static final int KNIGHT_OUTPOST_DEFENDED_BONUS = 5;
-
-    private int whiteScore;
-    private int blackScore;
 
     private final MaterialModule materialModule = new MaterialModule();
     private final PawnStructureModule pawnStructureModule = new PawnStructureModule();
     private final PieceSquareModule pieceSquareModule = new PieceSquareModule();
     private final ActivityModule activityModule = new ActivityModule();
     private final KingSafetyModule kingSafetyModule = new KingSafetyModule();
+
+    @JsonIgnore
     private final EvaluationPipeline evaluationPipeline;
+    @JsonIgnore
     private EvaluationContext evaluationContext;
-    private boolean pipelineInitialized;
-
-    // Mobility
-    private int whiteMobilityScore = 0;
-    private int blackMobilityScore = 0;
-
-    // King safety
-    private int whiteKingSafetyScore = 0;
-    private int blackKingSafetyScore = 0;
-    private int whiteQueenSafetyScore = 0;
-    private int blackQueenSafetyScore = 0;
-    private int whiteMinorPieceSafetyScore = 0;
-    private int blackMinorPieceSafetyScore = 0;
-
-    // Initialize bonuses and penalties
-    private int whiteCenterPawnBonus = 0;
-    private int blackCenterPawnBonus = 0;
-    private int whiteDoubledPawnPenalty = 0;
-    private int blackDoubledPawnPenalty = 0;
-    private int whiteIsolatedPawnPenalty = 0;
-    private int blackIsolatedPawnPenalty = 0;
-    private int whitePassedPawnBonus = 0;
-    private int blackPassedPawnBonus = 0;
-    private int whitePawnAdvanceBonus = 0;
-    private int blackPawnAdvanceBonus = 0;
-    private int whiteBlockedPawnPenalty = 0;
-    private int blackBlockedPawnPenalty = 0;
-    private int whiteBackwardPawnPenalty = 0;
-    private int blackBackwardPawnPenalty = 0;
-    private int whiteConnectedPawnBonus = 0;
-    private int blackConnectedPawnBonus = 0;
-    private int whitePawnIslandPenalty = 0;
-    private int blackPawnIslandPenalty = 0;
-    private int whiteRooksHalfOpenFileBonus = 0;
-    private int blackRooksHalfOpenFileBonus = 0;
-    private int whiteRooksOpenFileBonus = 0;
-    private int blackRooksOpenFileBonus = 0;
-    private int whiteKnightOutpostBonus = 0;
-    private int blackKnightOutpostBonus = 0;
-
-    private static final BishopHelper BISHOP_HELPER = BishopHelper.getInstance();
-    private static final RookHelper ROOK_HELPER = RookHelper.getInstance();
-    // Thread-local accumulator reused to avoid per-call allocations when recomputing mobility.
-    private static final ThreadLocal<int[]> MOBILITY_BUFFER = ThreadLocal.withInitial(() -> new int[2]);
-
-    // Initialize positional values
-    private int whiteKingCastlingAdjustment = 0;
-    private int blackKingCastlingAdjustment = 0;
-
-    // State bonuses
-    private int whiteStateBonus = 0;
-    private int blackStateBonus = 0;
-
-    private static final long NOT_A_FILE = ~FileMasks[0];
-    private static final long NOT_H_FILE = ~FileMasks[7];
 
     public Score() {
         materialModule.setPawnChangeListener(pawnStructureModule);
-        this.evaluationPipeline = createPipeline();
-        this.evaluationContext = null;
-        this.pipelineInitialized = false;
-        this.whiteScore = 0;
-        this.blackScore = 0;
-    }
-
-    public Score(Score other) {
-        materialModule.setPawnChangeListener(pawnStructureModule);
-        this.evaluationPipeline = createPipeline();
-        this.pipelineInitialized = false;
-        this.evaluationContext = other.evaluationContext != null ? other.evaluationContext.copy() : null;
-        this.whiteScore = other.whiteScore;
-        this.blackScore = other.blackScore;
-
-
-        this.whiteMobilityScore = other.whiteMobilityScore;
-        this.blackMobilityScore = other.blackMobilityScore;
-        this.whiteKingSafetyScore = other.whiteKingSafetyScore;
-        this.blackKingSafetyScore = other.blackKingSafetyScore;
-        this.whiteQueenSafetyScore = other.whiteQueenSafetyScore;
-        this.blackQueenSafetyScore = other.blackQueenSafetyScore;
-        this.whiteMinorPieceSafetyScore = other.whiteMinorPieceSafetyScore;
-        this.blackMinorPieceSafetyScore = other.blackMinorPieceSafetyScore;
-
-        this.whiteCenterPawnBonus = other.whiteCenterPawnBonus;
-        this.blackCenterPawnBonus = other.blackCenterPawnBonus;
-        this.whiteDoubledPawnPenalty = other.whiteDoubledPawnPenalty;
-        this.blackDoubledPawnPenalty = other.blackDoubledPawnPenalty;
-        this.whiteIsolatedPawnPenalty = other.whiteIsolatedPawnPenalty;
-        this.blackIsolatedPawnPenalty = other.blackIsolatedPawnPenalty;
-        this.whitePassedPawnBonus = other.whitePassedPawnBonus;
-        this.blackPassedPawnBonus = other.blackPassedPawnBonus;
-        this.whitePawnAdvanceBonus = other.whitePawnAdvanceBonus;
-        this.blackPawnAdvanceBonus = other.blackPawnAdvanceBonus;
-        this.whiteBlockedPawnPenalty = other.whiteBlockedPawnPenalty;
-        this.blackBlockedPawnPenalty = other.blackBlockedPawnPenalty;
-        this.whiteBackwardPawnPenalty = other.whiteBackwardPawnPenalty;
-        this.blackBackwardPawnPenalty = other.blackBackwardPawnPenalty;
-        this.whiteConnectedPawnBonus = other.whiteConnectedPawnBonus;
-        this.blackConnectedPawnBonus = other.blackConnectedPawnBonus;
-        this.whitePawnIslandPenalty = other.whitePawnIslandPenalty;
-        this.blackPawnIslandPenalty = other.blackPawnIslandPenalty;
-        this.whiteRooksHalfOpenFileBonus = other.whiteRooksHalfOpenFileBonus;
-        this.blackRooksHalfOpenFileBonus = other.blackRooksHalfOpenFileBonus;
-        this.whiteRooksOpenFileBonus = other.whiteRooksOpenFileBonus;
-        this.blackRooksOpenFileBonus = other.blackRooksOpenFileBonus;
-        this.whiteKnightOutpostBonus = other.whiteKnightOutpostBonus;
-        this.blackKnightOutpostBonus = other.blackKnightOutpostBonus;
-
-        this.whiteKingCastlingAdjustment = other.whiteKingCastlingAdjustment;
-        this.blackKingCastlingAdjustment = other.blackKingCastlingAdjustment;
-
-        this.whiteStateBonus = other.whiteStateBonus;
-        this.blackStateBonus = other.blackStateBonus;
-
-        if (other.pipelineInitialized && this.evaluationContext != null) {
-            syncPipeline(this.evaluationContext);
-        }
-    }
-
-
-    private EvaluationPipeline createPipeline() {
-        EvaluationModule module = new LegacyEvaluationModule();
-        return new EvaluationPipeline(List.of(
+        this.evaluationPipeline = new EvaluationPipeline(List.of(
                 materialModule,
                 pawnStructureModule,
                 pieceSquareModule,
                 activityModule,
-                kingSafetyModule,
-                module));
+                kingSafetyModule
+        ));
     }
 
-    private void syncPipeline(EvaluationContext context) {
-        if (context == null) {
-            return;
-        }
-        if (!pipelineInitialized) {
-            evaluationPipeline.initialize(context);
-            pipelineInitialized = true;
-        } else {
-            evaluationPipeline.updateContext(context);
-        }
-    }
-
-    private void applyPawnStructure(BitBoard bitBoard) {
-        PawnStructureModule.PawnStructureView view = pawnStructureModule.getView(bitBoard);
-        int phase = clampPhase(bitBoard.getPhase());
-        whiteCenterPawnBonus = view.whiteCenter().blend(phase);
-        blackCenterPawnBonus = view.blackCenter().blend(phase);
-        whiteDoubledPawnPenalty = view.whiteDoubled().blend(phase);
-        blackDoubledPawnPenalty = view.blackDoubled().blend(phase);
-        whiteIsolatedPawnPenalty = view.whiteIsolated().blend(phase);
-        blackIsolatedPawnPenalty = view.blackIsolated().blend(phase);
-        whiteConnectedPawnBonus = view.whiteConnected().blend(phase);
-        blackConnectedPawnBonus = view.blackConnected().blend(phase);
-        whitePawnIslandPenalty = view.whiteIslands().blend(phase);
-        blackPawnIslandPenalty = view.blackIslands().blend(phase);
-        whitePassedPawnBonus = view.whitePassed().blend(phase);
-        blackPassedPawnBonus = view.blackPassed().blend(phase);
-        whitePawnAdvanceBonus = view.whiteAdvance().blend(phase);
-        blackPawnAdvanceBonus = view.blackAdvance().blend(phase);
-        whiteBlockedPawnPenalty = view.whiteBlocked().blend(phase);
-        blackBlockedPawnPenalty = view.blackBlocked().blend(phase);
-        whiteBackwardPawnPenalty = view.whiteBackward().blend(phase);
-        blackBackwardPawnPenalty = view.blackBackward().blend(phase);
-    }
-
-    private static int clampPhase(int phase) {
-        if (phase < 0) {
-            return 0;
-        }
-        if (phase > 256) {
-            return 256;
-        }
-        return phase;
-    }
-
-    private final class LegacyEvaluationModule implements EvaluationModule {
-
-        private int midgameScoreCache;
-        private int endgameScoreCache;
-        private boolean dirty = true;
-
-        @Override
-        public void initialize(EvaluationContext context) {
-            markDirty();
-        }
-
-        @Override
-        public void evaluate(EvaluationContext context) {
-            int totalWhite = calculateTotalWhiteScore();
-            int totalBlack = calculateTotalBlackScore();
-            if (context != null) {
-                BitBoard board = context.getBoard();
-                if (board != null) {
-                    PawnStructureModule.PawnStructureView view = pawnStructureModule.getView(board);
-                    int phase = clampPhase(board.getPhase());
-                    totalWhite -= view.blendWhiteTotal(phase);
-                    totalBlack -= view.blendBlackTotal(phase);
-                }
+    public Score(Score other) {
+        this();
+        if (other != null && other.evaluationContext != null) {
+            this.evaluationContext = other.evaluationContext.copy();
+            if (other.evaluationPipeline.isInitialized()) {
+                evaluationPipeline.initialize(this.evaluationContext);
             }
-            midgameScoreCache = totalWhite - totalBlack;
-            endgameScoreCache = midgameScoreCache;
-            dirty = false;
-        }
-
-        @Override
-        public void applyMove(MoveContext moveContext) {
-            markDirty();
-        }
-
-        @Override
-        public void undoMove(MoveContext moveContext) {
-            markDirty();
-        }
-
-        @Override
-        public int getMidgameScore() {
-            return midgameScoreCache;
-        }
-
-        @Override
-        public int getEndgameScore() {
-            return endgameScoreCache;
-        }
-
-        @Override
-        public boolean isDirty() {
-            return dirty;
-        }
-
-        @Override
-        public void markDirty() {
-            dirty = true;
         }
     }
 
-
-    /**
-     * Score mechanisms of the Game
-     */
     public static Score initializeScore(BitBoard bitBoard) {
         Score score = new Score();
         score.initializeFrom(bitBoard);
@@ -337,765 +67,87 @@ public class Score {
     }
 
     private void initializeFrom(BitBoard bitBoard) {
-        long whitePawns = bitBoard.getWhitePawns();
-        long blackPawns = bitBoard.getBlackPawns();
-        long whiteKnights = bitBoard.getWhiteKnights();
-        long blackKnights = bitBoard.getBlackKnights();
-        long whiteBishops = bitBoard.getWhiteBishops();
-        long blackBishops = bitBoard.getBlackBishops();
-        long whiteRooks = bitBoard.getWhiteRooks();
-        long blackRooks = bitBoard.getBlackRooks();
-        long whiteQueens = bitBoard.getWhiteQueens();
-        long blackQueens = bitBoard.getBlackQueens();
-        long whiteKing = bitBoard.getWhiteKing();
-        long blackKing = bitBoard.getBlackKing();
-        int phase = bitBoard.getPhase();
-
-        applyPawnStructure(bitBoard);
-
-        updateRookHalfOpenFileBonusWhite(bitBoard);
-        updateRookHalfOpenFileBonusBlack(bitBoard);
-        updateRookOpenFileBonusWhite(bitBoard);
-        updateRookOpenFileBonusBlack(bitBoard);
-        updateKnightOutpostBonusWhite(whiteKnights, whitePawns, blackPawns);
-        updateKnightOutpostBonusBlack(blackKnights, blackPawns, whitePawns);
-
-        // Apply positional values to the pawns
-        int materialBalance = computeMaterialBalance(bitBoard);
-        updateWhiteKingsPositionBonus(whiteKing, whitePawns, blackPawns, bitBoard.isWhiteKingHasCastled(),
-                bitBoard.isWhiteKingMoved(), bitBoard.isWhiteRookA1Moved(), bitBoard.isWhiteRookH1Moved(), phase,
-                materialBalance);
-        updateBlackKingsPositionBonus(blackKing, blackPawns, whitePawns, bitBoard.isBlackKingHasCastled(),
-                bitBoard.isBlackKingMoved(), bitBoard.isBlackRookA8Moved(), bitBoard.isBlackRookH8Moved(), phase,
-                materialBalance);
-
-        // Mobility and king safety
-        updateMobilityScores(bitBoard);
-        updateKingSafety(bitBoard);
-
-        calculateTotalWhiteScore();
-        calculateTotalBlackScore();
-
+        Objects.requireNonNull(bitBoard, "bitBoard");
         EvaluationContext context = EvaluationContext.from(bitBoard, null);
         this.evaluationContext = context;
-        syncPipeline(context);
-    }
-
-
-    public double getScoreDifference() {
-        if (pipelineInitialized) {
-            return evaluationPipeline.getScoreDifference();
-        }
-        return (calculateTotalWhiteScore() - calculateTotalBlackScore()) / 100.0;
-    }
-
-    public int calculateTotalWhiteScore() {
-        int totalWhiteScore = 0;
-
-        totalWhiteScore += whiteCenterPawnBonus;
-        totalWhiteScore += whiteDoubledPawnPenalty;
-        totalWhiteScore += whiteIsolatedPawnPenalty;
-        totalWhiteScore += whitePassedPawnBonus;
-        totalWhiteScore += whitePawnAdvanceBonus;
-        totalWhiteScore += whiteBlockedPawnPenalty;
-        totalWhiteScore += whiteBackwardPawnPenalty;
-        totalWhiteScore += whiteConnectedPawnBonus;
-        totalWhiteScore += whitePawnIslandPenalty;
-
-        totalWhiteScore += whiteRooksHalfOpenFileBonus;
-        totalWhiteScore += whiteRooksOpenFileBonus;
-        totalWhiteScore += whiteKnightOutpostBonus;
-
-        totalWhiteScore += whiteKingCastlingAdjustment;
-
-        totalWhiteScore += whiteMobilityScore;
-        totalWhiteScore += whiteKingSafetyScore;
-        totalWhiteScore += whiteQueenSafetyScore;
-        totalWhiteScore += whiteMinorPieceSafetyScore;
-
-        totalWhiteScore += whiteStateBonus;
-
-        whiteScore = totalWhiteScore;
-        // Add other scores and penalties if any
-        return totalWhiteScore;
-    }
-
-    /**
-     * Method to calculate the total score for black.
-     */
-    public int calculateTotalBlackScore() {
-        int totalBlackScore = 0;
-
-        totalBlackScore += blackCenterPawnBonus;
-        totalBlackScore += blackDoubledPawnPenalty;
-        totalBlackScore += blackIsolatedPawnPenalty;
-        totalBlackScore += blackPassedPawnBonus;
-        totalBlackScore += blackPawnAdvanceBonus;
-        totalBlackScore += blackBlockedPawnPenalty;
-        totalBlackScore += blackBackwardPawnPenalty;
-        totalBlackScore += blackConnectedPawnBonus;
-        totalBlackScore += blackPawnIslandPenalty;
-
-        totalBlackScore += blackRooksHalfOpenFileBonus;
-        totalBlackScore += blackRooksOpenFileBonus;
-        totalBlackScore += blackKnightOutpostBonus;
-
-        totalBlackScore += blackKingCastlingAdjustment;
-
-        totalBlackScore += blackMobilityScore;
-        totalBlackScore += blackKingSafetyScore;
-        totalBlackScore += blackQueenSafetyScore;
-        totalBlackScore += blackMinorPieceSafetyScore;
-
-        totalBlackScore += blackStateBonus;
-
-        blackScore = totalBlackScore;
-        // Add other scores and penalties if any
-        return totalBlackScore;
-    }
-
-    public void updateRookHalfOpenFileBonusWhite(BitBoard bitBoard) {
-        long whiteRooks = bitBoard.getWhiteRooks();
-        int count = pawnStructureModule.countHalfOpenFilesWithRooks(bitBoard, whiteRooks, true);
-        whiteRooksHalfOpenFileBonus = count * ROOK_HALF_OPEN_FILE_BONUS;
-    }
-
-    public void updateRookHalfOpenFileBonusBlack(BitBoard bitBoard) {
-        long blackRooks = bitBoard.getBlackRooks();
-        int count = pawnStructureModule.countHalfOpenFilesWithRooks(bitBoard, blackRooks, false);
-        blackRooksHalfOpenFileBonus = count * ROOK_HALF_OPEN_FILE_BONUS;
-    }
-
-    public void updateRookOpenFileBonusWhite(BitBoard bitBoard) {
-        long whiteRooks = bitBoard.getWhiteRooks();
-        int count = pawnStructureModule.countOpenFilesWithRooks(bitBoard, whiteRooks);
-        whiteRooksOpenFileBonus = count * ROOK_OPEN_FILE_BONUS;
-    }
-
-    public void updateRookOpenFileBonusBlack(BitBoard bitBoard) {
-        long blackRooks = bitBoard.getBlackRooks();
-        int count = pawnStructureModule.countOpenFilesWithRooks(bitBoard, blackRooks);
-        blackRooksOpenFileBonus = count * ROOK_OPEN_FILE_BONUS;
-    }
-
-    public void updateKnightOutpostBonusWhite(long whiteKnights, long whitePawns, long blackPawns) {
-        long enemyAttacks = ((blackPawns & NOT_H_FILE) >>> 7) | ((blackPawns & NOT_A_FILE) >>> 9);
-        long ownAttacks = ((whitePawns & NOT_A_FILE) << 7) | ((whitePawns & NOT_H_FILE) << 9);
-        whiteKnightOutpostBonus = calculateKnightOutpostBonus(whiteKnights, ownAttacks, enemyAttacks);
-    }
-
-    public void updateKnightOutpostBonusBlack(long blackKnights, long blackPawns, long whitePawns) {
-        long enemyAttacks = ((whitePawns & NOT_A_FILE) << 7) | ((whitePawns & NOT_H_FILE) << 9);
-        long ownAttacks = ((blackPawns & NOT_H_FILE) >>> 7) | ((blackPawns & NOT_A_FILE) >>> 9);
-        blackKnightOutpostBonus = calculateKnightOutpostBonus(blackKnights, ownAttacks, enemyAttacks);
-    }
-
-    private int calculateKnightOutpostBonus(long knights, long ownPawnAttacks, long enemyPawnAttacks) {
-        int bonus = 0;
-        long remaining = knights;
-        while (remaining != 0) {
-            long knight = remaining & -remaining;
-            if ((enemyPawnAttacks & knight) == 0) {
-                bonus += KNIGHT_OUTPOST_BONUS;
-                if ((ownPawnAttacks & knight) != 0) {
-                    bonus += KNIGHT_OUTPOST_DEFENDED_BONUS;
-                }
-            }
-            remaining ^= knight;
-        }
-        return bonus;
-    }
-
-    private static int computeMaterialBalance(BitBoard bitBoard) {
-        int whiteMaterial = Long.bitCount(bitBoard.getWhitePawns()) * PAWN_VALUE
-                + Long.bitCount(bitBoard.getWhiteKnights()) * KNIGHT_VALUE
-                + Long.bitCount(bitBoard.getWhiteBishops()) * BISHOP_VALUE
-                + Long.bitCount(bitBoard.getWhiteRooks()) * ROOK_VALUE
-                + Long.bitCount(bitBoard.getWhiteQueens()) * QUEEN_VALUE;
-        int blackMaterial = Long.bitCount(bitBoard.getBlackPawns()) * PAWN_VALUE
-                + Long.bitCount(bitBoard.getBlackKnights()) * KNIGHT_VALUE
-                + Long.bitCount(bitBoard.getBlackBishops()) * BISHOP_VALUE
-                + Long.bitCount(bitBoard.getBlackRooks()) * ROOK_VALUE
-                + Long.bitCount(bitBoard.getBlackQueens()) * QUEEN_VALUE;
-        return whiteMaterial - blackMaterial;
-    }
-
-    public void updateWhiteKingsPositionBonus(long whiteKing, long whitePawns, long blackPawns,
-                                              boolean isCastled, boolean isWhiteKingMoved,
-                                              boolean rookA1Moved, boolean rookH1Moved, int phase,
-                                              int materialBalance) {
-        whiteKingCastlingAdjustment = 0;
-        int castlingBonus = CASTLING_BONUS * (256 - phase) / 256;
-        int rookMovePenalty = NOT_CASTLED_AND_ROOK_MOVE_PENALTY * (256 - phase) / 256;
-        if (materialBalance < 0) {
-            rookMovePenalty /= 2;
-        }
-
-        boolean applyPenalty = false;
-        if (!isCastled) {
-            int kingIndex = Long.numberOfTrailingZeros(whiteKing);
-            long forwardMask = (whiteKing << 8);
-            if ((whiteKing & NOT_A_FILE) != 0) forwardMask |= (whiteKing << 7);
-            if ((whiteKing & NOT_H_FILE) != 0) forwardMask |= (whiteKing << 9);
-
-            boolean missingShield = Long.bitCount(whitePawns & forwardMask) < 3;
-
-            int fileIndex = kingIndex % 8;
-            long fileMask = FileMasks[fileIndex];
-            boolean openOrHalfOpen = (whitePawns & fileMask) == 0;
-
-            applyPenalty = missingShield || openOrHalfOpen;
-        }
-
-        if (isCastled) {
-            whiteKingCastlingAdjustment += castlingBonus;
-        } else if (applyPenalty) {
-            if (rookA1Moved) {
-                whiteKingCastlingAdjustment += rookMovePenalty;
-            }
-            if (rookH1Moved) {
-                whiteKingCastlingAdjustment += rookMovePenalty;
-            }
-            if (isWhiteKingMoved) {
-                whiteKingCastlingAdjustment += rookMovePenalty * 2;
-            }
-        }
-    }
-
-    public void updateBlackKingsPositionBonus(long blackKing, long blackPawns, long whitePawns,
-                                              boolean isCastled, boolean isBlackKingMoved,
-                                              boolean rookA8Moved, boolean rookH8Moved, int phase,
-                                              int materialBalance) {
-        blackKingCastlingAdjustment = 0;
-        int castlingBonus = CASTLING_BONUS * (256 - phase) / 256;
-        int rookMovePenalty = NOT_CASTLED_AND_ROOK_MOVE_PENALTY * (256 - phase) / 256;
-        if (materialBalance > 0) {
-            rookMovePenalty /= 2;
-        }
-
-        boolean applyPenalty = false;
-        if (!isCastled) {
-            int kingIndex = Long.numberOfTrailingZeros(blackKing);
-            long forwardMask = (blackKing >>> 8);
-            if ((blackKing & NOT_A_FILE) != 0) forwardMask |= (blackKing >>> 9);
-            if ((blackKing & NOT_H_FILE) != 0) forwardMask |= (blackKing >>> 7);
-
-            boolean missingShield = Long.bitCount(blackPawns & forwardMask) < 3;
-
-            int fileIndex = kingIndex % 8;
-            long fileMask = FileMasks[fileIndex];
-            boolean openOrHalfOpen = (blackPawns & fileMask) == 0;
-
-            applyPenalty = missingShield || openOrHalfOpen;
-        }
-
-        if (isCastled) {
-            blackKingCastlingAdjustment += castlingBonus;
-        } else if (applyPenalty) {
-            if (rookA8Moved) {
-                blackKingCastlingAdjustment += rookMovePenalty;
-            }
-            if (rookH8Moved) {
-                blackKingCastlingAdjustment += rookMovePenalty;
-            }
-            if (isBlackKingMoved) {
-                blackKingCastlingAdjustment += rookMovePenalty * 2;
-            }
-        }
-    }
-
-
-    public void updateMobilityScores(int whiteScore, int blackScore) {
-        whiteMobilityScore = whiteScore;
-        blackMobilityScore = blackScore;
-    }
-
-    public void updateMobilityScores(BitBoard bitBoard) {
-        int[] mobility = MOBILITY_BUFFER.get();
-        mobility[0] = calculateMobility(bitBoard, true);
-        mobility[1] = calculateMobility(bitBoard, false);
-
-        updateMobilityScores(mobility[0], mobility[1]);
-    }
-
-    private int calculateMobility(BitBoard bitBoard, boolean white) {
-        long friendlyPieces = white ? bitBoard.getWhitePieces() : bitBoard.getBlackPieces();
-        long knights = white ? bitBoard.getWhiteKnights() : bitBoard.getBlackKnights();
-        long bishops = white ? bitBoard.getWhiteBishops() : bitBoard.getBlackBishops();
-        long rooks = white ? bitBoard.getWhiteRooks() : bitBoard.getBlackRooks();
-        long queens = white ? bitBoard.getWhiteQueens() : bitBoard.getBlackQueens();
-        long occupancy = bitBoard.getAllPieces();
-
-        int score = 0;
-
-        while (knights != 0) {
-            int square = Long.numberOfTrailingZeros(knights);
-            long attacks = knightMoveTable[square] & ~friendlyPieces;
-            score += mobilityFromAttacks(attacks, KNIGHT_MOBILITY_BONUS);
-            knights &= knights - 1;
-        }
-
-        while (bishops != 0) {
-            int square = Long.numberOfTrailingZeros(bishops);
-            long attacks = BISHOP_HELPER.calculateBishopMoves(square, occupancy) & ~friendlyPieces;
-            score += mobilityFromAttacks(attacks, BISHOP_MOBILITY_BONUS);
-            bishops &= bishops - 1;
-        }
-
-        while (rooks != 0) {
-            int square = Long.numberOfTrailingZeros(rooks);
-            long attacks = ROOK_HELPER.calculateRookMoves(square, occupancy) & ~friendlyPieces;
-            score += mobilityFromAttacks(attacks, ROOK_MOBILITY_BONUS);
-            rooks &= rooks - 1;
-        }
-
-        while (queens != 0) {
-            int square = Long.numberOfTrailingZeros(queens);
-            long attacks = (BISHOP_HELPER.calculateBishopMoves(square, occupancy)
-                    | ROOK_HELPER.calculateRookMoves(square, occupancy)) & ~friendlyPieces;
-            score += mobilityFromAttacks(attacks, QUEEN_MOBILITY_BONUS);
-            queens &= queens - 1;
-        }
-
-        return score;
-    }
-
-    private static int mobilityFromAttacks(long attacks, int mobilityBonus) {
-        if (attacks == 0) {
-            return 0;
-        }
-        int moves = Long.bitCount(attacks);
-        return (mobilityBonus * moves) + centerControlContribution(attacks);
-    }
-
-    private static int centerControlContribution(long attacks) {
-        long centerTargets = attacks & CENTRAL_SQUARES;
-        return centerTargets != 0 ? CENTER_CONTROL_BONUS * Long.bitCount(centerTargets) : 0;
-    }
-
-    private boolean hasNoLegalMove(BitBoard board, boolean white) {
-        MoveList moves = board.generateAllPossibleMoves(white);
-        for (int i = 0; i < moves.size(); i++) {
-            int move = moves.getMove(i);
-            BitBoard copy = new BitBoard(board);
-            copy.performMove(move);
-            if (!copy.isInCheck(white)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private int evaluateMinorPieceSafety(
-            long knights,
-            long bishops,
-            long rooks,
-            long friendlyPawns,
-            long friendlyQueens,
-            long friendlyKing,
-            long enemyPawns,
-            long enemyKnights,
-            long enemyBishops,
-            long enemyRooks,
-            long enemyQueens,
-            long enemyKing,
-            long allPieces,
-            long enemyAttacks,
-            boolean isWhite) {
-        long pieces = knights | bishops | rooks;
-        if (pieces == 0) {
-            return 0;
-        }
-
-        int penalty = 0;
-        BishopHelper bishopHelper = BishopHelper.getInstance();
-        RookHelper rookHelper = RookHelper.getInstance();
-        int enemyColor = isWhite ? 1 : 0;
-        int friendlyColor = isWhite ? 0 : 1;
-
-        while (pieces != 0) {
-            long sq = pieces & -pieces;
-            int index = Long.numberOfTrailingZeros(sq);
-
-            if ((enemyAttacks & sq) == 0) {
-                pieces ^= sq;
-                continue;
-            }
-
-            int pawnAttackers = countPawnAttacks(enemyPawns, index, enemyColor);
-            int knightAttackers = countKnightAttacks(enemyKnights, index);
-            int bishopAttackers = countBishopAttacks(enemyBishops, index, allPieces, bishopHelper);
-            int rookAttackers = countRookAttacks(enemyRooks, index, allPieces, rookHelper);
-            int queenAttackers = countQueenAttacks(enemyQueens, index, allPieces, bishopHelper, rookHelper);
-            int kingAttackers = countKingAttacks(enemyKing, index);
-
-            int totalAttackers = pawnAttackers + knightAttackers + bishopAttackers
-                    + rookAttackers + queenAttackers + kingAttackers;
-            if (totalAttackers == 0) {
-                pieces ^= sq;
-                continue;
-            }
-
-            long ignoreMask = sq;
-            int pawnDefenders = countPawnAttacks(friendlyPawns, index, friendlyColor);
-            int knightDefenders = countKnightAttacks(knights & ~ignoreMask, index);
-            int bishopDefenders = countBishopAttacks(bishops & ~ignoreMask, index, allPieces, bishopHelper);
-            int rookDefenders = countRookAttacks(rooks & ~ignoreMask, index, allPieces, rookHelper);
-            int queenDefenders = countQueenAttacks(friendlyQueens & ~ignoreMask, index, allPieces, bishopHelper, rookHelper);
-            int kingDefenders = countKingAttacks(friendlyKing & ~ignoreMask, index);
-
-            int totalDefenders = pawnDefenders + knightDefenders + bishopDefenders
-                    + rookDefenders + queenDefenders + kingDefenders;
-
-            if (totalAttackers > totalDefenders) {
-                penalty += MINOR_PIECE_ATTACK_PENALTY;
-            }
-            if (pawnAttackers > 0) {
-                penalty += MINOR_PIECE_PAWN_ATTACK_PENALTY;
-            }
-
-            pieces ^= sq;
-        }
-
-        return penalty;
-    }
-
-    private int countPawnAttacks(long pawns, int targetIndex, int pawnColor) {
-        if (pawns == 0) {
-            return 0;
-        }
-        int count = 0;
-        long mask = 1L << targetIndex;
-        long remaining = pawns;
-        while (remaining != 0) {
-            long sq = remaining & -remaining;
-            int index = Long.numberOfTrailingZeros(sq);
-            if ((PAWN_ATTACKS[pawnColor][index] & mask) != 0) {
-                count++;
-            }
-            remaining ^= sq;
-        }
-        return count;
-    }
-
-    private int countKnightAttacks(long knights, int targetIndex) {
-        if (knights == 0) {
-            return 0;
-        }
-        int count = 0;
-        long mask = 1L << targetIndex;
-        long remaining = knights;
-        while (remaining != 0) {
-            long sq = remaining & -remaining;
-            int index = Long.numberOfTrailingZeros(sq);
-            if ((knightMoveTable[index] & mask) != 0) {
-                count++;
-            }
-            remaining ^= sq;
-        }
-        return count;
-    }
-
-    private int countBishopAttacks(long bishops, int targetIndex, long allPieces, BishopHelper bishopHelper) {
-        if (bishops == 0) {
-            return 0;
-        }
-        int count = 0;
-        long mask = 1L << targetIndex;
-        long remaining = bishops;
-        while (remaining != 0) {
-            long sq = remaining & -remaining;
-            int index = Long.numberOfTrailingZeros(sq);
-            if ((bishopHelper.calculateBishopMoves(index, allPieces) & mask) != 0) {
-                count++;
-            }
-            remaining ^= sq;
-        }
-        return count;
-    }
-
-    private int countRookAttacks(long rooks, int targetIndex, long allPieces, RookHelper rookHelper) {
-        if (rooks == 0) {
-            return 0;
-        }
-        int count = 0;
-        long mask = 1L << targetIndex;
-        long remaining = rooks;
-        while (remaining != 0) {
-            long sq = remaining & -remaining;
-            int index = Long.numberOfTrailingZeros(sq);
-            if ((rookHelper.calculateRookMoves(index, allPieces) & mask) != 0) {
-                count++;
-            }
-            remaining ^= sq;
-        }
-        return count;
-    }
-
-    private int countQueenAttacks(long queens, int targetIndex, long allPieces,
-                                  BishopHelper bishopHelper, RookHelper rookHelper) {
-        if (queens == 0) {
-            return 0;
-        }
-        int count = 0;
-        long mask = 1L << targetIndex;
-        long remaining = queens;
-        while (remaining != 0) {
-            long sq = remaining & -remaining;
-            int index = Long.numberOfTrailingZeros(sq);
-            long attacks = bishopHelper.calculateBishopMoves(index, allPieces)
-                    | rookHelper.calculateRookMoves(index, allPieces);
-            if ((attacks & mask) != 0) {
-                count++;
-            }
-            remaining ^= sq;
-        }
-        return count;
-    }
-
-    private int countKingAttacks(long king, int targetIndex) {
-        if (king == 0) {
-            return 0;
-        }
-        int kingIndex = Long.numberOfTrailingZeros(king);
-        return (KING_ATTACKS[kingIndex] & (1L << targetIndex)) != 0 ? 1 : 0;
-    }
-
-    public void updateKingSafety(BitBoard bitBoard) {
-        long whiteKing = bitBoard.getWhiteKing();
-        long blackKing = bitBoard.getBlackKing();
-        long whitePawns = bitBoard.getWhitePawns();
-        long blackPawns = bitBoard.getBlackPawns();
-
-        long whiteAttacks = bitBoard.getAttackBitboard(true);
-        long blackAttacks = bitBoard.getAttackBitboard(false);
-        long allPieces = bitBoard.getAllPieces();
-        long whiteKnights = bitBoard.getWhiteKnights();
-        long whiteBishops = bitBoard.getWhiteBishops();
-        long whiteRooks = bitBoard.getWhiteRooks();
-        long whiteQueens = bitBoard.getWhiteQueens();
-        long blackKnights = bitBoard.getBlackKnights();
-        long blackBishops = bitBoard.getBlackBishops();
-        long blackRooks = bitBoard.getBlackRooks();
-        long blackQueens = bitBoard.getBlackQueens();
-
-        KingSafetyModule.KingSafetyView safetyView = kingSafetyModule.evaluate(bitBoard);
-        int phase = clampPhase(bitBoard.getPhase());
-        whiteKingSafetyScore = safetyView.whiteKing().blend(phase);
-        blackKingSafetyScore = safetyView.blackKing().blend(phase);
-        whiteQueenSafetyScore = safetyView.whiteQueen().blend(phase);
-        blackQueenSafetyScore = safetyView.blackQueen().blend(phase);
-
-        whiteMinorPieceSafetyScore = evaluateMinorPieceSafety(
-                whiteKnights,
-                whiteBishops,
-                whiteRooks,
-                whitePawns,
-                whiteQueens,
-                whiteKing,
-                blackPawns,
-                blackKnights,
-                blackBishops,
-                blackRooks,
-                blackQueens,
-                blackKing,
-                allPieces,
-                blackAttacks,
-                true);
-
-        blackMinorPieceSafetyScore = evaluateMinorPieceSafety(
-                blackKnights,
-                blackBishops,
-                blackRooks,
-                blackPawns,
-                blackQueens,
-                blackKing,
-                whitePawns,
-                whiteKnights,
-                whiteBishops,
-                whiteRooks,
-                whiteQueens,
-                whiteKing,
-                allPieces,
-                whiteAttacks,
-                false);
-
-    }
-
-    public void updateWhitePawnValues(BitBoard bitBoard) {
-        applyPawnStructure(bitBoard);
-        updateBlackRookValues(bitBoard);
-        updateWhiteRookValues(bitBoard);
-        updateWhiteKnightValues(bitBoard);
-        updateBlackKnightValues(bitBoard);
-    }
-
-    public void updateBlackPawnValues(BitBoard bitBoard) {
-        applyPawnStructure(bitBoard);
-        updateBlackRookValues(bitBoard);
-        updateWhiteRookValues(bitBoard);
-        updateWhiteKnightValues(bitBoard);
-        updateBlackKnightValues(bitBoard);
-    }
-
-    public void updateWhiteKnightValues(BitBoard bitBoard) {
-        long whiteKnights = bitBoard.getWhiteKnights();
-        long whiteBishops = bitBoard.getWhiteBishops();
-        long whiteRooks = bitBoard.getWhiteRooks();
-        long whiteQueens = bitBoard.getWhiteQueens();
-        long whitePawns = bitBoard.getWhitePawns();
-        long blackPawns = bitBoard.getBlackPawns();
-        updateKnightOutpostBonusWhite(whiteKnights, whitePawns, blackPawns);
-    }
-
-    public void updateBlackKnightValues(BitBoard bitBoard) {
-        long blackKnights = bitBoard.getBlackKnights();
-        long blackBishops = bitBoard.getBlackBishops();
-        long blackRooks = bitBoard.getBlackRooks();
-        long blackQueens = bitBoard.getBlackQueens();
-        long blackPawns = bitBoard.getBlackPawns();
-        long whitePawns = bitBoard.getWhitePawns();
-        updateKnightOutpostBonusBlack(blackKnights, blackPawns, whitePawns);
-    }
-
-    public void updateWhiteRookValues(BitBoard bitBoard) {
-        updateRookHalfOpenFileBonusWhite(bitBoard);
-        updateRookOpenFileBonusWhite(bitBoard);
-        updateKingValuesWhite(bitBoard);
-    }
-
-    public void updateBlackRookValues(BitBoard bitBoard) {
-        updateRookHalfOpenFileBonusBlack(bitBoard);
-        updateRookOpenFileBonusBlack(bitBoard);
-        updateKingValuesBlack(bitBoard);
+        evaluationPipeline.initialize(context);
     }
 
     public void applyMove(BitBoard bitBoard, int move, GameStateEnum state) {
-        boolean isWhite = MoveHelper.isWhitesMove(move);
-        int pieceTypeBits = MoveHelper.derivePieceTypeBits(move);
-        int capturedPieceTypeBits = MoveHelper.deriveCapturedPieceTypeBits(move);
-        int promotionPieceTypeBits = MoveHelper.derivePromotionPieceTypeBits(move);
-
-        updatePieceValues(isWhite, pieceTypeBits, bitBoard, state);
-
-        if (capturedPieceTypeBits != 0) {
-            updateCapturedPieceValues(isWhite, capturedPieceTypeBits, bitBoard);
-        }
-        if (promotionPieceTypeBits != 0) {
-            updatePromotionPieceValues(isWhite, promotionPieceTypeBits, bitBoard);
-        }
-
-        updateMobilityScores(bitBoard);
-        updateKingSafety(bitBoard);
-
-        EvaluationContext previousContext = this.evaluationContext;
-        EvaluationContext updatedContext = EvaluationContext.from(bitBoard, state);
-        this.evaluationContext = updatedContext;
-        syncPipeline(updatedContext);
-        MoveContext moveContext = new MoveContext(move, previousContext, updatedContext);
+        Objects.requireNonNull(bitBoard, "bitBoard");
+        EvaluationContext previous = this.evaluationContext;
+        EvaluationContext updated = EvaluationContext.from(bitBoard, state);
+        this.evaluationContext = updated;
+        synchronizePipeline(updated);
+        MoveContext moveContext = new MoveContext(move, previous, updated);
         evaluationPipeline.applyMove(moveContext);
     }
 
     public void undoMove(BitBoard bitBoard, int move, GameStateEnum state) {
-        // Board has already been reverted; reuse applyMove logic
-        applyMove(bitBoard, move, state);
+        Objects.requireNonNull(bitBoard, "bitBoard");
+        EvaluationContext previous = this.evaluationContext;
+        EvaluationContext updated = EvaluationContext.from(bitBoard, state);
+        this.evaluationContext = updated;
+        synchronizePipeline(updated);
+        MoveContext moveContext = new MoveContext(move, previous, updated);
+        evaluationPipeline.undoMove(moveContext);
     }
 
-    private void updatePieceValues(boolean isWhite, int pieceTypeBits, BitBoard bitBoard, GameStateEnum state) {
-        if (isWhite) {
-            updateValuesForWhite(pieceTypeBits, bitBoard);
-            updateStateValuesWhite(state);
+    private void synchronizePipeline(EvaluationContext context) {
+        if (!evaluationPipeline.isInitialized()) {
+            evaluationPipeline.initialize(context);
         } else {
-            updateValuesForBlack(pieceTypeBits, bitBoard);
-            updateStateValuesBlack(state);
+            evaluationPipeline.updateContext(context);
         }
     }
 
-    private void updateValuesForWhite(int pieceTypeBits, BitBoard bitBoard) {
-        switch (pieceTypeBits) {
-            case 1 -> updateWhitePawnValues(bitBoard);
-            case 2 -> updateWhiteKnightValues(bitBoard);
-            case 4 -> updateWhiteRookValues(bitBoard);
-            case 6 -> updateKingValuesWhite(bitBoard);
-            default -> {
-            }
+    public double getScoreDifference() {
+        if (!evaluationPipeline.isInitialized()) {
+            return 0.0;
         }
+        return evaluationPipeline.getScoreDifference();
     }
 
-    private void updateValuesForBlack(int pieceTypeBits, BitBoard bitBoard) {
-        switch (pieceTypeBits) {
-            case 1 -> updateBlackPawnValues(bitBoard);
-            case 2 -> updateBlackKnightValues(bitBoard);
-            case 4 -> updateBlackRookValues(bitBoard);
-            case 6 -> updateKingValuesBlack(bitBoard);
-            default -> {
-            }
+    public int getMidgameScore() {
+        if (!evaluationPipeline.isInitialized()) {
+            return 0;
         }
+        return evaluationPipeline.getMidgameScore();
     }
 
-    private void updateCapturedPieceValues(boolean isWhite, int capturedPieceTypeBits, BitBoard bitBoard) {
-        if (isWhite) {
-            updateValuesForBlack(capturedPieceTypeBits, bitBoard);
-        } else {
-            updateValuesForWhite(capturedPieceTypeBits, bitBoard);
+    public int getEndgameScore() {
+        if (!evaluationPipeline.isInitialized()) {
+            return 0;
         }
+        return evaluationPipeline.getEndgameScore();
     }
 
-    private void updatePromotionPieceValues(boolean isWhite, int promotionPieceTypeBits, BitBoard bitBoard) {
-        if (isWhite) {
-            updateValuesForWhite(promotionPieceTypeBits, bitBoard);
-        } else {
-            updateValuesForBlack(promotionPieceTypeBits, bitBoard);
+    public int getBlendedScore() {
+        if (!evaluationPipeline.isInitialized()) {
+            return 0;
         }
-    }
-
-    public void updateKingValuesWhite(BitBoard bitBoard) {
-        updateWhiteKingsPositionBonus(bitBoard.getWhiteKing(), bitBoard.getWhitePawns(), bitBoard.getBlackPawns(),
-                bitBoard.isWhiteKingHasCastled(), bitBoard.isWhiteKingMoved(), bitBoard.isWhiteRookA1Moved(),
-                bitBoard.isWhiteRookH1Moved(), bitBoard.getPhase(), computeMaterialBalance(bitBoard));
-    }
-
-    public void updateKingValuesBlack(BitBoard bitBoard) {
-        updateBlackKingsPositionBonus(bitBoard.getBlackKing(), bitBoard.getBlackPawns(), bitBoard.getWhitePawns(),
-                bitBoard.isBlackKingHasCastled(), bitBoard.isBlackKingMoved(), bitBoard.isBlackRookA8Moved(),
-                bitBoard.isBlackRookH8Moved(), bitBoard.getPhase(), computeMaterialBalance(bitBoard));
-    }
-
-    public int getWhiteKingsPosition() {
-        return whiteKingCastlingAdjustment;
-    }
-
-    public int getBlackKingsPosition() {
-        return blackKingCastlingAdjustment;
-    }
-
-    public void updateStateValuesWhite(GameStateEnum state) {
-        if (state.equals(GameStateEnum.WHITE_WON)) {
-            whiteStateBonus = CHECKMATE;
-        } else {
-            whiteStateBonus = 0;
-        }
-    }
-
-    public void updateStateValuesBlack(GameStateEnum state) {
-        if (state.equals(GameStateEnum.BLACK_WON)) {
-            blackStateBonus = CHECKMATE;
-        } else {
-            blackStateBonus = 0;
-        }
+        return evaluationPipeline.getBlendedScore();
     }
 
     public static int getPieceValue(int pieceTypeBits) {
         return switch (pieceTypeBits) {
-            case 1 -> PAWN_VALUE / 100;
-            case 2 -> KNIGHT_VALUE / 100;
-            case 3 -> BISHOP_VALUE / 100;
-            case 4 -> ROOK_VALUE / 100;
-            case 5 -> QUEEN_VALUE / 100;
+            case 1 -> MaterialModule.PAWN_VALUE / 100;
+            case 2 -> MaterialModule.KNIGHT_VALUE / 100;
+            case 3 -> MaterialModule.BISHOP_VALUE / 100;
+            case 4 -> MaterialModule.ROOK_VALUE / 100;
+            case 5 -> MaterialModule.QUEEN_VALUE / 100;
             case 6 -> 1000;
             default -> throw new IllegalStateException("Unexpected value: " + pieceTypeBits);
         };
     }
 
+    @JsonIgnore
+    public EvaluationContext getEvaluationContext() {
+        return evaluationContext;
+    }
 
+    @JsonIgnore
+    public EvaluationPipeline getEvaluationPipeline() {
+        return evaluationPipeline;
+    }
 }

--- a/src/main/resources/static/js/chess-data-fetching.js
+++ b/src/main/resources/static/js/chess-data-fetching.js
@@ -93,49 +93,10 @@ const updateGameDetails = (data) => {
     details += '<table class="details-table">';
     details += '<tr><td>Game State</td><td>' + data.gameState.state + '</td></tr>';
     details += '<tr><td>Overall Score</td><td>' + data.score + '</td></tr>';
-    details += '<tr><td>White Score</td><td>' + data.gameState.score.whiteScore + '</td></tr>';
-    details += '<tr><td>Black Score</td><td>' + data.gameState.score.blackScore + '</td></tr>';
-
-    // Piece Scores
-    details += '<tr><td>White Pawns</td><td>' + data.gameState.score.whitePawns + '</td></tr>';
-    details += '<tr><td>Black Pawns</td><td>' + data.gameState.score.blackPawns + '</td></tr>';
-    details += '<tr><td>White Knights</td><td>' + data.gameState.score.whiteKnights + '</td></tr>';
-    details += '<tr><td>Black Knights</td><td>' + data.gameState.score.blackKnights + '</td></tr>';
-    details += '<tr><td>White Bishops</td><td>' + data.gameState.score.whiteBishops + '</td></tr>';
-    details += '<tr><td>Black Bishops</td><td>' + data.gameState.score.blackBishops + '</td></tr>';
-    details += '<tr><td>White Rooks</td><td>' + data.gameState.score.whiteRooks + '</td></tr>';
-    details += '<tr><td>Black Rooks</td><td>' + data.gameState.score.blackRooks + '</td></tr>';
-    details += '<tr><td>White Queens</td><td>' + data.gameState.score.whiteQueens + '</td></tr>';
-    details += '<tr><td>Black Queens</td><td>' + data.gameState.score.blackQueens + '</td></tr>';
-
-    // Position and Penalty Scores
-    details += '<tr><td>White Center Pawn Bonus</td><td>' + data.gameState.score.whiteCenterPawnBonus + '</td></tr>';
-    details += '<tr><td>Black Center Pawn Bonus</td><td>' + data.gameState.score.blackCenterPawnBonus + '</td></tr>';
-    details += '<tr><td>White Doubled Pawn Penalty</td><td>' + data.gameState.score.whiteDoubledPawnPenalty + '</td></tr>';
-    details += '<tr><td>Black Doubled Pawn Penalty</td><td>' + data.gameState.score.blackDoubledPawnPenalty + '</td></tr>';
-    details += '<tr><td>White Isolated Pawn Penalty</td><td>' + data.gameState.score.whiteIsolatedPawnPenalty + '</td></tr>';
-    details += '<tr><td>Black Isolated Pawn Penalty</td><td>' + data.gameState.score.blackIsolatedPawnPenalty + '</td></tr>';
-
-    details += '<tr><td>White Pawns Position</td><td>' + data.gameState.score.whitePawnsPosition + '</td></tr>';
-    details += '<tr><td>Black Pawns Position</td><td>' + data.gameState.score.blackPawnsPosition + '</td></tr>';
-    details += '<tr><td>White Knights Position</td><td>' + data.gameState.score.whiteKnightsPosition + '</td></tr>';
-    details += '<tr><td>Black Knights Position</td><td>' + data.gameState.score.blackKnightsPosition + '</td></tr>';
-    details += '<tr><td>White Bishops Position</td><td>' + data.gameState.score.whiteBishopsPosition + '</td></tr>';
-    details += '<tr><td>Black Bishops Position</td><td>' + data.gameState.score.blackBishopsPosition + '</td></tr>';
-    details += '<tr><td>White Queens Position</td><td>' + data.gameState.score.whiteQueensPosition + '</td></tr>';
-    details += '<tr><td>Black Queens Position</td><td>' + data.gameState.score.blackQueensPosition + '</td></tr>';
-
-    details += '<tr><td>White King Position</td><td>' + data.gameState.score.whiteKingsPosition + '</td></tr>';
-    details += '<tr><td>Black King Position</td><td>' + data.gameState.score.blackKingsPosition + '</td></tr>';
-
-    details += '<tr><td>White Starting Square Penalty</td><td>' + data.gameState.score.whiteStartingSquarePenalty + '</td></tr>';
-    details += '<tr><td>Black Starting Square Penalty</td><td>' + data.gameState.score.blackStartingSquarePenalty + '</td></tr>';
-
-
-    // Misc Details
-    details += '<tr><td>Agility White</td><td>' + data.gameState.score.agilityWhite + '</td></tr>';
-    details += '<tr><td>Agility Black</td><td>' + data.gameState.score.agilityBlack + '</td></tr>';
-    details += '<tr><td>Score Difference</td><td>' + data.gameState.score.scoreDifference + '</td></tr>';
+    details += '<tr><td>Midgame Score (cp)</td><td>' + data.gameState.score.midgameScore + '</td></tr>';
+    details += '<tr><td>Endgame Score (cp)</td><td>' + data.gameState.score.endgameScore + '</td></tr>';
+    details += '<tr><td>Blended Score (cp)</td><td>' + data.gameState.score.blendedScore + '</td></tr>';
+    details += '<tr><td>Score Difference (pawns)</td><td>' + data.gameState.score.scoreDifference + '</td></tr>';
     details += '<tr><td>Game Over</td><td>' + data.gameState.gameOver + '</td></tr>';
     details += '<tr><td>In State Check</td><td>' + data.gameState.inStateCheck + '</td></tr>';
     details += '<tr><td>In State CheckMate</td><td>' + data.gameState.inStateCheckMate + '</td></tr>';

--- a/src/main/resources/static/js/ffb.js
+++ b/src/main/resources/static/js/ffb.js
@@ -34,12 +34,10 @@ $(document).ready(function () {
     const updateGameDetails = (data) => {
         let details = '<p>Game State: ' + data.gameState.state + '</p>';
         details += '<p>Score: ' + data.score + '</p>';
-        details += '<p>White Score: ' + data.gameState.score.whiteScore + '</p>';
-        details += '<p>Black Score: ' + data.gameState.score.blackScore + '</p>';
-        details += '<p>White Pawns: ' + data.gameState.score.whitePawns + '</p>';
-        details += '<p>Black Pawns: ' + data.gameState.score.blackPawns + '</p>';
-        // ... Add more details as per the structure
-        details += '<p>Score Difference: ' + data.gameState.score.scoreDifference + '</p>';
+        details += '<p>Midgame Score (cp): ' + data.gameState.score.midgameScore + '</p>';
+        details += '<p>Endgame Score (cp): ' + data.gameState.score.endgameScore + '</p>';
+        details += '<p>Blended Score (cp): ' + data.gameState.score.blendedScore + '</p>';
+        details += '<p>Score Difference (pawns): ' + data.gameState.score.scoreDifference + '</p>';
         details += '<p>Game Over: ' + data.gameState.gameOver + '</p>';
         details += '<p>In State Check: ' + data.gameState.inStateCheck + '</p>';
         details += '<p>In State CheckMate: ' + data.gameState.inStateCheckMate + '</p>';

--- a/src/test/java/julius/game/chessengine/utils/BishopPairBonusTest.java
+++ b/src/test/java/julius/game/chessengine/utils/BishopPairBonusTest.java
@@ -2,6 +2,9 @@ package julius.game.chessengine.utils;
 
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.evaluation.EvaluationContext;
+import julius.game.chessengine.evaluation.EvaluationPipeline;
+import julius.game.chessengine.evaluation.MaterialModule;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,18 +13,26 @@ public class BishopPairBonusTest {
 
     @Test
     void whiteBishopsPairGetsBonus() {
-        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/8/2B1KB2 w - - 0 1");
-        Score score = Score.initializeScore(board);
-        assertEquals(Score.BISHOP_PAIR_BONUS, score.getWhiteBishopPairBonus());
-        assertEquals(0, score.getBlackBishopPairBonus());
+        BitBoard pair = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/8/2B1KB2 w - - 0 1");
+        BitBoard single = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/8/4KB2 w - - 0 1");
+
+        int diff = materialScore(pair) - materialScore(single);
+        assertEquals(MaterialModule.BISHOP_VALUE + MaterialModule.BISHOP_PAIR_BONUS, diff);
     }
 
     @Test
     void blackBishopsPairGetsBonus() {
-        BitBoard board = FEN.translateFENtoBitBoard("2b1kb2/8/8/8/8/8/8/4K3 w - - 0 1");
-        Score score = Score.initializeScore(board);
-        assertEquals(Score.BISHOP_PAIR_BONUS, score.getBlackBishopPairBonus());
-        assertEquals(0, score.getWhiteBishopPairBonus());
+        BitBoard pair = FEN.translateFENtoBitBoard("2b1kb2/8/8/8/8/8/8/4K3 w - - 0 1");
+        BitBoard single = FEN.translateFENtoBitBoard("4kb2/8/8/8/8/8/8/4K3 w - - 0 1");
+
+        int diff = materialScore(single) - materialScore(pair);
+        assertEquals(MaterialModule.BISHOP_VALUE + MaterialModule.BISHOP_PAIR_BONUS, diff);
+    }
+
+    private static int materialScore(BitBoard board) {
+        MaterialModule module = new MaterialModule();
+        EvaluationPipeline pipeline = new EvaluationPipeline(java.util.List.of(module));
+        pipeline.initialize(EvaluationContext.from(board, null));
+        return pipeline.getMidgameScore();
     }
 }
-

--- a/src/test/java/julius/game/chessengine/utils/DevelopmentEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/utils/DevelopmentEvaluationTest.java
@@ -2,24 +2,26 @@ package julius.game.chessengine.utils;
 
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.evaluation.EvaluationContext;
+import julius.game.chessengine.evaluation.PieceSquareModule;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DevelopmentEvaluationTest {
 
     @Test
     void undevelopedBlackMinorsArePenalizedAfterOpening() {
         BitBoard undeveloped = FEN.translateFENtoBitBoard("rnb1kbnr/pppppppp/8/8/2B2B2/2N2N2/PPPPPPPP/R3K2R w KQkq - 0 1");
-        Score undevelopedScore = Score.initializeScore(undeveloped);
-
         BitBoard developed = FEN.translateFENtoBitBoard("r3k2r/pppbbppp/2n2n2/8/2B2B2/2N2N2/PPPPPPPP/R3K2R w KQkq - 0 1");
-        Score developedScore = Score.initializeScore(developed);
 
-        assertTrue(undevelopedScore.getBlackMinorDevelopmentPenalty() < 0,
+        int undevelopedPenalty = developmentContribution(undeveloped);
+        int developedPenalty = developmentContribution(developed);
+        assertTrue(undevelopedPenalty < developedPenalty,
                 "Black should be penalized for leaving minors on their home squares after the opening");
-        assertEquals(0, developedScore.getBlackMinorDevelopmentPenalty(),
-                "Fully developed minors should remove the penalty");
+
+        Score undevelopedScore = Score.initializeScore(undeveloped);
+        Score developedScore = Score.initializeScore(developed);
         assertTrue(undevelopedScore.getScoreDifference() > developedScore.getScoreDifference(),
                 "White should prefer the position where black remains undeveloped");
     }
@@ -27,16 +29,23 @@ public class DevelopmentEvaluationTest {
     @Test
     void earlyQueenDevelopmentIsDiscouraged() {
         BitBoard queenHome = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
-        Score queenHomeScore = Score.initializeScore(queenHome);
-
         BitBoard queenAdventure = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/7Q/8/8/PPPPPPPP/RNB1KBNR w KQkq - 0 3");
-        Score queenAdventureScore = Score.initializeScore(queenAdventure);
 
-        assertEquals(0, queenHomeScore.getWhiteQueenDevelopmentPenalty(),
-                "Keeping the queen at home should avoid any penalty");
-        assertTrue(queenAdventureScore.getWhiteQueenDevelopmentPenalty() < 0,
+        int homeContribution = developmentContribution(queenHome);
+        int adventureContribution = developmentContribution(queenAdventure);
+        assertTrue(adventureContribution < homeContribution,
                 "Advancing the queen before developing minors should be penalized");
+
+        Score queenHomeScore = Score.initializeScore(queenHome);
+        Score queenAdventureScore = Score.initializeScore(queenAdventure);
         assertTrue(queenAdventureScore.getScoreDifference() < queenHomeScore.getScoreDifference(),
                 "White's evaluation should drop when the queen comes out too early");
+    }
+
+    private static int developmentContribution(BitBoard board) {
+        PieceSquareModule module = new PieceSquareModule();
+        EvaluationContext context = EvaluationContext.from(board, null);
+        module.initialize(context);
+        return module.getDevelopmentContribution();
     }
 }

--- a/src/test/java/julius/game/chessengine/utils/NotCastledPenaltyTest.java
+++ b/src/test/java/julius/game/chessengine/utils/NotCastledPenaltyTest.java
@@ -2,42 +2,50 @@ package julius.game.chessengine.utils;
 
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.evaluation.KingSafetyModule;
+import julius.game.chessengine.evaluation.KingSafetyModule.KingSafetyView;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NotCastledPenaltyTest {
 
     @Test
     void penaltySkippedWhenShielded() {
         BitBoard baseline = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
-        Score scoreBaseline = Score.initializeScore(baseline);
-
         BitBoard noRights = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1");
-        Score scoreNoRights = Score.initializeScore(noRights);
 
-        assertEquals(scoreBaseline.getWhiteKingsPosition(), scoreNoRights.getWhiteKingsPosition());
+        assertEquals(whiteKingSafety(baseline), whiteKingSafety(noRights));
     }
 
     @Test
     void penaltyAppliedWhenOpenFile() {
         BitBoard shield = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1");
-        Score scoreShield = Score.initializeScore(shield);
-
         BitBoard openFile = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPP1PPP/RNBQKBNR w - - 0 1");
-        Score scoreOpen = Score.initializeScore(openFile);
 
-        assertTrue(scoreOpen.getWhiteKingsPosition() < scoreShield.getWhiteKingsPosition());
+        assertTrue(whiteKingSafety(openFile) < whiteKingSafety(shield));
+
+        Score scoreShield = Score.initializeScore(shield);
+        Score scoreOpen = Score.initializeScore(openFile);
+        assertTrue(scoreOpen.getScoreDifference() < scoreShield.getScoreDifference());
     }
 
     @Test
     void penaltyReducedWhenBehindMaterial() {
         BitBoard openFile = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPP1PPP/RNBQKBNR w - - 0 1");
-        Score evenScore = Score.initializeScore(openFile);
-
         BitBoard openFileWhiteDown = FEN.translateFENtoBitBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPP1PPP/RNBQKB1R w - - 0 1");
-        Score downScore = Score.initializeScore(openFileWhiteDown);
 
-        assertTrue(downScore.getWhiteKingsPosition() > evenScore.getWhiteKingsPosition());
+        assertTrue(whiteKingSafety(openFileWhiteDown) > whiteKingSafety(openFile));
+
+        Score evenScore = Score.initializeScore(openFile);
+        Score downScore = Score.initializeScore(openFileWhiteDown);
+        assertTrue(downScore.getScoreDifference() > evenScore.getScoreDifference());
+    }
+
+    private static int whiteKingSafety(BitBoard board) {
+        KingSafetyModule module = new KingSafetyModule();
+        KingSafetyView view = module.getView(board);
+        return view.whiteKing().blend(board.getPhase());
     }
 }

--- a/src/test/java/julius/game/chessengine/utils/PassedPawnScoreTest.java
+++ b/src/test/java/julius/game/chessengine/utils/PassedPawnScoreTest.java
@@ -2,6 +2,8 @@ package julius.game.chessengine.utils;
 
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.evaluation.PawnStructureModule;
+import julius.game.chessengine.evaluation.PawnStructureModule.PawnStructureView;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,17 +13,23 @@ public class PassedPawnScoreTest {
     @Test
     void whitePassedPawnGetsBonus() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/4P3/8/8/8/4K3 w - - 0 1");
-        Score score = Score.initializeScore(board);
-        assertEquals(Score.PASSED_PAWN_BONUS * 4, score.getWhitePassedPawnBonus());
-        assertEquals(0, score.getBlackPassedPawnBonus());
+        PawnStructureView view = pawnStructure(board);
+        assertEquals(PawnStructureModule.PASSED_PAWN_BONUS * 4,
+                view.whitePassed().blend(board.getPhase()));
+        assertEquals(0, view.blackPassed().blend(board.getPhase()));
     }
 
     @Test
     void blackPassedPawnGetsBonus() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/3p4/8/8/4K3 w - - 0 1");
-        Score score = Score.initializeScore(board);
-        assertEquals(Score.PASSED_PAWN_BONUS * 4, score.getBlackPassedPawnBonus());
-        assertEquals(0, score.getWhitePassedPawnBonus());
+        PawnStructureView view = pawnStructure(board);
+        assertEquals(PawnStructureModule.PASSED_PAWN_BONUS * 4,
+                view.blackPassed().blend(board.getPhase()));
+        assertEquals(0, view.whitePassed().blend(board.getPhase()));
+    }
+
+    private static PawnStructureView pawnStructure(BitBoard board) {
+        PawnStructureModule module = new PawnStructureModule();
+        return module.getView(board);
     }
 }
-

--- a/src/test/java/julius/game/chessengine/utils/RookOpenFileBonusTest.java
+++ b/src/test/java/julius/game/chessengine/utils/RookOpenFileBonusTest.java
@@ -2,6 +2,7 @@ package julius.game.chessengine.utils;
 
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.evaluation.PawnStructureModule;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -11,12 +12,16 @@ public class RookOpenFileBonusTest {
     @Test
     void rooksOnOpenFilesScoreHigherThanHalfOpen() {
         BitBoard openFile = FEN.translateFENtoBitBoard("4k3/p7/8/8/8/8/8/1R2K3 w - - 0 1");
-        Score openScore = Score.initializeScore(openFile);
-
         BitBoard halfOpenFile = FEN.translateFENtoBitBoard("4k3/p7/8/8/8/8/8/R3K3 w - - 0 1");
-        Score halfScore = Score.initializeScore(halfOpenFile);
 
-        assertTrue(openScore.getWhiteRooksOpenFileBonus() > halfScore.getWhiteRooksHalfOpenFileBonus());
+        int openCount = new PawnStructureModule()
+                .countOpenFilesWithRooks(openFile, openFile.getWhiteRooks());
+        int halfCount = new PawnStructureModule()
+                .countHalfOpenFilesWithRooks(halfOpenFile, halfOpenFile.getWhiteRooks(), true);
+        assertTrue(openCount > halfCount);
+
+        Score openScore = Score.initializeScore(openFile);
+        Score halfScore = Score.initializeScore(halfOpenFile);
         assertTrue(openScore.getScoreDifference() > halfScore.getScoreDifference());
     }
 }

--- a/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
@@ -2,52 +2,79 @@ package julius.game.chessengine.utils;
 
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.evaluation.ActivityModule;
+import julius.game.chessengine.evaluation.EvaluationContext;
+import julius.game.chessengine.evaluation.EvaluationModule;
+import julius.game.chessengine.evaluation.EvaluationPipeline;
+import julius.game.chessengine.evaluation.KingSafetyModule;
+import julius.game.chessengine.evaluation.PawnStructureModule;
+import julius.game.chessengine.evaluation.KingSafetyModule.KingSafetyView;
+import julius.game.chessengine.evaluation.PawnStructureModule.PawnStructureView;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ScoreEvaluationTest {
 
     @Test
     void stalemateHasLowestMobility() {
         BitBoard stalemate = FEN.translateFENtoBitBoard("7k/5Q2/6K1/8/8/8/8/8 b - - 0 1");
-        Score scoreStalemate = Score.initializeScore(stalemate);
-
         BitBoard active = FEN.translateFENtoBitBoard("7k/4Q3/6K1/8/8/8/8/8 b - - 0 1");
-        Score scoreActive = Score.initializeScore(active);
 
-        assertTrue(scoreStalemate.getBlackMobilityScore() <= scoreActive.getBlackMobilityScore());
-        assertTrue(scoreActive.getBlackMobilityScore() > 0);
+        int stalemateActivity = blendedModuleScore(new ActivityModule(), stalemate);
+        int activeActivity = blendedModuleScore(new ActivityModule(), active);
+        assertTrue(stalemateActivity > activeActivity);
+
+        Score scoreStalemate = Score.initializeScore(stalemate);
+        Score scoreActive = Score.initializeScore(active);
         assertTrue(scoreStalemate.getScoreDifference() > scoreActive.getScoreDifference());
     }
 
     @Test
     void exposedKingIsPenalized() {
         BitBoard safe = FEN.translateFENtoBitBoard("6k1/6pp/8/8/8/8/6PP/6K1 w - - 0 1");
-        Score scoreSafe = Score.initializeScore(safe);
-
         BitBoard exposed = FEN.translateFENtoBitBoard("6k1/8/8/6pp/8/8/6PP/6K1 w - - 0 1");
-        Score scoreExposed = Score.initializeScore(exposed);
 
-        assertTrue(scoreExposed.getBlackKingSafetyScore() < scoreSafe.getBlackKingSafetyScore());
+        KingSafetyView safeView = kingSafetyView(safe);
+        KingSafetyView exposedView = kingSafetyView(exposed);
+        int phase = safe.getPhase();
+        assertTrue(exposedView.blackKing().blend(phase) < safeView.blackKing().blend(phase));
+
+        Score scoreSafe = Score.initializeScore(safe);
+        Score scoreExposed = Score.initializeScore(exposed);
         assertTrue(scoreExposed.getScoreDifference() > scoreSafe.getScoreDifference());
     }
 
     @Test
     void centerPawnsGrantBonusToWhite() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/4P3/8/8/4K3 w - - 0 1");
-        Score score = Score.initializeScore(board);
-
-        assertEquals(Score.CENTER_PAWN_BONUS, score.getWhiteCenterPawnBonus());
-        assertEquals(0, score.getBlackCenterPawnBonus());
+        PawnStructureView view = pawnStructure(board);
+        assertEquals(PawnStructureModule.CENTER_PAWN_BONUS, view.whiteCenter().blend(board.getPhase()));
+        assertEquals(0, view.blackCenter().blend(board.getPhase()));
     }
 
     @Test
     void centerPawnsGrantBonusToBlack() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/4p3/8/8/8/4K3 w - - 0 1");
-        Score score = Score.initializeScore(board);
+        PawnStructureView view = pawnStructure(board);
+        assertEquals(PawnStructureModule.CENTER_PAWN_BONUS, view.blackCenter().blend(board.getPhase()));
+        assertEquals(0, view.whiteCenter().blend(board.getPhase()));
+    }
 
-        assertEquals(0, score.getWhiteCenterPawnBonus());
-        assertEquals(Score.CENTER_PAWN_BONUS, score.getBlackCenterPawnBonus());
+    private static int blendedModuleScore(EvaluationModule module, BitBoard board) {
+        EvaluationPipeline pipeline = new EvaluationPipeline(java.util.List.of(module));
+        pipeline.initialize(EvaluationContext.from(board, null));
+        return pipeline.getBlendedScore();
+    }
+
+    private static KingSafetyView kingSafetyView(BitBoard board) {
+        KingSafetyModule module = new KingSafetyModule();
+        return module.getView(board);
+    }
+
+    private static PawnStructureView pawnStructure(BitBoard board) {
+        PawnStructureModule module = new PawnStructureModule();
+        return module.getView(board);
     }
 }

--- a/src/test/java/julius/game/chessengine/utils/StartingSquarePenaltyTest.java
+++ b/src/test/java/julius/game/chessengine/utils/StartingSquarePenaltyTest.java
@@ -2,6 +2,8 @@ package julius.game.chessengine.utils;
 
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.evaluation.EvaluationContext;
+import julius.game.chessengine.evaluation.PieceSquareModule;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,21 +13,25 @@ public class StartingSquarePenaltyTest {
     @Test
     void noPenaltyWhenOnlyKnightsOnStartingSquares() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/R1B2B1R/1N2K1N1 w - - 0 1");
-        Score score = Score.initializeScore(board);
-        assertEquals(0, score.getWhiteStartingSquarePenalty());
+        assertEquals(0, developmentContribution(board));
     }
 
     @Test
     void noPenaltyWhenOnlyBishopsOnStartingSquares() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/2N2N2/R6R/2B1KB2 w - - 0 1");
-        Score score = Score.initializeScore(board);
-        assertEquals(0, score.getWhiteStartingSquarePenalty());
+        assertEquals(0, developmentContribution(board));
     }
 
     @Test
     void noPenaltyWhenOnlyRooksOnStartingSquares() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/2B2B2/2N2N2/8/R3K2R w - - 0 1");
-        Score score = Score.initializeScore(board);
-        assertEquals(0, score.getWhiteStartingSquarePenalty());
+        assertEquals(0, developmentContribution(board));
+    }
+
+    private static int developmentContribution(BitBoard board) {
+        PieceSquareModule module = new PieceSquareModule();
+        EvaluationContext context = EvaluationContext.from(board, null);
+        module.initialize(context);
+        return module.getDevelopmentContribution();
     }
 }


### PR DESCRIPTION
## Summary
- simplify `Score` to rely on the evaluation pipeline for initialization, move updates, and blended score retrieval
- move material constants into `MaterialModule`, expose piece-square development contribution, and adjust engine logging/UI to the new score fields
- update evaluation-focused tests to assert module and pipeline behaviour directly instead of legacy `Score` getters

## Testing
- `mvn test` *(fails: network is unreachable while resolving Maven parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68caa6a811b0832a858cff7d000bd0ed