### PR TITLE
Ensure simulations stay isolated and search honours time limits

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -787,11 +787,17 @@ public class AI {
 
     private void performCalculation() {
         try {
+            long boardStateHash = mainEngine.getBoardStateHash();
             Engine simulatorEngine = mainEngine.createSimulation();
-            long boardStateHash = simulatorEngine.getBoardStateHash();
+            long simulatorHash = simulatorEngine.getBoardStateHash();
+            if (simulatorHash != boardStateHash && log.isDebugEnabled()) {
+                log.debug("Simulation hash {} differed from live hash {}. Using live hash for tracking.",
+                        simulatorHash, boardStateHash);
+            }
             boolean isWhite = simulatorEngine.whitesTurn();
             long deadline = computeDeadlineNanos();
             beforeCalculationBoardState = boardStateHash;
+            currentBoardState = boardStateHash;
 
             int bookMove = mainEngine.getOpeningBook().getRandomMoveForBoardStateHash(boardStateHash);
             if (bookMove != -1) {

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -328,7 +328,9 @@ public class Engine {
      * - uses an internal scratch list for generation, but always publishes snapshots
      */
     public Engine createSimulation() {
-        return withBoardLock(() -> new Engine(this, false));
+        Engine simulation = withBoardLock(() -> new Engine(this, false));
+        simulation.setOnPositionChanged(null);
+        return simulation;
     }
 
     // --- Core move generation ---

--- a/src/test/java/julius/game/chessengine/engine/EngineSimulationIsolationTest.java
+++ b/src/test/java/julius/game/chessengine/engine/EngineSimulationIsolationTest.java
@@ -1,0 +1,22 @@
+package julius.game.chessengine.engine;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EngineSimulationIsolationTest {
+
+    @Test
+    public void simulationDoesNotTriggerMainListener() {
+        Engine engine = new Engine();
+        AtomicInteger counter = new AtomicInteger();
+        engine.setOnPositionChanged(hash -> counter.incrementAndGet());
+
+        Engine simulation = engine.createSimulation();
+        simulation.performMove(simulation.getAllLegalMoves().getMove(0));
+
+        assertEquals(0, counter.get(), "Simulation move should not notify the main engine listener");
+    }
+}


### PR DESCRIPTION
## Summary
- clear the position-changed listener on cloned simulation engines so they remain isolated from the live instance
- add a regression test that ensures simulation moves do not call the main engine's listener
- snapshot the live engine hash for search bookkeeping so speculative searches no longer abort early due to mismatched board hashes

## Testing
- mvn -Dtest=EngineSimulationIsolationTest test *(fails: cannot resolve Spring Boot parent due to offline environment)*
- mvn -Dtest=BestMoveSearchTest test *(fails: cannot resolve Spring Boot parent due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f1f8d008832aa191900885a2c5bf