### PR TITLE
Implement mate broadcasting in parallel root search

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -959,6 +959,7 @@ public class AI {
         return t != null ? t.getInstrumentation() : SearchInstrumentation.disabled();
     }
 
+
     private MoveAndScore getBestMoveParallel(Engine simulatorEngine,
                                              SearchTask task,
                                              int depth,
@@ -978,20 +979,25 @@ public class AI {
         SearchInstrumentation instr = instrumentation();
         instr.recordRootMovesGenerated(orderedMoves.size());
 
-        int firstMove = orderedMoves.getMove(0);
-        int bestMove = -1;
-        double bestScore = isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
-
         final AtomicReference<Double> alphaRef = new AtomicReference<>(alpha);
         final AtomicReference<Double> betaRef = new AtomicReference<>(beta);
         final java.util.concurrent.atomic.AtomicInteger bestMoveRef =
-                new java.util.concurrent.atomic.AtomicInteger(bestMove);
-        final AtomicReference<Double> bestScoreRef = new AtomicReference<>(bestScore);
+                new java.util.concurrent.atomic.AtomicInteger(-1);
+        final AtomicReference<Double> bestScoreRef = new AtomicReference<>(isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY);
+        final AtomicReference<MoveAndScore> fallbackMateRef = new AtomicReference<>();
+        final Set<Integer> refutedRootMoves = ConcurrentHashMap.newKeySet();
+        final AtomicBoolean stopRef = new AtomicBoolean(false);
+        final AtomicBoolean mateWinFound = new AtomicBoolean(false);
+
+        double bestScore = isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+        int bestMove = -1;
 
         if (abortRequested(deadline)) return null;
 
+        int firstMove = orderedMoves.getMove(0);
         instr.recordRootMoveExplored();
         simulatorEngine.performMove(firstMove);
+        long firstChildHash = simulatorEngine.getBoardStateHash();
         double firstScore;
         if (simulatorEngine.getGameState().isInStateCheckMate()) {
             firstScore = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
@@ -1007,27 +1013,28 @@ public class AI {
                 return null;
             }
         }
+        applyRootScore(isWhitesTurn, firstMove, firstScore, firstChildHash, depth - 1,
+                alphaRef, betaRef, bestMoveRef, bestScoreRef, fallbackMateRef,
+                refutedRootMoves, mateWinFound, stopRef);
         simulatorEngine.undoLastMove();
 
-        bestMove = firstMove;
-        bestScore = firstScore;
+        if (mateWinFound.get()) {
+            return new MoveAndScore(bestMoveRef.get(), bestScoreRef.get());
+        }
 
-        if (isWhitesTurn) alpha = Math.max(alpha, firstScore);
-        else beta = Math.min(beta, firstScore);
+        bestMove = bestMoveRef.get();
+        bestScore = bestScoreRef.get();
+        alpha = alphaRef.get();
+        beta = betaRef.get();
 
-        bestMoveRef.set(bestMove);
-        bestScoreRef.set(bestScore);
-        alphaRef.set(alpha);
-        betaRef.set(beta);
-        if (alpha >= beta) return new MoveAndScore(bestMove, bestScore);
+        if (orderedMoves.size() == 1) {
+            MoveAndScore fallback = fallbackMateRef.get();
+            return bestMove != -1 ? new MoveAndScore(bestMove, bestScore) : fallback;
+        }
 
         final int fanout = Math.min(Math.min(ROOT_PARALLEL_LIMIT, searchThreads * 2), orderedMoves.size() - 1);
-        if (fanout <= 0) return new MoveAndScore(bestMove, bestScore);
-
         final CompletionService<MoveAndScore> ecs = new ExecutorCompletionService<>(searchPool);
-        final List<Future<MoveAndScore>> futures = new ArrayList<>(fanout);
-
-        final AtomicBoolean stopRef = new AtomicBoolean(false);
+        final List<Future<MoveAndScore>> futures = new ArrayList<>(Math.max(fanout, 0));
         final java.util.concurrent.locks.ReentrantLock fullResLock = new java.util.concurrent.locks.ReentrantLock();
 
         for (int i = 1; i <= fanout; i++) {
@@ -1064,44 +1071,28 @@ public class AI {
                         if (probe == EXIT_FLAG || abortRequested(deadline)) return null;
                     }
 
-                    boolean needsFull = isWhitesTurn ? (probe > alphaRef.get() + 0.05) : (probe < betaRef.get() - 0.05);
                     double finalScore = probe;
+                    boolean needsFull = isWhitesTurn ? (probe > alphaRef.get() + 0.05) : (probe < betaRef.get() - 0.05);
 
                     if (needsFull && !stopRef.get()) {
                         fullResLock.lock();
                         try {
                             if (!stopRef.get() && !abortRequested(deadline)) {
-                                double aNow = alphaRef.get(), bNow = betaRef.get();
+                                double aNow = alphaRef.get();
+                                double bNow = betaRef.get();
                                 double full = alphaBeta(e, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt, 1, 0);
-                                if (full != EXIT_FLAG) {
-                                    finalScore = full;
-                                    if (isWhitesTurn) {
-                                        if (full > aNow) alphaRef.set(full);
-                                    } else {
-                                        if (full < bNow) betaRef.set(full);
-                                    }
-                                    Double curBest = bestScoreRef.get();
-                                    if (isBetterScore(isWhitesTurn, full, curBest)) {
-                                        bestScoreRef.set(full);
-                                        bestMoveRef.set(moveInt);
-                                    }
-                                    if (alphaRef.get() >= betaRef.get()) stopRef.set(true);
-                                }
+                                if (full == EXIT_FLAG) return null;
+                                finalScore = full;
                             }
                         } finally {
                             fullResLock.unlock();
                         }
-                    } else {
-                        Double curBest = bestScoreRef.get();
-                        if (isBetterScore(isWhitesTurn, finalScore, curBest)) {
-                            bestScoreRef.set(finalScore);
-                            bestMoveRef.set(moveInt);
-                            if (isWhitesTurn && finalScore > alphaRef.get()) alphaRef.set(finalScore);
-                            if (!isWhitesTurn && finalScore < betaRef.get()) betaRef.set(finalScore);
-                            if (alphaRef.get() >= betaRef.get()) stopRef.set(true);
-                        }
                     }
 
+                    long childHash = e.getBoardStateHash();
+                    applyRootScore(isWhitesTurn, moveInt, finalScore, childHash, depth - 1,
+                            alphaRef, betaRef, bestMoveRef, bestScoreRef, fallbackMateRef,
+                            refutedRootMoves, mateWinFound, stopRef);
                     return new MoveAndScore(moveInt, finalScore);
                 } finally {
                     if (helperHeuristics.hasUpdates()) {
@@ -1119,13 +1110,11 @@ public class AI {
                 if (stopRef.get() || abortRequested(deadline)) break;
                 Future<MoveAndScore> f = ecs.take();
                 completed++;
-                MoveAndScore res = f.get();
-                if (res == null) continue;
+                if (f.get() == null) continue;
 
-                alpha = alphaRef.get();
-                beta = betaRef.get();
+                if (mateWinFound.get()) break;
 
-                if (alpha >= beta) {
+                if (alphaRef.get() >= betaRef.get()) {
                     stopRef.set(true);
                     break;
                 }
@@ -1135,7 +1124,9 @@ public class AI {
         } catch (Exception ex) {
             log.warn("Parallel root YBWC error", ex);
         } finally {
-            for (Future<MoveAndScore> f : futures) if (!f.isDone()) f.cancel(true);
+            for (Future<MoveAndScore> f : futures) {
+                if (!f.isDone()) f.cancel(true);
+            }
         }
 
         alpha = alphaRef.get();
@@ -1143,15 +1134,21 @@ public class AI {
         bestMove = bestMoveRef.get();
         bestScore = bestScoreRef.get();
 
+        if (mateWinFound.get()) {
+            return new MoveAndScore(bestMoveRef.get(), bestScoreRef.get());
+        }
+
         if (!stopRef.get()) {
             for (int idx = fanout + 1; idx < orderedMoves.size(); idx++) {
                 if (abortRequested(deadline)) {
                     break;
                 }
-
                 int moveInt = orderedMoves.getMove(idx);
+                if (refutedRootMoves.contains(moveInt)) continue;
+
                 instr.recordRootMoveExplored();
                 simulatorEngine.performMove(moveInt);
+                long childHash = simulatorEngine.getBoardStateHash();
 
                 double score;
                 if (simulatorEngine.getGameState().isInStateCheckMate()) {
@@ -1168,21 +1165,19 @@ public class AI {
                         break;
                     }
                 }
+
+                applyRootScore(isWhitesTurn, moveInt, score, childHash, depth - 1,
+                        alphaRef, betaRef, bestMoveRef, bestScoreRef, fallbackMateRef,
+                        refutedRootMoves, mateWinFound, stopRef);
                 simulatorEngine.undoLastMove();
 
-                if (isBetterScore(isWhitesTurn, score, bestScore)) {
-                    bestScore = score;
-                    bestMove = moveInt;
-                    bestScoreRef.set(bestScore);
-                    bestMoveRef.set(bestMove);
-                }
+                alpha = alphaRef.get();
+                beta = betaRef.get();
+                bestMove = bestMoveRef.get();
+                bestScore = bestScoreRef.get();
 
-                if (isWhitesTurn) {
-                    alpha = Math.max(alpha, score);
-                    alphaRef.set(alpha);
-                } else {
-                    beta = Math.min(beta, score);
-                    betaRef.set(beta);
+                if (mateWinFound.get()) {
+                    return new MoveAndScore(bestMoveRef.get(), bestScoreRef.get());
                 }
 
                 if (alpha >= beta) {
@@ -1193,8 +1188,109 @@ public class AI {
             }
         }
 
-        return bestMove != -1 ? new MoveAndScore(bestMove, bestScore) : null;
+        if (bestMove != -1) {
+            return new MoveAndScore(bestMove, bestScore);
+        }
+        MoveAndScore fallback = fallbackMateRef.get();
+        return fallback != null ? fallback : null;
     }
+
+    private void applyRootScore(boolean isWhitesTurn,
+                                 int move,
+                                 double score,
+                                 long childHash,
+                                 int depthRemaining,
+                                 AtomicReference<Double> alphaRef,
+                                 AtomicReference<Double> betaRef,
+                                 java.util.concurrent.atomic.AtomicInteger bestMoveRef,
+                                 AtomicReference<Double> bestScoreRef,
+                                 AtomicReference<MoveAndScore> fallbackMateRef,
+                                 Set<Integer> refutedRootMoves,
+                                 AtomicBoolean mateWinFound,
+                                 AtomicBoolean stopRef) {
+        if (isWinningMateForUs(isWhitesTurn, score)) {
+            publishExactMateToTT(childHash, score, depthRemaining);
+            mateWinFound.set(true);
+            bestMoveRef.set(move);
+            bestScoreRef.set(score);
+            if (isWhitesTurn) {
+                alphaRef.updateAndGet(current -> Math.max(current, score));
+            } else {
+                betaRef.updateAndGet(current -> Math.min(current, score));
+            }
+            stopRef.set(true);
+            return;
+        }
+
+        if (isLosingMateForUs(isWhitesTurn, score)) {
+            publishExactMateToTT(childHash, score, depthRemaining);
+            refutedRootMoves.add(move);
+            updateFallbackMate(fallbackMateRef, isWhitesTurn, move, score);
+            return;
+        }
+
+        Double currentBest = bestScoreRef.get();
+        if (isBetterScore(isWhitesTurn, score, currentBest)) {
+            bestScoreRef.set(score);
+            bestMoveRef.set(move);
+        }
+
+        if (isWhitesTurn) {
+            alphaRef.updateAndGet(current -> Math.max(current, score));
+        } else {
+            betaRef.updateAndGet(current -> Math.min(current, score));
+        }
+
+        if (alphaRef.get() >= betaRef.get()) {
+            stopRef.set(true);
+        }
+    }
+
+    private void updateFallbackMate(AtomicReference<MoveAndScore> fallbackRef,
+                                    boolean isWhitesTurn,
+                                    int move,
+                                    double score) {
+        MoveAndScore candidate = null;
+        while (true) {
+            MoveAndScore current = fallbackRef.get();
+            if (current != null && !isBetterScore(isWhitesTurn, score, current.getScore())) {
+                return;
+            }
+            if (candidate == null) {
+                candidate = new MoveAndScore(move, score);
+            }
+            if (fallbackRef.compareAndSet(current, candidate)) {
+                return;
+            }
+        }
+    }
+
+    private boolean isWinningMateForUs(boolean isWhitesTurn, double score) {
+        double threshold = CHECKMATE - 50;
+        return isWhitesTurn ? score >= threshold : score <= -threshold;
+    }
+
+    private boolean isLosingMateForUs(boolean isWhitesTurn, double score) {
+        double threshold = CHECKMATE - 50;
+        return isWhitesTurn ? score <= -threshold : score >= threshold;
+    }
+
+    private void publishExactMateToTT(long childHash, double score, int depthRemaining) {
+        if (transpositionTable == null) {
+            return;
+        }
+        int depthForEntry = Math.max(maxDepth, Math.max(0, depthRemaining) + 6);
+        TranspositionTableEntry existing = transpositionTable.get(childHash);
+        if (existing != null
+                && existing.nodeType == NodeType.EXACT
+                && existing.depth >= depthForEntry
+                && existing.score == score) {
+            return;
+        }
+        transpositionTable.put(childHash,
+                new TranspositionTableEntry(score, depthForEntry, NodeType.EXACT, -1), depthForEntry);
+    }
+
 
 
     private boolean shouldStopCalculating(long deadline) {

--- a/src/test/java/julius/game/chessengine/ai/ParallelMateBroadcastTest.java
+++ b/src/test/java/julius/game/chessengine/ai/ParallelMateBroadcastTest.java
@@ -1,0 +1,104 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.board.MoveList;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.utils.Score;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParallelMateBroadcastTest {
+
+    private AI ai;
+
+    @BeforeEach
+    void setUp() {
+        ai = new AI(new Engine());
+        ai.setSearchThreads(2);
+        ai.setTimeLimit(Duration.ofSeconds(2).toMillis());
+    }
+
+    @Test
+    void winningMateBroadcastStopsWorkers() throws Exception {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("7k/6pp/8/8/8/8/6PP/5RK1 w - - 0 1");
+
+        SearchTask task = new SearchTask(1L, engine.getBoardStateHash(), engine.whitesTurn(),
+                System.nanoTime() + TimeUnit.SECONDS.toNanos(5), ai.getSearchThreads(), SearchInstrumentation.disabled());
+
+        MoveAndScore result = ai.searchRootMoves(engine, task, 4,
+                Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, new SplittableRandom(1));
+
+        assertNotNull(result, "Expected a winning mate move");
+
+        Engine verify = engine.createSimulation();
+        verify.performMove(result.getMove());
+        assertTrue(verify.getGameState().isInStateCheckMate(), "Returned move must deliver mate");
+
+        long childHash = verify.getBoardStateHash();
+        TranspositionTableEntry entry = lookupMainEntry(ai, childHash);
+        assertNotNull(entry, "Mate child should be cached");
+        assertEquals(NodeType.EXACT, entry.nodeType);
+        assertTrue(Math.abs(entry.score) >= Score.CHECKMATE - 50, "Mate entry should store mate score");
+    }
+
+    @Test
+    void losingMateBroadcastRefutesRootMove() throws Exception {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("6rk/5p2/8/6q1/2B5/8/7P/5R1K w - - 0 1");
+
+        SearchTask task = new SearchTask(2L, engine.getBoardStateHash(), engine.whitesTurn(),
+                System.nanoTime() + TimeUnit.SECONDS.toNanos(5), ai.getSearchThreads(), SearchInstrumentation.disabled());
+
+        MoveAndScore result = ai.searchRootMoves(engine, task, 4,
+                Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, new SplittableRandom(3));
+
+        assertNotNull(result, "Expected a best move even when facing mate threats");
+
+        int losingMove = findMove(engine,
+                MoveHelper.convertStringToIndex("c4"),
+                MoveHelper.convertStringToIndex("f7"));
+        assertNotEquals(losingMove, result.getMove(), "Losing mate move must be excluded from best choice");
+
+        Engine losingLine = engine.createSimulation();
+        losingLine.performMove(losingMove);
+        long mateChildHash = losingLine.getBoardStateHash();
+        TranspositionTableEntry entry = lookupMainEntry(ai, mateChildHash);
+        assertNotNull(entry, "Refuted move child should be cached");
+        assertEquals(NodeType.EXACT, entry.nodeType);
+        assertTrue(entry.score <= -(Score.CHECKMATE - 50), "Refuted move must record losing mate score");
+
+        int expectedSafeMove = findMove(engine,
+                MoveHelper.convertStringToIndex("f1"),
+                MoveHelper.convertStringToIndex("f2"));
+        assertEquals(expectedSafeMove, result.getMove(), "Engine should choose the safe defence");
+    }
+
+    private static int findMove(Engine engine, int from, int to) {
+        MoveList moves = engine.getAllLegalMoves();
+        for (int i = 0; i < moves.size(); i++) {
+            int mv = moves.getMove(i);
+            if (MoveHelper.deriveFromIndex(mv) == from && MoveHelper.deriveToIndex(mv) == to) {
+                return mv;
+            }
+        }
+        fail("Move " + from + " -> " + to + " not legal in this position");
+        return -1;
+    }
+
+    private static TranspositionTableEntry lookupMainEntry(AI ai, long hash) throws Exception {
+        Field field = AI.class.getDeclaredField("transpositionTable");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        TranspositionTable<TranspositionTableEntry> table =
+                (TranspositionTable<TranspositionTableEntry>) field.get(ai);
+        return table.get(hash);
+    }
+}


### PR DESCRIPTION
## Summary
- implement mate broadcasting in the parallel root search so winning mates stop workers and losing mates are refuted globally
- publish high-depth EXACT mate entries in the transposition table and add helpers for mate classification
- add regression tests covering root-level mate wins and refutations under parallel search

## Testing
- `mvn -o test` *(fails: missing parent POM in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68d309044ba0832a8851363bc018515e