### PR TITLE
Fix SEE occupancy tracking and draw bias scaling

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1721,8 +1721,8 @@ public class AI {
 
         if (simulatorEngine.getGameState().isInStateDraw()) {
             double scoreDiff = simulatorEngine.getGameState().getScore().getScoreDifference();
-            // stronger bias than ±1 to steer away from draws when ahead
-            final double DRAW_BIAS = 20.0;
+            // stronger bias than ±0.01 to steer away from draws when ahead
+            final double DRAW_BIAS = 0.20;
             if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
                 return DRAW - DRAW_BIAS; // discourage draws when ahead
             } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {
@@ -1830,8 +1830,8 @@ public class AI {
                 log.debug("DRAW");
             }
             double scoreDiff = gameState.getScore().getScoreDifference();
-            // stronger bias than ±1 to steer decisively
-            final double DRAW_BIAS = 20.0;
+            // stronger bias than ±0.01 to steer decisively
+            final double DRAW_BIAS = 0.20;
             if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
                 return DRAW - DRAW_BIAS; // avoid draws when ahead
             } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -485,7 +485,7 @@ public class BitBoard {
                 }
             }
             occ &= ~attMask; // from-square cleared
-            // place on 'to'
+            // place on 'to' (keep occupancy accurate for slider lookups)
             if (sideWhite) {
                 switch (attBits) {
                     case 1 -> W[1] |= toMask;
@@ -505,7 +505,7 @@ public class BitBoard {
                     case 6 -> B[6] |= toMask;
                 }
             }
-            // 'to' stays occupied in occ
+            occ |= toMask; // ensure destination remains occupied for future attack discovery
 
             // Push gain and toggle
             d++;
@@ -550,6 +550,7 @@ public class BitBoard {
         }
 
         occCopy &= ~fromMask;
+        occCopy |= toMask;
 
         return !isSquareAttackedInSee(target, !kingIsWhite, wCopy, bCopy, occCopy);
     }


### PR DESCRIPTION
## Summary
- ensure the SEE occupancy bitmap keeps the destination square set after each capture in the exchange simulation
- update king-capture legality helper to mirror the corrected occupancy bookkeeping
- scale the draw bias constants to pawn units so they no longer overwhelm evaluation scores

## Testing
- ./mvnw test *(fails: maven wrapper cannot download dependencies because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cad6f8bea0832aade3dcc6babf2821