### PR TITLE
Reduce attack map maintenance overhead

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -28,6 +28,9 @@ import static julius.game.chessengine.helper.KnightHelper.knightMoveTable;
 public class BitBoard {
 
     private static final PieceType[] PROMOTION_PIECES = {PieceType.QUEEN, PieceType.ROOK, PieceType.BISHOP, PieceType.KNIGHT};
+    private static final int[] SLIDER_FILE_DELTAS = {0, 0, 1, -1, 1, -1, 1, -1};
+    private static final int[] SLIDER_RANK_DELTAS = {1, -1, 0, 0, 1, 1, -1, -1};
+    private static final boolean[] SLIDER_DIRECTION_DIAGONAL = {false, false, false, false, true, true, true, true};
 
     BishopHelper bishopHelper = BishopHelper.getInstance();
     RookHelper rookHelper = RookHelper.getInstance();
@@ -59,7 +62,11 @@ public class BitBoard {
     private long blackAttackMap = 0L;
     private boolean whiteAttackDirty = true;
     private boolean blackAttackDirty = true;
+    private final int[] whiteAttackCounts = new int[64];
+    private final int[] blackAttackCounts = new int[64];
     private PieceType[] pieceBoard = new PieceType[64];
+    private static final int SLIDER_BUFFER_INITIAL_CAPACITY = 16;
+    private final ThreadLocal<SliderBuffer> sliderBufferHolder = ThreadLocal.withInitial(SliderBuffer::new);
 
     // Reusable buffer for move generation to avoid frequent allocations.
     private final MoveList moveGenerationBuffer = new MoveList();
@@ -214,6 +221,8 @@ public class BitBoard {
         this.blackAttackMap = other.blackAttackMap;
         this.whiteAttackDirty = other.whiteAttackDirty;
         this.blackAttackDirty = other.blackAttackDirty;
+        System.arraycopy(other.whiteAttackCounts, 0, this.whiteAttackCounts, 0, this.whiteAttackCounts.length);
+        System.arraycopy(other.blackAttackCounts, 0, this.blackAttackCounts, 0, this.blackAttackCounts.length);
         this.zKey = other.zKey;
         this.pieceBoard = Arrays.copyOf(other.pieceBoard, other.pieceBoard.length);
         this.halfmoveClock = other.halfmoveClock;
@@ -331,6 +340,8 @@ public class BitBoard {
 
         whiteAttackDirty = true;
         blackAttackDirty = true;
+        Arrays.fill(whiteAttackCounts, 0);
+        Arrays.fill(blackAttackCounts, 0);
     }
 
     /** Bishop-ray attacks from 'sq' with an explicit occupancy. */
@@ -881,13 +892,211 @@ public class BitBoard {
     }
 
     private void recomputeWhiteAttackMap() {
-        whiteAttackMap = generateAttackBitboard(true);
+        whiteAttackMap = 0L;
+        Arrays.fill(whiteAttackCounts, 0);
+        rebuildAttackMap(true);
         whiteAttackDirty = false;
     }
 
     private void recomputeBlackAttackMap() {
-        blackAttackMap = generateAttackBitboard(false);
+        blackAttackMap = 0L;
+        Arrays.fill(blackAttackCounts, 0);
+        rebuildAttackMap(false);
         blackAttackDirty = false;
+    }
+
+    private void rebuildAttackMap(boolean colorWhite) {
+        long pawns = colorWhite ? whitePawns : blackPawns;
+        while (pawns != 0) {
+            int index = Long.numberOfTrailingZeros(pawns);
+            applyAttackDelta(colorWhite, computePawnAttacks(index, colorWhite), 1);
+            pawns &= pawns - 1;
+        }
+
+        long knights = colorWhite ? whiteKnights : blackKnights;
+        while (knights != 0) {
+            int index = Long.numberOfTrailingZeros(knights);
+            applyAttackDelta(colorWhite, knightAttackBitmask(index), 1);
+            knights &= knights - 1;
+        }
+
+        long bishops = colorWhite ? whiteBishops : blackBishops;
+        while (bishops != 0) {
+            int index = Long.numberOfTrailingZeros(bishops);
+            applyAttackDelta(colorWhite, bishopAttackBitmask(index), 1);
+            bishops &= bishops - 1;
+        }
+
+        long rooks = colorWhite ? whiteRooks : blackRooks;
+        while (rooks != 0) {
+            int index = Long.numberOfTrailingZeros(rooks);
+            applyAttackDelta(colorWhite, rookAttackBitmask(index), 1);
+            rooks &= rooks - 1;
+        }
+
+        long queens = colorWhite ? whiteQueens : blackQueens;
+        while (queens != 0) {
+            int index = Long.numberOfTrailingZeros(queens);
+            applyAttackDelta(colorWhite, queenAttackBitmask(index), 1);
+            queens &= queens - 1;
+        }
+
+        long king = colorWhite ? whiteKing : blackKing;
+        if (king != 0) {
+            int index = Long.numberOfTrailingZeros(king);
+            applyAttackDelta(colorWhite, KING_ATTACKS[index], 1);
+        }
+    }
+
+    private long computeAttacksForPiece(PieceType pieceType, int square, boolean colorWhite) {
+        if (pieceType == null) {
+            return 0L;
+        }
+        return switch (pieceType) {
+            case PAWN -> computePawnAttacks(square, colorWhite);
+            case KNIGHT -> knightAttackBitmask(square);
+            case BISHOP -> bishopAttackBitmask(square);
+            case ROOK -> rookAttackBitmask(square);
+            case QUEEN -> queenAttackBitmask(square);
+            case KING -> KING_ATTACKS[square];
+        };
+    }
+
+    private long computePawnAttacks(int index, boolean colorWhite) {
+        long mask = 1L << index;
+        if (colorWhite) {
+            long attacks = 0L;
+            if ((mask & FileMasks[0]) == 0) {
+                attacks |= mask << 7;
+            }
+            if ((mask & FileMasks[7]) == 0) {
+                attacks |= mask << 9;
+            }
+            return attacks;
+        } else {
+            long attacks = 0L;
+            if ((mask & FileMasks[7]) == 0) {
+                attacks |= mask >>> 7;
+            }
+            if ((mask & FileMasks[0]) == 0) {
+                attacks |= mask >>> 9;
+            }
+            return attacks;
+        }
+    }
+
+    private void applyAttackDelta(boolean colorWhite, long attackMask, int delta) {
+        if (attackMask == 0L || delta == 0) {
+            return;
+        }
+
+        int[] counts = colorWhite ? whiteAttackCounts : blackAttackCounts;
+        long map = colorWhite ? whiteAttackMap : blackAttackMap;
+
+        long bits = attackMask;
+        while (bits != 0) {
+            int index = Long.numberOfTrailingZeros(bits);
+            int newValue = counts[index] += delta;
+            assert newValue >= 0 : "Negative attack count detected at square " + index;
+            long sqMask = 1L << index;
+            if (newValue > 0) {
+                map |= sqMask;
+            } else {
+                map &= ~sqMask;
+            }
+            bits &= bits - 1;
+        }
+
+        if (colorWhite) {
+            whiteAttackMap = map;
+        } else {
+            blackAttackMap = map;
+        }
+    }
+
+    private int prepareSliderUpdates(long impactedMask, SliderBuffer buffer) {
+        int count = 0;
+        long mask = impactedMask;
+        while (mask != 0) {
+            int square = Long.numberOfTrailingZeros(mask);
+            PieceType type = pieceBoard[square];
+            if (type != null && isSliderPiece(type)) {
+                buffer.ensureCapacity(count + 1);
+                boolean whitePiece = (whitePieces & (1L << square)) != 0;
+                applyAttackDelta(whitePiece, computeAttacksForPiece(type, square, whitePiece), -1);
+                buffer.squares[count] = square;
+                buffer.whitePieces[count] = whitePiece;
+                buffer.types[count] = type;
+                count++;
+            }
+            mask &= mask - 1;
+        }
+        return count;
+    }
+
+    private long collectSliderImpacts(int square) {
+        if (square < 0 || square >= 64) {
+            return 0L;
+        }
+        long impacted = 0L;
+        for (int dir = 0; dir < SLIDER_FILE_DELTAS.length; dir++) {
+            int current = square;
+            while (true) {
+                current = stepInDirection(current, SLIDER_FILE_DELTAS[dir], SLIDER_RANK_DELTAS[dir]);
+                if (current == -1) {
+                    break;
+                }
+                PieceType type = pieceBoard[current];
+                if (type != null) {
+                    if (isSliderInDirection(type, SLIDER_DIRECTION_DIAGONAL[dir])) {
+                        impacted |= 1L << current;
+                    }
+                    break;
+                }
+            }
+        }
+        return impacted;
+    }
+
+    private boolean isSliderPiece(PieceType type) {
+        return type == PieceType.BISHOP || type == PieceType.ROOK || type == PieceType.QUEEN;
+    }
+
+    private boolean isSliderInDirection(PieceType type, boolean diagonal) {
+        if (type == PieceType.QUEEN) {
+            return true;
+        }
+        if (diagonal) {
+            return type == PieceType.BISHOP;
+        }
+        return type == PieceType.ROOK;
+    }
+
+    private int stepInDirection(int square, int fileDelta, int rankDelta) {
+        int file = square & 7;
+        int rank = square >>> 3;
+        int newFile = file + fileDelta;
+        int newRank = rank + rankDelta;
+        if (newFile < 0 || newFile > 7 || newRank < 0 || newRank > 7) {
+            return -1;
+        }
+        return (newRank << 3) + newFile;
+    }
+
+    private static final class SliderBuffer {
+        private int[] squares = new int[SLIDER_BUFFER_INITIAL_CAPACITY];
+        private boolean[] whitePieces = new boolean[SLIDER_BUFFER_INITIAL_CAPACITY];
+        private PieceType[] types = new PieceType[SLIDER_BUFFER_INITIAL_CAPACITY];
+
+        private void ensureCapacity(int required) {
+            if (squares.length >= required) {
+                return;
+            }
+            int newCapacity = Math.max(required, squares.length << 1);
+            squares = Arrays.copyOf(squares, newCapacity);
+            whitePieces = Arrays.copyOf(whitePieces, newCapacity);
+            types = Arrays.copyOf(types, newCapacity);
+        }
     }
 
     private void generatePawnMoves(boolean whitesTurn, MoveList moves) {
@@ -1313,61 +1522,88 @@ public class BitBoard {
 
         PieceType movingPiece = pieceTypeFromBits(pieceBits);
         Color moverColor = isWhite ? Color.WHITE : Color.BLACK;
+        int captureIndex = -1;
+        PieceType capturedPieceType = null;
+        if (isCapture) {
+            captureIndex = isEnPassant ? (isWhite ? toIndex - 8 : toIndex + 8) : toIndex;
+            capturedPieceType = pieceBoard[captureIndex];
+            if (capturedPieceType == null) {
+                capturedPieceType = deducePieceTypeFromBitboards(captureIndex, !isWhite);
+            }
+        }
+
+        boolean requiresFullRebuild = isCastling;
+        SliderBuffer sliderBuffer = null;
+        int sliderCount = 0;
+
+        if (!requiresFullRebuild) {
+            applyAttackDelta(isWhite, computeAttacksForPiece(movingPiece, fromIndex, isWhite), -1);
+
+            if (isCapture && capturedPieceType != null) {
+                applyAttackDelta(!isWhite, computeAttacksForPiece(capturedPieceType, captureIndex, !isWhite), -1);
+            }
+
+            long impactedMask = collectSliderImpacts(fromIndex) | collectSliderImpacts(toIndex);
+            if (isEnPassant) {
+                int epCaptureIndex = isWhite ? toIndex - 8 : toIndex + 8;
+                impactedMask |= collectSliderImpacts(epCaptureIndex);
+            }
+            if (impactedMask != 0) {
+                sliderBuffer = sliderBufferHolder.get();
+                sliderCount = prepareSliderUpdates(impactedMask, sliderBuffer);
+            }
+        }
+
         xorPiece(moverColor, movingPiece, fromIndex);
         PieceType placedPiece = promoBits == 0 ? movingPiece : pieceTypeFromBits(promoBits);
         xorPiece(moverColor, placedPiece, toIndex);
 
         // ---- 1) Captures (fast, no aggregates yet)
         if (isCapture) {
-            int capIndex = isEnPassant ? (isWhite ? toIndex - 8 : toIndex + 8) : toIndex;
-            PieceType capType = pieceBoard[capIndex];
-            if (capType == null) {
-                capType = deducePieceTypeFromBitboards(capIndex, !isWhite);
-                if (capType == null) {
-                    log.warn("Capture from {} to {} expected a piece but none was found", fromIndex, capIndex);
-                }
+            if (capturedPieceType == null) {
+                log.warn("Capture from {} to {} expected a piece but none was found", fromIndex, captureIndex);
             }
-            int capturedBits = (capType != null) ? MoveHelper.pieceTypeToInt(capType) : 0;
+            int capturedBits = (capturedPieceType != null) ? MoveHelper.pieceTypeToInt(capturedPieceType) : 0;
             capturedPieceHistory.push(capturedBits);
             Color capColor = isWhite ? Color.BLACK : Color.WHITE;
-            if (capType != null) {
-                xorPiece(capColor, capType, capIndex);
+            if (capturedPieceType != null && captureIndex != -1) {
+                xorPiece(capColor, capturedPieceType, captureIndex);
             }
-            long capMask = 1L << capIndex;
+            long capMask = 1L << captureIndex;
 
             if (isWhite) {
                 if ((blackPawns & capMask) != 0) {
                     blackPawns &= ~capMask;
-                    pieceBoard[capIndex] = null;
+                    pieceBoard[captureIndex] = null;
                 } else if ((blackKnights & capMask) != 0) {
                     blackKnights &= ~capMask;
-                    pieceBoard[capIndex] = null;
+                    pieceBoard[captureIndex] = null;
                 } else if ((blackBishops & capMask) != 0) {
                     blackBishops &= ~capMask;
-                    pieceBoard[capIndex] = null;
+                    pieceBoard[captureIndex] = null;
                 } else if ((blackRooks & capMask) != 0) {
                     blackRooks &= ~capMask;
-                    pieceBoard[capIndex] = null;
+                    pieceBoard[captureIndex] = null;
                 } else if ((blackQueens & capMask) != 0) {
                     blackQueens &= ~capMask;
-                    pieceBoard[capIndex] = null;
+                    pieceBoard[captureIndex] = null;
                 } else if ((blackKing & capMask) != 0) throw new IllegalStateException("Cannot capture the king");
             } else {
                 if ((whitePawns & capMask) != 0) {
                     whitePawns &= ~capMask;
-                    pieceBoard[capIndex] = null;
+                    pieceBoard[captureIndex] = null;
                 } else if ((whiteKnights & capMask) != 0) {
                     whiteKnights &= ~capMask;
-                    pieceBoard[capIndex] = null;
+                    pieceBoard[captureIndex] = null;
                 } else if ((whiteBishops & capMask) != 0) {
                     whiteBishops &= ~capMask;
-                    pieceBoard[capIndex] = null;
+                    pieceBoard[captureIndex] = null;
                 } else if ((whiteRooks & capMask) != 0) {
                     whiteRooks &= ~capMask;
-                    pieceBoard[capIndex] = null;
+                    pieceBoard[captureIndex] = null;
                 } else if ((whiteQueens & capMask) != 0) {
                     whiteQueens &= ~capMask;
-                    pieceBoard[capIndex] = null;
+                    pieceBoard[captureIndex] = null;
                 } else if ((whiteKing & capMask) != 0) throw new IllegalStateException("Cannot capture the king");
             }
         }
@@ -1521,9 +1757,24 @@ public class BitBoard {
         // ---- 5) Finalize once
         updateAggregatedBitboards();
 
-        // Any move changes slider lines, so both sides’ maps become stale.
-        whiteAttackDirty = true;
-        blackAttackDirty = true;
+        if (requiresFullRebuild) {
+            whiteAttackDirty = true;
+            blackAttackDirty = true;
+        } else {
+            PieceType finalPiece = pieceBoard[toIndex];
+            applyAttackDelta(isWhite, computeAttacksForPiece(finalPiece, toIndex, isWhite), 1);
+            if (sliderBuffer != null) {
+                for (int i = 0; i < sliderCount; i++) {
+                    int square = sliderBuffer.squares[i];
+                    PieceType type = sliderBuffer.types[i];
+                    if (pieceBoard[square] == type) {
+                        boolean whitePiece = sliderBuffer.whitePieces[i];
+                        applyAttackDelta(whitePiece,
+                                computeAttacksForPiece(type, square, whitePiece), 1);
+                    }
+                }
+            }
+        }
 
         if (isCapture || pieceBits == 1) {
             halfmoveClock = 0;
@@ -1737,16 +1988,33 @@ public class BitBoard {
         PieceType movingPiece = pieceTypeFromBits(pieceTypeBits);
         Color moverColor = isWhite ? Color.WHITE : Color.BLACK;
         PieceType toPiece = promotionPieceTypeBits == 0 ? movingPiece : pieceTypeFromBits(promotionPieceTypeBits);
+        PieceType capturedPieceType = pieceTypeFromBits(capturedPieceTypeBits);
+        int captureIndex = isCapture ? (isEnPassantMove ? (isWhite ? toIndex - 8 : toIndex + 8) : toIndex) : -1;
+
+        boolean requiresFullRebuild = isCastlingMove;
+        SliderBuffer sliderBuffer = null;
+        int sliderCount = 0;
+
+        if (!requiresFullRebuild) {
+            applyAttackDelta(isWhite, computeAttacksForPiece(toPiece, toIndex, isWhite), -1);
+
+            long impactedMask = collectSliderImpacts(fromIndex) | collectSliderImpacts(toIndex);
+            if (isEnPassantMove) {
+                int epCaptureIndex = isWhite ? toIndex - 8 : toIndex + 8;
+                impactedMask |= collectSliderImpacts(epCaptureIndex);
+            }
+            if (impactedMask != 0) {
+                sliderBuffer = sliderBufferHolder.get();
+                sliderCount = prepareSliderUpdates(impactedMask, sliderBuffer);
+            }
+        }
+
         xorPiece(moverColor, toPiece, toIndex);
         xorPiece(moverColor, movingPiece, fromIndex);
 
-        if (isCapture) {
-            int capIndex = isEnPassantMove ? (isWhite ? toIndex - 8 : toIndex + 8) : toIndex;
-            PieceType capType = pieceTypeFromBits(capturedPieceTypeBits);
-            if (capType != null) {
-                Color capColor = isWhite ? Color.BLACK : Color.WHITE;
-                xorPiece(capColor, capType, capIndex);
-            }
+        if (isCapture && capturedPieceType != null && captureIndex != -1) {
+            Color capColor = isWhite ? Color.BLACK : Color.WHITE;
+            xorPiece(capColor, capturedPieceType, captureIndex);
         }
 
         if (isCastlingMove) {
@@ -1793,10 +2061,35 @@ public class BitBoard {
         if (oldBK != newBK) xorCastlingRight(2);
         if (oldBQ != newBQ) xorCastlingRight(3);
 
-        // 8) finalize aggregates once; mark attacks dirty (lazy recompute)
+        // 8) finalize aggregates once; update incremental attack state or mark dirty
         updateAggregatedBitboards();
-        whiteAttackDirty = true;
-        blackAttackDirty = true;
+        if (requiresFullRebuild) {
+            whiteAttackDirty = true;
+            blackAttackDirty = true;
+        } else {
+            PieceType restoredPiece = pieceBoard[fromIndex];
+            applyAttackDelta(isWhite, computeAttacksForPiece(restoredPiece, fromIndex, isWhite), 1);
+
+            if (isCapture && capturedPieceType != null && captureIndex != -1) {
+                PieceType restoredCaptured = pieceBoard[captureIndex];
+                if (restoredCaptured != null) {
+                    applyAttackDelta(!isWhite,
+                            computeAttacksForPiece(restoredCaptured, captureIndex, !isWhite), 1);
+                }
+            }
+
+            if (sliderBuffer != null) {
+                for (int i = 0; i < sliderCount; i++) {
+                    int square = sliderBuffer.squares[i];
+                    PieceType type = sliderBuffer.types[i];
+                    if (pieceBoard[square] == type) {
+                        boolean whitePiece = sliderBuffer.whitePieces[i];
+                        applyAttackDelta(whitePiece,
+                                computeAttacksForPiece(type, square, whitePiece), 1);
+                    }
+                }
+            }
+        }
 
         if (!halfmoveHistory.isEmpty()) {
             halfmoveClock = halfmoveHistory.pop();

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -6,6 +6,9 @@ import julius.game.chessengine.figures.PieceType;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static julius.game.chessengine.board.MoveHelper.convertStringToIndex;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -35,6 +38,25 @@ public class BitBoardTest {
     };
 
 
+    private static int createMove(BitBoard board, String from, String to, PieceType pieceType, boolean isWhite,
+                                   boolean isCapture, boolean isCastling, boolean isEnPassant,
+                                   PieceType promotionPiece, PieceType capturedPiece) {
+        int fromIndex = convertStringToIndex(from);
+        int toIndex = convertStringToIndex(to);
+        boolean kingFirstMove = pieceType == PieceType.KING && board.hasKingNotMoved(isWhite);
+        boolean rookFirstMove = pieceType == PieceType.ROOK && !board.hasRookMoved(fromIndex);
+        return MoveHelper.createMoveInt(fromIndex, toIndex, pieceType, isWhite, isCapture, isCastling, isEnPassant,
+                promotionPiece, capturedPiece, kingFirstMove, rookFirstMove, board.getLastMoveDoubleStepPawnIndex());
+    }
+
+    private static void assertCachedMapsMatch(BitBoard board) {
+        long expectedWhite = board.generateAttackBitboard(true);
+        long expectedBlack = board.generateAttackBitboard(false);
+        assertEquals(expectedWhite, board.getAttackBitboard(true), "White attack map mismatch");
+        assertEquals(expectedBlack, board.getAttackBitboard(false), "Black attack map mismatch");
+    }
+
+
     @Test
     public void HashTest() {
         Engine a = new Engine();
@@ -47,6 +69,143 @@ public class BitBoardTest {
         b.logBoard();
 
         assertEquals(a.getBoardStateHash(), b.getBoardStateHash());
+    }
+
+    @Test
+    void attackMapsStayAccurateAfterQuietSequence() {
+        BitBoard board = new BitBoard();
+        List<Integer> moves = new ArrayList<>();
+
+        moves.add(createMove(board, "g1", "f3", PieceType.KNIGHT, true,
+                false, false, false, null, null));
+        board.performMove(moves.get(moves.size() - 1));
+        assertFalse(board.isWhiteAttackDirty(), "Quiet move should keep white attack map clean");
+        assertFalse(board.isBlackAttackDirty(), "Quiet move should keep black attack map clean");
+        assertCachedMapsMatch(board);
+
+        moves.add(createMove(board, "b8", "c6", PieceType.KNIGHT, false,
+                false, false, false, null, null));
+        board.performMove(moves.get(moves.size() - 1));
+        assertFalse(board.isWhiteAttackDirty());
+        assertFalse(board.isBlackAttackDirty());
+        assertCachedMapsMatch(board);
+
+        moves.add(createMove(board, "e2", "e4", PieceType.PAWN, true,
+                false, false, false, null, null));
+        board.performMove(moves.get(moves.size() - 1));
+        assertFalse(board.isWhiteAttackDirty());
+        assertFalse(board.isBlackAttackDirty());
+        assertCachedMapsMatch(board);
+
+        moves.add(createMove(board, "e7", "e5", PieceType.PAWN, false,
+                false, false, false, null, null));
+        board.performMove(moves.get(moves.size() - 1));
+        assertFalse(board.isWhiteAttackDirty());
+        assertFalse(board.isBlackAttackDirty());
+        assertCachedMapsMatch(board);
+
+        moves.add(createMove(board, "f1", "c4", PieceType.BISHOP, true,
+                false, false, false, null, null));
+        board.performMove(moves.get(moves.size() - 1));
+        assertFalse(board.isWhiteAttackDirty());
+        assertFalse(board.isBlackAttackDirty());
+        assertCachedMapsMatch(board);
+
+        moves.add(createMove(board, "g8", "f6", PieceType.KNIGHT, false,
+                false, false, false, null, null));
+        board.performMove(moves.get(moves.size() - 1));
+        assertFalse(board.isWhiteAttackDirty());
+        assertFalse(board.isBlackAttackDirty());
+        assertCachedMapsMatch(board);
+
+        for (int i = moves.size() - 1; i >= 0; i--) {
+            board.undoMove(moves.get(i));
+            assertCachedMapsMatch(board);
+            assertFalse(board.isWhiteAttackDirty());
+            assertFalse(board.isBlackAttackDirty());
+        }
+    }
+
+    @Test
+    void attackMapsCorrectAfterCaptureAndEnPassant() {
+        BitBoard board = new BitBoard();
+        List<Integer> moves = new ArrayList<>();
+
+        moves.add(createMove(board, "e2", "e4", PieceType.PAWN, true,
+                false, false, false, null, null));
+        board.performMove(moves.get(moves.size() - 1));
+        assertFalse(board.isWhiteAttackDirty());
+        assertFalse(board.isBlackAttackDirty());
+        assertCachedMapsMatch(board);
+
+        moves.add(createMove(board, "d7", "d5", PieceType.PAWN, false,
+                false, false, false, null, null));
+        board.performMove(moves.get(moves.size() - 1));
+        assertFalse(board.isWhiteAttackDirty());
+        assertFalse(board.isBlackAttackDirty());
+        assertCachedMapsMatch(board);
+
+        moves.add(createMove(board, "e4", "d5", PieceType.PAWN, true,
+                true, false, false, null, PieceType.PAWN));
+        board.performMove(moves.get(moves.size() - 1));
+        assertFalse(board.isWhiteAttackDirty());
+        assertFalse(board.isBlackAttackDirty());
+        assertCachedMapsMatch(board);
+
+        moves.add(createMove(board, "e7", "e5", PieceType.PAWN, false,
+                false, false, false, null, null));
+        board.performMove(moves.get(moves.size() - 1));
+        assertFalse(board.isWhiteAttackDirty());
+        assertFalse(board.isBlackAttackDirty());
+        assertCachedMapsMatch(board);
+
+        int enPassantMove = createMove(board, "d5", "e6", PieceType.PAWN, true,
+                true, false, true, null, PieceType.PAWN);
+        moves.add(enPassantMove);
+        board.performMove(enPassantMove);
+
+        assertTrue(board.isWhiteAttackDirty(), "En passant should mark white attacks dirty for rebuild");
+        assertTrue(board.isBlackAttackDirty(), "En passant should mark black attacks dirty for rebuild");
+        long expectedWhite = board.generateAttackBitboard(true);
+        long expectedBlack = board.generateAttackBitboard(false);
+        assertEquals(expectedWhite, board.getAttackBitboard(true));
+        assertEquals(expectedBlack, board.getAttackBitboard(false));
+        assertFalse(board.isWhiteAttackDirty());
+        assertFalse(board.isBlackAttackDirty());
+
+        for (int i = moves.size() - 1; i >= 0; i--) {
+            board.undoMove(moves.get(i));
+            if (i == moves.size() - 1) {
+                assertTrue(board.isWhiteAttackDirty());
+                assertTrue(board.isBlackAttackDirty());
+                assertCachedMapsMatch(board);
+                assertFalse(board.isWhiteAttackDirty());
+                assertFalse(board.isBlackAttackDirty());
+            } else {
+                assertCachedMapsMatch(board);
+                assertFalse(board.isWhiteAttackDirty());
+                assertFalse(board.isBlackAttackDirty());
+            }
+        }
+    }
+
+    @Test
+    void attackMapsUpdatedAfterPromotion() {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("4k3/P7/8/8/8/8/8/4K3 w - - 0 1");
+        BitBoard board = engine.getBitBoard();
+
+        int promotionMove = createMove(board, "a7", "a8", PieceType.PAWN, true,
+                false, false, false, PieceType.QUEEN, null);
+        board.performMove(promotionMove);
+        assertFalse(board.isWhiteAttackDirty());
+        assertFalse(board.isBlackAttackDirty());
+        assertCachedMapsMatch(board);
+
+        board.undoMove(promotionMove);
+        assertCachedMapsMatch(board);
+        assertFalse(board.isWhiteAttackDirty());
+        assertFalse(board.isBlackAttackDirty());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- replace per-move slider update allocation with a reusable buffer backed by thread-local storage
- drop full rebuilds for en-passant moves and keep incremental deltas lightweight with assertion-only underflow checks

## Testing
- mvn test *(fails: network is unreachable while resolving the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d26645a5e4832a9d7be977283c4958