### PR TITLE
Report search depth in debug statistics

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -217,6 +217,9 @@ public class AI {
     @Getter
     private long nullMoveCount = 0;
 
+    @Getter
+    private volatile int lastCompletedDepth = 0;
+
     public AI(Engine mainEngine) {
         log.info("### SearchThreads = " + searchThreads + ", LazySmpThreads = " + lazySmpThreads);
         this.mainEngine = mainEngine;
@@ -610,6 +613,7 @@ public class AI {
         previousBestMove = -1;
         previousBestMoveHash = -1;
         searchResultReady = false;
+        lastCompletedDepth = 0;
     }
 
 
@@ -775,8 +779,10 @@ public class AI {
 
         BestMoveDepth best = task.getBest();
         int move = best.move;
+        int depth = best.depth;
 
         if (move != -1) {
+            lastCompletedDepth = depth;
             currentBestMove = move;
             bestMoveForHash = task.getBoardHash();
             previousBestMove = move;
@@ -801,6 +807,7 @@ public class AI {
         previousBestMove = -1;
         previousBestMoveHash = -1;
         searchResultReady = false;
+        lastCompletedDepth = 0;
         this.calculatedLine = Collections.synchronizedList(new ArrayList<>());
     }
 

--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -287,6 +287,7 @@ public class BestMoveSearchTest {
         double spread = evaluations.isEmpty()
                 ? Double.NaN
                 : evaluations.get(0).score() - evaluations.get(evaluations.size() - 1).score();
+        int completedDepth = Math.max(0, ai.getLastCompletedDepth());
 
         StringBuilder sb = new StringBuilder();
         sb.append(System.lineSeparator());
@@ -313,6 +314,7 @@ public class BestMoveSearchTest {
             sb.append("Chosen move: ").append(chosenMove)
                     .append(" -> ").append(formatCentipawns(chosenEval.score())).append(" pawns")
                     .append(" (Δ vs baseline: ").append(formatCentipawns(delta)).append(")")
+                    .append(" (depth: ").append(completedDepth).append(")")
                     .append(System.lineSeparator());
             if (!Double.isNaN(deltaVsBest) && Math.abs(deltaVsBest) > 0.005) {
                 sb.append("Rank among legal: ").append(chosenRank).append("/").append(legalMoveCount)
@@ -325,6 +327,7 @@ public class BestMoveSearchTest {
         } else {
             sb.append("Chosen move: ").append(chosenMove)
                     .append(" (not present in legal move snapshot)")
+                    .append(" (depth: ").append(completedDepth).append(")")
                     .append(System.lineSeparator());
         }
 


### PR DESCRIPTION
## Summary
- track the final completed search depth in the AI so tests can report it
- extend the BestMoveSearchTest statistics block to include the depth that produced the chosen move

## Testing
- ./mvnw -q test *(fails: Network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d16a6b1754832ab1c51a03b5b38861