### PR TITLE
Improve UCI search reporting and counters

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -210,6 +210,9 @@ public class AI {
     @Getter
     private volatile SearchDiagnostics lastDiagnostics = SearchDiagnostics.EMPTY;
 
+    public record SearchStatus(int depth, double score, int bestMove, boolean active) {
+    }
+
     public AI(Engine mainEngine) {
         log.info("### SearchThreads = {}, LazySmpThreads = {}", searchThreads, lazySmpThreads);
         this.mainEngine = mainEngine;
@@ -377,6 +380,30 @@ public class AI {
         return move;
     }
 
+    public SearchStatus snapshotSearchStatus() {
+        SearchTask task = activeSearch.get();
+        if (task != null) {
+            BestMoveDepth best = task.getBest();
+            int iterationDepth = Math.max(0, task.getCurrentIterationDepth());
+            int reportedDepth = Math.max(iterationDepth, best.depth());
+            double score = (best.move() != -1 && Double.isFinite(best.score()))
+                    ? best.score()
+                    : Double.NaN;
+            return new SearchStatus(reportedDepth, score, best.move(), true);
+        }
+
+        SearchDiagnostics diagnostics = lastDiagnostics;
+        int depth = diagnostics != null ? Math.max(0, diagnostics.bestDepth()) : 0;
+        double score = (diagnostics != null && Double.isFinite(diagnostics.bestScore()))
+                ? diagnostics.bestScore()
+                : Double.NaN;
+        int move = -1;
+        if (searchResultReady && bestMoveForHash == mainEngine.getBoardStateHash()) {
+            move = currentBestMove;
+        }
+        return new SearchStatus(depth, score, move, false);
+    }
+
     private void startCalculationThread() {
         keepCalculating = true;
 
@@ -457,6 +484,9 @@ public class AI {
 
             boolean firstAtDepth = task.beginIteration(currentDepth);
             prepareIterationState(task, heuristics, currentDepth, firstAtDepth);
+            if (firstAtDepth) {
+                instr.beginRootIteration();
+            }
 
             MoveAndScore ms = null;
 

--- a/src/main/java/julius/game/chessengine/ai/SearchInstrumentation.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchInstrumentation.java
@@ -91,7 +91,20 @@ final class SearchInstrumentation {
 
     void recordRootMoveExplored() {
         if (!enabled) return;
-        rootMovesExplored.incrementAndGet();
+        rootMovesExplored.updateAndGet(prev -> {
+            int next = prev + 1;
+            int generated = rootMovesGenerated.get();
+            if (generated <= 0) {
+                return next;
+            }
+            return Math.min(next, generated);
+        });
+    }
+
+    void beginRootIteration() {
+        if (!enabled) return;
+        rootMovesGenerated.set(0);
+        rootMovesExplored.set(0);
     }
 
     void recordRootBetaCutoff() {

--- a/src/main/java/julius/game/chessengine/ai/SearchTask.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchTask.java
@@ -47,6 +47,7 @@ public final class SearchTask {
     boolean isWhiteToMove() { return whiteToMove; }
     long getDeadline() { return deadline; }
     BestMoveDepth getBest() { return best.get(); }
+    int getCurrentIterationDepth() { return iterationDepth.get(); }
 
     void workerDone() { completion.countDown(); }
     void requestStop() { stop.set(true); }

--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -489,6 +489,7 @@ public class UciHandler {
         lastInfoNanos.set(now);
 
         List<MoveAndScore> line = new ArrayList<>(ai.getCalculatedLine());
+        AI.SearchStatus status = ai.snapshotSearchStatus();
         long nodes = ai.getNodesVisited();
         long elapsedMillis = ai.getSearchElapsedMillis();
         long nps = 0L;
@@ -499,18 +500,30 @@ public class UciHandler {
             }
         }
         StringBuilder builder = new StringBuilder("info");
-        if (!line.isEmpty()) {
-            builder.append(" depth ").append(line.size());
-            builder.append(' ').append(formatScore(line.getFirst().getScore()));
+        int depth = status != null ? status.depth() : 0;
+        if (depth <= 0 && !line.isEmpty()) {
+            depth = line.size();
+        }
+        if (depth > 0) {
+            builder.append(" depth ").append(depth);
+        }
+        double score = (status != null) ? status.score() : Double.NaN;
+        if (Double.isNaN(score) && !line.isEmpty()) {
+            score = line.getFirst().getScore();
+        }
+        if (!Double.isNaN(score)) {
+            builder.append(' ').append(formatScore(score));
         }
         builder.append(" nodes ").append(nodes);
         builder.append(" time ").append(elapsedMillis);
         builder.append(" nps ").append(nps);
-        if (!line.isEmpty()) {
-            String pv = buildPv(line);
-            if (!pv.isEmpty()) {
-                builder.append(" pv ").append(pv);
-            }
+        String pv = buildPv(line);
+        int bestMove = (status != null) ? status.bestMove() : -1;
+        if (pv.isEmpty() && bestMove != -1) {
+            pv = toUci(bestMove);
+        }
+        if (!pv.isEmpty()) {
+            builder.append(" pv ").append(pv);
         }
         output.accept(builder.toString());
 
@@ -519,7 +532,7 @@ public class UciHandler {
             int generated = diagnostics.rootMovesGenerated();
             int explored = diagnostics.rootMovesExplored();
             if (generated > 0 || explored > 0) {
-                int difference = generated - explored;
+                int difference = Math.max(0, generated - explored);
                 output.accept("info string rootmoves generated " + generated
                         + " explored " + explored
                         + " diff " + difference);


### PR DESCRIPTION
## Summary
- expose per-search status so UCI `info` lines report depth, score, and PV without stalling at depth 1
- reset and clamp root move counters between iterations to keep generated/explored tallies consistent
- surface iteration depth from `SearchTask` and reset instrumentation when a new depth begins

## Testing
- `./mvnw -q test` *(fails: unable to download Maven wrapper distribution in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ab577b74832aa33395622c908136