### PR TITLE
Keep ponder searches running until ponderhit

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -9,7 +9,6 @@ import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.utils.Score;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
 
@@ -186,8 +185,9 @@ public class AI {
     private int maxDepth = 64; // Adjust the level of depth according to your requirements
 
     @Getter
-    @Setter
     private long timeLimit; // milliseconds
+
+    public static final long INFINITE_TIME_LIMIT = Long.MAX_VALUE;
 
     private final boolean useNullMovePruning = Boolean.parseBoolean(
             System.getProperty("chessengine.nullMove", "true")
@@ -335,6 +335,19 @@ public class AI {
         }
         threadHeuristics.get().ensureCapacity(requestedDepth);
         this.maxDepth = requestedDepth;
+    }
+
+
+    public void setTimeLimit(long timeLimitMillis) {
+        if (timeLimitMillis <= 0L) {
+            this.timeLimit = INFINITE_TIME_LIMIT;
+            return;
+        }
+        if (timeLimitMillis >= INFINITE_TIME_LIMIT) {
+            this.timeLimit = INFINITE_TIME_LIMIT;
+            return;
+        }
+        this.timeLimit = timeLimitMillis;
     }
 
 
@@ -751,12 +764,33 @@ public class AI {
     }
 
 
+    private long computeDeadlineNanos() {
+        if (timeLimit >= INFINITE_TIME_LIMIT) {
+            return Long.MAX_VALUE;
+        }
+        long millis = timeLimit;
+        if (millis <= 0L) {
+            return Long.MAX_VALUE;
+        }
+        long nanos;
+        try {
+            nanos = Math.multiplyExact(millis, 1_000_000L);
+        } catch (ArithmeticException ex) {
+            return Long.MAX_VALUE;
+        }
+        long now = System.nanoTime();
+        if (nanos > 0L && now > Long.MAX_VALUE - nanos) {
+            return Long.MAX_VALUE;
+        }
+        return now + nanos;
+    }
+
     private void performCalculation() {
         try {
             Engine simulatorEngine = mainEngine.createSimulation();
             long boardStateHash = simulatorEngine.getBoardStateHash();
             boolean isWhite = simulatorEngine.whitesTurn();
-            long deadline = System.nanoTime() + timeLimit * 1_000_000;
+            long deadline = computeDeadlineNanos();
             beforeCalculationBoardState = boardStateHash;
 
             int bookMove = mainEngine.getOpeningBook().getRandomMoveForBoardStateHash(boardStateHash);

--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -299,7 +299,11 @@ public class UciHandler {
         long timeLeft = whitesTurn ? wtime : btime;
         long inc = whitesTurn ? winc : binc;
         long limit = computeTimeLimit(timeLeft, inc, movetime, movestogo, moveOverheadMs);
-        ai.setTimeLimit(limit);
+        if (ponder && movetime == 0) {
+            ai.setTimeLimit(AI.INFINITE_TIME_LIMIT);
+        } else {
+            ai.setTimeLimit(limit);
+        }
 
         ponderActive = ponder;
         ponderShouldOutputMove = false;

--- a/src/test/java/julius/game/chessengine/uci/UciProtocolTest.java
+++ b/src/test/java/julius/game/chessengine/uci/UciProtocolTest.java
@@ -100,7 +100,7 @@ public class UciProtocolTest {
         UciHandler handler = new UciHandler(outputs::add, running::get);
 
         handler.handle("position startpos");
-        handler.handle("go ponder wtime 60000 btime 60000");
+        handler.handle("go ponder wtime 1000 btime 1000");
 
         // give the search some time to start
         Thread.sleep(200);


### PR DESCRIPTION
## Summary
- allow the search to represent infinite ponder sessions by clamping non-positive or oversized limits and computing safe deadlines
- set an infinite time limit whenever the UCI handler starts a ponder search without an explicit movetime
- tighten the UCI protocol ponder test so it fails if the engine emits a bestmove before ponderhit

## Testing
- unable to run tests (Maven cannot resolve the parent POM without network access)


------
https://chatgpt.com/codex/tasks/task_e_68d2d0a70520832aba98aec9e65e242d