### PR TITLE
Handle search thread reconfiguration

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -36,7 +36,6 @@ public class AI {
      * can be adjusted at runtime via the UCI "Threads" option.
      */
     @Getter
-    @Setter
     private int searchThreads = Integer.getInteger("chessengine.searchThreads", 1);
 
     // number of Lazy SMP workers (≥1)
@@ -89,7 +88,7 @@ public class AI {
     /**
      * Thread pool for root-split parallel search (created only if searchThreads > 1).
      */
-    private final ExecutorService searchPool;
+    private ExecutorService searchPool;
 
     /**
      * Limit how many root moves we fan out in parallel to avoid oversubscription.
@@ -227,15 +226,7 @@ public class AI {
         this.globalHeuristics = new Heuristics(maxDepth);
         this.threadHeuristics = ThreadLocal.withInitial(() -> new Heuristics(maxDepth));
 
-        rebuildTranspositionTables();
-
-        this.searchPool = searchThreads > 1
-                ? Executors.newFixedThreadPool(searchThreads, r -> {
-            Thread t = new Thread(r, "AI-Search-" + System.identityHashCode(r));
-            t.setDaemon(true);
-            return t;
-        })
-                : null;
+        rebuildSearchPool(this.searchThreads);
 
         this.mainEngine.setOnPositionChanged(h -> updateBoardStateHash());
     }
@@ -533,6 +524,48 @@ public class AI {
             heuristics.mergeInto(globalHeuristics);
         }
         heuristics.resetUpdates();
+    }
+
+    private synchronized void rebuildSearchPool(int previousSearchThreads) {
+        ExecutorService oldPool = this.searchPool;
+        if (oldPool != null) {
+            oldPool.shutdownNow();
+        }
+
+        if (searchThreads > 1) {
+            this.searchPool = Executors.newFixedThreadPool(searchThreads, r -> {
+                Thread t = new Thread(r, "AI-Search-" + System.identityHashCode(r));
+                t.setDaemon(true);
+                return t;
+            });
+        } else {
+            this.searchPool = null;
+        }
+
+        boolean previousConcurrent = Math.max(previousSearchThreads, lazySmpThreads) > 1;
+        boolean newConcurrent = Math.max(searchThreads, lazySmpThreads) > 1;
+        if (transpositionTable == null || previousConcurrent != newConcurrent) {
+            rebuildTranspositionTables();
+        }
+    }
+
+    public void setSearchThreads(int requestedThreads) {
+        int clamped = Math.max(1, requestedThreads);
+        int previous;
+        synchronized (this) {
+            if (clamped == this.searchThreads) {
+                return;
+            }
+        }
+
+        stopCalculation();
+
+        synchronized (this) {
+            previous = this.searchThreads;
+            this.searchThreads = clamped;
+        }
+        rebuildSearchPool(previous);
+        log.info("Search thread count updated to {}", clamped);
     }
 
     private Heuristics prepareHelperHeuristics(SearchTask task, int depth) {

--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -93,7 +93,12 @@ public class UciHandler {
 
     private void registerOptions() {
         options.put("Threads", new UciOption("Threads", "spin", "1", 1, 128,
-                v -> ai.setSearchThreads(Integer.parseInt(v))));
+                v -> {
+                    int requested = Integer.parseInt(v);
+                    ai.setSearchThreads(requested);
+                    output.accept("info string Threads requested " + requested
+                            + " active " + ai.getSearchThreads());
+                }));
         options.put("Hash", new UciOption("Hash", "spin", "16",
                 AI.MIN_HASH_SIZE_MB, AI.MAX_HASH_SIZE_MB,
                 v -> ai.setHashSizeMb(Integer.parseInt(v))));


### PR DESCRIPTION
## Summary
- add a synchronized rebuildSearchPool helper that reinitialises the executor and concurrency-sensitive tables when the thread count changes
- implement a custom setSearchThreads that clamps inputs, stops any ongoing search, rebuilds the infrastructure, and logs the new value
- echo the requested and active thread counts via the Threads UCI option to make it easy to verify the setting

## Testing
- `./mvnw -q -DskipTests package` *(fails: Maven wrapper cannot download dependencies because outbound network access is blocked in the execution environment)*
- `mvn -q -DskipTests package` *(fails: Maven cannot resolve the Spring Boot parent POM without network access in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c11b860c832aba02bfc10e030128