### PR TITLE
Reduce rook file bonuses

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -33,8 +33,8 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     public static final int BACKWARD_PAWN_PENALTY = -12;
     public static final int OWN_KING_BLOCKS_PASSED_PAWN_PENALTY = -150;
     public static final int PASSED_PAWN_FREE_PATH_BONUS_PER_RANK = 12;
-    public static final int ROOK_HALF_OPEN_FILE_BONUS = 15;
-    public static final int ROOK_OPEN_FILE_BONUS = 25;
+    public static final int ROOK_HALF_OPEN_FILE_BONUS = 8;
+    public static final int ROOK_OPEN_FILE_BONUS = 12;
 
     private static final int WHITE = 0;
     private static final int BLACK = 1;


### PR DESCRIPTION
## Summary
- lower the rook half-open and open file bonuses to temper evaluation swings

## Testing
- `mvn -pl . -q -Dtest=BestMoveSearchTest test` *(fails: unable to resolve parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d254edbb48832aada577336218f6e8