### PR TITLE
Reuse capture move buffer in quiescence search

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2370,7 +2370,8 @@ public class AI {
 
     private MoveList getPossibleCapturesOrPromotions(Engine simulatorEngine) {
         MoveList allLegalMoves = simulatorEngine.getAllLegalMoves();
-        MoveList capturesAndPromotions = new MoveList();
+        MoveList capturesAndPromotions = sortBuffers.get().captureFilterMoves;
+        capturesAndPromotions.clear();
         for (int i = 0; i < allLegalMoves.size(); i++) {
             int m = allLegalMoves.getMove(i);
             if (MoveHelper.isCapture(m) || MoveHelper.isPawnPromotionMove(m)) {

--- a/src/main/java/julius/game/chessengine/ai/SortBuffers.java
+++ b/src/main/java/julius/game/chessengine/ai/SortBuffers.java
@@ -1,14 +1,18 @@
 package julius.game.chessengine.ai;
 
+import julius.game.chessengine.board.MoveList;
+
 final class SortBuffers {
 
     final int[] moveBuffer;
     final int[] scoreBuffer;
     final long[] sortKeyBuffer;
+    final MoveList captureFilterMoves;
 
     SortBuffers(int maxMoveListSize) {
         this.moveBuffer = new int[maxMoveListSize];
         this.scoreBuffer = new int[maxMoveListSize];
         this.sortKeyBuffer = new long[maxMoveListSize];
+        this.captureFilterMoves = new MoveList();
     }
 }


### PR DESCRIPTION
## Summary
- add a capture-filter move list to the existing thread-local sort buffers
- reuse the thread-local buffer when collecting capture and promotion moves during quiescence search

## Testing
- ./mvnw -q test *(fails: Network is unreachable while downloading the Maven wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f9ae02c0832a9e0763330216cef2