### PR TITLE
Guard Zobrist xor against null piece data

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -87,6 +87,10 @@ public class BitBoard {
     private boolean blackKingHasCastled = false;
 
     private void xorPiece(Color color, PieceType type, int square) {
+        if (type == null || color == null) {
+            log.warn("Attempted to xor Zobrist key with null piece information at square {}", square);
+            return;
+        }
         zKey ^= ZobristTable.getPieceSquareHash(getPieceIndex(type, color), square);
     }
 


### PR DESCRIPTION
## Summary
- avoid Zobrist table updates when move data lacks a piece type or color
- add logging to highlight attempts to update the hash with incomplete information

## Testing
- ./mvnw test *(fails: Maven wrapper cannot download due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_68caac64fca8832a957f564048b6fed5