### PR TITLE
Fix UCI search reporting and instrumentation

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -188,6 +188,79 @@ public class AI {
         return lastCompletedPrincipalVariation;
     }
 
+    public int getCurrentSearchDepth() {
+        SearchTask task = activeSearch.get();
+        if (task != null) {
+            int iterationDepth = task.getIterationDepth();
+            BestMoveDepth best = task.getBest();
+            if (best != null) {
+                iterationDepth = Math.max(iterationDepth, best.depth());
+            }
+            if (iterationDepth > 0) {
+                return iterationDepth;
+            }
+        }
+
+        SearchDiagnostics diagnostics = lastDiagnostics;
+        if (diagnostics != null) {
+            int depth = diagnostics.bestDepth();
+            if (depth > 0) {
+                return depth;
+            }
+        }
+        return 0;
+    }
+
+    public int getCurrentSelectiveDepth() {
+        SearchTask task = activeSearch.get();
+        if (task != null) {
+            SearchInstrumentation instr = task.getInstrumentation();
+            if (instr != null) {
+                int ply = Math.max(instr.currentDeepestPlyVisited(), instr.currentDeepestQuiescencePly());
+                if (ply > 0) {
+                    return ply;
+                }
+            }
+        }
+
+        SearchDiagnostics diagnostics = lastDiagnostics;
+        if (diagnostics != null) {
+            return Math.max(diagnostics.deepestPlyVisited(), diagnostics.deepestQuiescencePly());
+        }
+        return 0;
+    }
+
+    public double getCurrentSearchScore() {
+        SearchTask task = activeSearch.get();
+        if (task != null) {
+            BestMoveDepth best = task.getBest();
+            if (best != null && best.move() != -1) {
+                return best.score();
+            }
+        }
+
+        SearchDiagnostics diagnostics = lastDiagnostics;
+        if (diagnostics != null) {
+            double score = diagnostics.bestScore();
+            if (!Double.isNaN(score)) {
+                return score;
+            }
+        }
+
+        List<MoveAndScore> pv = lastCompletedPrincipalVariation;
+        if (pv != null) {
+            synchronized (pv) {
+                if (!pv.isEmpty()) {
+                    MoveAndScore head = pv.getFirst();
+                    if (head != null) {
+                        return head.getScore();
+                    }
+                }
+            }
+        }
+        return Double.NaN;
+    }
+
     // Game configuration parameters
 
     @Getter

--- a/src/main/java/julius/game/chessengine/ai/SearchInstrumentation.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchInstrumentation.java
@@ -26,8 +26,8 @@ final class SearchInstrumentation {
     private final AtomicInteger deepestPlyVisited = new AtomicInteger();
     private final AtomicInteger deepestQuiescencePly = new AtomicInteger();
 
-    private final AtomicInteger rootMovesGenerated = new AtomicInteger();
-    private final AtomicInteger rootMovesExplored = new AtomicInteger();
+    private final LongAdder rootMovesGenerated = new LongAdder();
+    private final LongAdder rootMovesExplored = new LongAdder();
     private final LongAdder rootBetaCutoffs = new LongAdder();
     private final LongAdder iterationsCompleted = new LongAdder();
 
@@ -86,12 +86,13 @@ final class SearchInstrumentation {
 
     void recordRootMovesGenerated(int count) {
         if (!enabled) return;
-        rootMovesGenerated.set(Math.max(0, count));
+        if (count <= 0) return;
+        rootMovesGenerated.add(count);
     }
 
     void recordRootMoveExplored() {
         if (!enabled) return;
-        rootMovesExplored.incrementAndGet();
+        rootMovesExplored.increment();
     }
 
     void recordRootBetaCutoff() {
@@ -103,6 +104,31 @@ final class SearchInstrumentation {
         if (!enabled) return;
         if (ply < 0) return;
         deepestPlyVisited.accumulateAndGet(ply, Math::max);
+    }
+
+    int currentBestDepth() {
+        if (!enabled) return 0;
+        return bestDepth.get();
+    }
+
+    int currentDeepestPlyVisited() {
+        if (!enabled) return 0;
+        return deepestPlyVisited.get();
+    }
+
+    int currentDeepestQuiescencePly() {
+        if (!enabled) return 0;
+        return deepestQuiescencePly.get();
+    }
+
+    long currentRootMovesGenerated() {
+        if (!enabled) return 0L;
+        return rootMovesGenerated.sum();
+    }
+
+    long currentRootMovesExplored() {
+        if (!enabled) return 0L;
+        return rootMovesExplored.sum();
     }
 
     void recordQuiescenceNode(int depth) {
@@ -204,8 +230,8 @@ final class SearchInstrumentation {
                 bestScore,
                 deepestPlyVisited.get(),
                 deepestQuiescencePly.get(),
-                rootMovesGenerated.get(),
-                rootMovesExplored.get(),
+                clampToInt(rootMovesGenerated.sum()),
+                clampToInt(rootMovesExplored.sum()),
                 rootBetaCutoffs.sum(),
                 iterationsCompleted.sum(),
                 aspirationFailHighs.sum(),
@@ -231,5 +257,11 @@ final class SearchInstrumentation {
                 quiescenceSeePrunes.sum(),
                 quiescenceCaptures.sum()
         );
+    }
+
+    private static int clampToInt(long value) {
+        if (value > Integer.MAX_VALUE) return Integer.MAX_VALUE;
+        if (value < Integer.MIN_VALUE) return Integer.MIN_VALUE;
+        return (int) value;
     }
 }

--- a/src/main/java/julius/game/chessengine/ai/SearchTask.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchTask.java
@@ -47,6 +47,7 @@ public final class SearchTask {
     boolean isWhiteToMove() { return whiteToMove; }
     long getDeadline() { return deadline; }
     BestMoveDepth getBest() { return best.get(); }
+    int getIterationDepth() { return iterationDepth.get(); }
 
     void workerDone() { completion.countDown(); }
     void requestStop() { stop.set(true); }

--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -499,9 +499,27 @@ public class UciHandler {
             }
         }
         StringBuilder builder = new StringBuilder("info");
+        int depth = ai.getCurrentSearchDepth();
+        if (depth > 0) {
+            builder.append(" depth ").append(depth);
+        }
+        int selDepth = ai.getCurrentSelectiveDepth();
+        if (selDepth > 0) {
+            builder.append(" seldepth ").append(selDepth);
+        }
+
+        double score = Double.NaN;
         if (!line.isEmpty()) {
-            builder.append(" depth ").append(line.size());
-            builder.append(' ').append(formatScore(line.getFirst().getScore()));
+            MoveAndScore head = line.getFirst();
+            if (head != null) {
+                score = head.getScore();
+            }
+        }
+        if (Double.isNaN(score)) {
+            score = ai.getCurrentSearchScore();
+        }
+        if (!Double.isNaN(score)) {
+            builder.append(' ').append(formatScore(score));
         }
         builder.append(" nodes ").append(nodes);
         builder.append(" time ").append(elapsedMillis);
@@ -519,7 +537,7 @@ public class UciHandler {
             int generated = diagnostics.rootMovesGenerated();
             int explored = diagnostics.rootMovesExplored();
             if (generated > 0 || explored > 0) {
-                int difference = generated - explored;
+                int difference = Math.max(0, generated - explored);
                 output.accept("info string rootmoves generated " + generated
                         + " explored " + explored
                         + " diff " + difference);


### PR DESCRIPTION
## Summary
- add APIs to expose the in-progress search depth, selective depth, and score so UCI updates advance with each iteration
- accumulate root move metrics inside the search instrumentation to keep generated/explored accounting consistent across iterations
- adjust the UCI info publisher to report depth/seldepth from the engine and clamp root move diffs to non-negative values

## Testing
- ./mvnw -q test *(fails: network is unreachable while downloading the Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ab577b74832aa33395622c908136