### PR TITLE
Use lightweight board view for evaluation context

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
@@ -1,6 +1,5 @@
 package julius.game.chessengine.evaluation;
 
-import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.BishopHelper;
@@ -398,7 +397,7 @@ public final class ActivityModule implements EvaluationModule {
         return pieceType == BISHOP || pieceType == ROOK || pieceType == QUEEN;
     }
 
-    private void rebuildFromBoard(BitBoard board) {
+    private void rebuildFromBoard(EvaluationContext.BoardView board) {
         Arrays.fill(midgameTotals, 0);
         Arrays.fill(endgameTotals, 0);
         for (PieceActivity activity : activities) {
@@ -408,6 +407,12 @@ public final class ActivityModule implements EvaluationModule {
         whitePieces = 0L;
         blackPieces = 0L;
         sliderSquares = 0L;
+
+        if (board == null) {
+            updateScoreCache();
+            dirty = false;
+            return;
+        }
 
         registerPieces(board.getWhitePawns(), WHITE, PAWN);
         registerPieces(board.getWhiteKnights(), WHITE, KNIGHT);

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationContext.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationContext.java
@@ -2,7 +2,9 @@ package julius.game.chessengine.evaluation;
 
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.figures.PieceType;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -12,14 +14,246 @@ import java.util.Objects;
  */
 public final class EvaluationContext {
 
-    private final BitBoard board;
+    /**
+     * Lightweight immutable view of the board tailored for evaluation purposes.  Only the data
+     * consumed by the evaluation modules is copied so we avoid instantiating a heavy {@link
+     * BitBoard} clone for every refresh.
+     */
+    public static final class BoardView {
+
+        private final boolean whitesTurn;
+        private final long whitePawns;
+        private final long blackPawns;
+        private final long whiteKnights;
+        private final long blackKnights;
+        private final long whiteBishops;
+        private final long blackBishops;
+        private final long whiteRooks;
+        private final long blackRooks;
+        private final long whiteQueens;
+        private final long blackQueens;
+        private final long whiteKing;
+        private final long blackKing;
+        private final long whitePieces;
+        private final long blackPieces;
+        private final long allPieces;
+        private final int lastMoveDoubleStepPawnIndex;
+        private final boolean whiteKingMoved;
+        private final boolean blackKingMoved;
+        private final boolean whiteRookA1Moved;
+        private final boolean whiteRookH1Moved;
+        private final boolean blackRookA8Moved;
+        private final boolean blackRookH8Moved;
+        private final boolean whiteKingHasCastled;
+        private final boolean blackKingHasCastled;
+        private final PieceType[] pieceTypes;
+
+        private BoardView(boolean whitesTurn,
+                           long whitePawns,
+                           long blackPawns,
+                           long whiteKnights,
+                           long blackKnights,
+                           long whiteBishops,
+                           long blackBishops,
+                           long whiteRooks,
+                           long blackRooks,
+                           long whiteQueens,
+                           long blackQueens,
+                           long whiteKing,
+                           long blackKing,
+                           long whitePieces,
+                           long blackPieces,
+                           long allPieces,
+                           int lastMoveDoubleStepPawnIndex,
+                           boolean whiteKingMoved,
+                           boolean blackKingMoved,
+                           boolean whiteRookA1Moved,
+                           boolean whiteRookH1Moved,
+                           boolean blackRookA8Moved,
+                           boolean blackRookH8Moved,
+                           boolean whiteKingHasCastled,
+                           boolean blackKingHasCastled,
+                           PieceType[] pieceTypes) {
+            this.whitesTurn = whitesTurn;
+            this.whitePawns = whitePawns;
+            this.blackPawns = blackPawns;
+            this.whiteKnights = whiteKnights;
+            this.blackKnights = blackKnights;
+            this.whiteBishops = whiteBishops;
+            this.blackBishops = blackBishops;
+            this.whiteRooks = whiteRooks;
+            this.blackRooks = blackRooks;
+            this.whiteQueens = whiteQueens;
+            this.blackQueens = blackQueens;
+            this.whiteKing = whiteKing;
+            this.blackKing = blackKing;
+            this.whitePieces = whitePieces;
+            this.blackPieces = blackPieces;
+            this.allPieces = allPieces;
+            this.lastMoveDoubleStepPawnIndex = lastMoveDoubleStepPawnIndex;
+            this.whiteKingMoved = whiteKingMoved;
+            this.blackKingMoved = blackKingMoved;
+            this.whiteRookA1Moved = whiteRookA1Moved;
+            this.whiteRookH1Moved = whiteRookH1Moved;
+            this.blackRookA8Moved = blackRookA8Moved;
+            this.blackRookH8Moved = blackRookH8Moved;
+            this.whiteKingHasCastled = whiteKingHasCastled;
+            this.blackKingHasCastled = blackKingHasCastled;
+            this.pieceTypes = Objects.requireNonNull(pieceTypes, "pieceTypes");
+        }
+
+        public static BoardView from(BitBoard bitBoard) {
+            PieceType[] pieces = new PieceType[64];
+            for (int i = 0; i < pieces.length; i++) {
+                pieces[i] = bitBoard.getPieceTypeAtIndex(i);
+            }
+            return new BoardView(
+                    bitBoard.isWhitesTurn(),
+                    bitBoard.getWhitePawns(),
+                    bitBoard.getBlackPawns(),
+                    bitBoard.getWhiteKnights(),
+                    bitBoard.getBlackKnights(),
+                    bitBoard.getWhiteBishops(),
+                    bitBoard.getBlackBishops(),
+                    bitBoard.getWhiteRooks(),
+                    bitBoard.getBlackRooks(),
+                    bitBoard.getWhiteQueens(),
+                    bitBoard.getBlackQueens(),
+                    bitBoard.getWhiteKing(),
+                    bitBoard.getBlackKing(),
+                    bitBoard.getWhitePieces(),
+                    bitBoard.getBlackPieces(),
+                    bitBoard.getAllPieces(),
+                    bitBoard.getLastMoveDoubleStepPawnIndex(),
+                    bitBoard.isWhiteKingMoved(),
+                    bitBoard.isBlackKingMoved(),
+                    bitBoard.isWhiteRookA1Moved(),
+                    bitBoard.isWhiteRookH1Moved(),
+                    bitBoard.isBlackRookA8Moved(),
+                    bitBoard.isBlackRookH8Moved(),
+                    bitBoard.isWhiteKingHasCastled(),
+                    bitBoard.isBlackKingHasCastled(),
+                    pieces
+            );
+        }
+
+        public boolean isWhitesTurn() {
+            return whitesTurn;
+        }
+
+        public long getWhitePawns() {
+            return whitePawns;
+        }
+
+        public long getBlackPawns() {
+            return blackPawns;
+        }
+
+        public long getWhiteKnights() {
+            return whiteKnights;
+        }
+
+        public long getBlackKnights() {
+            return blackKnights;
+        }
+
+        public long getWhiteBishops() {
+            return whiteBishops;
+        }
+
+        public long getBlackBishops() {
+            return blackBishops;
+        }
+
+        public long getWhiteRooks() {
+            return whiteRooks;
+        }
+
+        public long getBlackRooks() {
+            return blackRooks;
+        }
+
+        public long getWhiteQueens() {
+            return whiteQueens;
+        }
+
+        public long getBlackQueens() {
+            return blackQueens;
+        }
+
+        public long getWhiteKing() {
+            return whiteKing;
+        }
+
+        public long getBlackKing() {
+            return blackKing;
+        }
+
+        public long getWhitePieces() {
+            return whitePieces;
+        }
+
+        public long getBlackPieces() {
+            return blackPieces;
+        }
+
+        public long getAllPieces() {
+            return allPieces;
+        }
+
+        public int getLastMoveDoubleStepPawnIndex() {
+            return lastMoveDoubleStepPawnIndex;
+        }
+
+        public boolean isWhiteKingMoved() {
+            return whiteKingMoved;
+        }
+
+        public boolean isBlackKingMoved() {
+            return blackKingMoved;
+        }
+
+        public boolean isWhiteRookA1Moved() {
+            return whiteRookA1Moved;
+        }
+
+        public boolean isWhiteRookH1Moved() {
+            return whiteRookH1Moved;
+        }
+
+        public boolean isBlackRookA8Moved() {
+            return blackRookA8Moved;
+        }
+
+        public boolean isBlackRookH8Moved() {
+            return blackRookH8Moved;
+        }
+
+        public boolean isWhiteKingHasCastled() {
+            return whiteKingHasCastled;
+        }
+
+        public boolean isBlackKingHasCastled() {
+            return blackKingHasCastled;
+        }
+
+        public PieceType getPieceTypeAtIndex(int index) {
+            return pieceTypes[index];
+        }
+
+        public PieceType[] getPieceTypes() {
+            return Arrays.copyOf(pieceTypes, pieceTypes.length);
+        }
+    }
+
+    private final BoardView board;
     private final GameStateEnum gameState;
     private final int phase;
     private final long whiteAttackMap;
     private final long blackAttackMap;
     private final boolean whiteToMove;
 
-    private EvaluationContext(BitBoard board, GameStateEnum gameState, int phase,
+    private EvaluationContext(BoardView board, GameStateEnum gameState, int phase,
                               long whiteAttackMap, long blackAttackMap, boolean whiteToMove) {
         this.board = Objects.requireNonNull(board, "board");
         this.gameState = gameState;
@@ -31,14 +265,14 @@ public final class EvaluationContext {
 
     public static EvaluationContext from(BitBoard bitBoard, GameStateEnum gameState) {
         Objects.requireNonNull(bitBoard, "bitBoard");
-        BitBoard snapshot = new BitBoard(bitBoard);
+        BoardView snapshot = BoardView.from(bitBoard);
         long whiteAttacks = bitBoard.getAttackBitboard(true);
         long blackAttacks = bitBoard.getAttackBitboard(false);
         return new EvaluationContext(snapshot, gameState, bitBoard.getPhase(), whiteAttacks, blackAttacks,
                 bitBoard.isWhitesTurn());
     }
 
-    public BitBoard getBoard() {
+    public BoardView getBoard() {
         return board;
     }
 
@@ -63,6 +297,6 @@ public final class EvaluationContext {
     }
 
     public EvaluationContext copy() {
-        return new EvaluationContext(new BitBoard(board), gameState, phase, whiteAttackMap, blackAttackMap, whiteToMove);
+        return new EvaluationContext(board, gameState, phase, whiteAttackMap, blackAttackMap, whiteToMove);
     }
 }

--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -128,22 +128,10 @@ public final class KingSafetyModule implements EvaluationModule {
     }
 
     public KingSafetyView evaluate(BitBoard board) {
-        if (board == null) {
-            for (SideState state : sideStates) {
-                state.reset();
-            }
-            midgameScoreCache = 0;
-            endgameScoreCache = 0;
-            currentView = KingSafetyView.empty();
-            dirty = false;
-            return currentView;
-        }
-        long whiteAttacks = board.getAttackBitboard(true);
-        long blackAttacks = board.getAttackBitboard(false);
-        rebuildSideState(sideStates[WHITE], board, true, whiteAttacks, blackAttacks);
-        rebuildSideState(sideStates[BLACK], board, false, blackAttacks, whiteAttacks);
-        refreshScoreCaches();
-        dirty = false;
+        EvaluationContext.BoardView view = board == null ? null : EvaluationContext.BoardView.from(board);
+        long whiteAttacks = board == null ? 0L : board.getAttackBitboard(true);
+        long blackAttacks = board == null ? 0L : board.getAttackBitboard(false);
+        rebuildFromSnapshot(view, whiteAttacks, blackAttacks);
         return currentView;
     }
 
@@ -152,9 +140,24 @@ public final class KingSafetyModule implements EvaluationModule {
     }
 
     private void rebuildFromContext(EvaluationContext context) {
-        BitBoard board = context.getBoard();
-        long whiteAttacks = context.getWhiteAttackMap();
-        long blackAttacks = context.getBlackAttackMap();
+        if (context == null) {
+            rebuildFromSnapshot(null, 0L, 0L);
+            return;
+        }
+        rebuildFromSnapshot(context.getBoard(), context.getWhiteAttackMap(), context.getBlackAttackMap());
+    }
+
+    private void rebuildFromSnapshot(EvaluationContext.BoardView board, long whiteAttacks, long blackAttacks) {
+        for (SideState state : sideStates) {
+            state.reset();
+        }
+        if (board == null) {
+            midgameScoreCache = 0;
+            endgameScoreCache = 0;
+            currentView = KingSafetyView.empty();
+            dirty = false;
+            return;
+        }
         rebuildSideState(sideStates[WHITE], board, true, whiteAttacks, blackAttacks);
         rebuildSideState(sideStates[BLACK], board, false, blackAttacks, whiteAttacks);
         refreshScoreCaches();
@@ -214,8 +217,8 @@ public final class KingSafetyModule implements EvaluationModule {
                 return true;
             }
         }
-        BitBoard previousBoard = previous.getBoard();
-        BitBoard currentBoard = current.getBoard();
+        EvaluationContext.BoardView previousBoard = previous.getBoard();
+        EvaluationContext.BoardView currentBoard = current.getBoard();
         long prevQueens = side == WHITE ? previousBoard.getWhiteQueens() : previousBoard.getBlackQueens();
         long currQueens = side == WHITE ? currentBoard.getWhiteQueens() : currentBoard.getBlackQueens();
         if (prevQueens != currQueens) {
@@ -235,7 +238,8 @@ public final class KingSafetyModule implements EvaluationModule {
         return false;
     }
 
-    private void rebuildSideState(SideState state, BitBoard board, boolean isWhite, long friendlyAttacks, long enemyAttacks) {
+    private void rebuildSideState(SideState state, EvaluationContext.BoardView board, boolean isWhite,
+                                  long friendlyAttacks, long enemyAttacks) {
         state.reset();
         long kingBits = isWhite ? board.getWhiteKing() : board.getBlackKing();
         if (kingBits == 0) {
@@ -305,7 +309,7 @@ public final class KingSafetyModule implements EvaluationModule {
         state.endgameQueenPenalty = queenEnd;
     }
 
-    private void computeBackrankWeaknessPenalty(SideState state, BitBoard board, boolean isWhite) {
+    private void computeBackrankWeaknessPenalty(SideState state, EvaluationContext.BoardView board, boolean isWhite) {
         state.backrankWeaknessMidgame = 0;
         state.backrankWeaknessEndgame = 0;
         if (state.kingSquare < 0) {
@@ -371,7 +375,7 @@ public final class KingSafetyModule implements EvaluationModule {
         return mask;
     }
 
-    private long computeFriendlyNonKingAttacks(BitBoard board, boolean isWhite) {
+    private long computeFriendlyNonKingAttacks(EvaluationContext.BoardView board, boolean isWhite) {
         long attacks = 0L;
         long occupancy = board.getAllPieces();
 

--- a/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
@@ -2,7 +2,6 @@ package julius.game.chessengine.evaluation;
 
 import java.util.Arrays;
 
-import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.figures.PieceType;
 /**
@@ -158,10 +157,16 @@ public final class MaterialModule implements EvaluationModule {
         updateScoreCaches();
     }
 
-    private void rebuildFromBoard(BitBoard board) {
+    private void rebuildFromBoard(EvaluationContext.BoardView board) {
         Arrays.fill(midgameMaterial, 0);
         Arrays.fill(endgameMaterial, 0);
         Arrays.fill(bishopCounts, 0);
+
+        if (board == null) {
+            updateScoreCaches();
+            dirty = false;
+            return;
+        }
 
         accumulatePieces(WHITE, PAWN, Long.bitCount(board.getWhitePawns()));
         accumulatePieces(WHITE, KNIGHT, Long.bitCount(board.getWhiteKnights()));

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -60,17 +60,18 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
 
     @Override
     public void initialize(EvaluationContext context) {
-        BitBoard board = Objects.requireNonNull(context, "context").getBoard();
+        EvaluationContext.BoardView board = Objects.requireNonNull(context, "context").getBoard();
         markAllFilesDirty();
-        evaluate(board);
+        evaluate(board, context.getWhiteAttackMap(), context.getBlackAttackMap());
     }
 
     @Override
     public void evaluate(EvaluationContext context) {
-        evaluate(Objects.requireNonNull(context, "context").getBoard());
+        Objects.requireNonNull(context, "context");
+        evaluate(context.getBoard(), context.getWhiteAttackMap(), context.getBlackAttackMap());
     }
 
-    public PawnStructureView evaluate(BitBoard board) {
+    public PawnStructureView evaluate(EvaluationContext.BoardView board, long whiteAttacks, long blackAttacks) {
         if (board == null) {
             currentView = PawnStructureView.empty();
             midgameScoreCache = 0;
@@ -89,8 +90,6 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         long allPieces = board.getAllPieces();
         long whiteRooks = board.getWhiteRooks();
         long blackRooks = board.getBlackRooks();
-        long whiteAttacks = board.getAttackBitboard(true);
-        long blackAttacks = board.getAttackBitboard(false);
         long whiteKing = board.getWhiteKing();
         long blackKing = board.getBlackKing();
 
@@ -255,10 +254,14 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     }
 
     public PawnStructureView getView(BitBoard board) {
-        return evaluate(board);
+        if (board == null) {
+            return evaluate((EvaluationContext.BoardView) null, 0L, 0L);
+        }
+        EvaluationContext.BoardView view = EvaluationContext.BoardView.from(board);
+        return evaluate(view, board.getAttackBitboard(true), board.getAttackBitboard(false));
     }
 
-    public int countHalfOpenFilesWithRooks(BitBoard board, long rooksBitboard, boolean isWhite) {
+    public int countHalfOpenFilesWithRooks(EvaluationContext.BoardView board, long rooksBitboard, boolean isWhite) {
         if (rooksBitboard == 0L) {
             return 0;
         }
@@ -282,7 +285,12 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         return count;
     }
 
-    public int countOpenFilesWithRooks(BitBoard board, long rooksBitboard) {
+    public int countHalfOpenFilesWithRooks(BitBoard board, long rooksBitboard, boolean isWhite) {
+        EvaluationContext.BoardView view = board == null ? null : EvaluationContext.BoardView.from(board);
+        return countHalfOpenFilesWithRooks(view, rooksBitboard, isWhite);
+    }
+
+    public int countOpenFilesWithRooks(EvaluationContext.BoardView board, long rooksBitboard) {
         if (rooksBitboard == 0L) {
             return 0;
         }
@@ -297,6 +305,11 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
             }
         }
         return count;
+    }
+
+    public int countOpenFilesWithRooks(BitBoard board, long rooksBitboard) {
+        EvaluationContext.BoardView view = board == null ? null : EvaluationContext.BoardView.from(board);
+        return countOpenFilesWithRooks(view, rooksBitboard);
     }
 
     private void handleMove(int move) {
@@ -326,7 +339,7 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         }
     }
 
-    private void refreshFileMetadata(BitBoard board) {
+    private void refreshFileMetadata(EvaluationContext.BoardView board) {
         if (!metadataDirty || board == null) {
             return;
         }

--- a/src/main/java/julius/game/chessengine/evaluation/PieceSquareModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PieceSquareModule.java
@@ -2,7 +2,6 @@ package julius.game.chessengine.evaluation;
 
 import java.util.Arrays;
 
-import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.figures.PieceType;
 
@@ -494,7 +493,7 @@ public final class PieceSquareModule implements EvaluationModule {
         developmentDirty = false;
     }
 
-    private void recalculateCastlingContribution(BitBoard board, int phase) {
+    private void recalculateCastlingContribution(EvaluationContext.BoardView board, int phase) {
         if (!castlingDirty) {
             return;
         }
@@ -513,7 +512,7 @@ public final class PieceSquareModule implements EvaluationModule {
         castlingDirty = false;
     }
 
-    private int computeCastlingContribution(BitBoard board, int phase) {
+    private int computeCastlingContribution(EvaluationContext.BoardView board, int phase) {
         int materialBalance = computeMaterialBalance(board);
         int whiteAdjustment = computeCastlingAdjustment(
                 board.getWhiteKing(),
@@ -609,7 +608,7 @@ public final class PieceSquareModule implements EvaluationModule {
         return adjustment;
     }
 
-    private static int computeMaterialBalance(BitBoard board) {
+    private static int computeMaterialBalance(EvaluationContext.BoardView board) {
         int whiteMaterial = Long.bitCount(board.getWhitePawns()) * PAWN_VALUE
                 + Long.bitCount(board.getWhiteKnights()) * KNIGHT_VALUE
                 + Long.bitCount(board.getWhiteBishops()) * BISHOP_VALUE
@@ -623,7 +622,7 @@ public final class PieceSquareModule implements EvaluationModule {
         return whiteMaterial - blackMaterial;
     }
 
-    private void rebuildFromBoard(BitBoard board) {
+    private void rebuildFromBoard(EvaluationContext.BoardView board) {
         Arrays.fill(occupantColor, -1);
         Arrays.fill(occupantPiece, 0);
         Arrays.fill(midgameContributionBySquare, 0);
@@ -636,6 +635,13 @@ public final class PieceSquareModule implements EvaluationModule {
         endgameTotal = 0;
         developmentContribution = 0;
         castlingContribution = 0;
+
+        if (board == null) {
+            developmentDirty = true;
+            castlingDirty = true;
+            initialized = true;
+            return;
+        }
 
         fillPieces(board.getWhitePawns(), WHITE, PAWN);
         fillPieces(board.getWhiteKnights(), WHITE, KNIGHT);

--- a/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
@@ -1,6 +1,5 @@
 package julius.game.chessengine.evaluation;
 
-import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.BishopHelper;
@@ -62,7 +61,7 @@ public final class ThreatModule implements EvaluationModule {
             return;
         }
         Objects.requireNonNull(context, "context");
-        BitBoard board = context.getBoard();
+        EvaluationContext.BoardView board = context.getBoard();
         if (board == null) {
             midgameScoreCache = 0;
             endgameScoreCache = 0;
@@ -111,7 +110,7 @@ public final class ThreatModule implements EvaluationModule {
         dirty = true;
     }
 
-    private int evaluateSide(BitBoard board, boolean isWhite, long friendlyAttacks, long enemyAttacks) {
+    private int evaluateSide(EvaluationContext.BoardView board, boolean isWhite, long friendlyAttacks, long enemyAttacks) {
         long pieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
         long enemyPawns = isWhite ? board.getBlackPawns() : board.getWhitePawns();
         int enemyPawnColor = isWhite ? BLACK : WHITE;
@@ -179,7 +178,7 @@ public final class ThreatModule implements EvaluationModule {
         return Math.max(basePenalty, scaled);
     }
 
-    private int leastValuableDefenderValue(BitBoard board, boolean isWhite, int targetSquare) {
+    private int leastValuableDefenderValue(EvaluationContext.BoardView board, boolean isWhite, int targetSquare) {
         long mask = 1L << targetSquare;
         int colorIndex = isWhite ? WHITE : BLACK;
         int minValue = Integer.MAX_VALUE;


### PR DESCRIPTION
## Summary
- add a lightweight `EvaluationContext.BoardView` snapshot that captures the bitboard state needed by evaluators without cloning `BitBoard`
- update material, pawn structure, piece-square, activity, king safety, and threat modules to operate on the immutable snapshot and reuse context attack maps
- keep helper paths for tests while routing Score/EvaluationPipeline updates through the new snapshot flow

## Testing
- `./mvnw -q test` *(fails: Maven wrapper cannot download dependencies because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d17bc4a318832aa3a6c5507bdc998d