### PR TITLE
Add tactical threat and backrank safety penalties

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -36,6 +36,8 @@ public final class KingSafetyModule implements EvaluationModule {
     private static final int OPEN_FILE_PENALTY = -25;
     private static final int DEFENDER_BONUS = 5;
     private static final int QUEEN_ATTACKED_PENALTY = -135;
+    private static final int BACKRANK_WEAKNESS_MIDGAME_PENALTY = -30;
+    private static final int BACKRANK_WEAKNESS_ENDGAME_PENALTY = -15;
 
     private static final int[] ATTACK_WEIGHTS = new int[7];
 
@@ -272,8 +274,10 @@ public final class KingSafetyModule implements EvaluationModule {
         int shieldPenalty = state.missingShield * MISSING_PAWN_SHIELD_PENALTY;
         int attackPenalty = -state.totalAttackWeight;
         int defenderBonus = state.defenderCount * DEFENDER_BONUS;
-        state.midgameKingSafety = shieldPenalty + state.filePenalty + attackPenalty + defenderBonus;
-        state.endgameKingSafety = state.midgameKingSafety / 2;
+        computeBackrankWeaknessPenalty(state, board, isWhite, friendlyAttacks);
+        int baseMidgame = shieldPenalty + state.filePenalty + attackPenalty + defenderBonus;
+        state.midgameKingSafety = baseMidgame + state.backrankWeaknessMidgame;
+        state.endgameKingSafety = baseMidgame / 2 + state.backrankWeaknessEndgame;
 
         long queens = isWhite ? board.getWhiteQueens() : board.getBlackQueens();
         int queenMid = 0;
@@ -289,6 +293,68 @@ public final class KingSafetyModule implements EvaluationModule {
         }
         state.midgameQueenPenalty = queenMid;
         state.endgameQueenPenalty = queenEnd;
+    }
+
+    private void computeBackrankWeaknessPenalty(SideState state, BitBoard board, boolean isWhite,
+                                                long friendlyAttacks) {
+        state.backrankWeaknessMidgame = 0;
+        state.backrankWeaknessEndgame = 0;
+        if (state.kingSquare < 0) {
+            return;
+        }
+        int rank = state.kingSquare / 8;
+        if ((isWhite && rank != 0) || (!isWhite && rank != 7)) {
+            return;
+        }
+
+        long kingMask = 1L << state.kingSquare;
+        long escapeSquares = computeEscapeSquares(kingMask, isWhite);
+        long occupiedEscape = escapeSquares & board.getAllPieces();
+        if ((escapeSquares & ~occupiedEscape) != 0) {
+            return;
+        }
+
+        long backrankMask = computeBackrankMask(state.kingSquare);
+        if ((friendlyAttacks & backrankMask) != 0) {
+            return;
+        }
+
+        state.backrankWeaknessMidgame = BACKRANK_WEAKNESS_MIDGAME_PENALTY;
+        state.backrankWeaknessEndgame = BACKRANK_WEAKNESS_ENDGAME_PENALTY;
+    }
+
+    private static long computeEscapeSquares(long kingMask, boolean isWhite) {
+        long escape = 0L;
+        if (isWhite) {
+            escape |= kingMask << 8;
+            if ((kingMask & NOT_A_FILE) != 0) {
+                escape |= kingMask << 7;
+            }
+            if ((kingMask & NOT_H_FILE) != 0) {
+                escape |= kingMask << 9;
+            }
+        } else {
+            escape |= kingMask >>> 8;
+            if ((kingMask & NOT_A_FILE) != 0) {
+                escape |= kingMask >>> 9;
+            }
+            if ((kingMask & NOT_H_FILE) != 0) {
+                escape |= kingMask >>> 7;
+            }
+        }
+        return escape;
+    }
+
+    private static long computeBackrankMask(int kingSquare) {
+        long mask = 1L << kingSquare;
+        int file = kingSquare & 7;
+        if (file > 0) {
+            mask |= 1L << (kingSquare - 1);
+        }
+        if (file < 7) {
+            mask |= 1L << (kingSquare + 1);
+        }
+        return mask;
     }
 
     private void accumulatePawnAttacks(SideState state, long pawns, boolean pawnsAreWhite) {
@@ -517,6 +583,8 @@ public final class KingSafetyModule implements EvaluationModule {
         private int endgameKingSafety;
         private int midgameQueenPenalty;
         private int endgameQueenPenalty;
+        private int backrankWeaknessMidgame;
+        private int backrankWeaknessEndgame;
         private final int[] zoneAttackWeights = new int[64];
 
         private void reset() {
@@ -532,6 +600,8 @@ public final class KingSafetyModule implements EvaluationModule {
             endgameKingSafety = 0;
             midgameQueenPenalty = 0;
             endgameQueenPenalty = 0;
+            backrankWeaknessMidgame = 0;
+            backrankWeaknessEndgame = 0;
             Arrays.fill(zoneAttackWeights, 0);
         }
     }

--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -185,6 +185,8 @@ public final class KingSafetyModule implements EvaluationModule {
         }
         long prevEnemyAttacks = side == WHITE ? previous.getBlackAttackMap() : previous.getWhiteAttackMap();
         long currEnemyAttacks = side == WHITE ? current.getBlackAttackMap() : current.getWhiteAttackMap();
+        long prevFriendlyAttacks = side == WHITE ? previous.getWhiteAttackMap() : previous.getBlackAttackMap();
+        long currFriendlyAttacks = side == WHITE ? current.getWhiteAttackMap() : current.getBlackAttackMap();
         long zoneDiff = (prevEnemyAttacks ^ currEnemyAttacks) & state.kingZone;
         if (zoneDiff != 0) {
             return true;
@@ -227,6 +229,9 @@ public final class KingSafetyModule implements EvaluationModule {
             }
             queenMask ^= q;
         }
+        if (state.backrankMask != 0 && ((prevFriendlyAttacks ^ currFriendlyAttacks) & state.backrankMask) != 0) {
+            return true;
+        }
         return false;
     }
 
@@ -241,6 +246,11 @@ public final class KingSafetyModule implements EvaluationModule {
         state.kingZone = KING_ATTACKS[kingSquare];
         state.shieldMask = computeShieldMask(kingBits, isWhite);
         state.fileMask = FileMasks[kingSquare & 7];
+        state.backrankMask = 0L;
+        int rank = kingSquare / 8;
+        if ((isWhite && rank == 0) || (!isWhite && rank == 7)) {
+            state.backrankMask = computeBackrankMask(kingSquare);
+        }
 
         long friendlyPawns = isWhite ? board.getWhitePawns() : board.getBlackPawns();
         long enemyPawns = isWhite ? board.getBlackPawns() : board.getWhitePawns();
@@ -314,7 +324,11 @@ public final class KingSafetyModule implements EvaluationModule {
             return;
         }
 
-        long backrankMask = computeBackrankMask(state.kingSquare);
+        long backrankMask = state.backrankMask;
+        if (backrankMask == 0L) {
+            return;
+        }
+
         if ((friendlyAttacks & backrankMask) != 0) {
             return;
         }
@@ -586,6 +600,7 @@ public final class KingSafetyModule implements EvaluationModule {
         private int backrankWeaknessMidgame;
         private int backrankWeaknessEndgame;
         private final int[] zoneAttackWeights = new int[64];
+        private long backrankMask;
 
         private void reset() {
             kingSquare = -1;
@@ -602,6 +617,7 @@ public final class KingSafetyModule implements EvaluationModule {
             endgameQueenPenalty = 0;
             backrankWeaknessMidgame = 0;
             backrankWeaknessEndgame = 0;
+            backrankMask = 0L;
             Arrays.fill(zoneAttackWeights, 0);
         }
     }

--- a/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
@@ -1,0 +1,159 @@
+package julius.game.chessengine.evaluation;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.figures.PieceType;
+
+import java.util.Objects;
+
+import static julius.game.chessengine.helper.PawnMoveTables.PAWN_ATTACKS;
+
+/**
+ * Evaluates tactical vulnerabilities such as hanging pieces and pawn attacks on higher valued
+ * pieces. The module recomputes its contribution when marked dirty rather than maintaining
+ * incremental state.
+ */
+public final class ThreatModule implements EvaluationModule {
+
+    private static final int WHITE = 0;
+    private static final int BLACK = 1;
+
+    private static final int PAWN = MoveHelper.pieceTypeToInt(PieceType.PAWN);
+    private static final int KNIGHT = MoveHelper.pieceTypeToInt(PieceType.KNIGHT);
+    private static final int BISHOP = MoveHelper.pieceTypeToInt(PieceType.BISHOP);
+    private static final int ROOK = MoveHelper.pieceTypeToInt(PieceType.ROOK);
+    private static final int QUEEN = MoveHelper.pieceTypeToInt(PieceType.QUEEN);
+    private static final int KING = MoveHelper.pieceTypeToInt(PieceType.KING);
+
+    private static final int[] HANGING_PENALTIES = new int[7];
+    private static final int[] PAWN_THREAT_PENALTIES = new int[7];
+
+    static {
+        HANGING_PENALTIES[PAWN] = -12;
+        HANGING_PENALTIES[KNIGHT] = -30;
+        HANGING_PENALTIES[BISHOP] = -30;
+        HANGING_PENALTIES[ROOK] = -45;
+        HANGING_PENALTIES[QUEEN] = -70;
+
+        PAWN_THREAT_PENALTIES[KNIGHT] = -10;
+        PAWN_THREAT_PENALTIES[BISHOP] = -10;
+        PAWN_THREAT_PENALTIES[ROOK] = -18;
+        PAWN_THREAT_PENALTIES[QUEEN] = -25;
+    }
+
+    private int midgameScoreCache;
+    private int endgameScoreCache;
+    private boolean dirty = true;
+
+    @Override
+    public void initialize(EvaluationContext context) {
+        evaluate(context);
+    }
+
+    @Override
+    public void evaluate(EvaluationContext context) {
+        if (!dirty) {
+            return;
+        }
+        Objects.requireNonNull(context, "context");
+        BitBoard board = context.getBoard();
+        if (board == null) {
+            midgameScoreCache = 0;
+            endgameScoreCache = 0;
+            dirty = false;
+            return;
+        }
+
+        long whiteAttacks = context.getWhiteAttackMap();
+        long blackAttacks = context.getBlackAttackMap();
+
+        int whitePenalty = evaluateSide(board, true, whiteAttacks, blackAttacks);
+        int blackPenalty = evaluateSide(board, false, blackAttacks, whiteAttacks);
+
+        midgameScoreCache = whitePenalty - blackPenalty;
+        endgameScoreCache = midgameScoreCache;
+        dirty = false;
+    }
+
+    @Override
+    public void applyMove(MoveContext moveContext) {
+        dirty = true;
+    }
+
+    @Override
+    public void undoMove(MoveContext moveContext) {
+        dirty = true;
+    }
+
+    @Override
+    public int getMidgameScore() {
+        return midgameScoreCache;
+    }
+
+    @Override
+    public int getEndgameScore() {
+        return endgameScoreCache;
+    }
+
+    @Override
+    public boolean isDirty() {
+        return dirty;
+    }
+
+    @Override
+    public void markDirty() {
+        dirty = true;
+    }
+
+    private int evaluateSide(BitBoard board, boolean isWhite, long friendlyAttacks, long enemyAttacks) {
+        long pieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
+        long enemyPawns = isWhite ? board.getBlackPawns() : board.getWhitePawns();
+        int enemyPawnColor = isWhite ? BLACK : WHITE;
+        long enemyPawnAttacks = computePawnAttackMask(enemyPawns, enemyPawnColor);
+
+        int penalty = 0;
+        long remaining = pieces;
+        while (remaining != 0) {
+            long bit = remaining & -remaining;
+            int square = Long.numberOfTrailingZeros(bit);
+            PieceType type = board.getPieceTypeAtIndex(square);
+            if (type == null) {
+                remaining ^= bit;
+                continue;
+            }
+            int typeBits = MoveHelper.pieceTypeToInt(type);
+            if (typeBits == KING) {
+                remaining ^= bit;
+                continue;
+            }
+            long mask = 1L << square;
+            if ((enemyAttacks & mask) == 0) {
+                remaining ^= bit;
+                continue;
+            }
+            if ((friendlyAttacks & mask) != 0) {
+                remaining ^= bit;
+                continue;
+            }
+
+            penalty += HANGING_PENALTIES[typeBits];
+            if (typeBits > PAWN && (enemyPawnAttacks & mask) != 0) {
+                penalty += PAWN_THREAT_PENALTIES[typeBits];
+            }
+            remaining ^= bit;
+        }
+        return penalty;
+    }
+
+    private static long computePawnAttackMask(long pawns, int pawnColor) {
+        long mask = 0L;
+        long remaining = pawns;
+        while (remaining != 0) {
+            long pawn = remaining & -remaining;
+            int index = Long.numberOfTrailingZeros(pawn);
+            mask |= PAWN_ATTACKS[pawnColor][index];
+            remaining ^= pawn;
+        }
+        return mask;
+    }
+}

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -11,6 +11,7 @@ import julius.game.chessengine.evaluation.MaterialModule;
 import julius.game.chessengine.evaluation.MoveContext;
 import julius.game.chessengine.evaluation.PawnStructureModule;
 import julius.game.chessengine.evaluation.PieceSquareModule;
+import julius.game.chessengine.evaluation.ThreatModule;
 
 import java.util.List;
 import java.util.Objects;
@@ -33,6 +34,7 @@ public class Score {
     private final PieceSquareModule pieceSquareModule = new PieceSquareModule();
     private final ActivityModule activityModule = new ActivityModule();
     private final KingSafetyModule kingSafetyModule = new KingSafetyModule();
+    private final ThreatModule threatModule = new ThreatModule();
 
     @JsonIgnore
     private final EvaluationPipeline evaluationPipeline;
@@ -46,7 +48,8 @@ public class Score {
                 pawnStructureModule,
                 pieceSquareModule,
                 activityModule,
-                kingSafetyModule
+                kingSafetyModule,
+                threatModule
         ));
     }
 


### PR DESCRIPTION
## Summary
- introduce a threat evaluation module that penalizes hanging pieces and pawn attacks on higher-valued targets
- extend king safety scoring with a backrank weakness penalty when no luft exists and the king’s back rank lacks defenders
- register the new threat module with the score evaluation pipeline

## Testing
- `./mvnw -q test` *(fails: Maven wrapper could not download dependencies because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf28ad4658832a991330210470bddc