### PR TITLE
Fix piece type switch constant compilation errors

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
@@ -369,7 +369,11 @@ public final class ActivityModule implements EvaluationModule {
     }
 
     private long sliderRayMask(int pieceType, int square) {
-        return switch (pieceType) {
+        if (pieceType <= 0) {
+            return 0L;
+        }
+        PieceType type = MoveHelper.intToPieceType(pieceType);
+        return switch (type) {
             case BISHOP -> DIRECTION_RAYS[NORTH_EAST][square]
                     | DIRECTION_RAYS[NORTH_WEST][square]
                     | DIRECTION_RAYS[SOUTH_EAST][square]
@@ -521,7 +525,17 @@ public final class ActivityModule implements EvaluationModule {
         }
 
         long attacks = 0L;
-        switch (pieceType) {
+        if (pieceType <= 0) {
+            activity.mobilityCount = 0;
+            activity.centerCount = 0;
+            activity.midgameScore = 0;
+            activity.endgameScore = 0;
+            activity.attackMask = 0L;
+            return;
+        }
+
+        PieceType type = MoveHelper.intToPieceType(pieceType);
+        switch (type) {
             case KNIGHT -> attacks = KnightHelper.knightMoveTable[square];
             case BISHOP -> attacks = BISHOP_HELPER.calculateBishopMoves(square, allPieces);
             case ROOK -> attacks = ROOK_HELPER.calculateRookMoves(square, allPieces);

--- a/src/main/java/julius/game/chessengine/evaluation/PieceSquareModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PieceSquareModule.java
@@ -365,7 +365,11 @@ public final class PieceSquareModule implements EvaluationModule {
     }
 
     private void adjustDevelopmentOnEnter(int square, int color, int pieceType) {
-        switch (pieceType) {
+        if (pieceType <= 0) {
+            return;
+        }
+        PieceType type = MoveHelper.intToPieceType(pieceType);
+        switch (type) {
             case KNIGHT -> {
                 if (KNIGHT_HOME_SQUARE[color][square]) {
                     minorPiecesAtHome[color]++;
@@ -397,7 +401,11 @@ public final class PieceSquareModule implements EvaluationModule {
     }
 
     private void adjustDevelopmentOnLeave(int square, int color, int pieceType) {
-        switch (pieceType) {
+        if (pieceType <= 0) {
+            return;
+        }
+        PieceType type = MoveHelper.intToPieceType(pieceType);
+        switch (type) {
             case KNIGHT -> {
                 if (KNIGHT_HOME_SQUARE[color][square]) {
                     minorPiecesAtHome[color]--;


### PR DESCRIPTION
## Summary
- resolve Java 21 compilation errors by switching from int-based switch labels to enum-based switches
- guard against invalid piece type values before converting to enums in the evaluation modules

## Testing
- `./mvnw -q -DskipTests compile` *(fails: Maven wrapper cannot download dependencies in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caaa994470832aa09c169d93d85141