### PR TITLE
Add symmetric late move pruning guard

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1471,13 +1471,23 @@ public class AI {
             boolean lmpPrecomputed = false;
             boolean lmpGivesCheck = false;
             boolean lmpAttacksQueen = false;
+            boolean lmpAttacksKingZone = false;
             int lmpThreshold = 8 + depth * 2;
             if (!inCheckAtNode && !isTactical && depth <= 3 && index > lmpThreshold) {
                 simulatorEngine.performMove(move);
                 lmpGivesCheck = isSideInCheck(simulatorEngine, !isWhite);
                 lmpAttacksQueen = attacksOpponentQueenNow(simulatorEngine, isWhite);
+                lmpAttacksKingZone = attacksOpponentKingZone(simulatorEngine, isWhite);
                 lmpPrecomputed = true;
+                boolean skipQuiet = isQuiet
+                        && !lmpGivesCheck
+                        && !lmpAttacksQueen
+                        && !lmpAttacksKingZone
+                        && !seeWinsMaterial;
                 simulatorEngine.undoLastMove();
+                if (skipQuiet) {
+                    continue;
+                }
             }
 
             simulatorEngine.performMove(move);
@@ -1485,7 +1495,7 @@ public class AI {
 
             boolean givesCheck = lmpPrecomputed ? lmpGivesCheck : isSideInCheck(simulatorEngine, !isWhite);
             boolean attacksQueen = lmpPrecomputed ? lmpAttacksQueen : attacksOpponentQueenNow(simulatorEngine, isWhite);
-            boolean attacksKingZone = attacksOpponentKingZone(simulatorEngine, isWhite);
+            boolean attacksKingZone = lmpPrecomputed ? lmpAttacksKingZone : attacksOpponentKingZone(simulatorEngine, isWhite);
             boolean opensKingFile = openedFileTowardKing(simulatorEngine.getBitBoard(), kingFileMask, pawnsOnFileBefore, affectsKingFilePawns);
 
             int nextDepth = depth - 1;
@@ -1661,13 +1671,34 @@ public class AI {
             int pawnsOnFileBefore = (enemyKingSquare >= 0 && affectsKingFilePawns) ? countPawnsOnFile(boardBefore, kingFileMask) : 0;
 
             boolean isTactical = isCapture || isPromotion;
+            boolean lmpPrecomputed = false;
+            boolean lmpGivesCheck = false;
+            boolean lmpAttacksQueen = false;
+            boolean lmpAttacksKingZone = false;
+            int lmpThreshold = 8 + depth * 2;
+            if (!inCheckAtNode && !isTactical && depth <= 3 && index > lmpThreshold) {
+                simulatorEngine.performMove(move);
+                lmpGivesCheck = isSideInCheck(simulatorEngine, !isWhite);
+                lmpAttacksQueen = attacksOpponentQueenNow(simulatorEngine, isWhite);
+                lmpAttacksKingZone = attacksOpponentKingZone(simulatorEngine, isWhite);
+                lmpPrecomputed = true;
+                boolean skipQuiet = isQuiet
+                        && !lmpGivesCheck
+                        && !lmpAttacksQueen
+                        && !lmpAttacksKingZone
+                        && !seeWinsMaterial;
+                simulatorEngine.undoLastMove();
+                if (skipQuiet) {
+                    continue;
+                }
+            }
 
             simulatorEngine.performMove(move);
             long newBoardHash = simulatorEngine.getBoardStateHash();
 
-            boolean givesCheck = isSideInCheck(simulatorEngine, !isWhite);
-            boolean attacksQueen = attacksOpponentQueenNow(simulatorEngine, isWhite);
-            boolean attacksKingZone = attacksOpponentKingZone(simulatorEngine, isWhite);
+            boolean givesCheck = lmpPrecomputed ? lmpGivesCheck : isSideInCheck(simulatorEngine, !isWhite);
+            boolean attacksQueen = lmpPrecomputed ? lmpAttacksQueen : attacksOpponentQueenNow(simulatorEngine, isWhite);
+            boolean attacksKingZone = lmpPrecomputed ? lmpAttacksKingZone : attacksOpponentKingZone(simulatorEngine, isWhite);
             boolean opensKingFile = openedFileTowardKing(simulatorEngine.getBitBoard(), kingFileMask, pawnsOnFileBefore, affectsKingFilePawns);
 
             int nextDepth = depth - 1;

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -183,6 +183,48 @@ public class BitBoardTest {
     }
 
     @Test
+    public void PERFT_blackToMove() {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq -");
+
+        PerftNode d1 = perft(1, engine);
+        assertEquals(20, d1.getNodes());
+        assertEquals(0, d1.getCaptures());
+        assertEquals(0, d1.getEnPassant());
+        assertEquals(0, d1.getCastles());
+        assertEquals(0, d1.getPromotions());
+        assertEquals(0, d1.getChecks());
+        assertEquals(0, d1.getCheckmates());
+
+        PerftNode d2 = perft(2, engine);
+        assertEquals(400, d2.getNodes());
+        assertEquals(0, d2.getCaptures());
+        assertEquals(0, d2.getEnPassant());
+        assertEquals(0, d2.getCastles());
+        assertEquals(0, d2.getPromotions());
+        assertEquals(0, d2.getChecks());
+        assertEquals(0, d2.getCheckmates());
+
+        PerftNode d3 = perft(3, engine);
+        assertEquals(8902, d3.getNodes());
+        assertEquals(34, d3.getCaptures());
+        assertEquals(0, d3.getEnPassant());
+        assertEquals(0, d3.getCastles());
+        assertEquals(0, d3.getPromotions());
+        assertEquals(12, d3.getChecks());
+        assertEquals(0, d3.getCheckmates());
+
+        PerftNode d4 = perft(4, engine);
+        assertEquals(197281, d4.getNodes());
+        assertEquals(1576, d4.getCaptures());
+        assertEquals(0, d4.getEnPassant());
+        assertEquals(0, d4.getCastles());
+        assertEquals(0, d4.getPromotions());
+        assertEquals(469, d4.getChecks());
+        assertEquals(8, d4.getCheckmates());
+    }
+
+    @Test
 //    r . . . k . . r   8
 //    p . p p q p b .   7
 //    b n . . p n p .   6


### PR DESCRIPTION
## Summary
- add late-move pruning guard for both maximizing and minimizing nodes that skips quiet, non-forcing moves near the root
- keep forcing quiets by checking for checks, queen pressure, king-zone contact, and SEE wins before pruning
- add a perft regression test from the initial position with black to move to cover the new symmetry requirement

## Testing
- `mvn test` *(fails: network is unreachable when resolving org.springframework.boot:spring-boot-starter-parent:pom:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68d1929fdbb0832a95738b4d35a658a0