### PR TITLE
Adjust accept warning for already-started challenges

### DIFF
--- a/src/main/resources/py/lichess_bot.py
+++ b/src/main/resources/py/lichess_bot.py
@@ -962,8 +962,14 @@ def safe_accept_challenge(client: berserk.Client, chal_id: str) -> bool:
         return True
     except (berserk.exceptions.ResponseError, berserk.exceptions.ApiError) as e:
         status = getattr(getattr(e, "response", None), "status_code", None)
-        if status in (400, 404, 410):
-            print(f"[warn] Challenge {chal_id} vanished before accept (HTTP {status}).")
+        if status in (404, 410):
+            print(
+                f"[info] Challenge {chal_id} already resolved before accept (HTTP {status});"
+                " assuming game already created."
+            )
+            return True
+        if status == 400:
+            print(f"[warn] Challenge {chal_id} could not be accepted (HTTP {status}).")
             return False
         print(f"[-] Accept failed for {chal_id}: {e}")
         return False


### PR DESCRIPTION
## Summary
- treat 404/410 responses when accepting a challenge as informational since the game likely already started
- keep a clear warning only for 400 errors when the accept truly failed

## Testing
- python -m compileall src/main/resources/py/lichess_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68caf190f498832a90b8f3856ee42174