### PR TITLE
Log UCI communication to file

### DIFF
--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -32,6 +32,7 @@ public class UciHandler {
     private final AI ai;
     private final Consumer<String> output;
     private final Supplier<Boolean> running;
+    private final UciLogger logger;
     private Thread searchThread;
     private volatile boolean ponderActive = false;
     private volatile boolean ponderShouldOutputMove = false;
@@ -40,14 +41,19 @@ public class UciHandler {
     private final AtomicLong lastInfoNanos = new AtomicLong(0L);
 
     public UciHandler() {
-        this(System.out::println, () -> true);
+        this(System.out::println, () -> true, null);
     }
 
     public UciHandler(Consumer<String> output, Supplier<Boolean> running) {
+        this(output, running, null);
+    }
+
+    public UciHandler(Consumer<String> output, Supplier<Boolean> running, UciLogger logger) {
         this.engine = new Engine();
         this.ai = new AI(engine);
         this.output = Objects.requireNonNull(output, "output");
         this.running = Objects.requireNonNull(running, "running");
+        this.logger = logger;
         registerOptions();
     }
 
@@ -59,26 +65,51 @@ public class UciHandler {
         if (line == null || line.isEmpty()) {
             return true;
         }
+        logEvent("received: " + line);
         String[] tokens = line.trim().split("\\s+");
         String cmd = tokens[0];
         switch (cmd) {
-            case "uci" -> sendId();
+            case "uci" -> {
+                logEvent("command: uci");
+                sendId();
+            }
             case "isready" -> {
+                logEvent("command: isready");
                 stop();
                 output.accept("readyok");
             }
-            case "ucinewgame" -> newGame();
-            case "position" -> setPosition(tokens);
-            case "go" -> go(tokens);
-            case "stop" -> stop();
-            case "ponderhit" -> ponderHit();
-            case "setoption" -> setOption(tokens);
+            case "ucinewgame" -> {
+                logEvent("command: ucinewgame");
+                newGame();
+            }
+            case "position" -> {
+                logEvent("command: position");
+                setPosition(tokens);
+            }
+            case "go" -> {
+                logEvent("command: go");
+                go(tokens);
+            }
+            case "stop" -> {
+                logEvent("command: stop");
+                stop();
+            }
+            case "ponderhit" -> {
+                logEvent("command: ponderhit");
+                ponderHit();
+            }
+            case "setoption" -> {
+                logEvent("command: setoption");
+                setOption(tokens);
+            }
             case "quit" -> {
                 stop();
+                logEvent("command: quit");
                 return false;
             }
             default -> {
                 // Unknown commands are ignored for now
+                logEvent("command: unknown - " + cmd);
             }
         }
         return true;
@@ -92,6 +123,12 @@ public class UciHandler {
                     opt.name, opt.type, opt.defaultValue, opt.min, opt.max));
         }
         output.accept("uciok");
+    }
+
+    private void logEvent(String message) {
+        if (logger != null) {
+            logger.logEvent(message);
+        }
     }
 
     private void registerOptions() {

--- a/src/main/java/julius/game/chessengine/uci/UciLogger.java
+++ b/src/main/java/julius/game/chessengine/uci/UciLogger.java
@@ -1,0 +1,68 @@
+package julius.game.chessengine.uci;
+
+import java.io.BufferedWriter;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Utility class used for logging UCI communication to a file.
+ */
+public final class UciLogger implements Closeable {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_INSTANT;
+
+    private final PrintWriter writer;
+    private boolean closed = false;
+
+    public UciLogger(Path logFile) throws IOException {
+        Path parent = logFile.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        this.writer = new PrintWriter(new BufferedWriter(new OutputStreamWriter(
+                Files.newOutputStream(logFile,
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.WRITE,
+                        StandardOpenOption.APPEND),
+                StandardCharsets.UTF_8)), true);
+        logEvent("--- Logging started ---");
+    }
+
+    public void logReceived(String message) {
+        log("IN", message);
+    }
+
+    public void logSent(String message) {
+        log("OUT", message);
+    }
+
+    public void logEvent(String message) {
+        log("EVENT", message);
+    }
+
+    private synchronized void log(String type, String message) {
+        if (closed) {
+            return;
+        }
+        writer.printf("%s [%s] %s%n", FORMATTER.format(Instant.now()), type, message);
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        logEvent("--- Logging finished ---");
+        writer.flush();
+        writer.close();
+        closed = true;
+    }
+}

--- a/src/main/java/julius/game/chessengine/uci/UciMain.java
+++ b/src/main/java/julius/game/chessengine/uci/UciMain.java
@@ -3,6 +3,7 @@ package julius.game.chessengine.uci;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Path;
 
 /**
  * Entry point for running the engine via the UCI protocol on standard IO.
@@ -13,12 +14,19 @@ public final class UciMain {
     }
 
     public static void main(String[] args) throws IOException {
-        UciHandler handler = new UciHandler(System.out::println, () -> true);
-        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-        String line;
-        while ((line = reader.readLine()) != null) {
-            if (!handler.handle(line)) {
-                break;
+        Path logFile = Path.of("logs", "uci-communication.log");
+        try (UciLogger logger = new UciLogger(logFile)) {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+            UciHandler handler = new UciHandler(message -> {
+                logger.logSent(message);
+                System.out.println(message);
+            }, () -> true, logger);
+            String line;
+            while ((line = reader.readLine()) != null) {
+                logger.logReceived(line);
+                if (!handler.handle(line)) {
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a dedicated `UciLogger` utility to capture UCI protocol messages in a log file
- wrap the UCI entry point so that incoming commands and outgoing responses are written to the log while keeping console IO intact
- annotate the handler to record which commands are processed for better traceability

## Testing
- `./mvnw -q test` *(fails: Maven wrapper cannot download dependencies because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a635902c832a8f1a0663d049b703