### PR TITLE
Remove Lombok usage for Java 25 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- Boot uses this to set the compiler release -->
-        <java.version>21</java.version>
+        <java.version>25</java.version>
     </properties>
 
     <dependencies>
@@ -39,14 +39,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-
-        <!-- Lombok (compile-time only) -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.40</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Test stack -->

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -8,9 +8,8 @@ import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.utils.Score;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.log4j.Log4j2;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -24,22 +23,20 @@ import static julius.game.chessengine.helper.BitHelper.FileMasks;
 import static julius.game.chessengine.helper.KingHelper.KING_ATTACKS;
 import static julius.game.chessengine.utils.Score.*;
 
-@Log4j2
 @Component
 public class AI {
 
-    @Getter
+    private static final Logger log = LogManager.getLogger(AI.class);
+
     private final Engine mainEngine;
 
     /**
      * Number of threads used for searching. Defaults to single-threaded search but
      * can be adjusted at runtime via the UCI "Threads" option.
      */
-    @Getter
     private int searchThreads = Integer.getInteger("chessengine.searchThreads", 1);
 
     // number of Lazy SMP workers (≥1)
-    @Getter
     private int lazySmpThreads = Math.max(1, Integer.getInteger("chessengine.lazySmpThreads", 1));
 
     private Thread calculationCoordinator;
@@ -56,7 +53,6 @@ public class AI {
      * implementation does not dynamically resize the table, but the value is
      * tracked so that future improvements can honour it.
      */
-    @Getter
     private int hashSizeMb = 16;
 
     /**
@@ -109,7 +105,6 @@ public class AI {
      */
     private TranspositionTable<TranspositionTableEntry> transpositionTable;
 
-    @Getter
     private int transpositionTableCapacity;
 
     /**
@@ -117,7 +112,6 @@ public class AI {
      */
     private TranspositionTable<CaptureTranspositionTableEntry> captureTranspositionTable;
 
-    @Getter
     private int captureTranspositionTableCapacity;
 
     private static final int NUM_KILLER_MOVES = 2;
@@ -200,27 +194,20 @@ public class AI {
 
     private volatile long bestMoveForHash = -1;
 
-    @Getter
     private List<MoveAndScore> calculatedLine = Collections.synchronizedList(new ArrayList<>());
 
     // Game configuration parameters
 
-    @Getter
     private int maxDepth = 64; // Adjust the level of depth according to your requirements
 
-    @Getter
-    @Setter
     private long timeLimit; // milliseconds
 
     private final boolean useNullMovePruning = Boolean.parseBoolean(
             System.getProperty("chessengine.nullMove", "true")
     );
 
-    @Getter
     private long nodesVisited = 0;
-    @Getter
     private long nullMoveCount = 0;
-    @Getter
     private volatile SearchDiagnostics lastDiagnostics = SearchDiagnostics.EMPTY;
 
     public AI(Engine mainEngine) {
@@ -345,6 +332,58 @@ public class AI {
         }
         threadHeuristics.get().ensureCapacity(requestedDepth);
         this.maxDepth = requestedDepth;
+    }
+
+    public Engine getMainEngine() {
+        return mainEngine;
+    }
+
+    public int getSearchThreads() {
+        return searchThreads;
+    }
+
+    public int getLazySmpThreads() {
+        return lazySmpThreads;
+    }
+
+    public int getHashSizeMb() {
+        return hashSizeMb;
+    }
+
+    public int getTranspositionTableCapacity() {
+        return transpositionTableCapacity;
+    }
+
+    public int getCaptureTranspositionTableCapacity() {
+        return captureTranspositionTableCapacity;
+    }
+
+    public List<MoveAndScore> getCalculatedLine() {
+        return calculatedLine;
+    }
+
+    public int getMaxDepth() {
+        return maxDepth;
+    }
+
+    public long getTimeLimit() {
+        return timeLimit;
+    }
+
+    public void setTimeLimit(long timeLimit) {
+        this.timeLimit = timeLimit;
+    }
+
+    public long getNodesVisited() {
+        return nodesVisited;
+    }
+
+    public long getNullMoveCount() {
+        return nullMoveCount;
+    }
+
+    public SearchDiagnostics getLastDiagnostics() {
+        return lastDiagnostics;
     }
 
 

--- a/src/main/java/julius/game/chessengine/ai/CaptureTranspositionTableEntry.java
+++ b/src/main/java/julius/game/chessengine/ai/CaptureTranspositionTableEntry.java
@@ -1,8 +1,5 @@
 package julius.game.chessengine.ai;
 
-import lombok.Getter;
-
-@Getter
 public class CaptureTranspositionTableEntry {
     double score;
     boolean isWhite;
@@ -10,6 +7,14 @@ public class CaptureTranspositionTableEntry {
     public CaptureTranspositionTableEntry(double score, boolean isWhite) {
         this.score = score;
         this.isWhite = isWhite;
+    }
+
+    public double getScore() {
+        return score;
+    }
+
+    public boolean isWhite() {
+        return isWhite;
     }
 
     @Override

--- a/src/main/java/julius/game/chessengine/ai/MoveAndScore.java
+++ b/src/main/java/julius/game/chessengine/ai/MoveAndScore.java
@@ -1,8 +1,5 @@
 package julius.game.chessengine.ai;
 
-import lombok.Getter;
-
-@Getter
 public class MoveAndScore {
 
     int move;
@@ -11,6 +8,14 @@ public class MoveAndScore {
     MoveAndScore(int move, double score) {
         this.move = move;
         this.score = score;
+    }
+
+    public int getMove() {
+        return move;
+    }
+
+    public double getScore() {
+        return score;
     }
 
 }

--- a/src/main/java/julius/game/chessengine/ai/OpeningBook.java
+++ b/src/main/java/julius/game/chessengine/ai/OpeningBook.java
@@ -1,7 +1,8 @@
 package julius.game.chessengine.ai;
 
 import julius.game.chessengine.board.Move;
-import lombok.extern.log4j.Log4j2;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Component;
 
 import java.io.*;
@@ -9,12 +10,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 @Component
-@Log4j2
 public class OpeningBook {
     private static final String OPENINGS_FILE_PATH = "/opening/openings.txt";
     private final Map<Long, List<Integer>> openings = new HashMap<>();
 
     private static OpeningBook instance;
+
+    private static final Logger log = LogManager.getLogger(OpeningBook.class);
     
     private OpeningBook() {
         loadOpenings();
@@ -41,7 +43,7 @@ public class OpeningBook {
                 }
             }
         } catch (IOException | NullPointerException e) {
-            // Handle exceptions or log errors
+            log.warn("Failed to load opening book: {}", e.getMessage());
         }
     }
 
@@ -60,7 +62,7 @@ public class OpeningBook {
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, true))) {
             writer.write(move + "," + boardStateHash + "\n");
         } catch (IOException e) {
-            // Handle exceptions or log errors
+            log.warn("Failed to persist opening move {} for hash {}", move, boardStateHash, e);
         }
     }
 

--- a/src/main/java/julius/game/chessengine/ai/TranspositionTableEntry.java
+++ b/src/main/java/julius/game/chessengine/ai/TranspositionTableEntry.java
@@ -1,8 +1,5 @@
 package julius.game.chessengine.ai;
 
-import lombok.Getter;
-
-@Getter
 public class TranspositionTableEntry {
     double score;
     int depth;
@@ -14,6 +11,22 @@ public class TranspositionTableEntry {
         this.depth = depth;
         this.nodeType = nodeType;
         this.bestMove = bestMove;
+    }
+
+    public double getScore() {
+        return score;
+    }
+
+    public int getDepth() {
+        return depth;
+    }
+
+    public NodeType getNodeType() {
+        return nodeType;
+    }
+
+    public int getBestMove() {
+        return bestMove;
     }
 
     @Override

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -9,9 +9,8 @@ import julius.game.chessengine.utils.Color;
 import julius.game.chessengine.board.MoveHelper;
 
 import julius.game.chessengine.utils.Score;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.extern.log4j.Log4j2;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -23,9 +22,9 @@ import static julius.game.chessengine.helper.BitHelper.*;
 import static julius.game.chessengine.helper.KingHelper.KING_ATTACKS;
 import static julius.game.chessengine.helper.KnightHelper.knightMoveTable;
 
-@Log4j2
-@Getter
 public class BitBoard {
+
+    private static final Logger log = LogManager.getLogger(BitBoard.class);
 
     private static final PieceType[] PROMOTION_PIECES = {PieceType.QUEEN, PieceType.ROOK, PieceType.BISHOP, PieceType.KNIGHT};
 
@@ -64,15 +63,11 @@ public class BitBoard {
     // Reusable buffer for move generation to avoid frequent allocations.
     private final MoveList moveGenerationBuffer = new MoveList();
 
-    @Getter(AccessLevel.NONE)
     private final Deque<Integer> halfmoveHistory = new ArrayDeque<>();
-    @Getter(AccessLevel.NONE)
     private final Deque<Integer> fullmoveHistory = new ArrayDeque<>();
-    @Getter(AccessLevel.NONE)
     private final Deque<Integer> capturedPieceHistory = new ArrayDeque<>();
 
     // This variable needs to be set whenever a move is made
-    @Getter
     private int lastMoveDoubleStepPawnIndex;
 
     // Flags to track if the king and rooks have moved
@@ -2037,6 +2032,130 @@ public class BitBoard {
 
     public long getBoardStateHash() {
         return zKey;
+    }
+
+    public boolean isWhitesTurn() {
+        return whitesTurn;
+    }
+
+    public long getWhitePawns() {
+        return whitePawns;
+    }
+
+    public long getBlackPawns() {
+        return blackPawns;
+    }
+
+    public long getWhiteKnights() {
+        return whiteKnights;
+    }
+
+    public long getBlackKnights() {
+        return blackKnights;
+    }
+
+    public long getWhiteBishops() {
+        return whiteBishops;
+    }
+
+    public long getBlackBishops() {
+        return blackBishops;
+    }
+
+    public long getWhiteRooks() {
+        return whiteRooks;
+    }
+
+    public long getBlackRooks() {
+        return blackRooks;
+    }
+
+    public long getWhiteQueens() {
+        return whiteQueens;
+    }
+
+    public long getBlackQueens() {
+        return blackQueens;
+    }
+
+    public long getWhiteKing() {
+        return whiteKing;
+    }
+
+    public long getBlackKing() {
+        return blackKing;
+    }
+
+    public long getWhitePieces() {
+        return whitePieces;
+    }
+
+    public long getBlackPieces() {
+        return blackPieces;
+    }
+
+    public long getAllPieces() {
+        return allPieces;
+    }
+
+    public int getHalfmoveClock() {
+        return halfmoveClock;
+    }
+
+    public int getFullmoveNumber() {
+        return fullmoveNumber;
+    }
+
+    public int getLastMoveDoubleStepPawnIndex() {
+        return lastMoveDoubleStepPawnIndex;
+    }
+
+    public boolean isWhiteKingMoved() {
+        return whiteKingMoved;
+    }
+
+    public boolean isBlackKingMoved() {
+        return blackKingMoved;
+    }
+
+    public boolean isWhiteRookA1Moved() {
+        return whiteRookA1Moved;
+    }
+
+    public boolean isWhiteRookH1Moved() {
+        return whiteRookH1Moved;
+    }
+
+    public boolean isBlackRookA8Moved() {
+        return blackRookA8Moved;
+    }
+
+    public boolean isBlackRookH8Moved() {
+        return blackRookH8Moved;
+    }
+
+    public boolean isWhiteKingHasCastled() {
+        return whiteKingHasCastled;
+    }
+
+    public boolean isBlackKingHasCastled() {
+        return blackKingHasCastled;
+    }
+
+    public long getWhiteAttackMap() {
+        if (whiteAttackDirty) {
+            whiteAttackMap = computeAttackMap(true);
+            whiteAttackDirty = false;
+        }
+        return whiteAttackMap;
+    }
+
+    public long getBlackAttackMap() {
+        if (blackAttackDirty) {
+            blackAttackMap = computeAttackMap(false);
+            blackAttackDirty = false;
+        }
+        return blackAttackMap;
     }
 
 }

--- a/src/main/java/julius/game/chessengine/board/FEN.java
+++ b/src/main/java/julius/game/chessengine/board/FEN.java
@@ -3,17 +3,38 @@ package julius.game.chessengine.board;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.utils.Color;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Objects;
 
 import static julius.game.chessengine.board.MoveHelper.convertIndexToString;
 
-@Data
-@RequiredArgsConstructor
 public class FEN {
     private final String renderBoard;
+
+    public FEN(String renderBoard) {
+        this.renderBoard = renderBoard;
+    }
+
+    public String getRenderBoard() {
+        return renderBoard;
+    }
+
+    @Override
+    public String toString() {
+        return renderBoard;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FEN fen)) return false;
+        return Objects.equals(renderBoard, fen.renderBoard);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(renderBoard);
+    }
 
     public static FEN translateBoardToFEN(BitBoard board, GameState gameState) {
         Objects.requireNonNull(board, "board");

--- a/src/main/java/julius/game/chessengine/board/FrontendBoard.java
+++ b/src/main/java/julius/game/chessengine/board/FrontendBoard.java
@@ -1,11 +1,59 @@
 package julius.game.chessengine.board;
 
-import lombok.Data;
 import java.util.Map;
 
-@Data
 public class FrontendBoard {
     private Map<String, String> renderBoard;  // { "e2":"wP", ... }
     private String fen;                       // convenient if you need it
     private String enPassantTarget;           // e.g. "e3" or null
+
+    public Map<String, String> getRenderBoard() {
+        return renderBoard;
+    }
+
+    public void setRenderBoard(Map<String, String> renderBoard) {
+        this.renderBoard = renderBoard;
+    }
+
+    public String getFen() {
+        return fen;
+    }
+
+    public void setFen(String fen) {
+        this.fen = fen;
+    }
+
+    public String getEnPassantTarget() {
+        return enPassantTarget;
+    }
+
+    public void setEnPassantTarget(String enPassantTarget) {
+        this.enPassantTarget = enPassantTarget;
+    }
+
+    @Override
+    public String toString() {
+        return "FrontendBoard{" +
+                "renderBoard=" + renderBoard +
+                ", fen='" + fen + '\'' +
+                ", enPassantTarget='" + enPassantTarget + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FrontendBoard that)) return false;
+        if (renderBoard != null ? !renderBoard.equals(that.renderBoard) : that.renderBoard != null) return false;
+        if (fen != null ? !fen.equals(that.fen) : that.fen != null) return false;
+        return enPassantTarget != null ? enPassantTarget.equals(that.enPassantTarget) : that.enPassantTarget == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = renderBoard != null ? renderBoard.hashCode() : 0;
+        result = 31 * result + (fen != null ? fen.hashCode() : 0);
+        result = 31 * result + (enPassantTarget != null ? enPassantTarget.hashCode() : 0);
+        return result;
+    }
 }

--- a/src/main/java/julius/game/chessengine/board/Move.java
+++ b/src/main/java/julius/game/chessengine/board/Move.java
@@ -2,7 +2,6 @@ package julius.game.chessengine.board;
 
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.utils.Color;
-import lombok.Getter;
 
 public class Move {
 
@@ -31,21 +30,14 @@ public class Move {
     //  from      to   pieceColor   pieceType      sp     pp   isKingsfirstMove isRooksFirstMove  isCheck  isCheckMate   isAmbiguousMove
     //<111111> <111111>   <1>         <111>       <11>   <000>        <1>             <1>           <1>         <1>           <1>
 
-    // Getters for all the fields
-    @Getter
     private final Position from;
-    @Getter
     private final Position to;
-    @Getter
     private final PieceType pieceType;
-    @Getter
     private final boolean colorWhite; // Color of the piece being moved
     private final boolean isCapture;
     private final boolean isCastlingMove;
     private final boolean isEnPassantMove;
-    @Getter
     private final PieceType promotionPieceType; // This can be null if no promotion
-    @Getter
     private final PieceType capturedPieceType;
 
     private final boolean isKingFirstMove;
@@ -79,6 +71,30 @@ public class Move {
         this.capturedPieceType = originalMove.getCapturedPieceType();
         this.isKingFirstMove = originalMove.isKingFirstMove();
         this.isRookFirstMove = originalMove.isRookFirstMove();
+    }
+
+    public Position getFrom() {
+        return from;
+    }
+
+    public Position getTo() {
+        return to;
+    }
+
+    public PieceType getPieceType() {
+        return pieceType;
+    }
+
+    public boolean isColorWhite() {
+        return colorWhite;
+    }
+
+    public PieceType getPromotionPieceType() {
+        return promotionPieceType;
+    }
+
+    public PieceType getCapturedPieceType() {
+        return capturedPieceType;
     }
 
     public boolean isCapture() {

--- a/src/main/java/julius/game/chessengine/board/MoveList.java
+++ b/src/main/java/julius/game/chessengine/board/MoveList.java
@@ -1,10 +1,7 @@
 package julius.game.chessengine.board;
 
-import lombok.extern.log4j.Log4j2;
-
 import java.util.Arrays;
 
-@Log4j2
 public class MoveList {
     private int[] moves;
     private int moveCount;

--- a/src/main/java/julius/game/chessengine/board/Position.java
+++ b/src/main/java/julius/game/chessengine/board/Position.java
@@ -1,12 +1,7 @@
 package julius.game.chessengine.board;
 
-import lombok.Data;
-import lombok.extern.log4j.Log4j2;
-
 import java.util.List;
 
-@Data
-@Log4j2
 public class Position {
 
     private char x;
@@ -24,6 +19,36 @@ public class Position {
 
     public String toString() {
         return x + String.valueOf(y);
+    }
+
+    public char getX() {
+        return x;
+    }
+
+    public void setX(char x) {
+        this.x = x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public void setY(int y) {
+        this.y = y;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Position position)) return false;
+        return x == position.x && y == position.y;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) x;
+        result = 31 * result + y;
+        return result;
     }
 
 

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -5,8 +5,8 @@ import julius.game.chessengine.board.*;
 import julius.game.chessengine.cache.TimedLRUCache;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.utils.Color;
-import lombok.Getter;
-import lombok.extern.log4j.Log4j2;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 import static julius.game.chessengine.board.MoveHelper.convertIndexToString;
 
 @Service
-@Log4j2
 public class Engine {
 
     /*
@@ -116,17 +115,14 @@ public class Engine {
 
     private final Object boardLock = new Object();
 
-    @Getter
     private OpeningBook openingBook;
 
     private boolean legalMovesNeedUpdate = true;
     private MoveList legalMoves;
 
-    @Getter
     private ArrayList<Integer> line = new ArrayList<>();
     private ArrayList<Integer> redoLine = new ArrayList<>();
     private BitBoard bitBoard = new BitBoard();
-    @Getter
     private GameState gameState = new GameState(bitBoard);
 
     private LongConsumer onPositionChanged = h -> {};
@@ -174,6 +170,18 @@ public class Engine {
 
     public BitBoard getBitBoard() {
         return bitBoard;
+    }
+
+    public OpeningBook getOpeningBook() {
+        return openingBook;
+    }
+
+    public List<Integer> getLine() {
+        return line;
+    }
+
+    public GameState getGameState() {
+        return gameState;
     }
 
     public MoveList getAllLegalMoves() {
@@ -552,3 +560,4 @@ public class Engine {
         }
     }
 }
+    private static final Logger log = LogManager.getLogger(Engine.class);

--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -5,17 +5,11 @@ import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.MoveList;
 import julius.game.chessengine.utils.Score;
-import lombok.Data;
-import lombok.Getter;
-import lombok.extern.log4j.Log4j2;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
 
-
-@Data
-@Log4j2
 public class GameState {
 
     private final Deque<Long> hashHistory = new ArrayDeque<>(256);
@@ -27,9 +21,7 @@ public class GameState {
 
     private Score score;
 
-    @Getter
     private int halfmoveClock = 0;          // resets on pawn move or capture
-    @Getter
     private int fullmoveNumber = 1;
     private long lastZobrist = 0L;          // last committed root hash
 
@@ -192,6 +184,46 @@ public class GameState {
         }
         bitBoard.setHalfmoveClock(halfmoveClock);
         bitBoard.setFullmoveNumber(fullmoveNumber);
+    }
+
+    public GameStateEnum getState() {
+        return state;
+    }
+
+    public void setState(GameStateEnum state) {
+        this.state = state;
+    }
+
+    public Score getScore() {
+        return score;
+    }
+
+    public void setScore(Score score) {
+        this.score = score;
+    }
+
+    public int getHalfmoveClock() {
+        return halfmoveClock;
+    }
+
+    public void setHalfmoveClock(int halfmoveClock) {
+        this.halfmoveClock = halfmoveClock;
+    }
+
+    public int getFullmoveNumber() {
+        return fullmoveNumber;
+    }
+
+    public void setFullmoveNumber(int fullmoveNumber) {
+        this.fullmoveNumber = fullmoveNumber;
+    }
+
+    public Deque<Long> getHashHistory() {
+        return hashHistory;
+    }
+
+    public HashMap<Long, Integer> getRepetition() {
+        return repetition;
     }
 
     @Override

--- a/src/main/java/julius/game/chessengine/figures/PieceType.java
+++ b/src/main/java/julius/game/chessengine/figures/PieceType.java
@@ -1,8 +1,5 @@
 package julius.game.chessengine.figures;
 
-import lombok.Getter;
-
-@Getter
 public enum PieceType {
     PAWN('P'), KNIGHT('N'), BISHOP('B'), ROOK('R'), QUEEN('Q'), KING('K');
 
@@ -10,6 +7,10 @@ public enum PieceType {
 
     PieceType(char notation) {
         this.notation = notation;
+    }
+
+    public char getNotation() {
+        return notation;
     }
 
 }

--- a/src/main/java/julius/game/chessengine/helper/BishopHelper.java
+++ b/src/main/java/julius/game/chessengine/helper/BishopHelper.java
@@ -1,15 +1,17 @@
 package julius.game.chessengine.helper;
 
-import lombok.extern.log4j.Log4j2;
-
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-@Log4j2
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class BishopHelper {
+
+    private static final Logger log = LogManager.getLogger(BishopHelper.class);
 
     private static final String BISHOP_MAGIC_NUMBERS_PATH = "/magic/bishop_magic_numbers.txt";
     private static final String BISHOP_MAGIC_NUMBERS_PATH_write = "src/main/resources" + BISHOP_MAGIC_NUMBERS_PATH;

--- a/src/main/java/julius/game/chessengine/helper/PawnHelper.java
+++ b/src/main/java/julius/game/chessengine/helper/PawnHelper.java
@@ -1,12 +1,9 @@
 package julius.game.chessengine.helper;
 
-import lombok.extern.log4j.Log4j2;
-
 import static julius.game.chessengine.helper.BitHelper.FileMasks;
 import static julius.game.chessengine.helper.BitHelper.bitIndex;
 import static julius.game.chessengine.helper.BitHelper.fileBitboard;
 
-@Log4j2
 public class PawnHelper {
 
     public final static int[] WHITE_PAWN_MIDGAME_POSITIONAL_VALUES = {

--- a/src/main/java/julius/game/chessengine/helper/RookHelper.java
+++ b/src/main/java/julius/game/chessengine/helper/RookHelper.java
@@ -1,17 +1,19 @@
 package julius.game.chessengine.helper;
 
-import lombok.extern.log4j.Log4j2;
-
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import static julius.game.chessengine.helper.BitHelper.FileMasks;
 
-@Log4j2
 public class RookHelper {
+
+    private static final Logger log = LogManager.getLogger(RookHelper.class);
 
     private static final String ROOK_MAGIC_NUMBERS_PATH = "/magic/rook_magic_numbers.txt";
     private static final String ROOK_MAGIC_NUMBERS_PATH_write = "src/main/resources" + ROOK_MAGIC_NUMBERS_PATH;

--- a/src/main/java/julius/game/chessengine/helper/ZobristTable.java
+++ b/src/main/java/julius/game/chessengine/helper/ZobristTable.java
@@ -1,7 +1,5 @@
 package julius.game.chessengine.helper;
 
-import lombok.Getter;
-
 import java.util.Random;
 
 public class ZobristTable {
@@ -13,7 +11,6 @@ public class ZobristTable {
     private static final long[] castlingRightsHash = new long[CASTLING_RIGHTS];
     private static final long[] enPassantSquareHash = new long[SQUARES];
     // Method to get the hash value indicating it's Black's turn
-    @Getter
     private static final long blackTurnHash;
 
     static {
@@ -52,6 +49,10 @@ public class ZobristTable {
     // Method to get the hash value for a specific en passant file
     public static long getEnPassantSquareHash(int squareIndex) {
         return enPassantSquareHash[squareIndex];
+    }
+
+    public static long getBlackTurnHash() {
+        return blackTurnHash;
     }
 
 }


### PR DESCRIPTION
## Summary
- bump the build to target Java 25 and drop the Lombok dependency
- replace Lombok-provided loggers and accessors with explicit implementations across the engine
- expose the necessary getters and setters manually on data classes used by the AI, engine, and evaluation code

## Testing
- `mvn -q -DskipTests compile` *(fails: unable to download parent POM because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d27856dd14832a914f16b4a59e931e