### PR TITLE
Handle empty piece value in SEE

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -189,6 +189,7 @@ public class Score {
 
     public static int getPieceValue(int pieceTypeBits) {
         return switch (pieceTypeBits) {
+            case 0 -> 0; // No piece on the square / undefined piece type.
             case 1 -> MaterialModule.PAWN_VALUE / 100;
             case 2 -> MaterialModule.KNIGHT_VALUE / 100;
             case 3 -> MaterialModule.BISHOP_VALUE / 100;


### PR DESCRIPTION
## Summary
- return a zero score when SEE queries a piece type of 0 instead of throwing an exception
- document the meaning of the new switch case for clarity

## Testing
- ./mvnw -DskipTests package *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b25f7048832a9a80f41ac41b5b68