### PR TITLE
Avoid propagating callbacks in simulation clones

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -168,9 +168,14 @@ public class Engine {
             this.legalMovesCache = useMoveCache ? new TimedLRUCache<>(CACHE_CFG.maxSize, CACHE_CFG.maxAgeMs) : null;
 
             this.openingBook = other.openingBook;
-            LongConsumer callback = other.onPositionChanged;
-            this.onPositionChanged = (callback != null) ? callback : _ -> {
-            };
+            if (useMoveCache) {
+                LongConsumer callback = other.onPositionChanged;
+                this.onPositionChanged = (callback != null) ? callback : _ -> {
+                };
+            } else {
+                this.onPositionChanged = _ -> {
+                };
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- ensure cloned engines only retain the position callback when move caching is enabled
- install an explicit no-op callback for simulation engines created without caching

## Testing
- mvn -Dtest=BestMoveSearchTest test *(fails: Maven cannot reach repo.maven.apache.org in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f1398ed4832aa01776c2b0945e17