### PR TITLE
Fix quiescence perspective in alpha beta

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1025,10 +1025,9 @@ public class AI {
         // STRICT DEPTH MANAGEMENT:
         // Do NOT increase 'depth' at node entry. Child must always use < this depth.
         if (depth <= 0) {
-            // Quiescence returns white-oriented score; flip for black-to-move
+            // Quiescence evaluation is already returned from the side-to-move perspective
             double eval = evaluateBoard(simulatorEngine, isWhite, deadline);
             if (eval == EXIT_FLAG) return EXIT_FLAG;
-            if (!isWhite) eval = -eval;
             return eval;
         }
 


### PR DESCRIPTION
## Summary
- stop negating quiescence evaluations for black in alpha-beta when the search depth is exhausted
- clarify the comment that the evaluation already matches the side to move

## Testing
- mvn test *(fails: Maven cannot download the parent POM because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac66f30c0832abc597698188c9d77