### PR TITLE
Fix chess.js SRI hash

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -69,7 +69,7 @@
     </div>
     <script src="js/jquery-3.4.1.min.js"></script>
     <script src="js/prettify.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.13.4/chess.min.js" integrity="sha512-d18kG91w9fzv2xbYlR5c+3F4iAfDdc0AGJi/7luWGINuD/7++UZ5EKeosFVJeFt3uTJS3BM4tiTnA2zH9vvT/g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.13.4/chess.min.js" integrity="sha512-5nNBISa4noe7B2/Me0iHkkt7mUvXG9xYoeXuSrr8OmCQIxd5+Qwxhjy4npBLIuxGNQKwew/9fEup/f2SUVkkXg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="js/chessboard-1.0.0.min.js"></script>
     <script src="js/uci-client.js"></script>
     <script src="js/chess-data-fetching.js"></script>


### PR DESCRIPTION
## Summary
- update the Subresource Integrity hash for the chess.js CDN asset so the browser loads it successfully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd0660daa0832abb0220440d5f4d44