### PR TITLE
Introduce per-thread heuristics with centralized merging

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -117,15 +117,23 @@ public class AI {
     private int captureTranspositionTableCapacity;
 
     private static final int NUM_KILLER_MOVES = 2;
-    private volatile int[][] killerMoves; // 2D array for killer moves, initialized in the constructor
 
     /**
-     * History heuristic table. Indexed by from and to square (0-63), it stores a
-     * score indicating how often a quiet move has caused a beta cutoff. Higher
-     * scores mean the move should be ordered earlier in the move list.
+     * Global heuristic tables shared across searches. Search threads work with
+     * thread-local copies that are periodically merged back into this
+     * structure between iterative-deepening iterations.
      */
-    private final int[][] historyTable; // [from][to]
-    private final int[][] counterMove; // [prevFrom][prevTo] -> reply move
+    private final Heuristics globalHeuristics;
+
+    /**
+     * Per-thread heuristic state used during move ordering. The tables are
+     * initialised from {@link #globalHeuristics} at the beginning of each
+     * iterative-deepening iteration, updated locally during the search and
+     * merged back afterwards.
+     */
+    private final ThreadLocal<Heuristics> threadHeuristics;
+
+    private final Object heuristicsLock = new Object();
 
     // Buffers used for move ordering. Reused across calls to avoid repeated
     // allocations when ordering moves.
@@ -214,11 +222,8 @@ public class AI {
         this.mainEngine = mainEngine;
         this.timeLimit = 50;
 
-        // Initialize killer moves etc...
-        this.killerMoves = allocateKillerMoves(maxDepth);
-        this.historyTable = new int[64][64];
-        this.counterMove = new int[64][64];
-        for (int f = 0; f < 64; f++) Arrays.fill(counterMove[f], -1);
+        this.globalHeuristics = new Heuristics(maxDepth);
+        this.threadHeuristics = ThreadLocal.withInitial(() -> new Heuristics(maxDepth));
 
         rebuildTranspositionTables();
 
@@ -337,26 +342,11 @@ public class AI {
      */
     public synchronized void setMaxDepth(int depth) {
         int requestedDepth = Math.max(1, depth);
-        if (requestedDepth > killerMoves.length) {
-            killerMoves = resizeKillerMoves(killerMoves, requestedDepth);
+        synchronized (heuristicsLock) {
+            globalHeuristics.ensureCapacity(requestedDepth);
         }
+        threadHeuristics.get().ensureCapacity(requestedDepth);
         this.maxDepth = requestedDepth;
-    }
-
-    private static int[][] allocateKillerMoves(int depth) {
-        int[][] table = new int[depth][NUM_KILLER_MOVES];
-        for (int i = 0; i < depth; i++) {
-            Arrays.fill(table[i], -1);
-        }
-        return table;
-    }
-
-    private static int[][] resizeKillerMoves(int[][] current, int newDepth) {
-        int[][] expanded = allocateKillerMoves(newDepth);
-        for (int i = 0; i < current.length; i++) {
-            System.arraycopy(current[i], 0, expanded[i], 0, current[i].length);
-        }
-        return expanded;
     }
 
 
@@ -450,16 +440,13 @@ public class AI {
 
     private void iterativeDeepening(SearchTask task, Engine simulatorEngine, SplittableRandom rng) {
         Double lastIterScore = null;
+        Heuristics heuristics = threadHeuristics.get();
 
         for (int currentDepth = 1; currentDepth <= maxDepth; currentDepth++) {
             if (shouldStopCalculating(task.getDeadline())) break;
 
-            if (transpositionTable != null) {
-                transpositionTable.advanceAge();
-            }
-            if (captureTranspositionTable != null) {
-                captureTranspositionTable.advanceAge();
-            }
+            boolean firstAtDepth = task.beginIteration(currentDepth);
+            prepareIterationState(task, heuristics, currentDepth, firstAtDepth);
 
             /**
              * Ply hint for distance-to-mate normalization (set per ID iteration).
@@ -499,18 +486,62 @@ public class AI {
 
             if (ms == null) {
                 ms = searchRootMoves(simulatorEngine, task, currentDepth, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, rng);
-                if (ms == null) break;
+                if (ms == null) {
+                    if (heuristics.hasUpdates()) {
+                        mergeThreadHeuristics(heuristics);
+                    }
+                    break;
+                }
             }
 
             lastIterScore = ms.score;
             task.publishBest(ms, currentDepth, simulatorEngine);
+            if (heuristics.hasUpdates()) {
+                mergeThreadHeuristics(heuristics);
+            }
             if (task.isStopRequested()) break;
         }
     }
 
+    private void prepareIterationState(SearchTask task, Heuristics heuristics, int currentDepth, boolean firstAtDepth) {
+        synchronized (heuristicsLock) {
+            globalHeuristics.ensureCapacity(maxDepth);
+            if (firstAtDepth) {
+                if (transpositionTable != null) {
+                    transpositionTable.advanceAge();
+                }
+                if (captureTranspositionTable != null) {
+                    captureTranspositionTable.advanceAge();
+                }
+                globalHeuristics.decayHistory();
+            }
+            heuristics.beginIteration(globalHeuristics, maxDepth);
+            heuristics.markPrepared(task.getId(), currentDepth);
+        }
+    }
+
+    private void mergeThreadHeuristics(Heuristics heuristics) {
+        synchronized (heuristicsLock) {
+            heuristics.mergeInto(globalHeuristics);
+        }
+        heuristics.resetUpdates();
+    }
+
+    private Heuristics prepareHelperHeuristics(SearchTask task, int depth) {
+        Heuristics heuristics = threadHeuristics.get();
+        if (!heuristics.isPreparedFor(task.getId(), depth)) {
+            synchronized (heuristicsLock) {
+                globalHeuristics.ensureCapacity(maxDepth);
+                heuristics.beginIteration(globalHeuristics, maxDepth);
+                heuristics.markPrepared(task.getId(), depth);
+            }
+        }
+        return heuristics;
+    }
+
     protected MoveAndScore searchRootMoves(Engine sim, SearchTask task, int depth, double alpha, double beta, SplittableRandom rng) {
         if (searchThreads > 1) {
-            return getBestMoveParallel(sim, task.isWhiteToMove(), depth, task.getDeadline(), alpha, beta, rng);
+            return getBestMoveParallel(sim, task, depth, task.getDeadline(), alpha, beta, rng);
         }
         return getBestMove(sim, task.isWhiteToMove(), depth, task.getDeadline(), alpha, beta, rng);
     }
@@ -675,7 +706,6 @@ public class AI {
 
     private void performCalculation() {
         log.debug(" --- TranspositionTable[{}/{}] --- ", transpositionTable.size(), transpositionTableCapacity);
-        decayHistoryTable();
 
         try {
             Engine simulatorEngine = mainEngine.createSimulation();
@@ -825,16 +855,17 @@ public class AI {
     }
 
     private MoveAndScore getBestMoveParallel(Engine simulatorEngine,
-                                             boolean isWhitesTurn,
+                                             SearchTask task,
                                              int depth,
                                              long deadline,
                                              double alpha,
                                              double beta,
                                              SplittableRandom rng) {
         if (searchPool == null || abortRequested(deadline)) {
-            return getBestMove(simulatorEngine, isWhitesTurn, depth, deadline, alpha, beta, rng);
+            return getBestMove(simulatorEngine, task.isWhiteToMove(), depth, deadline, alpha, beta, rng);
         }
 
+        final boolean isWhitesTurn = task.isWhiteToMove();
         MoveList legal = simulatorEngine.getAllLegalMoves();
         MoveList orderedMoves = sortMovesByEfficiency(legal, depth, simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
         if (orderedMoves.size() == 0) return null;
@@ -888,73 +919,81 @@ public class AI {
             final int moveInt = orderedMoves.getMove(i);
             futures.add(ecs.submit(() -> {
                 if (stopRef.get() || abortRequested(deadline)) return null;
+                Heuristics helperHeuristics = prepareHelperHeuristics(task, depth);
+                try {
+                    Engine e = simulatorEngine.createSimulation();
+                    e.performMove(moveInt);
 
-                Engine e = simulatorEngine.createSimulation();
-                e.performMove(moveInt);
-
-                double currentAlpha = alphaRef.get();
-                double currentBeta = betaRef.get();
-                double pAlpha, pBeta;
-                if (isWhitesTurn) {
-                    pAlpha = currentAlpha;
-                    pBeta = currentAlpha + 1;
-                } else {
-                    pAlpha = currentBeta - 1;
-                    pBeta = currentBeta;
-                }
-
-                double probe;
-                if (e.getGameState().isInStateCheckMate()) {
-                    probe = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
-                } else if (e.getGameState().isInStateDraw()) {
-                    probe = evaluateStaticPosition(e.getGameState(), !isWhitesTurn, depth);
+                    double currentAlpha = alphaRef.get();
+                    double currentBeta = betaRef.get();
+                    double pAlpha, pBeta;
                     if (isWhitesTurn) {
-                        probe = -probe;
+                        pAlpha = currentAlpha;
+                        pBeta = currentAlpha + 1;
+                    } else {
+                        pAlpha = currentBeta - 1;
+                        pBeta = currentBeta;
                     }
-                } else {
-                    probe = alphaBeta(e, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline, moveInt, 1, 0);
-                    if (probe == EXIT_FLAG || abortRequested(deadline)) return null;
-                }
 
-                boolean needsFull = isWhitesTurn ? (probe > alphaRef.get()) : (probe < betaRef.get());
-                double finalScore = probe;
-
-                if (needsFull && !stopRef.get()) {
-                    fullResLock.lock();
-                    try {
-                        if (!stopRef.get() && !abortRequested(deadline)) {
-                            double aNow = alphaRef.get(), bNow = betaRef.get();
-                            double full = alphaBeta(e, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt, 1, 0);
-                            if (full != EXIT_FLAG) {
-                                finalScore = full;
-                                if (isWhitesTurn) {
-                                    if (full > aNow) alphaRef.set(full);
-                                } else {
-                                    if (full < bNow) betaRef.set(full);
-                                }
-                                Double curBest = bestScoreRef.get();
-                                if (isBetterScore(isWhitesTurn, full, curBest)) {
-                                    bestScoreRef.set(full);
-                                    bestMoveRef.set(moveInt);
-                                }
-                                if (alphaRef.get() >= betaRef.get()) stopRef.set(true);
-                            }
+                    double probe;
+                    if (e.getGameState().isInStateCheckMate()) {
+                        probe = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
+                    } else if (e.getGameState().isInStateDraw()) {
+                        probe = evaluateStaticPosition(e.getGameState(), !isWhitesTurn, depth);
+                        if (isWhitesTurn) {
+                            probe = -probe;
                         }
-                    } finally {
-                        fullResLock.unlock();
+                    } else {
+                        probe = alphaBeta(e, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline, moveInt, 1, 0);
+                        if (probe == EXIT_FLAG || abortRequested(deadline)) return null;
                     }
-                } else {
-                    Double curBest = bestScoreRef.get();
-                    if (isBetterScore(isWhitesTurn, finalScore, curBest)) {
-                        bestScoreRef.set(finalScore);
-                        bestMoveRef.set(moveInt);
-                        if (isWhitesTurn && finalScore > alphaRef.get()) alphaRef.set(finalScore);
-                        if (!isWhitesTurn && finalScore < betaRef.get()) betaRef.set(finalScore);
-                        if (alphaRef.get() >= betaRef.get()) stopRef.set(true);
+
+                    boolean needsFull = isWhitesTurn ? (probe > alphaRef.get()) : (probe < betaRef.get());
+                    double finalScore = probe;
+
+                    if (needsFull && !stopRef.get()) {
+                        fullResLock.lock();
+                        try {
+                            if (!stopRef.get() && !abortRequested(deadline)) {
+                                double aNow = alphaRef.get(), bNow = betaRef.get();
+                                double full = alphaBeta(e, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt, 1, 0);
+                                if (full != EXIT_FLAG) {
+                                    finalScore = full;
+                                    if (isWhitesTurn) {
+                                        if (full > aNow) alphaRef.set(full);
+                                    } else {
+                                        if (full < bNow) betaRef.set(full);
+                                    }
+                                    Double curBest = bestScoreRef.get();
+                                    if (isBetterScore(isWhitesTurn, full, curBest)) {
+                                        bestScoreRef.set(full);
+                                        bestMoveRef.set(moveInt);
+                                    }
+                                    if (alphaRef.get() >= betaRef.get()) stopRef.set(true);
+                                }
+                            }
+                        } finally {
+                            fullResLock.unlock();
+                        }
+                    } else {
+                        Double curBest = bestScoreRef.get();
+                        if (isBetterScore(isWhitesTurn, finalScore, curBest)) {
+                            bestScoreRef.set(finalScore);
+                            bestMoveRef.set(moveInt);
+                            if (isWhitesTurn && finalScore > alphaRef.get()) alphaRef.set(finalScore);
+                            if (!isWhitesTurn && finalScore < betaRef.get()) betaRef.set(finalScore);
+                            if (alphaRef.get() >= betaRef.get()) stopRef.set(true);
+                        }
+                    }
+
+                    return new MoveAndScore(moveInt, finalScore);
+                } finally {
+                    if (helperHeuristics.hasUpdates()) {
+                        mergeThreadHeuristics(helperHeuristics);
+                    } else {
+                        helperHeuristics.resetUpdates();
                     }
                 }
-
-                return new MoveAndScore(moveInt, finalScore);
             }));
         }
 
@@ -1360,6 +1399,8 @@ public class AI {
         int bestMoveAtThisNode = -1;
 
         final boolean inCheckAtNode = isSideInCheck(simulatorEngine, isWhite);
+        final Heuristics heuristics = threadHeuristics.get();
+        final int[][] historyTable = heuristics.history;
 
         MoveList orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove, simulatorEngine);
         final Map<Integer, Integer> seeCache = seeCacheThreadLocal.get();
@@ -1518,10 +1559,7 @@ public class AI {
             if (beta <= alpha) {
                 updateKillerMoves(depth, move);
                 incrementHistory(move, depth);
-                if (prevMove >= 0) {
-                    int pf = prevMove & 0x3F, pt = (prevMove >>> 6) & 0x3F;
-                    counterMove[pf][pt] = move;
-                }
+                heuristics.recordCounterMove(prevMove, move);
                 break;
             }
         }
@@ -1551,6 +1589,8 @@ public class AI {
         int bestMoveAtThisNode = -1;
 
         final boolean inCheckAtNode = isSideInCheck(simulatorEngine, isWhite);
+        final Heuristics heuristics = threadHeuristics.get();
+        final int[][] historyTable = heuristics.history;
 
         MoveList orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove, simulatorEngine);
         final Map<Integer, Integer> seeCache = seeCacheThreadLocal.get();
@@ -1702,10 +1742,7 @@ public class AI {
             if (alpha >= beta) {
                 updateKillerMoves(depth, move);
                 incrementHistory(move, depth);
-                if (prevMove >= 0) {
-                    int pf = prevMove & 0x3F, pt = (prevMove >>> 6) & 0x3F;
-                    counterMove[pf][pt] = move;
-                }
+                heuristics.recordCounterMove(prevMove, move);
                 break;
             }
         }
@@ -1748,6 +1785,11 @@ public class AI {
         final int[] moveBuffer = buffers.moveBuffer;
         final int[] scoreBuffer = buffers.scoreBuffer;
         final long[] sortKeys = buffers.sortKeyBuffer;
+
+        final Heuristics heuristics = threadHeuristics.get();
+        final int[][] killerMoves = heuristics.killers;
+        final int[][] historyTable = heuristics.history;
+        final int[][] counterMove = heuristics.counter;
 
         final int depthIndex = Math.max(0, Math.min(currentDepth, killerMoves.length - 1));
 
@@ -2056,44 +2098,29 @@ public class AI {
     }
 
     private void updateKillerMoves(int depth, int move) {
-        // Ensure depth is within bounds of the killerMoves array
-        int depthIndex = Math.max(0, Math.min(depth, killerMoves.length - 1));
-        int numKillerMoves = killerMoves[depthIndex].length; // Get the number of killer moves for this depth
-
-        // Check if the move is already in the killer moves array
-        for (int i = 0; i < numKillerMoves; i++) {
-            if (killerMoves[depthIndex][i] == move) {
-                return; // If move is already a killer move, no need to update
-            }
-        }
-
-        // Shift existing killer moves down and insert the new move at the beginning
-        for (int i = numKillerMoves - 1; i > 0; i--) {
-            killerMoves[depthIndex][i] = killerMoves[depthIndex][i - 1];
-        }
-        killerMoves[depthIndex][0] = move; // Insert new killer move at the top
+        threadHeuristics.get().recordKiller(depth, move);
     }
 
     private void incrementHistory(int move, int depth) {
-        if (MoveHelper.isCapture(move)) {
-            return; // history heuristic tracks only quiet moves
-        }
-        int from = move & 0x3F;
-        int to = (move >> 6) & 0x3F;
-        historyTable[from][to] += depth * depth;
+        threadHeuristics.get().addHistory(move, depth);
     }
 
     private void decayHistoryTable() {
-        for (int i = 0; i < 64; i++) {
-            for (int j = 0; j < 64; j++) {
-                historyTable[i][j] >>= 1; // divide by 2
-            }
+        synchronized (heuristicsLock) {
+            globalHeuristics.decayHistory();
         }
     }
 
     private void clearHistoryTable() {
-        for (int i = 0; i < 64; i++) {
-            Arrays.fill(historyTable[i], 0);
+        synchronized (heuristicsLock) {
+            globalHeuristics.clearHistory();
+            globalHeuristics.clearCounter();
+        }
+    }
+
+    int[][] snapshotKillerMoves() {
+        synchronized (heuristicsLock) {
+            return globalHeuristics.snapshotKillers();
         }
     }
 
@@ -2104,5 +2131,249 @@ public class AI {
         int victimValue = Score.getPieceValue(MoveHelper.deriveCapturedPieceTypeBits(move));
         int attackerValue = Score.getPieceValue(MoveHelper.derivePieceTypeBits(move));
         return victimValue - attackerValue;
+    }
+
+    private static final class Heuristics {
+        private static final int BOARD_SQUARES = 64;
+        private static final int HISTORY_SIZE = BOARD_SQUARES * BOARD_SQUARES;
+
+        private int[][] killers;
+        private final int[][] history;
+        private final int[][] counter;
+
+        private boolean[] killerDirty;
+        private int[] killerDirtyList;
+        private int killerDirtyCount;
+
+        private final int[] historyDelta;
+        private final boolean[] historyDirty;
+        private final int[] historyDirtyList;
+        private int historyDirtyCount;
+
+        private final int[] counterUpdates;
+        private final boolean[] counterDirty;
+        private final int[] counterDirtyList;
+        private int counterDirtyCount;
+
+        private long preparedTaskId = Long.MIN_VALUE;
+        private int preparedDepth = -1;
+
+        Heuristics(int depth) {
+            this.killers = allocateKillers(Math.max(1, depth));
+            this.history = new int[BOARD_SQUARES][BOARD_SQUARES];
+            this.counter = new int[BOARD_SQUARES][BOARD_SQUARES];
+            for (int f = 0; f < BOARD_SQUARES; f++) {
+                Arrays.fill(counter[f], -1);
+            }
+            this.killerDirty = new boolean[Math.max(1, depth)];
+            this.killerDirtyList = new int[Math.max(1, depth)];
+            this.historyDelta = new int[HISTORY_SIZE];
+            this.historyDirty = new boolean[HISTORY_SIZE];
+            this.historyDirtyList = new int[HISTORY_SIZE];
+            this.counterUpdates = new int[HISTORY_SIZE];
+            Arrays.fill(counterUpdates, -1);
+            this.counterDirty = new boolean[HISTORY_SIZE];
+            this.counterDirtyList = new int[HISTORY_SIZE];
+        }
+
+        private static int[][] allocateKillers(int depth) {
+            int[][] table = new int[depth][NUM_KILLER_MOVES];
+            for (int i = 0; i < depth; i++) {
+                Arrays.fill(table[i], -1);
+            }
+            return table;
+        }
+
+        void ensureCapacity(int depth) {
+            if (depth <= killers.length) {
+                return;
+            }
+            int[][] expanded = allocateKillers(depth);
+            for (int i = 0; i < killers.length; i++) {
+                System.arraycopy(killers[i], 0, expanded[i], 0, killers[i].length);
+            }
+            killers = expanded;
+            killerDirty = Arrays.copyOf(killerDirty, depth);
+            killerDirtyList = Arrays.copyOf(killerDirtyList, depth);
+        }
+
+        void beginIteration(Heuristics base, int requiredDepth) {
+            resetUpdates();
+            ensureCapacity(requiredDepth);
+            base.ensureCapacity(requiredDepth);
+            int limit = Math.min(requiredDepth, base.killers.length);
+            for (int d = 0; d < limit; d++) {
+                System.arraycopy(base.killers[d], 0, killers[d], 0, NUM_KILLER_MOVES);
+            }
+            for (int f = 0; f < BOARD_SQUARES; f++) {
+                System.arraycopy(base.history[f], 0, history[f], 0, BOARD_SQUARES);
+                System.arraycopy(base.counter[f], 0, counter[f], 0, BOARD_SQUARES);
+            }
+        }
+
+        boolean isPreparedFor(long taskId, int depth) {
+            return preparedTaskId == taskId && preparedDepth == depth;
+        }
+
+        void markPrepared(long taskId, int depth) {
+            this.preparedTaskId = taskId;
+            this.preparedDepth = depth;
+        }
+
+        void resetUpdates() {
+            for (int i = 0; i < killerDirtyCount; i++) {
+                killerDirty[killerDirtyList[i]] = false;
+            }
+            killerDirtyCount = 0;
+
+            for (int i = 0; i < historyDirtyCount; i++) {
+                int idx = historyDirtyList[i];
+                historyDirty[idx] = false;
+                historyDelta[idx] = 0;
+            }
+            historyDirtyCount = 0;
+
+            for (int i = 0; i < counterDirtyCount; i++) {
+                int idx = counterDirtyList[i];
+                counterDirty[idx] = false;
+                counterUpdates[idx] = -1;
+            }
+            counterDirtyCount = 0;
+            preparedTaskId = Long.MIN_VALUE;
+            preparedDepth = -1;
+        }
+
+        boolean hasUpdates() {
+            return killerDirtyCount > 0 || historyDirtyCount > 0 || counterDirtyCount > 0;
+        }
+
+        void recordKiller(int depth, int move) {
+            if (move == -1) {
+                return;
+            }
+            int depthIndex = Math.max(0, Math.min(depth, killers.length - 1));
+            int[] row = killers[depthIndex];
+            for (int i = 0; i < row.length; i++) {
+                if (row[i] == move) {
+                    return;
+                }
+            }
+            for (int i = row.length - 1; i > 0; i--) {
+                row[i] = row[i - 1];
+            }
+            row[0] = move;
+            if (!killerDirty[depthIndex]) {
+                killerDirty[depthIndex] = true;
+                killerDirtyList[killerDirtyCount++] = depthIndex;
+            }
+        }
+
+        void addHistory(int move, int depth) {
+            if (move == -1 || MoveHelper.isCapture(move)) {
+                return;
+            }
+            int from = move & 0x3F;
+            int to = (move >>> 6) & 0x3F;
+            int delta = depth * depth;
+            history[from][to] += delta;
+            int idx = (from << 6) | to;
+            if (!historyDirty[idx]) {
+                historyDirty[idx] = true;
+                historyDirtyList[historyDirtyCount++] = idx;
+            }
+            historyDelta[idx] += delta;
+        }
+
+        void recordCounterMove(int prevMove, int move) {
+            if (prevMove < 0) {
+                return;
+            }
+            int pf = prevMove & 0x3F;
+            int pt = (prevMove >>> 6) & 0x3F;
+            counter[pf][pt] = move;
+            int idx = (pf << 6) | pt;
+            if (!counterDirty[idx]) {
+                counterDirty[idx] = true;
+                counterDirtyList[counterDirtyCount++] = idx;
+            }
+            counterUpdates[idx] = move;
+        }
+
+        void mergeInto(Heuristics target) {
+            for (int i = 0; i < killerDirtyCount; i++) {
+                int depth = killerDirtyList[i];
+                target.ensureCapacity(depth + 1);
+                int[] row = killers[depth];
+                for (int move : row) {
+                    if (move != -1) {
+                        target.insertKiller(depth, move);
+                    }
+                }
+            }
+            for (int i = 0; i < historyDirtyCount; i++) {
+                int idx = historyDirtyList[i];
+                int from = idx >>> 6;
+                int to = idx & 0x3F;
+                target.history[from][to] += historyDelta[idx];
+            }
+            for (int i = 0; i < counterDirtyCount; i++) {
+                int idx = counterDirtyList[i];
+                int from = idx >>> 6;
+                int to = idx & 0x3F;
+                target.counter[from][to] = counterUpdates[idx];
+            }
+        }
+
+        void insertKiller(int depth, int move) {
+            if (move == -1) {
+                return;
+            }
+            int depthIndex = Math.max(0, Math.min(depth, killers.length - 1));
+            int[] row = killers[depthIndex];
+            for (int i = 0; i < row.length; i++) {
+                if (row[i] == move) {
+                    return;
+                }
+            }
+            for (int i = row.length - 1; i > 0; i--) {
+                row[i] = row[i - 1];
+            }
+            row[0] = move;
+        }
+
+        void decayHistory() {
+            for (int f = 0; f < BOARD_SQUARES; f++) {
+                for (int t = 0; t < BOARD_SQUARES; t++) {
+                    history[f][t] >>= 1;
+                }
+            }
+        }
+
+        void clearHistory() {
+            for (int f = 0; f < BOARD_SQUARES; f++) {
+                Arrays.fill(history[f], 0);
+            }
+            resetUpdates();
+        }
+
+        void clearCounter() {
+            for (int f = 0; f < BOARD_SQUARES; f++) {
+                Arrays.fill(counter[f], -1);
+            }
+            for (int i = 0; i < counterDirtyCount; i++) {
+                int idx = counterDirtyList[i];
+                counterDirty[idx] = false;
+                counterUpdates[idx] = -1;
+            }
+            counterDirtyCount = 0;
+        }
+
+        int[][] snapshotKillers() {
+            int[][] snapshot = new int[killers.length][];
+            for (int i = 0; i < killers.length; i++) {
+                snapshot[i] = Arrays.copyOf(killers[i], killers[i].length);
+            }
+            return snapshot;
+        }
     }
 }

--- a/src/main/java/julius/game/chessengine/ai/SearchTask.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchTask.java
@@ -5,6 +5,7 @@ import julius.game.chessengine.engine.Engine;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static julius.game.chessengine.utils.Score.CHECKMATE;
@@ -21,6 +22,7 @@ public final class SearchTask {
     private final CountDownLatch completion;
     private final AtomicBoolean stop = new AtomicBoolean(false);
     private final AtomicReference<BestMoveDepth> best;
+    private final AtomicInteger iterationDepth = new AtomicInteger(0);
 
     SearchTask(long id, long boardHash, boolean whiteToMove, long deadline, int threadCount) {
         this.id = id;
@@ -41,6 +43,18 @@ public final class SearchTask {
     void workerDone() { completion.countDown(); }
     void requestStop() { stop.set(true); }
     boolean isStopRequested() { return stop.get(); }
+
+    boolean beginIteration(int depth) {
+        while (true) {
+            int current = iterationDepth.get();
+            if (current >= depth) {
+                return false;
+            }
+            if (iterationDepth.compareAndSet(current, depth)) {
+                return true;
+            }
+        }
+    }
 
     void awaitCompletion() {
         try {

--- a/src/test/java/julius/game/chessengine/ai/IterativeDeepeningMaxDepthTest.java
+++ b/src/test/java/julius/game/chessengine/ai/IterativeDeepeningMaxDepthTest.java
@@ -3,7 +3,6 @@ package julius.game.chessengine.ai;
 import julius.game.chessengine.engine.Engine;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.SplittableRandom;
 import java.util.concurrent.TimeUnit;
@@ -50,10 +49,8 @@ class IterativeDeepeningMaxDepthTest {
                 "iterative deepening should reach the configured depth");
     }
 
-    private static int[][] extractKillerMoves(AI ai) throws Exception {
-        Field field = AI.class.getDeclaredField("killerMoves");
-        field.setAccessible(true);
-        return (int[][]) field.get(ai);
+    private static int[][] extractKillerMoves(AI ai) {
+        return ai.snapshotKillerMoves();
     }
 
     private static void setLongField(AI ai, String fieldName, long value) throws Exception {


### PR DESCRIPTION
## Summary
- add thread-local heuristic tables with a global aggregator that ages the TT once per iteration
- ensure helper threads participating in root parallelism copy and merge their heuristic updates safely
- expose a snapshot accessor for killer moves and adjust the max-depth unit test

## Testing
- `mvn test` *(fails: requires network access to download Maven parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cb240252dc832aad484a9726516381