### PR TITLE
Handle uninitialized evaluation pipeline before applying moves

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -78,6 +78,12 @@ public class Score {
         EvaluationContext previous = this.evaluationContext;
         EvaluationContext updated = EvaluationContext.from(bitBoard, state);
         this.evaluationContext = updated;
+
+        if (previous == null || !evaluationPipeline.isInitialized()) {
+            evaluationPipeline.initialize(updated);
+            return;
+        }
+
         synchronizePipeline(updated);
         MoveContext moveContext = new MoveContext(move, previous, updated);
         evaluationPipeline.applyMove(moveContext);
@@ -88,6 +94,12 @@ public class Score {
         EvaluationContext previous = this.evaluationContext;
         EvaluationContext updated = EvaluationContext.from(bitBoard, state);
         this.evaluationContext = updated;
+
+        if (previous == null || !evaluationPipeline.isInitialized()) {
+            evaluationPipeline.initialize(updated);
+            return;
+        }
+
         synchronizePipeline(updated);
         MoveContext moveContext = new MoveContext(move, previous, updated);
         evaluationPipeline.undoMove(moveContext);


### PR DESCRIPTION
## Summary
- guard Score.applyMove/undoMove against running incremental updates when the evaluation pipeline has not been initialized yet
- fall back to initializing the pipeline with the current context so scoring remains correct after refactors

## Testing
- `mvn -q -DskipTests=false test` *(fails: missing spring-boot-starter-parent due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cab45d4f08832abbdf877b7ad216f0