### PR TITLE
Add detailed search diagnostics and enhance best-move reporting

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -216,6 +216,8 @@ public class AI {
     private long nodesVisited = 0;
     @Getter
     private long nullMoveCount = 0;
+    @Getter
+    private volatile SearchDiagnostics lastDiagnostics = SearchDiagnostics.EMPTY;
 
     public AI(Engine mainEngine) {
         log.info("### SearchThreads = " + searchThreads + ", LazySmpThreads = " + lazySmpThreads);
@@ -441,6 +443,7 @@ public class AI {
     private void iterativeDeepening(SearchTask task, Engine simulatorEngine, SplittableRandom rng) {
         Double lastIterScore = null;
         Heuristics heuristics = threadHeuristics.get();
+        SearchInstrumentation instr = task.getInstrumentation();
 
         for (int currentDepth = 1; currentDepth <= maxDepth; currentDepth++) {
             if (shouldStopCalculating(task.getDeadline())) break;
@@ -465,19 +468,23 @@ public class AI {
                     ms = searchRootMoves(simulatorEngine, task, currentDepth, alpha, beta, rng);
                     if (ms == null) break;
                     if (ms.score <= alpha) {
+                        instr.recordAspirationFailLow();
                         window *= 2.0;
                         alpha = ms.score - window;
                         if (++retries > 3) {
                             alpha = Double.NEGATIVE_INFINITY;
                             beta = Double.POSITIVE_INFINITY;
+                            instr.recordAspirationReset();
                         } else continue;
                     }
                     if (ms.score >= beta) {
+                        instr.recordAspirationFailHigh();
                         window *= 2.0;
                         beta = ms.score + window;
                         if (++retries > 3) {
                             alpha = Double.NEGATIVE_INFINITY;
                             beta = Double.POSITIVE_INFINITY;
+                            instr.recordAspirationReset();
                         } else continue;
                     }
                     break;
@@ -496,6 +503,7 @@ public class AI {
 
             lastIterScore = ms.score;
             task.publishBest(ms, currentDepth, simulatorEngine);
+            instr.recordIterationComplete(currentDepth);
             if (heuristics.hasUpdates()) {
                 mergeThreadHeuristics(heuristics);
             }
@@ -724,10 +732,13 @@ public class AI {
                 previousBestMoveHash = boardStateHash;
                 searchResultReady = true;
                 this.calculatedLine = List.of(new MoveAndScore(bookMove, 0.0));
+                lastDiagnostics = SearchDiagnostics.EMPTY;
                 return;
             }
 
-            SearchTask task = new SearchTask(searchIdGenerator.incrementAndGet(), boardStateHash, isWhite, deadline, lazySmpThreads);
+            SearchInstrumentation instrumentation = SearchInstrumentation.enabled();
+            lastDiagnostics = SearchDiagnostics.EMPTY;
+            SearchTask task = new SearchTask(searchIdGenerator.incrementAndGet(), boardStateHash, isWhite, deadline, lazySmpThreads, instrumentation);
             activeSearch.set(task);
             if (bestMoveForHash == boardStateHash && currentBestMove != -1) {
                 previousBestMove = currentBestMove;
@@ -783,6 +794,7 @@ public class AI {
             previousBestMoveHash = task.getBoardHash();
             searchResultReady = true;
             fillCalculatedLine(simulatorEngine);
+            lastDiagnostics = task.getInstrumentation().snapshot(best.depth, best.score);
             return;
         }
 
@@ -793,6 +805,7 @@ public class AI {
             previousBestMoveHash = task.getBoardHash();
             searchResultReady = true;
             fillCalculatedLine(simulatorEngine);
+            lastDiagnostics = task.getInstrumentation().snapshot(best.depth, best.score);
             return;
         }
 
@@ -802,6 +815,7 @@ public class AI {
         previousBestMoveHash = -1;
         searchResultReady = false;
         this.calculatedLine = Collections.synchronizedList(new ArrayList<>());
+        lastDiagnostics = task.getInstrumentation().snapshot(best.depth, best.score);
     }
 
     private boolean isMoveStillLegal(Engine simulatorEngine, int move) {
@@ -854,6 +868,11 @@ public class AI {
         return t != null && t.isStopRequested();
     }
 
+    private SearchInstrumentation instrumentation() {
+        SearchTask t = threadSearchTask.get();
+        return t != null ? t.getInstrumentation() : SearchInstrumentation.disabled();
+    }
+
     private MoveAndScore getBestMoveParallel(Engine simulatorEngine,
                                              SearchTask task,
                                              int depth,
@@ -870,6 +889,8 @@ public class AI {
         MoveList orderedMoves = sortMovesByEfficiency(legal, depth, simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
         if (orderedMoves.size() == 0) return null;
         maybeRotateRootMoves(orderedMoves, rng);
+        SearchInstrumentation instr = instrumentation();
+        instr.recordRootMovesGenerated(orderedMoves.size());
 
         int firstMove = orderedMoves.getMove(0);
         int bestMove = -1;
@@ -883,6 +904,7 @@ public class AI {
 
         if (abortRequested(deadline)) return null;
 
+        instr.recordRootMoveExplored();
         simulatorEngine.performMove(firstMove);
         double firstScore;
         if (simulatorEngine.getGameState().isInStateCheckMate()) {
@@ -930,6 +952,7 @@ public class AI {
                 try {
                     Engine e = simulatorEngine.createSimulation();
                     e.performMove(moveInt);
+                    instr.recordRootMoveExplored();
 
                     double currentAlpha = alphaRef.get();
                     double currentBeta = betaRef.get();
@@ -1129,11 +1152,14 @@ public class AI {
         MoveList sortedMoves = sortMovesByEfficiency(simulatorEngine.getAllLegalMoves(), depth,
                 simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
         maybeRotateRootMoves(sortedMoves, rng);
+        SearchInstrumentation instr = instrumentation();
+        instr.recordRootMovesGenerated(sortedMoves.size());
 
         for (int idx = 0; idx < sortedMoves.size(); idx++) {
             int moveInt = sortedMoves.getMove(idx);
             if (abortRequested(deadline)) break;
 
+            instr.recordRootMoveExplored();
             simulatorEngine.performMove(moveInt);
             double score;
             if (simulatorEngine.getGameState().isInStateCheckMate()) {
@@ -1158,7 +1184,10 @@ public class AI {
             }
             if (isWhitesTurn) alpha = Math.max(alpha, score);
             else beta = Math.min(beta, score);
-            if (alpha >= beta) break;
+            if (alpha >= beta) {
+                instr.recordRootBetaCutoff();
+                break;
+            }
         }
         return bestMove != -1 ? new MoveAndScore(bestMove, bestScore) : null;
     }
@@ -1174,6 +1203,8 @@ public class AI {
                              boolean isWhite, long deadline, int prevMove, int plyFromRoot,
                              int extStreak) {
         nodesVisited++;
+        SearchInstrumentation instr = instrumentation();
+        instr.recordVisitedPly(plyFromRoot);
 
         if (abortRequested(deadline)) return EXIT_FLAG;
 
@@ -1210,12 +1241,23 @@ public class AI {
         long boardHash = simulatorEngine.getBoardStateHash();
 
         // Transposition table lookup
+        instr.recordTranspositionLookup();
         TranspositionTableEntry entry = transpositionTable.get(boardHash);
-        if (entry != null && entry.depth >= depth) {
-            if (entry.nodeType == NodeType.EXACT) return entry.score;
-            if (entry.nodeType == NodeType.LOWERBOUND && entry.score > alpha) alpha = entry.score;
-            else if (entry.nodeType == NodeType.UPPERBOUND && entry.score < beta) beta = entry.score;
-            if (alpha >= beta) return entry.score;
+        if (entry != null) {
+            boolean usable = entry.depth >= depth;
+            if (usable) {
+                if (entry.nodeType == NodeType.EXACT) {
+                    instr.recordTranspositionHit(entry.nodeType, true);
+                    return entry.score;
+                }
+                if (entry.nodeType == NodeType.LOWERBOUND && entry.score > alpha) alpha = entry.score;
+                else if (entry.nodeType == NodeType.UPPERBOUND && entry.score < beta) beta = entry.score;
+                boolean cutoff = alpha >= beta;
+                instr.recordTranspositionHit(entry.nodeType, cutoff);
+                if (cutoff) return entry.score;
+            } else {
+                instr.recordTranspositionHit(entry.nodeType, false);
+            }
         }
 
         // -------- Safer Null-move pruning (same as before, but use depthHere) --------
@@ -1238,6 +1280,7 @@ public class AI {
             int reduction = computeNullMoveReduction(bitBoard, depth, isWhite, mobility);
             int savedEp = simulatorEngine.doNullMoveForSearch();
             nullMoveCount++;
+            instr.recordNullMoveAttempt();
             double nullScore = alphaBeta(simulatorEngine, depth - 1 - reduction, alpha, beta, !isWhite, deadline, -1, plyFromRoot + 1, 0);
             simulatorEngine.undoNullMoveForSearch(savedEp);
 
@@ -1253,6 +1296,7 @@ public class AI {
                         || swing >= swingThreshold;
 
                 if (requiresVerification) {
+                    instr.recordNullMoveVerification();
                     double verificationScore = alphaBeta(simulatorEngine, depth - 1, alpha, beta, isWhite, deadline, prevMove, plyFromRoot, 0);
                     if (verificationScore == EXIT_FLAG) return EXIT_FLAG;
                     if (Math.abs(verificationScore) < mateThreshold) {
@@ -1260,10 +1304,14 @@ public class AI {
                     } else {
                         nullFailHigh = false;
                     }
+                    if (!nullFailHigh) {
+                        instr.recordNullMoveVerificationFail();
+                    }
                 }
             }
 
             if (nullFailHigh) {
+                instr.recordNullMovePrune();
                 return isWhite ? beta : alpha;
             }
         }
@@ -1436,6 +1484,7 @@ public class AI {
         long start = log.isDebugEnabled() ? System.nanoTime() : 0L;
         double maxEval = Double.NEGATIVE_INFINITY;
         int bestMoveAtThisNode = -1;
+        SearchInstrumentation instr = instrumentation();
 
         final boolean inCheckAtNode = isSideInCheck(simulatorEngine, isWhite);
         final Heuristics heuristics = threadHeuristics.get();
@@ -1510,6 +1559,7 @@ public class AI {
                         && !seeWinsMaterial;
                 simulatorEngine.undoLastMove();
                 if (skipQuiet) {
+                    instr.recordLateMovePrune();
                     continue;
                 }
             }
@@ -1545,19 +1595,25 @@ public class AI {
                 double margin = computeStandPatMargin(simulatorEngine.getBitBoard(), depth, nextDepth);
                 if (staticEval + margin <= alpha) {
                     simulatorEngine.undoLastMove();
+                    instr.recordFutilityPrune();
                     continue;
                 }
             }
 
             double eval;
+            instr.recordTranspositionLookup();
             TranspositionTableEntry entry = transpositionTable.get(newBoardHash);
             boolean ttExactHit = entry != null
                     && entry.nodeType == NodeType.EXACT
                     && entry.depth >= nextDepth;
 
             if (ttExactHit) {
+                instr.recordTranspositionHit(entry.nodeType, false);
                 eval = entry.score;
             } else {
+                if (entry != null) {
+                    instr.recordTranspositionHit(entry.nodeType, false);
+                }
                 boolean canReduce = !inCheckAtNode
                         && !isTactical
                         && !givesCheck
@@ -1580,6 +1636,7 @@ public class AI {
                 if (canReduce) {
                     reduction = lmrReduction(nextDepth, index, historyScore);
                     if (reduction <= 0) canReduce = false;
+                    else instr.recordLateMoveReduction(reduction);
                 }
 
                 if (canReduce) {
@@ -1633,6 +1690,7 @@ public class AI {
                 updateKillerMoves(depth, move);
                 incrementHistory(move, depth);
                 heuristics.recordCounterMove(prevMove, move);
+                instr.recordBetaCutoff();
                 break;
             }
         }
@@ -1660,6 +1718,7 @@ public class AI {
         long start = log.isDebugEnabled() ? System.nanoTime() : 0L;
         double minEval = Double.POSITIVE_INFINITY;
         int bestMoveAtThisNode = -1;
+        SearchInstrumentation instr = instrumentation();
 
         final boolean inCheckAtNode = isSideInCheck(simulatorEngine, isWhite);
         final Heuristics heuristics = threadHeuristics.get();
@@ -1734,6 +1793,7 @@ public class AI {
                         && !seeWinsMaterial;
                 simulatorEngine.undoLastMove();
                 if (skipQuiet) {
+                    instr.recordLateMovePrune();
                     continue;
                 }
             }
@@ -1769,19 +1829,25 @@ public class AI {
                 double margin = computeStandPatMargin(simulatorEngine.getBitBoard(), depth, nextDepth);
                 if (staticEval - margin >= beta) {
                     simulatorEngine.undoLastMove();
+                    instr.recordFutilityPrune();
                     continue;
                 }
             }
 
             double eval;
+            instr.recordTranspositionLookup();
             TranspositionTableEntry entry = transpositionTable.get(newBoardHash);
             boolean ttExactHit = entry != null
                     && entry.nodeType == NodeType.EXACT
                     && entry.depth >= nextDepth;
 
             if (ttExactHit) {
+                instr.recordTranspositionHit(entry.nodeType, false);
                 eval = entry.score;
             } else {
+                if (entry != null) {
+                    instr.recordTranspositionHit(entry.nodeType, false);
+                }
                 boolean canReduce = !inCheckAtNode
                         && !isTactical
                         && !givesCheck
@@ -1804,6 +1870,7 @@ public class AI {
                 if (canReduce) {
                     reduction = lmrReduction(nextDepth, index, historyScore);
                     if (reduction <= 0) canReduce = false;
+                    else instr.recordLateMoveReduction(reduction);
                 }
 
                 if (canReduce) {
@@ -1858,6 +1925,7 @@ public class AI {
                 updateKillerMoves(depth, move);
                 incrementHistory(move, depth);
                 heuristics.recordCounterMove(prevMove, move);
+                instr.recordBetaCutoff();
                 break;
             }
         }
@@ -2098,10 +2166,13 @@ public class AI {
 
         // If side to move is in check, search all legal evasions (not only captures)
         boolean inCheck = isSideInCheck(simulatorEngine, isWhitesTurn);
+        SearchInstrumentation instr = instrumentation();
+        instr.recordQuiescenceNode(depth);
 
         double standPat = evaluateStaticPosition(simulatorEngine.getGameState(), isWhitesTurn, depth);
         if (!inCheck) {
             if (standPat >= beta) {
+                instr.recordQuiescenceStandPatCut();
                 return beta; // fail-hard beta
             }
             if (alpha < standPat) {
@@ -2111,6 +2182,7 @@ public class AI {
             // Simple delta/futility-like guard: if even a big swing cannot beat alpha, cut
             final int BIG_DELTA = 1000; // ~queen
             if (standPat + BIG_DELTA < alpha) {
+                instr.recordQuiescenceDeltaPrune();
                 return alpha;
             }
         }
@@ -2135,10 +2207,14 @@ public class AI {
                     simulatorEngine.performMove(m);
                     boolean givesCheck = isSideInCheck(simulatorEngine, !isWhitesTurn);
                     simulatorEngine.undoLastMove();
-                    if (!givesCheck) continue;
+                    if (!givesCheck) {
+                        instr.recordQuiescenceSeePrune();
+                        continue;
+                    }
                 }
             }
             simulatorEngine.performMove(m);
+            instr.recordQuiescenceCaptureSearched();
             // Propagate timeout BEFORE negation
             double child = quiescenceSearch(simulatorEngine, !isWhitesTurn, -beta, -alpha, deadline, depth + 1);
             simulatorEngine.undoLastMove();
@@ -2158,6 +2234,7 @@ public class AI {
     }
 
     private double evaluateStaticPosition(GameState gameState, boolean isWhitesTurn, int depthOrPly) {
+        instrumentation().recordStaticEvalCall();
 
         if (gameState.isInStateCheckMate()) {
             return -(CHECKMATE - depthOrPly);

--- a/src/main/java/julius/game/chessengine/ai/SearchDiagnostics.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchDiagnostics.java
@@ -66,6 +66,7 @@ public record SearchDiagnostics(
             0L,
             0L,
             0L,
+            0L,
             0L
     );
 

--- a/src/main/java/julius/game/chessengine/ai/SearchDiagnostics.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchDiagnostics.java
@@ -1,0 +1,79 @@
+package julius.game.chessengine.ai;
+
+import java.util.Locale;
+
+/**
+ * Immutable snapshot of search instrumentation captured after a completed search task.
+ */
+public record SearchDiagnostics(
+        int bestDepth,
+        double bestScore,
+        int deepestPlyVisited,
+        int deepestQuiescencePly,
+        int rootMovesGenerated,
+        int rootMovesExplored,
+        long rootBetaCutoffs,
+        long iterationsCompleted,
+        long aspirationFailHighs,
+        long aspirationFailLows,
+        long aspirationResets,
+        long transpositionLookups,
+        long transpositionHits,
+        long transpositionExactHits,
+        long transpositionCutoffs,
+        long nullMoveTries,
+        long nullMovePrunes,
+        long nullMoveVerifications,
+        long nullMoveVerificationFails,
+        long lateMoveReductions,
+        long lateMoveReductionSum,
+        long lateMovePrunes,
+        long futilityPrunes,
+        long betaCutoffs,
+        long staticEvalCalls,
+        long quiescenceNodes,
+        long quiescenceStandPatCuts,
+        long quiescenceDeltaPrunes,
+        long quiescenceSeePrunes,
+        long quiescenceCaptures
+) {
+    public static final SearchDiagnostics EMPTY = new SearchDiagnostics(
+            0,
+            Double.NaN,
+            0,
+            0,
+            0,
+            0,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L
+    );
+
+    public String formatAverageLmrReduction() {
+        if (lateMoveReductions <= 0L) {
+            return "0.0";
+        }
+        double avg = (double) lateMoveReductionSum / (double) lateMoveReductions;
+        return String.format(Locale.US, "%.2f", avg);
+    }
+}

--- a/src/main/java/julius/game/chessengine/ai/SearchInstrumentation.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchInstrumentation.java
@@ -1,0 +1,239 @@
+package julius.game.chessengine.ai;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Mutable collector for search heuristics metrics. Instances are attached to a {@link SearchTask}
+ * and accumulate counts across all worker threads involved in the search. Once the search is
+ * finished the values are frozen into a {@link SearchDiagnostics} snapshot.
+ */
+final class SearchInstrumentation {
+
+    private static final SearchInstrumentation DISABLED = new SearchInstrumentation(false);
+
+    static SearchInstrumentation disabled() {
+        return DISABLED;
+    }
+
+    static SearchInstrumentation enabled() {
+        return new SearchInstrumentation(true);
+    }
+
+    private final boolean enabled;
+
+    private final AtomicInteger bestDepth = new AtomicInteger();
+    private final AtomicInteger deepestPlyVisited = new AtomicInteger();
+    private final AtomicInteger deepestQuiescencePly = new AtomicInteger();
+
+    private final AtomicInteger rootMovesGenerated = new AtomicInteger();
+    private final AtomicInteger rootMovesExplored = new AtomicInteger();
+    private final LongAdder rootBetaCutoffs = new LongAdder();
+    private final LongAdder iterationsCompleted = new LongAdder();
+
+    private final LongAdder aspirationFailHighs = new LongAdder();
+    private final LongAdder aspirationFailLows = new LongAdder();
+    private final LongAdder aspirationResets = new LongAdder();
+
+    private final LongAdder transpositionLookups = new LongAdder();
+    private final LongAdder transpositionHits = new LongAdder();
+    private final LongAdder transpositionExactHits = new LongAdder();
+    private final LongAdder transpositionCutoffs = new LongAdder();
+
+    private final LongAdder nullMoveTries = new LongAdder();
+    private final LongAdder nullMovePrunes = new LongAdder();
+    private final LongAdder nullMoveVerifications = new LongAdder();
+    private final LongAdder nullMoveVerificationFails = new LongAdder();
+
+    private final LongAdder lateMoveReductions = new LongAdder();
+    private final LongAdder lateMoveReductionSum = new LongAdder();
+    private final LongAdder lateMovePrunes = new LongAdder();
+    private final LongAdder futilityPrunes = new LongAdder();
+
+    private final LongAdder betaCutoffs = new LongAdder();
+    private final LongAdder staticEvalCalls = new LongAdder();
+
+    private final LongAdder quiescenceNodes = new LongAdder();
+    private final LongAdder quiescenceStandPatCuts = new LongAdder();
+    private final LongAdder quiescenceDeltaPrunes = new LongAdder();
+    private final LongAdder quiescenceSeePrunes = new LongAdder();
+    private final LongAdder quiescenceCaptures = new LongAdder();
+
+    private SearchInstrumentation(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    boolean isEnabled() {
+        return enabled;
+    }
+
+    void recordIterationComplete(int depth) {
+        if (!enabled) return;
+        iterationsCompleted.increment();
+        bestDepth.accumulateAndGet(depth, Math::max);
+    }
+
+    void recordAspirationFailHigh() {
+        if (!enabled) return;
+        aspirationFailHighs.increment();
+    }
+
+    void recordAspirationFailLow() {
+        if (!enabled) return;
+        aspirationFailLows.increment();
+    }
+
+    void recordAspirationReset() {
+        if (!enabled) return;
+        aspirationResets.increment();
+    }
+
+    void recordRootMovesGenerated(int count) {
+        if (!enabled) return;
+        rootMovesGenerated.set(Math.max(0, count));
+    }
+
+    void recordRootMoveExplored() {
+        if (!enabled) return;
+        rootMovesExplored.incrementAndGet();
+    }
+
+    void recordRootBetaCutoff() {
+        if (!enabled) return;
+        rootBetaCutoffs.increment();
+    }
+
+    void recordVisitedPly(int ply) {
+        if (!enabled) return;
+        if (ply < 0) return;
+        deepestPlyVisited.accumulateAndGet(ply, Math::max);
+    }
+
+    void recordQuiescenceNode(int depth) {
+        if (!enabled) return;
+        quiescenceNodes.increment();
+        if (depth >= 0) {
+            deepestQuiescencePly.accumulateAndGet(depth, Math::max);
+        }
+    }
+
+    void recordQuiescenceStandPatCut() {
+        if (!enabled) return;
+        quiescenceStandPatCuts.increment();
+    }
+
+    void recordQuiescenceDeltaPrune() {
+        if (!enabled) return;
+        quiescenceDeltaPrunes.increment();
+    }
+
+    void recordQuiescenceSeePrune() {
+        if (!enabled) return;
+        quiescenceSeePrunes.increment();
+    }
+
+    void recordQuiescenceCaptureSearched() {
+        if (!enabled) return;
+        quiescenceCaptures.increment();
+    }
+
+    void recordTranspositionLookup() {
+        if (!enabled) return;
+        transpositionLookups.increment();
+    }
+
+    void recordTranspositionHit(NodeType type, boolean cutoff) {
+        if (!enabled) return;
+        transpositionHits.increment();
+        if (type == NodeType.EXACT) {
+            transpositionExactHits.increment();
+        }
+        if (cutoff) {
+            transpositionCutoffs.increment();
+        }
+    }
+
+    void recordNullMoveAttempt() {
+        if (!enabled) return;
+        nullMoveTries.increment();
+    }
+
+    void recordNullMovePrune() {
+        if (!enabled) return;
+        nullMovePrunes.increment();
+    }
+
+    void recordNullMoveVerification() {
+        if (!enabled) return;
+        nullMoveVerifications.increment();
+    }
+
+    void recordNullMoveVerificationFail() {
+        if (!enabled) return;
+        nullMoveVerificationFails.increment();
+    }
+
+    void recordLateMoveReduction(int reduction) {
+        if (!enabled || reduction <= 0) return;
+        lateMoveReductions.increment();
+        lateMoveReductionSum.add(reduction);
+    }
+
+    void recordLateMovePrune() {
+        if (!enabled) return;
+        lateMovePrunes.increment();
+    }
+
+    void recordFutilityPrune() {
+        if (!enabled) return;
+        futilityPrunes.increment();
+    }
+
+    void recordBetaCutoff() {
+        if (!enabled) return;
+        betaCutoffs.increment();
+    }
+
+    void recordStaticEvalCall() {
+        if (!enabled) return;
+        staticEvalCalls.increment();
+    }
+
+    SearchDiagnostics snapshot(int depth, double bestScore) {
+        if (!enabled) {
+            return SearchDiagnostics.EMPTY;
+        }
+        return new SearchDiagnostics(
+                Math.max(depth, bestDepth.get()),
+                bestScore,
+                deepestPlyVisited.get(),
+                deepestQuiescencePly.get(),
+                rootMovesGenerated.get(),
+                rootMovesExplored.get(),
+                rootBetaCutoffs.sum(),
+                iterationsCompleted.sum(),
+                aspirationFailHighs.sum(),
+                aspirationFailLows.sum(),
+                aspirationResets.sum(),
+                transpositionLookups.sum(),
+                transpositionHits.sum(),
+                transpositionExactHits.sum(),
+                transpositionCutoffs.sum(),
+                nullMoveTries.sum(),
+                nullMovePrunes.sum(),
+                nullMoveVerifications.sum(),
+                nullMoveVerificationFails.sum(),
+                lateMoveReductions.sum(),
+                lateMoveReductionSum.sum(),
+                lateMovePrunes.sum(),
+                futilityPrunes.sum(),
+                betaCutoffs.sum(),
+                staticEvalCalls.sum(),
+                quiescenceNodes.sum(),
+                quiescenceStandPatCuts.sum(),
+                quiescenceDeltaPrunes.sum(),
+                quiescenceSeePrunes.sum(),
+                quiescenceCaptures.sum()
+        );
+    }
+}

--- a/src/main/java/julius/game/chessengine/ai/SearchTask.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchTask.java
@@ -23,9 +23,19 @@ public final class SearchTask {
     private final AtomicBoolean stop = new AtomicBoolean(false);
     private final AtomicReference<BestMoveDepth> best;
     private final AtomicInteger iterationDepth = new AtomicInteger(0);
+    private final SearchInstrumentation instrumentation;
     private static final double SCORE_EPSILON = 1e-3;
 
     SearchTask(long id, long boardHash, boolean whiteToMove, long deadline, int threadCount) {
+        this(id, boardHash, whiteToMove, deadline, threadCount, SearchInstrumentation.disabled());
+    }
+
+    SearchTask(long id,
+               long boardHash,
+               boolean whiteToMove,
+               long deadline,
+               int threadCount,
+               SearchInstrumentation instrumentation) {
         this.id = id;
         this.boardHash = boardHash;
         this.whiteToMove = whiteToMove;
@@ -33,6 +43,7 @@ public final class SearchTask {
         this.completion = new CountDownLatch(Math.max(1, threadCount));
         double initialScore = whiteToMove ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
         this.best = new AtomicReference<>(new BestMoveDepth(-1, initialScore, 0));
+        this.instrumentation = instrumentation != null ? instrumentation : SearchInstrumentation.disabled();
     }
 
     long getId() { return id; }
@@ -44,6 +55,8 @@ public final class SearchTask {
     void workerDone() { completion.countDown(); }
     void requestStop() { stop.set(true); }
     boolean isStopRequested() { return stop.get(); }
+
+    SearchInstrumentation getInstrumentation() { return instrumentation; }
 
     boolean beginIteration(int depth) {
         while (true) {

--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -372,6 +372,11 @@ public class BestMoveSearchTest {
             sb.append(renderWhyNotExpected(fen, whiteToMove, chosenEval, expectedRef));
         }
 
+        SearchDiagnostics diagnostics = ai.getLastDiagnostics();
+        if (diagnostics != null && diagnostics != SearchDiagnostics.EMPTY) {
+            sb.append(renderSearchDiagnostics(diagnostics));
+        }
+
         sb.append("Total legal moves: ").append(legalMoveCount);
         if (!Double.isNaN(spread)) {
             sb.append(" (evaluation spread: ").append(formatCentipawns(spread)).append(")");
@@ -395,6 +400,50 @@ public class BestMoveSearchTest {
                 .append(System.lineSeparator());
         sb.append("==================================").append(System.lineSeparator());
 
+        return sb.toString();
+    }
+
+    private String renderSearchDiagnostics(SearchDiagnostics diagnostics) {
+        String ls = System.lineSeparator();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Search heuristics summary:").append(ls);
+
+        String bestScore = Double.isNaN(diagnostics.bestScore())
+                ? "n/a"
+                : formatCentipawns(diagnostics.bestScore() * 100.0) + " pawns";
+
+        sb.append(String.format(Locale.US,
+                "  Depth reached: %d plies (selective: %d, qsearch max: %d)%n",
+                diagnostics.bestDepth(), diagnostics.deepestPlyVisited(), diagnostics.deepestQuiescencePly()));
+        sb.append(String.format(Locale.US,
+                "  Best score: %s, iterations: %d%n",
+                bestScore,
+                diagnostics.iterationsCompleted()));
+        sb.append(String.format(Locale.US,
+                "  Root moves: %d generated, %d explored, root β-cutoffs: %d%n",
+                diagnostics.rootMovesGenerated(), diagnostics.rootMovesExplored(), diagnostics.rootBetaCutoffs()));
+        sb.append(String.format(Locale.US,
+                "  Aspiration window restarts: fail-low %d, fail-high %d, full resets %d%n",
+                diagnostics.aspirationFailLows(), diagnostics.aspirationFailHighs(), diagnostics.aspirationResets()));
+        sb.append(String.format(Locale.US,
+                "  TT lookups: %d (hits %d, exact %d, cutoffs %d)%n",
+                diagnostics.transpositionLookups(), diagnostics.transpositionHits(), diagnostics.transpositionExactHits(),
+                diagnostics.transpositionCutoffs()));
+        sb.append(String.format(Locale.US,
+                "  Null-move pruning: tries %d, prunes %d, verifications %d (fails %d)%n",
+                diagnostics.nullMoveTries(), diagnostics.nullMovePrunes(), diagnostics.nullMoveVerifications(),
+                diagnostics.nullMoveVerificationFails()));
+        sb.append(String.format(Locale.US,
+                "  Late move reductions: %d applied (avg %s plies), prunes %d, futility prunes %d%n",
+                diagnostics.lateMoveReductions(), diagnostics.formatAverageLmrReduction(),
+                diagnostics.lateMovePrunes(), diagnostics.futilityPrunes()));
+        sb.append(String.format(Locale.US,
+                "  Interior β-cutoffs: %d, static eval calls: %d%n",
+                diagnostics.betaCutoffs(), diagnostics.staticEvalCalls()));
+        sb.append(String.format(Locale.US,
+                "  Quiescence: nodes %d, stand-pat cuts %d, delta prunes %d, SEE prunes %d, captures %d%n",
+                diagnostics.quiescenceNodes(), diagnostics.quiescenceStandPatCuts(), diagnostics.quiescenceDeltaPrunes(),
+                diagnostics.quiescenceSeePrunes(), diagnostics.quiescenceCaptures()));
         return sb.toString();
     }
 


### PR DESCRIPTION
## Summary
- add SearchDiagnostics and SearchInstrumentation to capture detailed search heuristics metrics
- integrate instrumentation into AI search flow and expose last search diagnostics
- extend BestMoveSearchTest statistics output with heuristic summaries for tuning insights

## Testing
- `./mvnw test` *(fails: Maven wrapper cannot download dependencies in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b2991ad0832aa84fe45c35d5cf67