### PR TITLE
Fix TT depth and node type checks

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1424,22 +1424,26 @@ public class AI {
             simulatorEngine.performMove(move);
             long newBoardHash = simulatorEngine.getBoardStateHash();
 
+            boolean givesCheck = isSideInCheck(simulatorEngine, !isWhite);
+            boolean attacksQueen = attacksOpponentQueenNow(simulatorEngine, isWhite);
+            boolean attacksKingZone = attacksOpponentKingZone(simulatorEngine, isWhite);
+            boolean opensKingFile = openedFileTowardKing(simulatorEngine.getBitBoard(), kingFileMask, pawnsOnFileBefore, affectsKingFilePawns);
+
+            int nextDepth = depth - 1;
+            boolean forcing = givesCheck || attacksQueen;
+            boolean allowExtend = forcing && extStreak < MAX_CHECK_EXTENSIONS_IN_A_ROW;
+            if (allowExtend) nextDepth++;
+            int nextExtStreak = allowExtend ? extStreak + 1 : 0;
+
             double eval;
             TranspositionTableEntry entry = transpositionTable.get(newBoardHash);
-            if (entry != null && entry.depth >= depth) {
+            boolean ttExactHit = entry != null
+                    && entry.nodeType == NodeType.EXACT
+                    && entry.depth >= nextDepth;
+
+            if (ttExactHit) {
                 eval = entry.score;
             } else {
-                boolean givesCheck = isSideInCheck(simulatorEngine, !isWhite);
-                boolean attacksQueen = attacksOpponentQueenNow(simulatorEngine, isWhite);
-                boolean attacksKingZone = attacksOpponentKingZone(simulatorEngine, isWhite);
-                boolean opensKingFile = openedFileTowardKing(simulatorEngine.getBitBoard(), kingFileMask, pawnsOnFileBefore, affectsKingFilePawns);
-
-                int nextDepth = depth - 1;
-                boolean forcing = givesCheck || attacksQueen;
-                boolean allowExtend = forcing && extStreak < MAX_CHECK_EXTENSIONS_IN_A_ROW;
-                if (allowExtend) nextDepth++;
-                int nextExtStreak = allowExtend ? extStreak + 1 : 0;
-
                 boolean canReduce = !inCheckAtNode
                         && !isTactical
                         && !givesCheck
@@ -1603,22 +1607,26 @@ public class AI {
             simulatorEngine.performMove(move);
             long newBoardHash = simulatorEngine.getBoardStateHash();
 
+            boolean givesCheck = isSideInCheck(simulatorEngine, !isWhite);
+            boolean attacksQueen = attacksOpponentQueenNow(simulatorEngine, isWhite);
+            boolean attacksKingZone = attacksOpponentKingZone(simulatorEngine, isWhite);
+            boolean opensKingFile = openedFileTowardKing(simulatorEngine.getBitBoard(), kingFileMask, pawnsOnFileBefore, affectsKingFilePawns);
+
+            int nextDepth = depth - 1;
+            boolean forcing = givesCheck || attacksQueen;
+            boolean allowExtend = forcing && extStreak < MAX_CHECK_EXTENSIONS_IN_A_ROW;
+            if (allowExtend) nextDepth++;
+            int nextExtStreak = allowExtend ? extStreak + 1 : 0;
+
             double eval;
             TranspositionTableEntry entry = transpositionTable.get(newBoardHash);
-            if (entry != null && entry.depth >= depth) {
+            boolean ttExactHit = entry != null
+                    && entry.nodeType == NodeType.EXACT
+                    && entry.depth >= nextDepth;
+
+            if (ttExactHit) {
                 eval = entry.score;
             } else {
-                boolean givesCheck = isSideInCheck(simulatorEngine, !isWhite);
-                boolean attacksQueen = attacksOpponentQueenNow(simulatorEngine, isWhite);
-                boolean attacksKingZone = attacksOpponentKingZone(simulatorEngine, isWhite);
-                boolean opensKingFile = openedFileTowardKing(simulatorEngine.getBitBoard(), kingFileMask, pawnsOnFileBefore, affectsKingFilePawns);
-
-                int nextDepth = depth - 1;
-                boolean forcing = givesCheck || attacksQueen;
-                boolean allowExtend = forcing && extStreak < MAX_CHECK_EXTENSIONS_IN_A_ROW;
-                if (allowExtend) nextDepth++;
-                int nextExtStreak = allowExtend ? extStreak + 1 : 0;
-
                 boolean canReduce = !inCheckAtNode
                         && !isTactical
                         && !givesCheck


### PR DESCRIPTION
## Summary
- ensure maximizer and minimizer only use transposition table hits when entries are exact and at least as deep as the child search
- reuse the computed child depth when assessing extensions and reductions so bound entries no longer short-circuit search prematurely

## Testing
- `./mvnw -q test` *(fails: Maven wrapper cannot download due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1c3c8f14832a8bdd35eb199b78d0