### PR TITLE
Reset search counters each go and report UCI timing

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -195,6 +195,7 @@ public class AI {
 
     @Getter
     private long nodesVisited = 0;
+    private volatile long searchStartTimeNanos = 0L;
     @Getter
     private long nullMoveCount = 0;
     @Getter
@@ -585,9 +586,28 @@ public class AI {
         searchResultReady = false;
         currentBoardState = -1;
         beforeCalculationBoardState = -2;
+        nodesVisited = 0L;
+        searchStartTimeNanos = 0L;
         clearPrincipalVariation();
         mainEngine.startNewGame();
         clearHistoryTable();
+    }
+
+    public long getSearchElapsedMillis() {
+        long start = searchStartTimeNanos;
+        if (start == 0L) {
+            return 0L;
+        }
+        long elapsedNanos = System.nanoTime() - start;
+        if (elapsedNanos <= 0L) {
+            return 0L;
+        }
+        return TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+    }
+
+    private void resetSearchCounters() {
+        nodesVisited = 0L;
+        searchStartTimeNanos = System.nanoTime();
     }
 
     public void stopCalculation() {
@@ -753,6 +773,7 @@ public class AI {
 
             SearchInstrumentation instrumentation = SearchInstrumentation.enabled();
             lastDiagnostics = SearchDiagnostics.EMPTY;
+            resetSearchCounters();
             SearchTask task = new SearchTask(searchIdGenerator.incrementAndGet(), boardStateHash, isWhite, deadline, lazySmpThreads, instrumentation);
             activeSearch.set(task);
             if (bestMoveForHash == boardStateHash && currentBestMove != -1) {

--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -376,17 +376,27 @@ public class UciHandler {
 
         List<MoveAndScore> line = new ArrayList<>(ai.getCalculatedLine());
         long nodes = ai.getNodesVisited();
+        long elapsedMillis = ai.getSearchElapsedMillis();
+        long nps = 0L;
+        if (elapsedMillis > 0L) {
+            double perSecond = (nodes * 1000.0) / elapsedMillis;
+            if (perSecond > 0.0) {
+                nps = (long) perSecond;
+            }
+        }
         StringBuilder builder = new StringBuilder("info");
         if (!line.isEmpty()) {
             builder.append(" depth ").append(line.size());
             builder.append(' ').append(formatScore(line.getFirst().getScore()));
-            builder.append(" nodes ").append(nodes);
+        }
+        builder.append(" nodes ").append(nodes);
+        builder.append(" time ").append(elapsedMillis);
+        builder.append(" nps ").append(nps);
+        if (!line.isEmpty()) {
             String pv = buildPv(line);
             if (!pv.isEmpty()) {
                 builder.append(" pv ").append(pv);
             }
-        } else {
-            builder.append(" nodes ").append(nodes);
         }
         output.accept(builder.toString());
 


### PR DESCRIPTION
## Summary
- reset the per-search node counter and track search start time when a new SearchTask is issued
- expose the elapsed search time so the UCI handler can add time and nodes-per-second fields to its info output

## Testing
- `mvn -q test` *(fails: unable to resolve the Spring Boot parent POM because the Maven Central repository is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d29435d0b4832a9042f67e8e8b6976