### PR TITLE
Include ponder move in UCI bestmove response

### DIFF
--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -224,6 +224,50 @@ public class UciHandler {
         return from + to;
     }
 
+    private String formatBestMove(String bestMove, String ponderMove) {
+        if (ponderMove == null || ponderMove.isEmpty()) {
+            return "bestmove " + bestMove;
+        }
+        return "bestmove " + bestMove + " ponder " + ponderMove;
+    }
+
+    private String computePonderMove(int bestMove) {
+        List<MoveAndScore> principalVariation = ai.getCalculatedLine();
+        if (principalVariation == null) {
+            return null;
+        }
+
+        List<MoveAndScore> snapshot;
+        synchronized (principalVariation) {
+            snapshot = new ArrayList<>(principalVariation);
+        }
+
+        if (snapshot.isEmpty()) {
+            return null;
+        }
+
+        MoveAndScore firstMove = snapshot.get(0);
+        if (firstMove == null || firstMove.getMove() != bestMove) {
+            return null;
+        }
+
+        if (snapshot.size() < 2) {
+            return null;
+        }
+
+        MoveAndScore ponderCandidate = snapshot.get(1);
+        if (ponderCandidate == null) {
+            return null;
+        }
+
+        int ponderMove = ponderCandidate.getMove();
+        if (ponderMove < 0) {
+            return null;
+        }
+
+        return toUci(ponderMove);
+    }
+
     static long estimateMovesToGo(long timeLeft, long increment) {
         if (timeLeft <= 0) {
             return 1;
@@ -340,8 +384,9 @@ public class UciHandler {
                     output.accept("bestmove 0000");
                 } else {
                     if (bm != null && bm != -1) {
+                        String ponderMove = computePonderMove(bm);
                         engine.performMove(bm);
-                        output.accept("bestmove " + toUci(bm));
+                        output.accept(formatBestMove(toUci(bm), ponderMove));
                     } else {
                         MoveList legal = engine.getAllLegalMoves();
                         if (legal.size() > 0) {


### PR DESCRIPTION
## Summary
- derive the opponent reply from the principal variation and emit it as the ponder move
- reuse the helper to build bestmove lines that include ponder information when available

## Testing
- mvn -q -DskipTests package *(fails: cannot resolve spring-boot-starter-parent because Maven Central is unreachable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d62a7de0832ab02ec864dbed0f2a