### PR TITLE
Update build for Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,8 @@
 
     <properties>
         <!-- Boot uses this to set the compiler release -->
-        <java.version>21</java.version>
+        <java.version>25</java.version>
+        <lombok.version>1.18.42</lombok.version>
     </properties>
 
     <dependencies>
@@ -45,7 +46,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.40</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -99,6 +100,20 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
 
             <!-- Guardrails: fail on version drift and wrong toolchains -->


### PR DESCRIPTION
## Summary
- raise the Maven java.version property to 25 and centralise the Lombok version
- upgrade Lombok to 1.18.42 for Java 25 compatibility and wire it into the compiler's annotation processor path

## Testing
- ./mvnw -q -DskipTests package *(fails: Maven wrapper cannot download distribution because network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d27856dd14832a914f16b4a59e931e