### PR TITLE
Handle mate states in check detection and test f4 mate threat

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1275,7 +1275,16 @@ public class AI {
 
     private boolean isSideInCheck(Engine engine, boolean isWhite) {
         GameStateEnum state = engine.getGameState().getState();
-        return (isWhite && state == GameStateEnum.WHITE_IN_CHECK) || (!isWhite && state == GameStateEnum.BLACK_IN_CHECK);
+        if (isWhite) {
+            if (state == GameStateEnum.WHITE_IN_CHECK || state == GameStateEnum.BLACK_WON) {
+                return true;
+            }
+        } else {
+            if (state == GameStateEnum.BLACK_IN_CHECK || state == GameStateEnum.WHITE_WON) {
+                return true;
+            }
+        }
+        return engine.getBitBoard().isInCheck(isWhite);
     }
 
     private boolean attacksOpponentQueenNow(Engine e, boolean moverIsWhite) {

--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -3,6 +3,7 @@ package julius.game.chessengine.ai;
 import julius.game.chessengine.board.Move;
 import julius.game.chessengine.board.MoveList;
 import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.utils.Score;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -169,6 +170,54 @@ public class BestMoveSearchTest {
         Assertions.assertTrue(expectedMoves.contains(moveString),
                 "Expected one of " + expectedMoves + " but got " + moveString + " for FEN: " + fen
                         + statistics);
+    }
+
+    @Test
+    void detectsMateThreatAndChoosesF4() throws InterruptedException {
+        String fen = "rnbqk2r/2bp3p/3qpp1n/P5p1/Q1P3P1/PN6/4BPNP/R4RK1 w - - 1 24";
+
+        Engine engine = new Engine();
+        engine.importBoardFromFen(fen);
+
+        AI ai = new AI(engine);
+        ai.setTimeLimit(1000L);
+        ai.startAutoPlay(true, false);
+
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(3);
+        int lastMove = -1;
+        while (System.currentTimeMillis() < deadline) {
+            lastMove = engine.getLastMove();
+            if (lastMove != -1) {
+                break;
+            }
+            TimeUnit.MILLISECONDS.sleep(25);
+        }
+
+        Assertions.assertNotEquals(-1, lastMove, "Engine failed to move in mate-threat scenario");
+
+        List<MoveAndScore> pvSnapshot = new ArrayList<>(ai.getCalculatedLine());
+        ai.stopCalculation();
+
+        String chosenMove = Move.convertIntToMove(lastMove).toString();
+        Assertions.assertEquals("f4", chosenMove,
+                "Engine must choose f4 to guard against the …Qxh2# threat");
+
+        Assertions.assertTrue(pvSnapshot.size() >= 2,
+                "Principal variation should include the mating reply illustrating the threat");
+
+        String pvFirst = Move.convertIntToMove(pvSnapshot.get(0).getMove()).toString();
+        String pvSecond = Move.convertIntToMove(pvSnapshot.get(1).getMove()).toString();
+        Assertions.assertEquals("f4", pvFirst,
+                "The search principal variation should start with f4 in the critical position");
+        Assertions.assertEquals("Qxh2", pvSecond,
+                "PV should reveal …Qxh2 as the looming mate if White delays f4");
+
+        Engine verification = new Engine();
+        verification.importBoardFromFen(fen);
+        verification.performMove(pvSnapshot.get(0).getMove());
+        verification.performMove(pvSnapshot.get(1).getMove());
+        Assertions.assertEquals(GameStateEnum.BLACK_WON, verification.getGameState().getState(),
+                "…Qxh2 should immediately end the game, confirming the mate threat that motivates f4");
     }
 
     private String compileMoveStatistics(String fen, String chosenMove, AI ai, List<String> expectedMoves) {


### PR DESCRIPTION
## Summary
- treat opposing-side mate states as check when deciding whether to prune and fall back to bitboard detection when state alone is inconclusive
- extend the best-move regression suite with a reproduction of the f4 position, verifying the PV shows the …Qxh2# threat

## Testing
- mvn -o test -Dtest=julius.game.chessengine.ai.BestMoveSearchTest#detectsMateThreatAndChoosesF4 *(fails: missing cached parent POM because the Maven Central repository is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbde7b1f0832a8b3891a2a603a960