### PR TITLE
Fix backrank defense detection

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -329,7 +329,8 @@ public final class KingSafetyModule implements EvaluationModule {
         }
 
         long friendlyNonKingAttacks = computeFriendlyNonKingAttacks(board, isWhite);
-        if ((friendlyNonKingAttacks & backrankMask) != 0) {
+        long defendedSquares = friendlyNonKingAttacks & (backrankMask & ~kingMask);
+        if (defendedSquares != 0) {
             return;
         }
 

--- a/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
@@ -68,6 +68,20 @@ public class ScoreEvaluationTest {
     }
 
     @Test
+    void defendingBackrankWithKnightRemovesPenalty() {
+        BitBoard vulnerable = FEN.translateFENtoBitBoard("2rr1k2/pp1q1ppp/2np1n2/1N2P3/5Qb1/5N2/PPPB1PPP/2K2B1R w - - 0 1");
+        BitBoard defended = FEN.translateFENtoBitBoard("2rr1k2/pp1q1ppp/2np1n2/4P3/5Qb1/2N2N2/PPPB1PPP/2K2B1R w - - 0 1");
+
+        KingSafetyView vulnerableView = kingSafetyView(vulnerable);
+        KingSafetyView defendedView = kingSafetyView(defended);
+
+        int vulnerableScore = vulnerableView.whiteKing().blend(vulnerable.getPhase());
+        int defendedScore = defendedView.whiteKing().blend(defended.getPhase());
+
+        assertTrue(vulnerableScore < defendedScore);
+    }
+
+    @Test
     void centerPawnsGrantBonusToWhite() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/4P3/8/8/4K3 w - - 0 1");
         PawnStructureView view = pawnStructure(board);


### PR DESCRIPTION
## Summary
- ignore attacks on the king square itself when checking if the backrank is defended so real defenders must cover the entry squares
- add a regression test that ensures a knight defending d1 removes the backrank penalty in the reported position

## Testing
- mvn -o -Dtest=ScoreEvaluationTest test *(fails: missing cached spring-boot-starter-parent while running offline)*

------
https://chatgpt.com/codex/tasks/task_e_68cf33d2e29c832ab5146b16c6a9f102