### PR TITLE
Fix frontend websocket fallback and document web UI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,23 @@ java -jar target/chess-engine-<version>-uci.jar
 The process listens on standard input and speaks the UCI protocol on standard
 output.
 
+## Running the web UI
+
+To use the HTML/JavaScript frontend, start the Spring Boot application instead
+of the standalone UCI main class. You can either run
+`julius.game.chessengine.ChessEngineApplication` from your IDE or execute:
+
+```bash
+./mvnw spring-boot:run
+```
+
+With the application running, open `http://localhost:8080` in your browser. The
+static assets are served from the running application and the page connects to
+the embedded WebSocket endpoint at `/ws/uci`.
+
+If you prefer to open `index.html` directly from disk (for example from within
+IntelliJ), keep the Spring Boot application running in the background. When the
+page is loaded via the `file://` protocol, it automatically falls back to
+`ws://localhost:8080/ws/uci`, so the UI remains fully functional as long as the
+backend is reachable at that address.
+

--- a/src/main/resources/static/js/chess-data-fetching.js
+++ b/src/main/resources/static/js/chess-data-fetching.js
@@ -1,8 +1,14 @@
 (function (global, $) {
     'use strict';
 
-    const WS_PROTOCOL = window.location.protocol === 'https:' ? 'wss' : 'ws';
-    const WS_URL = `${WS_PROTOCOL}://${window.location.host}/ws/uci`;
+    const determineWebSocketUrl = () => {
+        const protocol = window.location.protocol;
+        const wsProtocol = protocol === 'https:' ? 'wss' : 'ws';
+        const host = window.location.host || 'localhost:8080';
+        return `${wsProtocol}://${host}/ws/uci`;
+    };
+
+    const WS_URL = determineWebSocketUrl();
 
     const squareColorClass = (square) => ($(`#board .square-${square}`).hasClass('black-3c85d') ? 'lightskyblue' : 'blue');
 


### PR DESCRIPTION
## Summary
- add a WebSocket URL helper that falls back to localhost when the page is opened from disk
- document how to run the Spring Boot application so the web UI can connect to the engine

## Testing
- `./mvnw test` *(fails: Maven wrapper cannot download dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9479d37c832a8dc76941fd9922ca