### PR TITLE
Allow deeper iterations to replace best move

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/SearchTask.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchTask.java
@@ -92,8 +92,13 @@ public final class SearchTask {
             BestMoveDepth cur = best.get();
             boolean betterScore = isBetterScore(whiteToMove, ms.score, cur.score());
             boolean scoresApproximatelyEqual = Math.abs(ms.score - cur.score()) <= SCORE_EPSILON;
-            boolean deeperTie = scoresApproximatelyEqual && depth > cur.depth();
-            if (!betterScore && !deeperTie ) return false;
+            boolean strictlyDeeper = depth > cur.depth();
+            boolean deeperTie = scoresApproximatelyEqual && strictlyDeeper;
+            if (!betterScore) {
+                if (!strictlyDeeper && !deeperTie) {
+                    return false;
+                }
+            }
 
             BestMoveDepth next = new BestMoveDepth(ms.move, ms.score, depth);
             if (best.compareAndSet(cur, next)) {


### PR DESCRIPTION
## Summary
- allow SearchTask to accept deeper results even when they score worse so that iterative deepening can publish them

## Testing
- Failed: `mvn -q -Dtest=ParallelMateBroadcastTest test` *(cannot resolve parent POM because the Maven Central repository is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d31108d714832a97cfced0dc16c071