### PR TITLE
Fix fail-hard mate detection for mover

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/SearchTask.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchTask.java
@@ -84,7 +84,7 @@ public final class SearchTask {
 
             BestMoveDepth next = new BestMoveDepth(ms.move, ms.score, depth);
             if (best.compareAndSet(cur, next)) {
-                if (isFailHardMate(ms.score)) requestStop();
+                if (isFailHardMateForMover(whiteToMove, ms.score)) requestStop();
                 return true;
             }
         }
@@ -94,7 +94,8 @@ public final class SearchTask {
     private static boolean isBetterScore(boolean whiteToMove, double score, double bestScore) {
         return whiteToMove ? score > bestScore : score < bestScore;
     }
-    private static boolean isFailHardMate(double score) {
-        return Math.abs(score) >= CHECKMATE - 50;
+    private static boolean isFailHardMateForMover(boolean whiteToMove, double score) {
+        double threshold = CHECKMATE - 50;
+        return whiteToMove ? score >= threshold : score <= -threshold;
     }
 }

--- a/src/test/java/julius/game/chessengine/ai/SearchTaskTest.java
+++ b/src/test/java/julius/game/chessengine/ai/SearchTaskTest.java
@@ -1,0 +1,58 @@
+package julius.game.chessengine.ai;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static julius.game.chessengine.utils.Score.CHECKMATE;
+
+class SearchTaskTest {
+
+    @Test
+    void losingMateForWhiteDoesNotStopSearch() {
+        SearchTask task = new SearchTask(1L, 42L, true,
+                System.nanoTime() + 1_000_000_000L, 1);
+
+        MoveAndScore losingMate = new MoveAndScore(123, -CHECKMATE + 10);
+        assertTrue(task.publishBest(losingMate, 1, null));
+        assertFalse(task.isStopRequested(),
+                "Fail-hard mate against the mover must not stop the search");
+
+        MoveAndScore savingMove = new MoveAndScore(456, 0);
+        assertTrue(task.publishBest(savingMove, 2, null));
+        BestMoveDepth best = task.getBest();
+        assertEquals(456, best.move);
+        assertEquals(0.0, best.score, 0.0001);
+    }
+
+    @Test
+    void losingMateForBlackDoesNotStopSearch() {
+        SearchTask task = new SearchTask(2L, 99L, false,
+                System.nanoTime() + 1_000_000_000L, 1);
+
+        MoveAndScore losingMate = new MoveAndScore(321, CHECKMATE - 10);
+        assertTrue(task.publishBest(losingMate, 1, null));
+        assertFalse(task.isStopRequested(),
+                "Fail-hard mate against the mover must not stop the search");
+
+        MoveAndScore savingMove = new MoveAndScore(654, 0);
+        assertTrue(task.publishBest(savingMove, 2, null));
+        BestMoveDepth best = task.getBest();
+        assertEquals(654, best.move);
+        assertEquals(0.0, best.score, 0.0001);
+    }
+
+    @Test
+    void winningMateForMoverStopsSearch() {
+        SearchTask whiteTask = new SearchTask(3L, 111L, true,
+                System.nanoTime() + 1_000_000_000L, 1);
+        assertTrue(whiteTask.publishBest(new MoveAndScore(11, CHECKMATE - 5), 1, null));
+        assertTrue(whiteTask.isStopRequested(),
+                "Winning mate for side to move should stop the search");
+
+        SearchTask blackTask = new SearchTask(4L, 222L, false,
+                System.nanoTime() + 1_000_000_000L, 1);
+        assertTrue(blackTask.publishBest(new MoveAndScore(22, -CHECKMATE + 5), 1, null));
+        assertTrue(blackTask.isStopRequested(),
+                "Winning mate for side to move should stop the search");
+    }
+}


### PR DESCRIPTION
## Summary
- ensure SearchTask only flags fail-hard mates that favour the side to move so losing mates no longer abort the search
- add regression tests covering both colour orientations to confirm searches continue past forced losses and still stop on winning mates

## Testing
- `mvn test` *(fails: network is unreachable while downloading Maven parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc19250b4832aaa70025a329f3f38