### PR TITLE
Optimize evaluation module incrementality

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
@@ -343,8 +343,11 @@ public final class ActivityModule implements EvaluationModule {
                 continue;
             }
 
-            long rayMask = sliderRayMask(activity.pieceType, square);
-            if ((rayMask & affectedMask) != 0) {
+            long dependency = activity.dependencyMask;
+            if (dependency == 0L) {
+                dependency = sliderRayMask(activity.pieceType, square);
+            }
+            if ((dependency & affectedMask) != 0) {
                 recalculatePiece(square);
             }
         }
@@ -453,6 +456,7 @@ public final class ActivityModule implements EvaluationModule {
         activity.pieceType = pieceType;
         activity.midgameScore = 0;
         activity.endgameScore = 0;
+        activity.dependencyMask = 0L;
 
         long mask = 1L << square;
         if (color == WHITE) {
@@ -524,6 +528,7 @@ public final class ActivityModule implements EvaluationModule {
             default -> {
                 activity.midgameScore = 0;
                 activity.endgameScore = 0;
+                activity.dependencyMask = 0L;
                 return;
             }
         }
@@ -544,6 +549,11 @@ public final class ActivityModule implements EvaluationModule {
 
         activity.midgameScore = midgameContribution;
         activity.endgameScore = endgameContribution;
+        if (isSlider(pieceType)) {
+            activity.dependencyMask = computeSliderDependency(square, type, allPieces);
+        } else {
+            activity.dependencyMask = 0L;
+        }
     }
 
     private void updateScoreCache() {
@@ -566,17 +576,52 @@ public final class ActivityModule implements EvaluationModule {
         private int pieceType;
         private int midgameScore;
         private int endgameScore;
+        private long dependencyMask;
 
         private void reset() {
             color = -1;
             pieceType = 0;
             midgameScore = 0;
             endgameScore = 0;
+            dependencyMask = 0L;
         }
 
     }
 
     private record CastlingUpdate(long affectedMask, int rookDestination) {
+    }
+
+    private long computeSliderDependency(int square, PieceType type, long occupancy) {
+        long mask = 0L;
+        if (type == PieceType.BISHOP || type == PieceType.QUEEN) {
+            mask |= traceDirection(square, 1, 1, occupancy);
+            mask |= traceDirection(square, 1, -1, occupancy);
+            mask |= traceDirection(square, -1, 1, occupancy);
+            mask |= traceDirection(square, -1, -1, occupancy);
+        }
+        if (type == PieceType.ROOK || type == PieceType.QUEEN) {
+            mask |= traceDirection(square, 1, 0, occupancy);
+            mask |= traceDirection(square, -1, 0, occupancy);
+            mask |= traceDirection(square, 0, 1, occupancy);
+            mask |= traceDirection(square, 0, -1, occupancy);
+        }
+        return mask;
+    }
+
+    private long traceDirection(int square, int rankDelta, int fileDelta, long occupancy) {
+        long mask = 0L;
+        int rank = square / 8 + rankDelta;
+        int file = square % 8 + fileDelta;
+        while (rank >= 0 && rank < 8 && file >= 0 && file < 8) {
+            int target = rank * 8 + file;
+            mask |= 1L << target;
+            if (((occupancy >>> target) & 1L) != 0) {
+                break;
+            }
+            rank += rankDelta;
+            file += fileDelta;
+        }
+        return mask;
     }
 }
 

--- a/src/main/java/julius/game/chessengine/evaluation/BatteryModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/BatteryModule.java
@@ -3,12 +3,17 @@ package julius.game.chessengine.evaluation;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.figures.PieceType;
 
+import java.util.Arrays;
+
 /**
  * Rewards coordinated long-range pieces that form batteries (stacked along the same ray) and
  * penalizes the opponent when the battery directly targets valuable pieces. The module only
  * recomputes its contribution when marked dirty.
  */
 public final class BatteryModule implements EvaluationModule {
+
+    private static final int WHITE = 0;
+    private static final int BLACK = 1;
 
     private static final int PAWN = MoveHelper.pieceTypeToInt(PieceType.PAWN);
     private static final int KNIGHT = MoveHelper.pieceTypeToInt(PieceType.KNIGHT);
@@ -26,13 +31,24 @@ public final class BatteryModule implements EvaluationModule {
     private static final int[] BATTERY_ATTACK_ENDGAME = new int[7];
 
     private static final Direction[] DIAGONAL_DIRECTIONS = {
-            new Direction(1, 1),   // north-east
-            new Direction(1, -1)   // north-west
+            new Direction(1, 1),
+            new Direction(1, -1)
     };
 
     private static final Direction[] ORTHOGONAL_DIRECTIONS = {
-            new Direction(1, 0),   // north
-            new Direction(0, 1)    // east
+            new Direction(1, 0),
+            new Direction(0, 1)
+    };
+
+    private static final Direction[] ALL_DIRECTIONS = {
+            new Direction(1, 0),
+            new Direction(-1, 0),
+            new Direction(0, 1),
+            new Direction(0, -1),
+            new Direction(1, 1),
+            new Direction(1, -1),
+            new Direction(-1, 1),
+            new Direction(-1, -1)
     };
 
     static {
@@ -55,6 +71,11 @@ public final class BatteryModule implements EvaluationModule {
         BATTERY_ATTACK_ENDGAME[KING] = 28;
     }
 
+    private final int[][] perSquareMidgame = new int[2][64];
+    private final int[][] perSquareEndgame = new int[2][64];
+    private final int[] midgameTotals = new int[2];
+    private final int[] endgameTotals = new int[2];
+
     private int midgameScoreCache;
     private int endgameScoreCache;
     private boolean dirty = true;
@@ -69,30 +90,22 @@ public final class BatteryModule implements EvaluationModule {
         if (!dirty) {
             return;
         }
-        if (context == null) {
-            midgameScoreCache = 0;
-            endgameScoreCache = 0;
-            dirty = false;
-            return;
-        }
-        EvaluationContext.BoardView board = context.board();
-
-        BatteryScore white = evaluateSide(board, true);
-        BatteryScore black = evaluateSide(board, false);
-
-        midgameScoreCache = white.midgame - black.midgame;
-        endgameScoreCache = white.endgame - black.endgame;
-        dirty = false;
+        EvaluationContext.BoardView board = context == null ? null : context.board();
+        rebuildFromBoard(board);
     }
 
     @Override
     public void applyMove(MoveContext moveContext) {
-        dirty = true;
+        if (!updateForMove(moveContext)) {
+            EvaluationContext current = moveContext.currentContext();
+            EvaluationContext.BoardView board = current == null ? null : current.board();
+            rebuildFromBoard(board);
+        }
     }
 
     @Override
     public void undoMove(MoveContext moveContext) {
-        dirty = true;
+        applyMove(moveContext);
     }
 
     @Override
@@ -115,37 +128,152 @@ public final class BatteryModule implements EvaluationModule {
         dirty = true;
     }
 
-    private BatteryScore evaluateSide(EvaluationContext.BoardView board, boolean isWhite) {
+    private void rebuildFromBoard(EvaluationContext.BoardView board) {
+        Arrays.fill(midgameTotals, 0);
+        Arrays.fill(endgameTotals, 0);
+        for (int[] cache : perSquareMidgame) {
+            Arrays.fill(cache, 0);
+        }
+        for (int[] cache : perSquareEndgame) {
+            Arrays.fill(cache, 0);
+        }
+
+        if (board == null) {
+            updateScoreCache();
+            dirty = false;
+            return;
+        }
+
+        rebuildSide(board, true);
+        rebuildSide(board, false);
+        updateScoreCache();
+        dirty = false;
+    }
+
+    private boolean updateForMove(MoveContext moveContext) {
+        EvaluationContext current = moveContext.currentContext();
+        EvaluationContext previous = moveContext.previousContext();
+        EvaluationContext.BoardView currentBoard = current == null ? null : current.board();
+        if (currentBoard == null) {
+            Arrays.fill(midgameTotals, 0);
+            Arrays.fill(endgameTotals, 0);
+            updateScoreCache();
+            dirty = false;
+            return true;
+        }
+        if (previous == null) {
+            rebuildFromBoard(currentBoard);
+            return true;
+        }
+
+        EvaluationContext.BoardView previousBoard = previous.board();
+        long impacted = collectAnchorSquares(moveContext.move());
+        impacted |= collectSliderSquares(previousBoard, impacted);
+        impacted |= collectSliderSquares(currentBoard, impacted);
+
+        if (impacted == 0) {
+            dirty = false;
+            return true;
+        }
+
+        long removed = impacted;
+        while (removed != 0) {
+            int square = Long.numberOfTrailingZeros(removed);
+            removed &= removed - 1;
+            removeContribution(square, WHITE);
+            removeContribution(square, BLACK);
+        }
+
+        long toUpdate = impacted;
+        while (toUpdate != 0) {
+            int square = Long.numberOfTrailingZeros(toUpdate);
+            toUpdate &= toUpdate - 1;
+            addContribution(currentBoard, square, true);
+            addContribution(currentBoard, square, false);
+        }
+
+        updateScoreCache();
+        dirty = false;
+        return true;
+    }
+
+    private void rebuildSide(EvaluationContext.BoardView board, boolean isWhite) {
+        long candidates = 0L;
+        if (isWhite) {
+            candidates |= board.whiteBishops();
+            candidates |= board.whiteRooks();
+            candidates |= board.whiteQueens();
+        } else {
+            candidates |= board.blackBishops();
+            candidates |= board.blackRooks();
+            candidates |= board.blackQueens();
+        }
+        int colorIndex = isWhite ? WHITE : BLACK;
+        while (candidates != 0) {
+            long bit = candidates & -candidates;
+            int square = Long.numberOfTrailingZeros(bit);
+            BatteryScore score = evaluateSquare(board, isWhite, square);
+            perSquareMidgame[colorIndex][square] = score.midgame;
+            perSquareEndgame[colorIndex][square] = score.endgame;
+            midgameTotals[colorIndex] += score.midgame;
+            endgameTotals[colorIndex] += score.endgame;
+            candidates ^= bit;
+        }
+    }
+
+    private void addContribution(EvaluationContext.BoardView board, int square, boolean white) {
+        int colorIndex = white ? WHITE : BLACK;
+        PieceType type = board.getPieceTypeAtIndex(square);
+        if (type == null) {
+            return;
+        }
+        long mask = 1L << square;
+        long pieces = white ? board.whitePieces() : board.blackPieces();
+        if ((pieces & mask) == 0) {
+            return;
+        }
+        if (!isSlider(type)) {
+            return;
+        }
+        BatteryScore score = evaluateSquare(board, white, square);
+        perSquareMidgame[colorIndex][square] = score.midgame;
+        perSquareEndgame[colorIndex][square] = score.endgame;
+        midgameTotals[colorIndex] += score.midgame;
+        endgameTotals[colorIndex] += score.endgame;
+    }
+
+    private void removeContribution(int square, int colorIndex) {
+        int mid = perSquareMidgame[colorIndex][square];
+        int end = perSquareEndgame[colorIndex][square];
+        if (mid == 0 && end == 0) {
+            return;
+        }
+        midgameTotals[colorIndex] -= mid;
+        endgameTotals[colorIndex] -= end;
+        perSquareMidgame[colorIndex][square] = 0;
+        perSquareEndgame[colorIndex][square] = 0;
+    }
+
+    private BatteryScore evaluateSquare(EvaluationContext.BoardView board, boolean isWhite, int square) {
         BatteryScore score = new BatteryScore();
+        PieceType type = board.getPieceTypeAtIndex(square);
+        if (type == null) {
+            return score;
+        }
+
         long occupancy = board.allPieces();
         long friendlyPieces = isWhite ? board.whitePieces() : board.blackPieces();
         long enemyPieces = isWhite ? board.blackPieces() : board.whitePieces();
 
-        long l = isWhite ? board.whiteQueens() : board.blackQueens();
-        long diagonalCandidates = (isWhite ? board.whiteBishops() : board.blackBishops())
-                | l;
-        accumulateBatteries(board, diagonalCandidates, DIAGONAL_DIRECTIONS, occupancy,
-                friendlyPieces, enemyPieces, true, score);
-
-        long orthogonalCandidates = (isWhite ? board.whiteRooks() : board.blackRooks())
-                | l;
-        accumulateBatteries(board, orthogonalCandidates, ORTHOGONAL_DIRECTIONS, occupancy,
-                friendlyPieces, enemyPieces, false, score);
-
-        return score;
-    }
-
-    private void accumulateBatteries(EvaluationContext.BoardView board, long candidates,
-                                     Direction[] directions, long occupancy, long friendlyPieces,
-                                     long enemyPieces, boolean diagonal, BatteryScore score) {
-        long remaining = candidates;
-        while (remaining != 0) {
-            long bit = remaining & -remaining;
-            int square = Long.numberOfTrailingZeros(bit);
-            accumulateFromSquare(board, square, directions, occupancy, friendlyPieces,
-                    enemyPieces, diagonal, score);
-            remaining ^= bit;
+        if (supportsDirection(type, true)) {
+            accumulateFromSquare(board, square, DIAGONAL_DIRECTIONS, occupancy, friendlyPieces,
+                    enemyPieces, true, score);
         }
+        if (supportsDirection(type, false)) {
+            accumulateFromSquare(board, square, ORTHOGONAL_DIRECTIONS, occupancy, friendlyPieces,
+                    enemyPieces, false, score);
+        }
+        return score;
     }
 
     private void accumulateFromSquare(EvaluationContext.BoardView board, int square,
@@ -211,6 +339,72 @@ public final class BatteryModule implements EvaluationModule {
             r += direction.rankDelta;
             f += direction.fileDelta;
         }
+    }
+
+    private long collectAnchorSquares(int move) {
+        int from = MoveHelper.deriveFromIndex(move);
+        int to = MoveHelper.deriveToIndex(move);
+        long anchors = (1L << from) | (1L << to);
+        if (MoveHelper.isEnPassantMove(move)) {
+            int capture = MoveHelper.isWhitesMove(move) ? to - 8 : to + 8;
+            anchors |= 1L << capture;
+        }
+        return anchors;
+    }
+
+    private long collectSliderSquares(EvaluationContext.BoardView board, long anchors) {
+        if (board == null) {
+            return 0L;
+        }
+        long impacted = 0L;
+        long remaining = anchors;
+        while (remaining != 0) {
+            int square = Long.numberOfTrailingZeros(remaining);
+            impacted |= slidersAlongDirections(board, square);
+            remaining &= remaining - 1;
+        }
+        return impacted;
+    }
+
+    private long slidersAlongDirections(EvaluationContext.BoardView board, int square) {
+        long impacted = 0L;
+        for (Direction direction : ALL_DIRECTIONS) {
+            int rank = square / 8 + direction.rankDelta;
+            int file = square % 8 + direction.fileDelta;
+            while (rank >= 0 && rank < 8 && file >= 0 && file < 8) {
+                int target = rank * 8 + file;
+                PieceType type = board.getPieceTypeAtIndex(target);
+                if (type != null) {
+                    if (isSliderInDirection(type, direction)) {
+                        impacted |= 1L << target;
+                    }
+                    break;
+                }
+                rank += direction.rankDelta;
+                file += direction.fileDelta;
+            }
+        }
+        return impacted;
+    }
+
+    private boolean isSlider(PieceType type) {
+        return type == PieceType.BISHOP || type == PieceType.ROOK || type == PieceType.QUEEN;
+    }
+
+    private boolean isSliderInDirection(PieceType type, Direction direction) {
+        if (!isSlider(type)) {
+            return false;
+        }
+        boolean diagonal = Math.abs(direction.rankDelta) == Math.abs(direction.fileDelta);
+        if (diagonal) {
+            return type == PieceType.BISHOP || type == PieceType.QUEEN;
+        }
+        return type == PieceType.ROOK || type == PieceType.QUEEN;
+    }
+
+    private void updateScoreCache() {
+        midgameScoreCache = midgameTotals[WHITE] - midgameTotals[BLACK];
+        endgameScoreCache = endgameTotals[WHITE] - endgameTotals[BLACK];
     }
 
     private static boolean supportsDirection(PieceType type, boolean diagonal) {

--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -79,10 +79,14 @@ public final class KingSafetyModule implements EvaluationModule {
 
     @Override
     public void applyMove(MoveContext moveContext) {
-        EvaluationContext previous = moveContext.previousContext();
         EvaluationContext current = moveContext.currentContext();
+        EvaluationContext previous = moveContext.previousContext();
         if (previous == null) {
             rebuildFromContext(current);
+            return;
+        }
+        if (current == null) {
+            rebuildFromContext(null);
             return;
         }
         int move = moveContext.move();
@@ -92,11 +96,27 @@ public final class KingSafetyModule implements EvaluationModule {
             rebuildFromContext(current);
             return;
         }
-        boolean updateWhite = sideNeedsUpdate(WHITE, moveContext);
-        boolean updateBlack = sideNeedsUpdate(BLACK, moveContext);
-        if (updateWhite || updateBlack) {
-            rebuildFromContext(current);
+        EvaluationContext.BoardView board = current.board();
+        if (board == null) {
+            rebuildFromContext(null);
+            return;
         }
+        boolean updateWhite = sideNeedsUpdate(WHITE, board, current.whiteAttackMap(), current.blackAttackMap());
+        boolean updateBlack = sideNeedsUpdate(BLACK, board, current.blackAttackMap(), current.whiteAttackMap());
+        if (!updateWhite && !updateBlack) {
+            dirty = false;
+            return;
+        }
+        if (updateWhite) {
+            sideStates[WHITE].reset();
+            rebuildSideState(sideStates[WHITE], board, true, current.whiteAttackMap(), current.blackAttackMap());
+        }
+        if (updateBlack) {
+            sideStates[BLACK].reset();
+            rebuildSideState(sideStates[BLACK], board, false, current.blackAttackMap(), current.whiteAttackMap());
+        }
+        refreshScoreCaches();
+        dirty = false;
     }
 
     @Override
@@ -161,63 +181,49 @@ public final class KingSafetyModule implements EvaluationModule {
         dirty = false;
     }
 
-    private boolean sideNeedsUpdate(int side, MoveContext moveContext) {
+    private boolean sideNeedsUpdate(int side, EvaluationContext.BoardView board,
+                                    long friendlyAttacks, long enemyAttacks) {
         SideState state = sideStates[side];
-        if (state.kingSquare < 0) {
+        if (state.kingSquare < 0 || board == null) {
             return true;
         }
-        EvaluationContext previous = moveContext.previousContext();
-        EvaluationContext current = moveContext.currentContext();
-        if (previous == null) {
+        boolean isWhite = side == WHITE;
+        long friendlyPawns = isWhite ? board.whitePawns() : board.blackPawns();
+        long enemyPawns = isWhite ? board.blackPawns() : board.whitePawns();
+
+        long shield = friendlyPawns & state.shieldMask;
+        if (shield != state.cachedShield) {
             return true;
         }
-        long prevEnemyAttacks = side == WHITE ? previous.blackAttackMap() : previous.whiteAttackMap();
-        long currEnemyAttacks = side == WHITE ? current.blackAttackMap() : current.whiteAttackMap();
-        long prevFriendlyAttacks = side == WHITE ? previous.whiteAttackMap() : previous.blackAttackMap();
-        long currFriendlyAttacks = side == WHITE ? current.whiteAttackMap() : current.blackAttackMap();
-        long zoneDiff = (prevEnemyAttacks ^ currEnemyAttacks) & state.kingZone;
-        if (zoneDiff != 0) {
+        long file = friendlyPawns & state.fileMask;
+        if (file != state.cachedFile) {
             return true;
         }
-        int move = moveContext.move();
-        int from = MoveHelper.deriveFromIndex(move);
-        int to = MoveHelper.deriveToIndex(move);
-        long moveMask = (1L << from) | (1L << to);
-        if ((moveMask & (state.kingZone | state.shieldMask | state.fileMask)) != 0) {
+        long enemyFile = enemyPawns & state.fileMask;
+        if (enemyFile != state.cachedEnemyFile) {
             return true;
         }
-        int movedPiece = MoveHelper.derivePieceTypeBits(move);
-        if (movedPiece == PAWN) {
-            if (((1L << from) & state.fileMask) != 0 || ((1L << to) & state.fileMask) != 0) {
-                return true;
-            }
-        }
-        int capturedPiece = MoveHelper.deriveCapturedPieceTypeBits(move);
-        if (capturedPiece == PAWN) {
-            long captureMask = 1L << to;
-            if (MoveHelper.isEnPassantMove(move)) {
-                captureMask = side == WHITE ? (1L << (to - 8)) : (1L << (to + 8));
-            }
-            if ((captureMask & (state.shieldMask | state.fileMask)) != 0) {
-                return true;
-            }
-        }
-        EvaluationContext.BoardView previousBoard = previous.board();
-        EvaluationContext.BoardView currentBoard = current.board();
-        long prevQueens = side == WHITE ? previousBoard.whiteQueens() : previousBoard.blackQueens();
-        long currQueens = side == WHITE ? currentBoard.whiteQueens() : currentBoard.blackQueens();
-        if (prevQueens != currQueens) {
+
+        long enemyZone = enemyAttacks & state.kingZone;
+        if (enemyZone != state.cachedEnemyZoneAttacks) {
             return true;
         }
-        long queenMask = currQueens;
-        while (queenMask != 0) {
-            long q = queenMask & -queenMask;
-            if (((prevEnemyAttacks ^ currEnemyAttacks) & q) != 0) {
-                return true;
-            }
-            queenMask ^= q;
+        long friendlyZone = friendlyAttacks & state.kingZone;
+        if (friendlyZone != state.cachedFriendlyZoneAttacks) {
+            return true;
         }
-        return state.backrankMask != 0 && ((prevFriendlyAttacks ^ currFriendlyAttacks) & state.backrankMask) != 0;
+
+        long friendlyBackrank = state.backrankMask == 0L ? 0L : (friendlyAttacks & state.backrankMask);
+        if (friendlyBackrank != state.cachedFriendlyBackrankAttacks) {
+            return true;
+        }
+
+        long queens = isWhite ? board.whiteQueens() : board.blackQueens();
+        if (queens != state.cachedQueens) {
+            return true;
+        }
+        long queenThreats = enemyAttacks & queens;
+        return queenThreats != state.cachedQueenThreats;
     }
 
     private void rebuildSideState(SideState state, EvaluationContext.BoardView board, boolean isWhite,
@@ -249,7 +255,8 @@ public final class KingSafetyModule implements EvaluationModule {
             state.filePenalty = (enemyPawns & state.fileMask) != 0 ? HALF_OPEN_FILE_PENALTY : OPEN_FILE_PENALTY;
         }
 
-        state.defenderCount = Long.bitCount(friendlyAttacks & state.kingZone);
+        long friendlyZone = friendlyAttacks & state.kingZone;
+        state.defenderCount = Long.bitCount(friendlyZone);
 
         long allPieces = board.allPieces();
         accumulatePawnAttacks(state, enemyPawns, !isWhite);
@@ -289,6 +296,17 @@ public final class KingSafetyModule implements EvaluationModule {
         }
         state.midgameQueenPenalty = queenMid;
         state.endgameQueenPenalty = queenEnd;
+
+        state.cachedShield = friendlyPawns & state.shieldMask;
+        state.cachedFile = friendlyPawns & state.fileMask;
+        state.cachedEnemyFile = enemyPawns & state.fileMask;
+        state.cachedEnemyZoneAttacks = enemyAttacks & state.kingZone;
+        state.cachedFriendlyZoneAttacks = friendlyZone;
+        state.cachedFriendlyBackrankAttacks = state.backrankMask == 0L
+                ? 0L
+                : (friendlyAttacks & state.backrankMask);
+        state.cachedQueens = isWhite ? board.whiteQueens() : board.blackQueens();
+        state.cachedQueenThreats = enemyAttacks & state.cachedQueens;
     }
 
     private void computeBackrankWeaknessPenalty(SideState state, EvaluationContext.BoardView board, boolean isWhite) {
@@ -582,6 +600,14 @@ public final class KingSafetyModule implements EvaluationModule {
         private int backrankWeaknessEndgame;
         private final int[] zoneAttackWeights = new int[64];
         private long backrankMask;
+        private long cachedShield;
+        private long cachedFile;
+        private long cachedEnemyFile;
+        private long cachedEnemyZoneAttacks;
+        private long cachedFriendlyZoneAttacks;
+        private long cachedFriendlyBackrankAttacks;
+        private long cachedQueens;
+        private long cachedQueenThreats;
 
         private void reset() {
             kingSquare = -1;
@@ -599,6 +625,14 @@ public final class KingSafetyModule implements EvaluationModule {
             backrankWeaknessMidgame = 0;
             backrankWeaknessEndgame = 0;
             backrankMask = 0L;
+            cachedShield = 0L;
+            cachedFile = 0L;
+            cachedEnemyFile = 0L;
+            cachedEnemyZoneAttacks = 0L;
+            cachedFriendlyZoneAttacks = 0L;
+            cachedFriendlyBackrankAttacks = 0L;
+            cachedQueens = 0L;
+            cachedQueenThreats = 0L;
             Arrays.fill(zoneAttackWeights, 0);
         }
     }

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -121,26 +121,29 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         PhaseScore blackPassed = PhaseScore.constant(
                 calculatePassedPawnBonus(blackPawns, whitePawns, allPieces, blackKing, false));
 
+        DynamicPawnStats whiteStats = computeDynamicStats(whitePawns, blackPawns, allPieces, blackAttacks, true);
+        DynamicPawnStats blackStats = computeDynamicStats(blackPawns, whitePawns, allPieces, whiteAttacks, false);
+
         PhaseScore whiteAdvance = PhaseScore.of(
-                calculatePawnAdvanceBonus(whitePawns, allPieces, blackAttacks, true, 0),
-                calculatePawnAdvanceBonus(whitePawns, allPieces, blackAttacks, true, 256));
+                scaleByPhase(whiteStats.advanceBase(), 0),
+                scaleByPhase(whiteStats.advanceBase(), 256));
         PhaseScore blackAdvance = PhaseScore.of(
-                calculatePawnAdvanceBonus(blackPawns, allPieces, whiteAttacks, false, 0),
-                calculatePawnAdvanceBonus(blackPawns, allPieces, whiteAttacks, false, 256));
+                scaleByPhase(blackStats.advanceBase(), 0),
+                scaleByPhase(blackStats.advanceBase(), 256));
 
         PhaseScore whiteBlocked = PhaseScore.of(
-                calculateBlockedPawnPenalty(whitePawns, allPieces, true, 0),
-                calculateBlockedPawnPenalty(whitePawns, allPieces, true, 256));
+                scaleByPhase(whiteStats.blockedBase(), 0),
+                scaleByPhase(whiteStats.blockedBase(), 256));
         PhaseScore blackBlocked = PhaseScore.of(
-                calculateBlockedPawnPenalty(blackPawns, allPieces, false, 0),
-                calculateBlockedPawnPenalty(blackPawns, allPieces, false, 256));
+                scaleByPhase(blackStats.blockedBase(), 0),
+                scaleByPhase(blackStats.blockedBase(), 256));
 
         PhaseScore whiteBackward = PhaseScore.of(
-                calculateBackwardPawnPenalty(whitePawns, blackPawns, allPieces, true, 0),
-                calculateBackwardPawnPenalty(whitePawns, blackPawns, allPieces, true, 256));
+                scaleByPhase(whiteStats.backwardBase(), 0),
+                scaleByPhase(whiteStats.backwardBase(), 256));
         PhaseScore blackBackward = PhaseScore.of(
-                calculateBackwardPawnPenalty(blackPawns, whitePawns, allPieces, false, 0),
-                calculateBackwardPawnPenalty(blackPawns, whitePawns, allPieces, false, 256));
+                scaleByPhase(blackStats.backwardBase(), 0),
+                scaleByPhase(blackStats.backwardBase(), 256));
 
         PhaseScore[] whiteComponents = new PhaseScore[]{
                 whiteCenter,
@@ -371,55 +374,44 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         return STRUCTURE_CACHE.computeIfAbsent(key, _ -> new CachedStructure(whitePawns, blackPawns));
     }
 
-    private static int calculatePawnAdvanceBonus(long pawns, long allPieces, long enemyAttacks, boolean isWhite, int phase) {
-        int bonus = 0;
+    private static DynamicPawnStats computeDynamicStats(long pawns, long enemyPawns, long allPieces,
+                                                        long enemyAttacks, boolean isWhite) {
+        int advance = 0;
+        int blocked = 0;
+        int backward = 0;
+        if (pawns == 0) {
+            return new DynamicPawnStats(advance, blocked, backward);
+        }
         long advancedRanks = isWhite
                 ? (RankMasks[3] | RankMasks[4] | RankMasks[5] | RankMasks[6])
                 : (RankMasks[4] | RankMasks[3] | RankMasks[2] | RankMasks[1]);
-        long advancedPawns = pawns & advancedRanks;
-        while (advancedPawns != 0) {
-            int square = Long.numberOfTrailingZeros(advancedPawns);
-            long forward = PAWN_PUSHES[isWhite ? WHITE : BLACK][square];
-            if ((forward & (allPieces | enemyAttacks)) == 0) {
-                int rank = square / 8 + 1;
-                int rankBonus = isWhite ? (rank - 3) : (6 - rank);
-                bonus += ADVANCED_PAWN_BONUS * rankBonus;
-            }
-            advancedPawns &= advancedPawns - 1;
-        }
-        return scaleByPhase(bonus, phase);
-    }
-
-    private static int calculateBlockedPawnPenalty(long pawns, long allPieces, boolean isWhite, int phase) {
-        int penalty = 0;
+        int color = isWhite ? WHITE : BLACK;
         long remaining = pawns;
         while (remaining != 0) {
-            int square = Long.numberOfTrailingZeros(remaining);
-            long forward = PAWN_PUSHES[isWhite ? WHITE : BLACK][square];
-            if ((forward & allPieces) != 0) {
-                penalty += BLOCKED_PAWN_PENALTY;
-            }
-            remaining &= remaining - 1;
-        }
-        return scaleByPhase(penalty, phase);
-    }
-
-    private static int calculateBackwardPawnPenalty(long pawns, long enemyPawns, long allPieces, boolean isWhite, int phase) {
-        int penalty = 0;
-        long remaining = pawns;
-        while (remaining != 0) {
-            int square = Long.numberOfTrailingZeros(remaining);
-            long forward = PAWN_PUSHES[isWhite ? WHITE : BLACK][square];
-            if ((forward & allPieces) == 0) {
-                int forwardIndex = Long.numberOfTrailingZeros(forward);
-                long enemyAttack = PAWN_ATTACKS[isWhite ? WHITE : BLACK][forwardIndex] & enemyPawns;
-                if (enemyAttack != 0) {
-                    penalty += BACKWARD_PAWN_PENALTY;
+            long bit = remaining & -remaining;
+            int square = Long.numberOfTrailingZeros(bit);
+            long forward = PAWN_PUSHES[color][square];
+            if (forward != 0) {
+                if ((forward & allPieces) != 0) {
+                    blocked += BLOCKED_PAWN_PENALTY;
+                } else {
+                    if ((bit & advancedRanks) != 0 && (forward & enemyAttacks) == 0) {
+                        int rank = square / 8 + 1;
+                        int rankBonus = isWhite ? (rank - 3) : (6 - rank);
+                        if (rankBonus > 0) {
+                            advance += ADVANCED_PAWN_BONUS * rankBonus;
+                        }
+                    }
+                    int forwardIndex = Long.numberOfTrailingZeros(forward);
+                    long enemyAttack = PAWN_ATTACKS[color][forwardIndex] & enemyPawns;
+                    if (enemyAttack != 0) {
+                        backward += BACKWARD_PAWN_PENALTY;
+                    }
                 }
             }
-            remaining &= remaining - 1;
+            remaining ^= bit;
         }
-        return scaleByPhase(penalty, phase);
+        return new DynamicPawnStats(advance, blocked, backward);
     }
 
     private static int sumMidgame(PhaseScore... scores) {
@@ -508,6 +500,9 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     private static int scaleByPhase(int value, int phase) {
         int clamped = Math.max(0, Math.min(256, phase));
         return value * (256 + clamped) / 256;
+    }
+
+    private record DynamicPawnStats(int advanceBase, int blockedBase, int backwardBase) {
     }
 
     private record PawnStructureKey(long white, long black) { }

--- a/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
@@ -5,15 +5,17 @@ import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.BishopHelper;
 import julius.game.chessengine.helper.RookHelper;
 
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.function.IntPredicate;
 
-import static julius.game.chessengine.helper.PawnMoveTables.PAWN_ATTACKS;
 import static julius.game.chessengine.helper.KingHelper.KING_ATTACKS;
+import static julius.game.chessengine.helper.PawnMoveTables.PAWN_ATTACKS;
 
 /**
  * Evaluates tactical vulnerabilities such as hanging pieces and pawn attacks on higher valued
- * pieces. The module recomputes its contribution when marked dirty rather than maintaining
- * incremental state.
+ * pieces. The module keeps per-piece penalty caches so that only the squares affected by a move
+ * need to be refreshed.
  */
 public final class ThreatModule implements EvaluationModule {
 
@@ -46,6 +48,9 @@ public final class ThreatModule implements EvaluationModule {
         PAWN_THREAT_PENALTIES[QUEEN] = -25;
     }
 
+    private final int[][] squarePenalties = new int[2][64];
+    private final int[] sideTotals = new int[2];
+
     private int midgameScoreCache;
     private int endgameScoreCache;
     private boolean dirty = true;
@@ -63,31 +68,29 @@ public final class ThreatModule implements EvaluationModule {
         Objects.requireNonNull(context, "context");
         EvaluationContext.BoardView board = context.board();
         if (board == null) {
-            midgameScoreCache = 0;
-            endgameScoreCache = 0;
-            dirty = false;
+            resetCaches();
             return;
         }
 
-        long whiteAttacks = context.whiteAttackMap();
-        long blackAttacks = context.blackAttackMap();
-
-        int whitePenalty = evaluateSide(board, true, whiteAttacks, blackAttacks);
-        int blackPenalty = evaluateSide(board, false, blackAttacks, whiteAttacks);
-
-        midgameScoreCache = whitePenalty - blackPenalty;
-        endgameScoreCache = midgameScoreCache;
-        dirty = false;
+        rebuildFromBoard(board, context.whiteAttackMap(), context.blackAttackMap());
     }
 
     @Override
     public void applyMove(MoveContext moveContext) {
-        dirty = true;
+        if (!updateForMove(moveContext)) {
+            EvaluationContext current = moveContext.currentContext();
+            EvaluationContext.BoardView board = current == null ? null : current.board();
+            if (board == null) {
+                resetCaches();
+            } else {
+                rebuildFromBoard(board, current.whiteAttackMap(), current.blackAttackMap());
+            }
+        }
     }
 
     @Override
     public void undoMove(MoveContext moveContext) {
-        dirty = true;
+        applyMove(moveContext);
     }
 
     @Override
@@ -110,48 +113,156 @@ public final class ThreatModule implements EvaluationModule {
         dirty = true;
     }
 
-    private int evaluateSide(EvaluationContext.BoardView board, boolean isWhite, long friendlyAttacks, long enemyAttacks) {
-        long pieces = isWhite ? board.whitePieces() : board.blackPieces();
-        long enemyPawns = isWhite ? board.blackPawns() : board.whitePawns();
-        int enemyPawnColor = isWhite ? BLACK : WHITE;
-        long enemyPawnAttacks = computePawnAttackMask(enemyPawns, enemyPawnColor);
+    private void rebuildFromBoard(EvaluationContext.BoardView board, long whiteAttacks, long blackAttacks) {
+        Arrays.fill(sideTotals, 0);
+        for (int[] cache : squarePenalties) {
+            Arrays.fill(cache, 0);
+        }
 
-        int penalty = 0;
+        long whitePawnAttacks = computePawnAttackMask(board.whitePawns(), WHITE);
+        long blackPawnAttacks = computePawnAttackMask(board.blackPawns(), BLACK);
+
+        evaluateSide(board, true, whiteAttacks, blackAttacks, blackPawnAttacks);
+        evaluateSide(board, false, blackAttacks, whiteAttacks, whitePawnAttacks);
+        updateScoreCache();
+    }
+
+    private boolean updateForMove(MoveContext moveContext) {
+        EvaluationContext current = moveContext.currentContext();
+        EvaluationContext previous = moveContext.previousContext();
+        if (current == null) {
+            resetCaches();
+            return true;
+        }
+        if (previous == null) {
+            rebuildFromBoard(current.board(), current.whiteAttackMap(), current.blackAttackMap());
+            return true;
+        }
+
+        EvaluationContext.BoardView currentBoard = current.board();
+        EvaluationContext.BoardView previousBoard = previous.board();
+        if (currentBoard == null || previousBoard == null) {
+            rebuildFromBoard(currentBoard, current.whiteAttackMap(), current.blackAttackMap());
+            return true;
+        }
+
+        long impacted = collectAnchorSquares(moveContext.move());
+        long attackDiff = previous.whiteAttackMap() ^ current.whiteAttackMap();
+        attackDiff |= previous.blackAttackMap() ^ current.blackAttackMap();
+        impacted |= attackDiff;
+
+        long removalMask = impacted;
+        while (removalMask != 0) {
+            int square = Long.numberOfTrailingZeros(removalMask);
+            removalMask &= removalMask - 1;
+            removePenalty(square, WHITE);
+            removePenalty(square, BLACK);
+        }
+
+        long whitePawnAttacks = computePawnAttackMask(currentBoard.whitePawns(), WHITE);
+        long blackPawnAttacks = computePawnAttackMask(currentBoard.blackPawns(), BLACK);
+
+        long updateMask = impacted;
+        while (updateMask != 0) {
+            int square = Long.numberOfTrailingZeros(updateMask);
+            updateMask &= updateMask - 1;
+            addPenalty(currentBoard, square, true, current.whiteAttackMap(), current.blackAttackMap(),
+                    blackPawnAttacks);
+            addPenalty(currentBoard, square, false, current.blackAttackMap(), current.whiteAttackMap(),
+                    whitePawnAttacks);
+        }
+
+        updateScoreCache();
+        dirty = false;
+        return true;
+    }
+
+    private void evaluateSide(EvaluationContext.BoardView board, boolean isWhite, long friendlyAttacks,
+                              long enemyAttacks, long enemyPawnAttacks) {
+        long pieces = isWhite ? board.whitePieces() : board.blackPieces();
+        int colorIndex = isWhite ? WHITE : BLACK;
         long remaining = pieces;
         while (remaining != 0) {
             long bit = remaining & -remaining;
             int square = Long.numberOfTrailingZeros(bit);
-            PieceType type = board.getPieceTypeAtIndex(square);
-            if (type == null) {
-                remaining ^= bit;
-                continue;
-            }
-            int typeBits = MoveHelper.pieceTypeToInt(type);
-            if (typeBits == KING) {
-                remaining ^= bit;
-                continue;
-            }
-            long mask = 1L << square;
-            if ((enemyAttacks & mask) == 0) {
-                remaining ^= bit;
-                continue;
-            }
-            boolean defended = (friendlyAttacks & mask) != 0;
-            if (!defended) {
-                penalty += HANGING_PENALTIES[typeBits];
-            }
-            if (typeBits > PAWN && (enemyPawnAttacks & mask) != 0) {
-                int defenderValue = defended
-                        ? leastValuableDefenderValue(board, isWhite, square)
-                        : materialValueFor(typeBits);
-                if (defenderValue <= 0) {
-                    defenderValue = materialValueFor(typeBits);
-                }
-                penalty += scalePawnThreatPenalty(typeBits, defenderValue);
-            }
+            int penalty = evaluatePiece(board, isWhite, square, friendlyAttacks, enemyAttacks, enemyPawnAttacks);
+            squarePenalties[colorIndex][square] = penalty;
+            sideTotals[colorIndex] += penalty;
             remaining ^= bit;
         }
+    }
+
+    private void addPenalty(EvaluationContext.BoardView board, int square, boolean isWhite,
+                            long friendlyAttacks, long enemyAttacks, long enemyPawnAttacks) {
+        int colorIndex = isWhite ? WHITE : BLACK;
+        PieceType type = board.getPieceTypeAtIndex(square);
+        if (type == null) {
+            return;
+        }
+        long mask = 1L << square;
+        long pieces = isWhite ? board.whitePieces() : board.blackPieces();
+        if ((pieces & mask) == 0) {
+            return;
+        }
+        int penalty = evaluatePiece(board, isWhite, square, friendlyAttacks, enemyAttacks, enemyPawnAttacks);
+        squarePenalties[colorIndex][square] = penalty;
+        sideTotals[colorIndex] += penalty;
+    }
+
+    private void removePenalty(int square, int colorIndex) {
+        int penalty = squarePenalties[colorIndex][square];
+        if (penalty == 0) {
+            return;
+        }
+        sideTotals[colorIndex] -= penalty;
+        squarePenalties[colorIndex][square] = 0;
+    }
+
+    private int evaluatePiece(EvaluationContext.BoardView board, boolean isWhite, int square,
+                               long friendlyAttacks, long enemyAttacks, long enemyPawnAttacks) {
+        PieceType type = board.getPieceTypeAtIndex(square);
+        if (type == null) {
+            return 0;
+        }
+        int typeBits = MoveHelper.pieceTypeToInt(type);
+        if (typeBits == KING) {
+            return 0;
+        }
+        long mask = 1L << square;
+        if ((enemyAttacks & mask) == 0) {
+            return 0;
+        }
+        boolean defended = (friendlyAttacks & mask) != 0;
+        int penalty = 0;
+        if (!defended) {
+            penalty += HANGING_PENALTIES[typeBits];
+        }
+        if (typeBits > PAWN && (enemyPawnAttacks & mask) != 0) {
+            int defenderValue = defended
+                    ? leastValuableDefenderValue(board, isWhite, square)
+                    : materialValueFor(typeBits);
+            if (defenderValue <= 0) {
+                defenderValue = materialValueFor(typeBits);
+            }
+            penalty += scalePawnThreatPenalty(typeBits, defenderValue);
+        }
         return penalty;
+    }
+
+    private void updateScoreCache() {
+        midgameScoreCache = sideTotals[WHITE] - sideTotals[BLACK];
+        endgameScoreCache = midgameScoreCache;
+        dirty = false;
+    }
+
+    private void resetCaches() {
+        Arrays.fill(sideTotals, 0);
+        for (int[] cache : squarePenalties) {
+            Arrays.fill(cache, 0);
+        }
+        midgameScoreCache = 0;
+        endgameScoreCache = 0;
+        dirty = false;
     }
 
     private static int materialValueFor(int pieceType) {
@@ -230,8 +341,7 @@ public final class ThreatModule implements EvaluationModule {
         return minValue;
     }
 
-    private int findCheapestDefender(long pieces, int value, int currentMin,
-                                     java.util.function.IntPredicate attacksSquare) {
+    private int findCheapestDefender(long pieces, int value, int currentMin, IntPredicate attacksSquare) {
         long remaining = pieces;
         while (remaining != 0 && currentMin > MaterialModule.PAWN_VALUE) {
             long bit = remaining & -remaining;
@@ -258,4 +368,16 @@ public final class ThreatModule implements EvaluationModule {
         }
         return mask;
     }
+
+    private long collectAnchorSquares(int move) {
+        int from = MoveHelper.deriveFromIndex(move);
+        int to = MoveHelper.deriveToIndex(move);
+        long anchors = (1L << from) | (1L << to);
+        if (MoveHelper.isEnPassantMove(move)) {
+            int capture = MoveHelper.isWhitesMove(move) ? to - 8 : to + 8;
+            anchors |= 1L << capture;
+        }
+        return anchors;
+    }
 }
+


### PR DESCRIPTION
## Summary
- add per-square caches to BatteryModule so updates touch only rays impacted by the move
- track threat penalties per piece and refresh impacted squares using attack map deltas
- narrow KingSafetyModule rebuilds with cached per-side metadata and incremental updates
- reuse pawn-loop work via DynamicPawnStats to avoid repeated scans in PawnStructureModule
- remember slider blocker dependencies in ActivityModule to reduce full rebuild fallbacks

## Testing
- `./mvnw -q test` *(fails: Maven wrapper could not download dependencies because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cf5f1670832aa4aa392ffb7a5bd0