### PR TITLE
Add context-only synchronization for incremental evaluations

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
@@ -66,6 +66,12 @@ public final class EvaluationPipeline {
         markAllDirty();
     }
 
+    public void setContextWithoutInvalidation(EvaluationContext context) {
+        ensureInitialized();
+        this.context = Objects.requireNonNull(context, "context");
+        aggregateDirty = true;
+    }
+
     public void applyMove(MoveContext moveContext) {
         ensureInitialized();
         for (ModuleState state : modules) {

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -105,7 +105,7 @@ public class Score {
             return;
         }
 
-        synchronizePipeline(updated);
+        synchronizePipeline(updated, false);
         MoveContext moveContext = new MoveContext(move, previous, updated);
         evaluationPipeline.applyMove(moveContext);
     }
@@ -121,16 +121,22 @@ public class Score {
             return;
         }
 
-        synchronizePipeline(updated);
+        synchronizePipeline(updated, false);
         MoveContext moveContext = new MoveContext(move, previous, updated);
         evaluationPipeline.undoMove(moveContext);
     }
 
     private void synchronizePipeline(EvaluationContext context) {
+        synchronizePipeline(context, true);
+    }
+
+    private void synchronizePipeline(EvaluationContext context, boolean invalidateModules) {
         if (!evaluationPipeline.isInitialized()) {
             evaluationPipeline.initialize(context);
-        } else {
+        } else if (invalidateModules) {
             evaluationPipeline.updateContext(context);
+        } else {
+            evaluationPipeline.setContextWithoutInvalidation(context);
         }
     }
 

--- a/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
@@ -214,6 +214,40 @@ public class ScoreEvaluationTest {
         assertEquals(initialEndgame, score.getEndgameScore());
     }
 
+    @Test
+    void incrementalSearchPathRefreshesBlendedScore() {
+        BitBoard board = FEN.translateFENtoBitBoard("8/8/8/3p4/3P4/8/8/8 w - - 0 1");
+        Score score = Score.initializeScore(board);
+
+        int initialBlended = score.getBlendedScore();
+
+        int from = MoveHelper.convertStringToIndex("d4");
+        int to = MoveHelper.convertStringToIndex("d5");
+        int move = MoveHelper.createMoveInt(from, to, PieceType.PAWN, true, true,
+                false, false, null, PieceType.PAWN, false, false, board.getLastMoveDoubleStepPawnIndex());
+
+        board.performMove(move);
+        score.applyMove(board, move, null);
+
+        int afterCapture = score.getBlendedScore();
+        assertTrue(afterCapture > initialBlended);
+
+        board.undoMove(move);
+        score.undoMove(board, move, null);
+
+        assertEquals(initialBlended, score.getBlendedScore());
+
+        board.performMove(move);
+        score.applyMove(board, move, null);
+
+        assertEquals(afterCapture, score.getBlendedScore());
+
+        board.undoMove(move);
+        score.undoMove(board, move, null);
+
+        assertEquals(initialBlended, score.getBlendedScore());
+    }
+
     private static int blendedModuleScore(EvaluationModule module, BitBoard board) {
         EvaluationPipeline pipeline = new EvaluationPipeline(java.util.List.of(module));
         pipeline.initialize(EvaluationContext.from(board, null));


### PR DESCRIPTION
## Summary
- add an EvaluationPipeline API that updates the context without invalidating module caches while still marking aggregate totals dirty
- call the new API from incremental move and undo synchronization while preserving the existing full refresh behavior
- exercise a representative search path in ScoreEvaluationTest to ensure blended scores refresh correctly

## Testing
- mvn test *(fails: unable to resolve remote parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d2644a2454832a86ae1d584f37b7e7