### PR TITLE
Refresh score pipeline after null move

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -440,6 +440,8 @@ public class Engine {
             // Mark move list stale so the next search ply regenerates for the new side.
             legalMovesNeedUpdate = true;
 
+            gameState.refreshScore(bitBoard);
+
             return previousDoubleStep;
         }
     }
@@ -455,6 +457,8 @@ public class Engine {
 
             // Mark stale again so we rebuild for the restored side.
             legalMovesNeedUpdate = true;
+
+            gameState.refreshScore(bitBoard);
         }
     }
 

--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -52,6 +52,10 @@ public class GameState {
         this.halfmoveStack.addAll(other.halfmoveStack);
         this.fullmoveStack.addAll(other.fullmoveStack);
     }
+
+    public void refreshScore(BitBoard bitBoard) {
+        score.refresh(bitBoard, state);
+    }
     public void update(BitBoard bitBoard, MoveList legalMoves, int move, boolean isOpeningMove) {
         updateState(bitBoard, legalMoves, isOpeningMove);
 

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -73,6 +73,21 @@ public class Score {
         evaluationPipeline.initialize(context);
     }
 
+    public void refresh(BitBoard bitBoard, GameStateEnum state) {
+        Objects.requireNonNull(bitBoard, "bitBoard");
+        EvaluationContext updated = EvaluationContext.from(bitBoard, state);
+        this.evaluationContext = updated;
+
+        if (!evaluationPipeline.isInitialized()) {
+            evaluationPipeline.initialize(updated);
+        } else {
+            evaluationPipeline.updateContext(updated);
+        }
+
+        // Prime the aggregate totals so subsequent lookups observe the refreshed context immediately.
+        evaluationPipeline.getBlendedScore();
+    }
+
     public void applyMove(BitBoard bitBoard, int move, GameStateEnum state) {
         Objects.requireNonNull(bitBoard, "bitBoard");
         EvaluationContext previous = this.evaluationContext;

--- a/src/test/java/julius/game/chessengine/ai/NullMoveScoreConsistencyTest.java
+++ b/src/test/java/julius/game/chessengine/ai/NullMoveScoreConsistencyTest.java
@@ -1,0 +1,36 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.engine.GameState;
+import julius.game.chessengine.utils.Score;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NullMoveScoreConsistencyTest {
+
+    private static final String COMPLEX_FEN = "r3k2r/pppb1ppp/2n1bn2/2Pp4/3P4/2N1PN2/PPPB1PPP/R3K2R w KQkq d6 7 12";
+
+    @Test
+    void nullMoveSequenceKeepsScoreSynchronized() {
+        Engine engine = new Engine();
+        engine.importBoardFromFen(COMPLEX_FEN);
+
+        GameState state = engine.getGameState();
+
+        assertScoreMatchesFreshEvaluation(engine, state);
+
+        int previousEp = engine.doNullMoveForSearch();
+        assertScoreMatchesFreshEvaluation(engine, state);
+
+        engine.undoNullMoveForSearch(previousEp);
+        assertScoreMatchesFreshEvaluation(engine, state);
+    }
+
+    private static void assertScoreMatchesFreshEvaluation(Engine engine, GameState state) {
+        Score fresh = new Score();
+        fresh.refresh(engine.getBitBoard(), state.getState());
+        assertEquals(fresh.getBlendedScore(), state.getScore().getBlendedScore(),
+                "Score pipeline is out of sync with board after null move simulation");
+    }
+}


### PR DESCRIPTION
## Summary
- add a Score.refresh helper that rebuilds the evaluation context without simulating a move
- expose the refresh helper through GameState and invoke it during null-move search bookkeeping
- extend search tests to ensure null-move simulations keep the blended score in sync with a fresh evaluation

## Testing
- `mvn test` *(fails: unable to download Maven parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cac8eefa7c832abdd1b6b78747fb75