### PR TITLE
Relax late move pruning guard

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1461,20 +1461,23 @@ public class AI {
             int pawnsOnFileBefore = (enemyKingSquare >= 0 && affectsKingFilePawns) ? countPawnsOnFile(boardBefore, kingFileMask) : 0;
 
             boolean isTactical = isCapture || isPromotion;
+            boolean lmpPrecomputed = false;
+            boolean lmpGivesCheck = false;
+            boolean lmpAttacksQueen = false;
             int lmpThreshold = 8 + depth * 2;
             if (!inCheckAtNode && !isTactical && depth <= 3 && index > lmpThreshold) {
                 simulatorEngine.performMove(move);
-                boolean givesCheckTmp = isSideInCheck(simulatorEngine, !isWhite);
-                boolean attacksQueenTmp = attacksOpponentQueenNow(simulatorEngine, isWhite);
+                lmpGivesCheck = isSideInCheck(simulatorEngine, !isWhite);
+                lmpAttacksQueen = attacksOpponentQueenNow(simulatorEngine, isWhite);
+                lmpPrecomputed = true;
                 simulatorEngine.undoLastMove();
-                if (!givesCheckTmp && !attacksQueenTmp) continue;
             }
 
             simulatorEngine.performMove(move);
             long newBoardHash = simulatorEngine.getBoardStateHash();
 
-            boolean givesCheck = isSideInCheck(simulatorEngine, !isWhite);
-            boolean attacksQueen = attacksOpponentQueenNow(simulatorEngine, isWhite);
+            boolean givesCheck = lmpPrecomputed ? lmpGivesCheck : isSideInCheck(simulatorEngine, !isWhite);
+            boolean attacksQueen = lmpPrecomputed ? lmpAttacksQueen : attacksOpponentQueenNow(simulatorEngine, isWhite);
             boolean attacksKingZone = attacksOpponentKingZone(simulatorEngine, isWhite);
             boolean opensKingFile = openedFileTowardKing(simulatorEngine.getBitBoard(), kingFileMask, pawnsOnFileBefore, affectsKingFilePawns);
 


### PR DESCRIPTION
## Summary
- remove the continue-based late move pruning in `AI.maximizer` and reuse the precomputed check/queen attack results when available

## Testing
- `./mvnw test` *(fails: maven wrapper cannot download due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc39e3294832a8966abe68d841ee0