### PR TITLE
Pre-size TimedLRUCache backing map

### DIFF
--- a/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
+++ b/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
@@ -21,6 +21,10 @@ import java.util.function.BiConsumer;
  *       evicts only by LRU when capacity is exceeded.</li>
  *   <li>Eviction happens incrementally on {@link #put(long, Object)}, {@link #get(long)},
  *       and {@link #cleanup()} calls.</li>
+ *   <li>The backing hash map is sized up-front using a default load factor of
+ *       approximately {@value #DEFAULT_LOAD_FACTOR} to avoid repeated rehashes
+ *       during warm-up. Use {@link #TimedLRUCache(int, long, float)} to override
+ *       the load factor if a different density is required.</li>
  * </ul>
  *
  * @param <V> value type
@@ -37,25 +41,46 @@ public class TimedLRUCache<V> {
         }
     }
 
+    private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+
     private final int maxSize;
     private final long maxAgeMs;
 
-    private final Long2ObjectOpenHashMap<Entry<V>> map = new Long2ObjectOpenHashMap<>();
+    private final Long2ObjectOpenHashMap<Entry<V>> map;
     private final LongArrayFIFOQueue keyQueue = new LongArrayFIFOQueue();
     private final LongArrayFIFOQueue timeQueue = new LongArrayFIFOQueue();
     private final Object lock = new Object();
 
     /**
+     * Uses the default load factor of approximately {@value #DEFAULT_LOAD_FACTOR}.
+     *
      * @param maxSize maximum number of entries to retain (LRU when exceeded)
      * @param maxAgeMs maximum age in milliseconds before an entry is considered stale;
      *                 set {@code <= 0} to disable time-based expiry
      */
     public TimedLRUCache(int maxSize, long maxAgeMs) {
+        this(maxSize, maxAgeMs, DEFAULT_LOAD_FACTOR);
+    }
+
+    /**
+     * @param maxSize maximum number of entries to retain (LRU when exceeded)
+     * @param maxAgeMs maximum age in milliseconds before an entry is considered stale;
+     *                 set {@code <= 0} to disable time-based expiry
+     * @param loadFactor desired load factor for the underlying open-addressed hash map;
+     *                   defaults to approximately {@value #DEFAULT_LOAD_FACTOR}
+     */
+    public TimedLRUCache(int maxSize, long maxAgeMs, float loadFactor) {
         if (maxSize <= 0) {
             throw new IllegalArgumentException("maxSize must be > 0");
         }
+        if (!(loadFactor > 0.0f && loadFactor < 1.0f)) {
+            throw new IllegalArgumentException("loadFactor must be within (0, 1)");
+        }
         this.maxSize = maxSize;
         this.maxAgeMs = maxAgeMs;
+        int expectedEntries = sanitizeExpectedSize(maxSize);
+        // fastutil will expand to the nearest power-of-two >= expected/loadFactor.
+        this.map = new Long2ObjectOpenHashMap<>(expectedEntries, loadFactor);
     }
 
     public V get(long key) {
@@ -152,6 +177,11 @@ public class TimedLRUCache<V> {
             keyQueue.clear();
             timeQueue.clear();
         }
+    }
+
+    private static int sanitizeExpectedSize(int maxSize) {
+        long sanitized = Math.max(2L, maxSize);
+        return (int) Math.min(Integer.MAX_VALUE - 8L, sanitized);
     }
 
     public void forEach(BiConsumer<Long, V> action) {

--- a/src/test/java/julius/game/chessengine/cache/TimedLRUCacheWarmupTest.java
+++ b/src/test/java/julius/game/chessengine/cache/TimedLRUCacheWarmupTest.java
@@ -1,0 +1,48 @@
+package julius.game.chessengine.cache;
+
+import it.unimi.dsi.fastutil.HashCommon;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TimedLRUCacheWarmupTest {
+
+    @Test
+    void warmupDoesNotTriggerRehashes() throws Exception {
+        int maxSize = 4096;
+        TimedLRUCache<Object> cache = new TimedLRUCache<>(maxSize, 0);
+
+        Field mapField = TimedLRUCache.class.getDeclaredField("map");
+        mapField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Long2ObjectOpenHashMap<?> map = (Long2ObjectOpenHashMap<?>) mapField.get(cache);
+
+        Field capacityField = Long2ObjectOpenHashMap.class.getDeclaredField("n");
+        capacityField.setAccessible(true);
+
+        Field loadFactorField = Long2ObjectOpenHashMap.class.getDeclaredField("f");
+        loadFactorField.setAccessible(true);
+        float loadFactor = loadFactorField.getFloat(map);
+
+        int previousCapacity = capacityField.getInt(map);
+        int expectedCapacity = HashCommon.arraySize(maxSize, loadFactor);
+        assertEquals(expectedCapacity, previousCapacity,
+                "Map should be pre-sized to avoid rehashing during warm-up");
+        int rehashCount = 0;
+
+        for (int i = 0; i < maxSize; i++) {
+            cache.put(i, new Object());
+            int currentCapacity = capacityField.getInt(map);
+            if (currentCapacity != previousCapacity) {
+                rehashCount++;
+                previousCapacity = currentCapacity;
+            }
+        }
+
+        assertEquals(0, rehashCount,
+                "Expected no rehash operations during warm-up inserts but observed " + rehashCount);
+    }
+}


### PR DESCRIPTION
## Summary
- pre-size the fastutil backing map in `TimedLRUCache` using a sanitized expected size and optional load factor override
- document the default load-factor assumption and expose a constructor for custom load factors
- add a warm-up instrumentation test that verifies the cache avoids rehashing during initial population

## Testing
- `./mvnw test` *(fails: Maven wrapper cannot download distribution in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d27451c674832ab41090e126d7c868