### PR TITLE
Stop exploring negative SEE sacrifices

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1758,12 +1758,7 @@ public class AI {
                 seeGain = seeCache.computeIfAbsent(move, simulatorEngine::see);
                 seeEvaluated = true;
                 if (seeGain < 0) {
-                    simulatorEngine.performMove(move);
-                    boolean givesCheckTmp = isSideInCheck(simulatorEngine, false);
-                    simulatorEngine.undoLastMove();
-                    if (!givesCheckTmp) {
-                        continue;
-                    }
+                    continue;
                 }
             }
 


### PR DESCRIPTION
## Summary
- stop exploring capture or quiet moves with negative SEE results instead of searching checking sacrifices that lose material

## Testing
- mvnw test *(fails: Maven wrapper cannot download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bcc34f10832a9e9e944c69f7be0a