### PR TITLE
Document frontend usage steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,49 @@ output.
 
 ## Running the web UI
 
-To use the HTML/JavaScript frontend, start the Spring Boot application instead
-of the standalone UCI main class. You can either run
-`julius.game.chessengine.ChessEngineApplication` from your IDE or execute:
+The browser UI talks to the engine through a WebSocket that is hosted by the
+Spring Boot application. You **do not** need to start `UciMain` separately; each
+browser tab gets its own engine instance through the WebSocket handler.
 
-```bash
-./mvnw spring-boot:run
-```
+Follow these steps to get the frontend running and play a game:
 
-With the application running, open `http://localhost:8080` in your browser. The
-static assets are served from the running application and the page connects to
-the embedded WebSocket endpoint at `/ws/uci`.
+1. Build the project (optional, but makes sure all resources are generated):
 
-If you prefer to open `index.html` directly from disk (for example from within
-IntelliJ), keep the Spring Boot application running in the background. When the
-page is loaded via the `file://` protocol, it automatically falls back to
-`ws://localhost:8080/ws/uci`, so the UI remains fully functional as long as the
-backend is reachable at that address.
+   ```bash
+   ./mvnw clean package
+   ```
+
+2. Start the Spring Boot app so the static files and WebSocket endpoint become
+   available:
+
+   ```bash
+   ./mvnw spring-boot:run
+   ```
+
+   Wait until the logs contain `Started ChessEngineApplication`.
+
+3. Open `http://localhost:8080/index.html` in your browser. The page should show
+   the toolbar and an empty chessboard. The info bar initially displays
+   `Loading...` while the WebSocket performs the `uci`/`isready` handshake and
+   switches to `Engine ready` once the backend responds.
+
+4. Click **Play as White** or **Play as Black** to pick a side, then drag a piece
+   to make your first move. The engine will automatically reply on its turn. You
+   can also:
+
+   * Press **Computer Move** to force the engine to play the side to move.
+   * Toggle **Autoplay** to let the engine play both sides at the configured
+     move time (adjust the slider under the board).
+   * Use **Reset Board**, **Undo**, **Redo**, **Import from FEN**, and **PGN** to
+     manage the current game.
+
+If the page stays on `Loading...`, check that the Spring Boot process is still
+running and that your browser allows WebSocket connections to
+`ws://localhost:8080/ws/uci`. Corporate VPNs or browser extensions that block
+WebSockets can prevent the engine from connecting.
+
+You can also open `src/main/resources/static/index.html` directly from disk (for
+example via `file://`). Keep the Spring Boot application running in the
+background: the page automatically connects to `ws://localhost:8080/ws/uci` when
+it is not served by the app itself.
 


### PR DESCRIPTION
## Summary
- explain that the Spring Boot application alone serves the frontend and engine
- add step-by-step instructions for launching the UI and starting a game
- document troubleshooting tips for a persistent "Loading" message and note that opening the HTML file directly still requires the backend

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd0557f768832a9f877d68494661ba