### PR TITLE
Handle search timeouts without random fallback

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -178,6 +178,9 @@ public class AI {
     private volatile long beforeCalculationBoardState = -2;
 
     private volatile int currentBestMove = -1;
+    private volatile int previousBestMove = -1;
+    private volatile long previousBestMoveHash = -1;
+    private volatile boolean searchResultReady = false;
 
     private volatile long bestMoveForHash = -1;
 
@@ -354,6 +357,9 @@ public class AI {
 
 
     public Integer getCurrentBestMoveInt() {
+        if (!searchResultReady) {
+            return -1;
+        }
         int move = currentBestMove;
         if (move == -1) {
             return -1;
@@ -492,6 +498,9 @@ public class AI {
         stopCalculation();
         currentBestMove = -1;
         bestMoveForHash = -1;
+        previousBestMove = -1;
+        previousBestMoveHash = -1;
+        searchResultReady = false;
         currentBoardState = -1;
         beforeCalculationBoardState = -2;
         calculatedLine = Collections.synchronizedList(new ArrayList<>());
@@ -537,6 +546,11 @@ public class AI {
 
         activeSearch.set(null);
         calculatedLine = Collections.synchronizedList(new ArrayList<>());
+        currentBestMove = -1;
+        bestMoveForHash = -1;
+        previousBestMove = -1;
+        previousBestMoveHash = -1;
+        searchResultReady = false;
     }
 
 
@@ -556,7 +570,8 @@ public class AI {
                 return;
             }
             if ((aiIsWhite && mainEngine.whitesTurn()) || (aiIsBlack && !mainEngine.whitesTurn())) {
-                if (currentBestMove != -1 && bestMoveForHash == mainEngine.getBoardStateHash()) {
+                if (searchResultReady && currentBestMove != -1 &&
+                        bestMoveForHash == mainEngine.getBoardStateHash()) {
                     performMove();
                 }
             }
@@ -570,6 +585,10 @@ public class AI {
         if (now != bestMoveForHash) {
             log.info("Stale best move for hash {}, current {}", bestMoveForHash, now);
             currentBestMove = -1;                           // <-- stop re-trying the stale move
+            bestMoveForHash = -1;
+            previousBestMove = -1;
+            previousBestMoveHash = -1;
+            searchResultReady = false;
             synchronized (calculationLock) {
                 calculationLock.notifyAll();
             } // <-- wake recalculation
@@ -579,6 +598,10 @@ public class AI {
         if (MoveHelper.isWhitesMove(currentBestMove) != mainEngine.whitesTurn()) {
             log.info("Best move {} not for side to move", Move.convertIntToMove(currentBestMove));
             currentBestMove = -1;                           // (optional) also drop here
+            bestMoveForHash = -1;
+            previousBestMove = -1;
+            previousBestMoveHash = -1;
+            searchResultReady = false;
             return;
         }
 
@@ -588,6 +611,10 @@ public class AI {
             calculationLock.notifyAll();
         }
         currentBestMove = -1; // don’t re-play it
+        bestMoveForHash = -1;
+        previousBestMove = -1;
+        previousBestMoveHash = -1;
+        searchResultReady = false;
     }
 
 
@@ -632,14 +659,25 @@ public class AI {
             if (bookMove != -1) {
                 currentBestMove = bookMove;
                 bestMoveForHash = boardStateHash;
+                previousBestMove = bookMove;
+                previousBestMoveHash = boardStateHash;
+                searchResultReady = true;
                 this.calculatedLine = List.of(new MoveAndScore(bookMove, 0.0));
                 return;
             }
 
             SearchTask task = new SearchTask(searchIdGenerator.incrementAndGet(), boardStateHash, isWhite, deadline, lazySmpThreads);
             activeSearch.set(task);
+            if (bestMoveForHash == boardStateHash && currentBestMove != -1) {
+                previousBestMove = currentBestMove;
+                previousBestMoveHash = bestMoveForHash;
+            } else {
+                previousBestMove = -1;
+                previousBestMoveHash = -1;
+            }
             currentBestMove = -1;
             bestMoveForHash = -1;
+            searchResultReady = false;
             this.calculatedLine = Collections.synchronizedList(new ArrayList<>());
 
             synchronized (calculationLock) {
@@ -652,8 +690,17 @@ public class AI {
 
         } catch (IllegalStateException e) {
             log.warn("Illegal board state during search: {}", e.getMessage());
-            MoveList legalMoves = mainEngine.getAllLegalMoves();
-            currentBestMove = (legalMoves.size() > 0) ? legalMoves.getMove(0) : -1;
+            if (bestMoveForHash == mainEngine.getBoardStateHash() && currentBestMove != -1) {
+                previousBestMove = currentBestMove;
+                previousBestMoveHash = bestMoveForHash;
+                searchResultReady = true;
+            } else {
+                currentBestMove = -1;
+                bestMoveForHash = -1;
+                previousBestMove = -1;
+                previousBestMoveHash = -1;
+                searchResultReady = false;
+            }
         } catch (Exception e) {
             log.error("Unexpected error during calculation", e);
         } finally {
@@ -661,30 +708,49 @@ public class AI {
         }
     }
 
-    private void completeSearchTask(SearchTask task, Engine simulatorEngine) {
+    void completeSearchTask(SearchTask task, Engine simulatorEngine) {
         if (task == null) return;
         if (currentBoardState != task.getBoardHash()) return;
 
         BestMoveDepth best = task.getBest();
         int move = best.move;
 
-        if (move == -1) {
-            MoveList legalMoves = simulatorEngine.getAllLegalMoves();
-            if (legalMoves.size() > 0) {
-                move = legalMoves.getMove(0);
-                currentBestMove = move;
-                bestMoveForHash = task.getBoardHash();
-            } else {
-                currentBestMove = -1;
-                this.calculatedLine = Collections.synchronizedList(new ArrayList<>());
-                return;
-            }
-        } else {
+        if (move != -1) {
             currentBestMove = move;
             bestMoveForHash = task.getBoardHash();
+            previousBestMove = move;
+            previousBestMoveHash = task.getBoardHash();
+            searchResultReady = true;
+            fillCalculatedLine(simulatorEngine);
+            return;
         }
 
-        fillCalculatedLine(simulatorEngine);
+        if (previousBestMove != -1 && previousBestMoveHash == task.getBoardHash() &&
+                isMoveStillLegal(simulatorEngine, previousBestMove)) {
+            currentBestMove = previousBestMove;
+            bestMoveForHash = task.getBoardHash();
+            previousBestMoveHash = task.getBoardHash();
+            searchResultReady = true;
+            fillCalculatedLine(simulatorEngine);
+            return;
+        }
+
+        currentBestMove = -1;
+        bestMoveForHash = -1;
+        previousBestMove = -1;
+        previousBestMoveHash = -1;
+        searchResultReady = false;
+        this.calculatedLine = Collections.synchronizedList(new ArrayList<>());
+    }
+
+    private boolean isMoveStillLegal(Engine simulatorEngine, int move) {
+        MoveList legalMoves = simulatorEngine.getAllLegalMoves();
+        for (int i = 0; i < legalMoves.size(); i++) {
+            if (legalMoves.getMove(i) == move) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void maybeRotateRootMoves(MoveList moves, SplittableRandom rng) {

--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -5,10 +5,12 @@ import julius.game.chessengine.board.MoveList;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.utils.Score;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -77,6 +79,45 @@ public class BestMoveSearchTest {
                 }
 
         );
+    }
+
+    @Test
+    void timeoutDoesNotFallbackToFirstLegalMove() throws Exception {
+        Engine engine = new Engine();
+        String fen = "rnbqkbnr/pppp1ppp/8/4p3/3PP3/8/PPP2PPP/RNBQKBNR b KQkq - 0 2";
+        engine.importBoardFromFen(fen);
+
+        MoveList legalMoves = engine.getAllLegalMoves();
+        Assertions.assertTrue(legalMoves.size() > 1, "Test position must allow multiple legal moves");
+        int firstLegal = legalMoves.getMove(0);
+        int preservedBest = legalMoves.getMove(legalMoves.size() - 1);
+        Assertions.assertNotEquals(firstLegal, preservedBest,
+                "The preserved best move should differ from the first generated legal move");
+
+        AI ai = new AI(engine);
+        long hash = engine.getBoardStateHash();
+
+        setPrivateField(ai, "currentBoardState", hash);
+        setPrivateField(ai, "previousBestMove", preservedBest);
+        setPrivateField(ai, "previousBestMoveHash", hash);
+        setPrivateField(ai, "currentBestMove", -1);
+        setPrivateField(ai, "bestMoveForHash", -1L);
+        setPrivateField(ai, "searchResultReady", false);
+
+        SearchTask task = new SearchTask(99L, hash, engine.whitesTurn(), System.nanoTime(), 1);
+
+        ai.completeSearchTask(task, engine);
+
+        int bestAfterTimeout = ai.getCurrentBestMoveInt();
+        Assertions.assertEquals(preservedBest, bestAfterTimeout,
+                "Search completion without a new result must reuse the preserved best move");
+        Assertions.assertNotEquals(firstLegal, bestAfterTimeout,
+                "Engine must not fall back to the first legal move after a timeout");
+
+        List<MoveAndScore> pv = ai.getCalculatedLine();
+        Assertions.assertFalse(pv.isEmpty(), "Principal variation should reflect the preserved best move");
+        Assertions.assertEquals(preservedBest, pv.get(0).getMove(),
+                "PV root move should match the preserved best move");
     }
 
     @ParameterizedTest(name = "Best move {1} for FEN {0}")
@@ -219,6 +260,12 @@ public class BestMoveSearchTest {
             return (centipawns > 0 ? "#+" : "#-") + (plies > 0 ? plies : "");
         }
         return String.format(Locale.US, "%+.2f", centipawns / 100.0);
+    }
+
+    private static void setPrivateField(Object target, String name, Object value) throws Exception {
+        Field field = AI.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
     }
 
     private record MoveEvaluation(String move, double score) {


### PR DESCRIPTION
## Summary
- retain the previous search result when a search task ends without producing a new move and drop the old "first legal move" fallback
- gate autoplay move execution behind a published search result and reset best-move state whenever it goes stale
- add a regression test that simulates a timed-out search and ensures the engine reuses the preserved best move instead of the first legal move

## Testing
- `mvn test` *(fails: requires downloading Maven parent POM, but the build environment has no network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cafda621f4832abd78e9ba76b6a7aa