### PR TITLE
Ensure ponderhit finalizes ponder search

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -677,6 +677,20 @@ public class AI {
     }
 
 
+    /**
+     * Request the currently active search task to stop after its current iteration.
+     * Unlike {@link #stopCalculation()}, this does not tear down the worker threads
+     * or reset the cached best move, allowing callers to obtain the final result
+     * once the workers finish gracefully.
+     */
+    public void requestStop() {
+        SearchTask task = activeSearch.get();
+        if (task != null) {
+            task.requestStop();
+        }
+    }
+
+
     public void startAutoPlay(boolean aiIsWhite, boolean aiIsBlack) {
 
         if (scheduler != null && !scheduler.isShutdown()) {

--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -436,6 +436,7 @@ public class UciHandler {
     private void ponderHit() {
         if (ponderActive) {
             ponderShouldOutputMove = true;
+            ai.requestStop();
         }
     }
 


### PR DESCRIPTION
## Summary
- add a lightweight stop-request API to the AI to stop the current search without clearing the best move
- invoke the new stop request when a ponderhit command is processed so the ponder search concludes and produces a move

## Testing
- `mvn -Dtest=julius.game.chessengine.uci.UciProtocolTest#testGoPonderRequiresPonderhitForBestmove test` *(fails: unable to download Maven parent POM because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d306fbc1e8832ab1f206520af4c4a8