### PR TITLE
Fix abort logic for standalone searches

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -949,9 +949,16 @@ public class AI {
     private boolean abortRequested(long deadline) {
         if (Thread.currentThread().isInterrupted()) return true;
         if (System.nanoTime() > deadline) return true;
-        if (positionChanged()) return true;
+
         SearchTask t = threadSearchTask.get();
-        return t != null && t.isStopRequested();
+        if (t == null) {
+            // When no worker task is active (e.g. direct test invocations) there is no
+            // ongoing monitored position, so ignore stale-board checks.
+            return false;
+        }
+
+        if (positionChanged()) return true;
+        return t.isStopRequested();
     }
 
     private SearchInstrumentation instrumentation() {


### PR DESCRIPTION
## Summary
- avoid aborting searches that are invoked directly without an active worker task by skipping stale-position checks in that scenario
- keep existing stop handling for worker-driven searches unchanged

## Testing
- mvn -q test -Dtest=ParallelMateBroadcastTest *(fails: network is unreachable while resolving the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d30f8efa10832abaa8d48db22ad9da