### PR TITLE
Adjust challenge acceptance logging

### DIFF
--- a/src/main/resources/py/lichess_bot.py
+++ b/src/main/resources/py/lichess_bot.py
@@ -962,8 +962,14 @@ def safe_accept_challenge(client: berserk.Client, chal_id: str) -> bool:
         return True
     except (berserk.exceptions.ResponseError, berserk.exceptions.ApiError) as e:
         status = getattr(getattr(e, "response", None), "status_code", None)
-        if status in (400, 404, 410):
+        if status == 400:
             print(f"[warn] Challenge {chal_id} vanished before accept (HTTP {status}).")
+            return False
+        if status in (404, 410):
+            print(
+                f"[info] Challenge {chal_id} no longer available before accept (HTTP {status})."
+                " Likely already converted to a game."
+            )
             return False
         print(f"[-] Accept failed for {chal_id}: {e}")
         return False


### PR DESCRIPTION
## Summary
- treat challenge acceptance 404/410 responses as informational instead of warnings
- clarify message that the challenge likely already converted into a game

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caf190f498832a90b8f3856ee42174