### PR TITLE
Allow deeper iteration best replacement

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/SearchTask.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchTask.java
@@ -79,8 +79,7 @@ public final class SearchTask {
         while (true) {
             BestMoveDepth cur = best.get();
             boolean betterScore = isBetterScore(whiteToMove, ms.score, cur.score);
-            boolean deeperTie = ms.score == cur.score && depth > cur.depth;
-            if (!betterScore && !deeperTie) return false;
+            if (!betterScore && depth <= cur.depth) return false;
 
             BestMoveDepth next = new BestMoveDepth(ms.move, ms.score, depth);
             if (best.compareAndSet(cur, next)) {

--- a/src/test/java/julius/game/chessengine/ai/SearchTaskTest.java
+++ b/src/test/java/julius/game/chessengine/ai/SearchTaskTest.java
@@ -55,4 +55,22 @@ class SearchTaskTest {
         assertTrue(blackTask.isStopRequested(),
                 "Winning mate for side to move should stop the search");
     }
+
+    @Test
+    void deeperIterationReplacesWorseScore() {
+        SearchTask task = new SearchTask(5L, 333L, true,
+                System.nanoTime() + 1_000_000_000L, 1);
+
+        MoveAndScore shallowBest = new MoveAndScore(111, 1.0);
+        assertTrue(task.publishBest(shallowBest, 2, null));
+
+        MoveAndScore deeperButWorse = new MoveAndScore(222, 0.5);
+        assertTrue(task.publishBest(deeperButWorse, 3, null));
+
+        BestMoveDepth best = task.getBest();
+        assertEquals(222, best.move);
+        assertEquals(0.5, best.score, 0.0001);
+        assertEquals(3, best.depth);
+        assertFalse(task.isStopRequested());
+    }
 }


### PR DESCRIPTION
## Summary
- update `SearchTask.publishBest` so deeper iterations always replace the best entry
- keep fail-hard mate stop handling when an update occurs
- add a unit test covering the deeper-with-worse-score replacement case

## Testing
- mvn -q test *(fails: Non-resolvable parent POM due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc52dc058832ab8d95132ff94ffe1