### PR TITLE
Ensure all root moves evaluated after parallel search

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1054,6 +1054,61 @@ public class AI {
             for (Future<MoveAndScore> f : futures) if (!f.isDone()) f.cancel(true);
         }
 
+        alpha = alphaRef.get();
+        beta = betaRef.get();
+        bestMove = bestMoveRef.get();
+        bestScore = bestScoreRef.get();
+
+        if (!stopRef.get()) {
+            for (int idx = fanout + 1; idx < orderedMoves.size(); idx++) {
+                if (abortRequested(deadline)) {
+                    break;
+                }
+
+                int moveInt = orderedMoves.getMove(idx);
+                instr.recordRootMoveExplored();
+                simulatorEngine.performMove(moveInt);
+
+                double score;
+                if (simulatorEngine.getGameState().isInStateCheckMate()) {
+                    score = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
+                } else if (simulatorEngine.getGameState().isInStateDraw()) {
+                    score = evaluateStaticPosition(simulatorEngine.getGameState(), !isWhitesTurn, depth);
+                    if (isWhitesTurn) {
+                        score = -score;
+                    }
+                } else {
+                    score = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, moveInt, 1, 0);
+                    if (score == EXIT_FLAG || abortRequested(deadline)) {
+                        simulatorEngine.undoLastMove();
+                        break;
+                    }
+                }
+                simulatorEngine.undoLastMove();
+
+                if (isBetterScore(isWhitesTurn, score, bestScore)) {
+                    bestScore = score;
+                    bestMove = moveInt;
+                    bestScoreRef.set(bestScore);
+                    bestMoveRef.set(bestMove);
+                }
+
+                if (isWhitesTurn) {
+                    alpha = Math.max(alpha, score);
+                    alphaRef.set(alpha);
+                } else {
+                    beta = Math.min(beta, score);
+                    betaRef.set(beta);
+                }
+
+                if (alpha >= beta) {
+                    instr.recordRootBetaCutoff();
+                    stopRef.set(true);
+                    break;
+                }
+            }
+        }
+
         return bestMove != -1 ? new MoveAndScore(bestMove, bestScore) : null;
     }
 

--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -2,6 +2,7 @@ package julius.game.chessengine.uci;
 
 import julius.game.chessengine.ai.AI;
 import julius.game.chessengine.ai.MoveAndScore;
+import julius.game.chessengine.ai.SearchDiagnostics;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.MoveList;
 import julius.game.chessengine.engine.Engine;
@@ -398,6 +399,18 @@ public class UciHandler {
             builder.append(" nodes ").append(nodes);
         }
         output.accept(builder.toString());
+
+        SearchDiagnostics diagnostics = ai.getLastDiagnostics();
+        if (diagnostics != null) {
+            int generated = diagnostics.rootMovesGenerated();
+            int explored = diagnostics.rootMovesExplored();
+            if (generated > 0 || explored > 0) {
+                int difference = generated - explored;
+                output.accept("info string rootmoves generated " + generated
+                        + " explored " + explored
+                        + " diff " + difference);
+            }
+        }
 
         GameState gameState = ai.getMainEngine().getGameState();
         if (gameState != null && gameState.getState() != null) {


### PR DESCRIPTION
## Summary
- ensure the parallel root search finishes by evaluating any remaining root moves sequentially with alpha-beta to keep alpha/beta bounds up to date
- add UCI info logging to display root move generation and exploration counts for verification

## Testing
- ./mvnw -q test *(fails: network unreachable while downloading Maven wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ba96469c832abfe252b1143385cc