### PR TITLE
Improve incremental evaluation updates

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
@@ -43,6 +43,8 @@ public final class ActivityModule implements EvaluationModule {
     private static final int SOUTH_WEST = 7;
 
     private static final long[][] DIRECTION_RAYS = new long[8][64];
+    private static final int[] RANK_DELTAS = {1, -1, 0, 0, 1, 1, -1, -1};
+    private static final int[] FILE_DELTAS = {0, 0, 1, -1, 1, -1, 1, -1};
 
     private static final BishopHelper BISHOP_HELPER = BishopHelper.getInstance();
     private static final RookHelper ROOK_HELPER = RookHelper.getInstance();
@@ -343,37 +345,11 @@ public final class ActivityModule implements EvaluationModule {
                 continue;
             }
 
-            long rayMask = sliderRayMask(activity.pieceType, square);
-            if ((rayMask & affectedMask) != 0) {
+            long relevantMask = activity.attackMask | activity.blockerMask;
+            if ((relevantMask & affectedMask) != 0) {
                 recalculatePiece(square);
             }
         }
-    }
-
-    private long sliderRayMask(int pieceType, int square) {
-        if (pieceType <= 0) {
-            return 0L;
-        }
-        PieceType type = MoveHelper.intToPieceType(pieceType);
-        return switch (type) {
-            case BISHOP -> DIRECTION_RAYS[NORTH_EAST][square]
-                    | DIRECTION_RAYS[NORTH_WEST][square]
-                    | DIRECTION_RAYS[SOUTH_EAST][square]
-                    | DIRECTION_RAYS[SOUTH_WEST][square];
-            case ROOK -> DIRECTION_RAYS[NORTH][square]
-                    | DIRECTION_RAYS[SOUTH][square]
-                    | DIRECTION_RAYS[EAST][square]
-                    | DIRECTION_RAYS[WEST][square];
-            case QUEEN -> DIRECTION_RAYS[NORTH][square]
-                    | DIRECTION_RAYS[SOUTH][square]
-                    | DIRECTION_RAYS[EAST][square]
-                    | DIRECTION_RAYS[WEST][square]
-                    | DIRECTION_RAYS[NORTH_EAST][square]
-                    | DIRECTION_RAYS[NORTH_WEST][square]
-                    | DIRECTION_RAYS[SOUTH_EAST][square]
-                    | DIRECTION_RAYS[SOUTH_WEST][square];
-            default -> 0L;
-        };
     }
 
     private boolean isSlider(int pieceType) {
@@ -453,6 +429,8 @@ public final class ActivityModule implements EvaluationModule {
         activity.pieceType = pieceType;
         activity.midgameScore = 0;
         activity.endgameScore = 0;
+        activity.attackMask = 0L;
+        activity.blockerMask = 0L;
 
         long mask = 1L << square;
         if (color == WHITE) {
@@ -475,6 +453,8 @@ public final class ActivityModule implements EvaluationModule {
         int color = activity.color;
         midgameTotals[color] -= activity.midgameScore;
         endgameTotals[color] -= activity.endgameScore;
+        activity.attackMask = 0L;
+        activity.blockerMask = 0L;
 
         long mask = 1L << square;
         if (color == WHITE) {
@@ -503,6 +483,8 @@ public final class ActivityModule implements EvaluationModule {
             endgameTotals[activity.color] -= activity.endgameScore;
             activity.midgameScore = 0;
             activity.endgameScore = 0;
+            activity.attackMask = 0L;
+            activity.blockerMask = 0L;
             return;
         }
 
@@ -510,6 +492,8 @@ public final class ActivityModule implements EvaluationModule {
         if (pieceType <= 0) {
             activity.midgameScore = 0;
             activity.endgameScore = 0;
+            activity.attackMask = 0L;
+            activity.blockerMask = 0L;
             return;
         }
 
@@ -524,9 +508,14 @@ public final class ActivityModule implements EvaluationModule {
             default -> {
                 activity.midgameScore = 0;
                 activity.endgameScore = 0;
+                activity.attackMask = 0L;
+                activity.blockerMask = 0L;
                 return;
             }
         }
+
+        activity.attackMask = attacks;
+        activity.blockerMask = computeBlockerMask(square, type, allPieces);
 
         long friendlyPieces = activity.color == WHITE ? whitePieces : blackPieces;
         long legalTargets = attacks & ~friendlyPieces;
@@ -544,6 +533,42 @@ public final class ActivityModule implements EvaluationModule {
 
         activity.midgameScore = midgameContribution;
         activity.endgameScore = endgameContribution;
+    }
+
+    private long computeBlockerMask(int square, PieceType type, long occupancy) {
+        if (type != PieceType.BISHOP && type != PieceType.ROOK && type != PieceType.QUEEN) {
+            return 0L;
+        }
+        long blockers = 0L;
+        if (type == PieceType.BISHOP || type == PieceType.QUEEN) {
+            blockers |= firstBlocker(square, NORTH_EAST, occupancy);
+            blockers |= firstBlocker(square, NORTH_WEST, occupancy);
+            blockers |= firstBlocker(square, SOUTH_EAST, occupancy);
+            blockers |= firstBlocker(square, SOUTH_WEST, occupancy);
+        }
+        if (type == PieceType.ROOK || type == PieceType.QUEEN) {
+            blockers |= firstBlocker(square, NORTH, occupancy);
+            blockers |= firstBlocker(square, SOUTH, occupancy);
+            blockers |= firstBlocker(square, EAST, occupancy);
+            blockers |= firstBlocker(square, WEST, occupancy);
+        }
+        return blockers;
+    }
+
+    private long firstBlocker(int square, int directionIndex, long occupancy) {
+        int rankDelta = RANK_DELTAS[directionIndex];
+        int fileDelta = FILE_DELTAS[directionIndex];
+        int r = square / 8 + rankDelta;
+        int f = square % 8 + fileDelta;
+        while (r >= 0 && r < 8 && f >= 0 && f < 8) {
+            int target = r * 8 + f;
+            if (((occupancy >>> target) & 1L) != 0) {
+                return 1L << target;
+            }
+            r += rankDelta;
+            f += fileDelta;
+        }
+        return 0L;
     }
 
     private void updateScoreCache() {
@@ -566,12 +591,16 @@ public final class ActivityModule implements EvaluationModule {
         private int pieceType;
         private int midgameScore;
         private int endgameScore;
+        private long attackMask;
+        private long blockerMask;
 
         private void reset() {
             color = -1;
             pieceType = 0;
             midgameScore = 0;
             endgameScore = 0;
+            attackMask = 0L;
+            blockerMask = 0L;
         }
 
     }

--- a/src/main/java/julius/game/chessengine/evaluation/BatteryModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/BatteryModule.java
@@ -3,6 +3,8 @@ package julius.game.chessengine.evaluation;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.figures.PieceType;
 
+import java.util.Arrays;
+
 /**
  * Rewards coordinated long-range pieces that form batteries (stacked along the same ray) and
  * penalizes the opponent when the battery directly targets valuable pieces. The module only
@@ -55,6 +57,22 @@ public final class BatteryModule implements EvaluationModule {
         BATTERY_ATTACK_ENDGAME[KING] = 28;
     }
 
+    private static final Direction[] ALL_DIRECTIONS = {
+            new Direction(1, 0),    // north
+            new Direction(-1, 0),   // south
+            new Direction(0, 1),    // east
+            new Direction(0, -1),   // west
+            new Direction(1, 1),    // north-east
+            new Direction(1, -1),   // north-west
+            new Direction(-1, 1),   // south-east
+            new Direction(-1, -1)   // south-west
+    };
+
+    private final int[][] midgameContributions = new int[2][64];
+    private final int[][] endgameContributions = new int[2][64];
+    private final int[] midgameTotals = new int[2];
+    private final int[] endgameTotals = new int[2];
+
     private int midgameScoreCache;
     private int endgameScoreCache;
     private boolean dirty = true;
@@ -69,30 +87,17 @@ public final class BatteryModule implements EvaluationModule {
         if (!dirty) {
             return;
         }
-        if (context == null) {
-            midgameScoreCache = 0;
-            endgameScoreCache = 0;
-            dirty = false;
-            return;
-        }
-        EvaluationContext.BoardView board = context.board();
-
-        BatteryScore white = evaluateSide(board, true);
-        BatteryScore black = evaluateSide(board, false);
-
-        midgameScoreCache = white.midgame - black.midgame;
-        endgameScoreCache = white.endgame - black.endgame;
-        dirty = false;
+        rebuildFromBoard(context == null ? null : context.board());
     }
 
     @Override
     public void applyMove(MoveContext moveContext) {
-        dirty = true;
+        updateForMove(moveContext);
     }
 
     @Override
     public void undoMove(MoveContext moveContext) {
-        dirty = true;
+        updateForMove(moveContext);
     }
 
     @Override
@@ -115,46 +120,86 @@ public final class BatteryModule implements EvaluationModule {
         dirty = true;
     }
 
-    private BatteryScore evaluateSide(EvaluationContext.BoardView board, boolean isWhite) {
-        BatteryScore score = new BatteryScore();
+    private void rebuildFromBoard(EvaluationContext.BoardView board) {
+        for (int i = 0; i < 2; i++) {
+            Arrays.fill(midgameContributions[i], 0);
+            Arrays.fill(endgameContributions[i], 0);
+            midgameTotals[i] = 0;
+            endgameTotals[i] = 0;
+        }
+
+        if (board == null) {
+            updateScoreCache();
+            dirty = false;
+            return;
+        }
+
+        rebuildSide(board, true);
+        rebuildSide(board, false);
+        updateScoreCache();
+        dirty = false;
+    }
+
+    private void rebuildSide(EvaluationContext.BoardView board, boolean isWhite) {
+        int colorIndex = isWhite ? 0 : 1;
         long occupancy = board.allPieces();
         long friendlyPieces = isWhite ? board.whitePieces() : board.blackPieces();
         long enemyPieces = isWhite ? board.blackPieces() : board.whitePieces();
 
-        long l = isWhite ? board.whiteQueens() : board.blackQueens();
-        long diagonalCandidates = (isWhite ? board.whiteBishops() : board.blackBishops())
-                | l;
-        accumulateBatteries(board, diagonalCandidates, DIAGONAL_DIRECTIONS, occupancy,
-                friendlyPieces, enemyPieces, true, score);
+        long queens = isWhite ? board.whiteQueens() : board.blackQueens();
+        long diagonalCandidates = (isWhite ? board.whiteBishops() : board.blackBishops()) | queens;
+        long orthogonalCandidates = (isWhite ? board.whiteRooks() : board.blackRooks()) | queens;
 
-        long orthogonalCandidates = (isWhite ? board.whiteRooks() : board.blackRooks())
-                | l;
-        accumulateBatteries(board, orthogonalCandidates, ORTHOGONAL_DIRECTIONS, occupancy,
-                friendlyPieces, enemyPieces, false, score);
-
-        return score;
+        accumulateCandidates(board, diagonalCandidates, colorIndex, occupancy, friendlyPieces,
+                enemyPieces, true);
+        accumulateCandidates(board, orthogonalCandidates, colorIndex, occupancy, friendlyPieces,
+                enemyPieces, false);
     }
 
-    private void accumulateBatteries(EvaluationContext.BoardView board, long candidates,
-                                     Direction[] directions, long occupancy, long friendlyPieces,
-                                     long enemyPieces, boolean diagonal, BatteryScore score) {
+    private void accumulateCandidates(EvaluationContext.BoardView board, long candidates,
+                                      int colorIndex, long occupancy, long friendlyPieces,
+                                      long enemyPieces, boolean diagonal) {
         long remaining = candidates;
         while (remaining != 0) {
             long bit = remaining & -remaining;
             int square = Long.numberOfTrailingZeros(bit);
-            accumulateFromSquare(board, square, directions, occupancy, friendlyPieces,
-                    enemyPieces, diagonal, score);
+            updateContribution(board, colorIndex, square, occupancy, friendlyPieces, enemyPieces,
+                    diagonal, true);
             remaining ^= bit;
         }
     }
 
-    private void accumulateFromSquare(EvaluationContext.BoardView board, int square,
-                                      Direction[] directions, long occupancy, long friendlyPieces,
-                                      long enemyPieces, boolean diagonal, BatteryScore score) {
+    private void updateContribution(EvaluationContext.BoardView board, int colorIndex, int square,
+                                    long occupancy, long friendlyPieces, long enemyPieces,
+                                    boolean diagonal, boolean additive) {
+        PieceType type = board.getPieceTypeAtIndex(square);
+        if (type == null) {
+            return;
+        }
+        boolean isDiagonalSlider = isDiagonalSlider(type);
+        boolean isOrthSlider = isOrthogonalSlider(type);
+
+        if ((diagonal && !isDiagonalSlider) || (!diagonal && !isOrthSlider)) {
+            return;
+        }
+
+        BatteryScore contribution = computeContribution(board, square,
+                diagonal ? DIAGONAL_DIRECTIONS : ORTHOGONAL_DIRECTIONS,
+                occupancy, friendlyPieces, enemyPieces, diagonal);
+
+        applyContribution(colorIndex, square, contribution, additive);
+    }
+
+    private BatteryScore computeContribution(EvaluationContext.BoardView board, int square,
+                                             Direction[] directions, long occupancy,
+                                             long friendlyPieces, long enemyPieces,
+                                             boolean diagonal) {
+        BatteryScore score = new BatteryScore();
         for (Direction direction : directions) {
             accumulateInDirection(board, square, direction, occupancy, friendlyPieces,
                     enemyPieces, diagonal, score);
         }
+        return score;
     }
 
     private void accumulateInDirection(EvaluationContext.BoardView board, int square,
@@ -211,6 +256,200 @@ public final class BatteryModule implements EvaluationModule {
             r += direction.rankDelta;
             f += direction.fileDelta;
         }
+    }
+
+    private void applyContribution(int colorIndex, int square, BatteryScore contribution,
+                                   boolean additive) {
+        int deltaMid = contribution.midgame;
+        int deltaEnd = contribution.endgame;
+        if (!additive) {
+            deltaMid = -deltaMid;
+            deltaEnd = -deltaEnd;
+        }
+        midgameTotals[colorIndex] += deltaMid;
+        endgameTotals[colorIndex] += deltaEnd;
+        midgameContributions[colorIndex][square] += deltaMid;
+        endgameContributions[colorIndex][square] += deltaEnd;
+    }
+
+    private void updateForMove(MoveContext moveContext) {
+        EvaluationContext current = moveContext.currentContext();
+        if (current == null || current.board() == null) {
+            rebuildFromBoard(null);
+            return;
+        }
+        EvaluationContext previous = moveContext.previousContext();
+        if (previous == null || previous.board() == null) {
+            rebuildFromBoard(current.board());
+            return;
+        }
+
+        if (dirty) {
+            rebuildFromBoard(current.board());
+            return;
+        }
+
+        if (!updateIncrementally(moveContext.move(), previous.board(), current.board())) {
+            rebuildFromBoard(current.board());
+        }
+    }
+
+    private boolean updateIncrementally(int move, EvaluationContext.BoardView previousBoard,
+                                        EvaluationContext.BoardView currentBoard) {
+        boolean[] impacted = new boolean[64];
+        markChangedSquares(move, impacted);
+        collectImpactedSliders(previousBoard, impacted);
+        collectImpactedSliders(currentBoard, impacted);
+
+        boolean any = false;
+        for (boolean flag : impacted) {
+            if (flag) {
+                any = true;
+                break;
+            }
+        }
+        if (!any) {
+            return true;
+        }
+
+        for (int square = 0; square < 64; square++) {
+            if (!impacted[square]) {
+                continue;
+            }
+            removeContribution(square);
+            recomputeContribution(currentBoard, square);
+        }
+
+        updateScoreCache();
+        return true;
+    }
+
+    private void markChangedSquares(int move, boolean[] impacted) {
+        int from = MoveHelper.deriveFromIndex(move);
+        int to = MoveHelper.deriveToIndex(move);
+        addImpacted(impacted, from);
+        addImpacted(impacted, to);
+
+        int capturedPiece = MoveHelper.deriveCapturedPieceTypeBits(move);
+        if (capturedPiece != 0) {
+            int captureSquare = MoveHelper.isEnPassantMove(move)
+                    ? enPassantCaptureSquare(to, MoveHelper.isWhitesMove(move))
+                    : to;
+            addImpacted(impacted, captureSquare);
+        }
+
+        if (MoveHelper.isCastlingMove(move)) {
+            handleCastlingSquares(MoveHelper.isWhitesMove(move), to, impacted);
+        }
+    }
+
+    private void addImpacted(boolean[] impacted, int square) {
+        if (square >= 0 && square < impacted.length) {
+            impacted[square] = true;
+        }
+    }
+
+    private void collectImpactedSliders(EvaluationContext.BoardView board, boolean[] impacted) {
+        if (board == null) {
+            return;
+        }
+        for (int square = 0; square < impacted.length; square++) {
+            if (!impacted[square]) {
+                continue;
+            }
+            for (Direction direction : ALL_DIRECTIONS) {
+                int r = square / 8 + direction.rankDelta;
+                int f = square % 8 + direction.fileDelta;
+                while (r >= 0 && r < 8 && f >= 0 && f < 8) {
+                    int target = r * 8 + f;
+                    PieceType type = board.getPieceTypeAtIndex(target);
+                    if (type != null) {
+                        if (isDirectionalSlider(type, direction)) {
+                            impacted[target] = true;
+                            r += direction.rankDelta;
+                            f += direction.fileDelta;
+                            continue;
+                        }
+                        break;
+                    }
+                    r += direction.rankDelta;
+                    f += direction.fileDelta;
+                }
+            }
+        }
+    }
+
+    private void removeContribution(int square) {
+        for (int color = 0; color < 2; color++) {
+            int deltaMid = midgameContributions[color][square];
+            int deltaEnd = endgameContributions[color][square];
+            if (deltaMid == 0 && deltaEnd == 0) {
+                continue;
+            }
+            midgameTotals[color] -= deltaMid;
+            endgameTotals[color] -= deltaEnd;
+            midgameContributions[color][square] = 0;
+            endgameContributions[color][square] = 0;
+        }
+    }
+
+    private void recomputeContribution(EvaluationContext.BoardView board, int square) {
+        PieceType type = board.getPieceTypeAtIndex(square);
+        if (type == null) {
+            return;
+        }
+        boolean isWhite = (board.whitePieces() & (1L << square)) != 0;
+
+        int colorIndex = isWhite ? 0 : 1;
+        long occupancy = board.allPieces();
+        long friendlyPieces = isWhite ? board.whitePieces() : board.blackPieces();
+        long enemyPieces = isWhite ? board.blackPieces() : board.whitePieces();
+
+        if (isDiagonalSlider(type)) {
+            BatteryScore diagonal = computeContribution(board, square, DIAGONAL_DIRECTIONS,
+                    occupancy, friendlyPieces, enemyPieces, true);
+            applyContribution(colorIndex, square, diagonal, true);
+        }
+        if (isOrthogonalSlider(type)) {
+            BatteryScore orthogonal = computeContribution(board, square, ORTHOGONAL_DIRECTIONS,
+                    occupancy, friendlyPieces, enemyPieces, false);
+            applyContribution(colorIndex, square, orthogonal, true);
+        }
+    }
+
+    private void updateScoreCache() {
+        midgameScoreCache = midgameTotals[0] - midgameTotals[1];
+        endgameScoreCache = endgameTotals[0] - endgameTotals[1];
+    }
+
+    private static int enPassantCaptureSquare(int to, boolean moverIsWhite) {
+        return moverIsWhite ? to - 8 : to + 8;
+    }
+
+    private static void handleCastlingSquares(boolean whiteMove, int kingDestination,
+                                               boolean[] impacted) {
+        if (whiteMove) {
+            if (kingDestination == 6) {
+                impacted[5] = true;
+                impacted[7] = true;
+            } else {
+                impacted[3] = true;
+                impacted[0] = true;
+            }
+        } else {
+            if (kingDestination == 62) {
+                impacted[61] = true;
+                impacted[63] = true;
+            } else {
+                impacted[59] = true;
+                impacted[56] = true;
+            }
+        }
+    }
+
+    private static boolean isDirectionalSlider(PieceType type, Direction direction) {
+        boolean diagonal = Math.abs(direction.rankDelta) == Math.abs(direction.fileDelta);
+        return diagonal ? isDiagonalSlider(type) : isOrthogonalSlider(type);
     }
 
     private static boolean supportsDirection(PieceType type, boolean diagonal) {

--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -244,11 +244,11 @@ public final class KingSafetyModule implements EvaluationModule {
             return true;
         }
 
-        long enemyQueens = isWhite ? board.blackQueens() : board.whiteQueens();
-        if (enemyQueens != state.enemyQueens) {
+        long friendlyQueens = isWhite ? board.whiteQueens() : board.blackQueens();
+        if (friendlyQueens != state.enemyQueens) {
             return true;
         }
-        long queenAttackMask = enemyQueens & enemyAttacks;
+        long queenAttackMask = friendlyQueens & enemyAttacks;
         if (queenAttackMask != state.enemyQueenAttackMask) {
             return true;
         }
@@ -259,7 +259,7 @@ public final class KingSafetyModule implements EvaluationModule {
         state.enemyZoneAttacks = enemyZone;
         state.friendlyZoneAttacks = friendlyZone;
         state.friendlyBackrankControl = backrankControl;
-        state.enemyQueens = enemyQueens;
+        state.enemyQueens = friendlyQueens;
         state.enemyQueenAttackMask = queenAttackMask;
         return false;
     }

--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -166,58 +166,102 @@ public final class KingSafetyModule implements EvaluationModule {
         if (state.kingSquare < 0) {
             return true;
         }
-        EvaluationContext previous = moveContext.previousContext();
         EvaluationContext current = moveContext.currentContext();
-        if (previous == null) {
+        EvaluationContext previous = moveContext.previousContext();
+        if (current == null || current.board() == null || previous == null || previous.board() == null) {
             return true;
         }
-        long prevEnemyAttacks = side == WHITE ? previous.blackAttackMap() : previous.whiteAttackMap();
-        long currEnemyAttacks = side == WHITE ? current.blackAttackMap() : current.whiteAttackMap();
-        long prevFriendlyAttacks = side == WHITE ? previous.whiteAttackMap() : previous.blackAttackMap();
-        long currFriendlyAttacks = side == WHITE ? current.whiteAttackMap() : current.blackAttackMap();
-        long zoneDiff = (prevEnemyAttacks ^ currEnemyAttacks) & state.kingZone;
-        if (zoneDiff != 0) {
+        boolean isWhite = side == WHITE;
+        EvaluationContext.BoardView board = current.board();
+        long kingBits = isWhite ? board.whiteKing() : board.blackKing();
+        if (kingBits == 0) {
             return true;
         }
+        int kingSquare = Long.numberOfTrailingZeros(kingBits);
+        if (kingSquare != state.kingSquare) {
+            return true;
+        }
+
         int move = moveContext.move();
         int from = MoveHelper.deriveFromIndex(move);
         int to = MoveHelper.deriveToIndex(move);
-        long moveMask = (1L << from) | (1L << to);
-        if ((moveMask & (state.kingZone | state.shieldMask | state.fileMask)) != 0) {
+        long affectedMask = (1L << from) | (1L << to);
+        int capturedPiece = MoveHelper.deriveCapturedPieceTypeBits(move);
+        if (capturedPiece != 0) {
+            int captureSquare = MoveHelper.isEnPassantMove(move)
+                    ? (MoveHelper.isWhitesMove(move) ? to - 8 : to + 8)
+                    : to;
+            affectedMask |= 1L << captureSquare;
+        }
+        long criticalMask = state.kingZone | state.shieldMask | state.fileMask | state.backrankMask;
+        if ((affectedMask & criticalMask) != 0) {
             return true;
         }
+
         int movedPiece = MoveHelper.derivePieceTypeBits(move);
         if (movedPiece == PAWN) {
             if (((1L << from) & state.fileMask) != 0 || ((1L << to) & state.fileMask) != 0) {
                 return true;
             }
         }
-        int capturedPiece = MoveHelper.deriveCapturedPieceTypeBits(move);
         if (capturedPiece == PAWN) {
-            long captureMask = 1L << to;
-            if (MoveHelper.isEnPassantMove(move)) {
-                captureMask = side == WHITE ? (1L << (to - 8)) : (1L << (to + 8));
-            }
-            if ((captureMask & (state.shieldMask | state.fileMask)) != 0) {
+            int captureSquare = MoveHelper.isEnPassantMove(move)
+                    ? (MoveHelper.isWhitesMove(move) ? to - 8 : to + 8)
+                    : to;
+            if (((1L << captureSquare) & (state.shieldMask | state.fileMask)) != 0) {
                 return true;
             }
         }
-        EvaluationContext.BoardView previousBoard = previous.board();
-        EvaluationContext.BoardView currentBoard = current.board();
-        long prevQueens = side == WHITE ? previousBoard.whiteQueens() : previousBoard.blackQueens();
-        long currQueens = side == WHITE ? currentBoard.whiteQueens() : currentBoard.blackQueens();
-        if (prevQueens != currQueens) {
+
+        long friendlyPawns = isWhite ? board.whitePawns() : board.blackPawns();
+        long enemyPawns = isWhite ? board.blackPawns() : board.whitePawns();
+        long shieldPawns = friendlyPawns & state.shieldMask;
+        if (shieldPawns != state.shieldPawns) {
             return true;
         }
-        long queenMask = currQueens;
-        while (queenMask != 0) {
-            long q = queenMask & -queenMask;
-            if (((prevEnemyAttacks ^ currEnemyAttacks) & q) != 0) {
-                return true;
-            }
-            queenMask ^= q;
+        boolean friendlyPawnOnFile = (friendlyPawns & state.fileMask) != 0;
+        if (friendlyPawnOnFile != state.friendlyPawnOnFile) {
+            return true;
         }
-        return state.backrankMask != 0 && ((prevFriendlyAttacks ^ currFriendlyAttacks) & state.backrankMask) != 0;
+        boolean enemyPawnOnFile = (enemyPawns & state.fileMask) != 0;
+        if (enemyPawnOnFile != state.enemyPawnOnFile) {
+            return true;
+        }
+
+        long friendlyAttacks = isWhite ? current.whiteAttackMap() : current.blackAttackMap();
+        long enemyAttacks = isWhite ? current.blackAttackMap() : current.whiteAttackMap();
+        long enemyZone = enemyAttacks & state.kingZone;
+        if (enemyZone != state.enemyZoneAttacks) {
+            return true;
+        }
+        long friendlyZone = friendlyAttacks & state.kingZone;
+        if (friendlyZone != state.friendlyZoneAttacks) {
+            return true;
+        }
+
+        long backrankControl = state.backrankMask == 0 ? 0L : (friendlyAttacks & state.backrankMask);
+        if (backrankControl != state.friendlyBackrankControl) {
+            return true;
+        }
+
+        long enemyQueens = isWhite ? board.blackQueens() : board.whiteQueens();
+        if (enemyQueens != state.enemyQueens) {
+            return true;
+        }
+        long queenAttackMask = enemyQueens & enemyAttacks;
+        if (queenAttackMask != state.enemyQueenAttackMask) {
+            return true;
+        }
+
+        state.shieldPawns = shieldPawns;
+        state.friendlyPawnOnFile = friendlyPawnOnFile;
+        state.enemyPawnOnFile = enemyPawnOnFile;
+        state.enemyZoneAttacks = enemyZone;
+        state.friendlyZoneAttacks = friendlyZone;
+        state.friendlyBackrankControl = backrankControl;
+        state.enemyQueens = enemyQueens;
+        state.enemyQueenAttackMask = queenAttackMask;
+        return false;
     }
 
     private void rebuildSideState(SideState state, EvaluationContext.BoardView board, boolean isWhite,
@@ -241,15 +285,18 @@ public final class KingSafetyModule implements EvaluationModule {
         long friendlyPawns = isWhite ? board.whitePawns() : board.blackPawns();
         long enemyPawns = isWhite ? board.blackPawns() : board.whitePawns();
 
-        int shieldCount = Long.bitCount(friendlyPawns & state.shieldMask);
+        state.shieldPawns = friendlyPawns & state.shieldMask;
+        int shieldCount = Long.bitCount(state.shieldPawns);
         state.missingShield = Math.max(0, 3 - shieldCount);
 
-        boolean friendlyPawnOnFile = (friendlyPawns & state.fileMask) != 0;
-        if (!friendlyPawnOnFile) {
-            state.filePenalty = (enemyPawns & state.fileMask) != 0 ? HALF_OPEN_FILE_PENALTY : OPEN_FILE_PENALTY;
+        state.friendlyPawnOnFile = (friendlyPawns & state.fileMask) != 0;
+        state.enemyPawnOnFile = (enemyPawns & state.fileMask) != 0;
+        if (!state.friendlyPawnOnFile) {
+            state.filePenalty = state.enemyPawnOnFile ? HALF_OPEN_FILE_PENALTY : OPEN_FILE_PENALTY;
         }
 
-        state.defenderCount = Long.bitCount(friendlyAttacks & state.kingZone);
+        state.friendlyZoneAttacks = friendlyAttacks & state.kingZone;
+        state.defenderCount = Long.bitCount(state.friendlyZoneAttacks);
 
         long allPieces = board.allPieces();
         accumulatePawnAttacks(state, enemyPawns, !isWhite);
@@ -266,11 +313,13 @@ public final class KingSafetyModule implements EvaluationModule {
             zone &= zone - 1;
         }
         state.totalAttackWeight = total;
+        state.enemyZoneAttacks = enemyAttacks & state.kingZone;
 
         int shieldPenalty = state.missingShield * MISSING_PAWN_SHIELD_PENALTY;
         int attackPenalty = -state.totalAttackWeight;
         int defenderBonus = state.defenderCount * DEFENDER_BONUS;
         computeBackrankWeaknessPenalty(state, board, isWhite);
+        state.friendlyBackrankControl = state.backrankMask == 0 ? 0L : (friendlyAttacks & state.backrankMask);
         int baseMidgame = shieldPenalty + state.filePenalty + attackPenalty + defenderBonus;
         state.midgameKingSafety = baseMidgame + state.backrankWeaknessMidgame;
         state.endgameKingSafety = baseMidgame / 2 + state.backrankWeaknessEndgame;
@@ -289,6 +338,8 @@ public final class KingSafetyModule implements EvaluationModule {
         }
         state.midgameQueenPenalty = queenMid;
         state.endgameQueenPenalty = queenEnd;
+        state.enemyQueens = queens;
+        state.enemyQueenAttackMask = queens & enemyAttacks;
     }
 
     private void computeBackrankWeaknessPenalty(SideState state, EvaluationContext.BoardView board, boolean isWhite) {
@@ -582,6 +633,14 @@ public final class KingSafetyModule implements EvaluationModule {
         private int backrankWeaknessEndgame;
         private final int[] zoneAttackWeights = new int[64];
         private long backrankMask;
+        private long shieldPawns;
+        private boolean friendlyPawnOnFile;
+        private boolean enemyPawnOnFile;
+        private long enemyZoneAttacks;
+        private long friendlyZoneAttacks;
+        private long enemyQueens;
+        private long enemyQueenAttackMask;
+        private long friendlyBackrankControl;
 
         private void reset() {
             kingSquare = -1;
@@ -599,6 +658,14 @@ public final class KingSafetyModule implements EvaluationModule {
             backrankWeaknessMidgame = 0;
             backrankWeaknessEndgame = 0;
             backrankMask = 0L;
+            shieldPawns = 0L;
+            friendlyPawnOnFile = false;
+            enemyPawnOnFile = false;
+            enemyZoneAttacks = 0L;
+            friendlyZoneAttacks = 0L;
+            enemyQueens = 0L;
+            enemyQueenAttackMask = 0L;
+            friendlyBackrankControl = 0L;
             Arrays.fill(zoneAttackWeights, 0);
         }
     }

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -121,26 +121,32 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         PhaseScore blackPassed = PhaseScore.constant(
                 calculatePassedPawnBonus(blackPawns, whitePawns, allPieces, blackKing, false));
 
+        int whiteAdvanceBase = calculatePawnAdvanceBase(whitePawns, allPieces, blackAttacks, true);
         PhaseScore whiteAdvance = PhaseScore.of(
-                calculatePawnAdvanceBonus(whitePawns, allPieces, blackAttacks, true, 0),
-                calculatePawnAdvanceBonus(whitePawns, allPieces, blackAttacks, true, 256));
+                scaleByPhase(whiteAdvanceBase, 0),
+                scaleByPhase(whiteAdvanceBase, 256));
+        int blackAdvanceBase = calculatePawnAdvanceBase(blackPawns, allPieces, whiteAttacks, false);
         PhaseScore blackAdvance = PhaseScore.of(
-                calculatePawnAdvanceBonus(blackPawns, allPieces, whiteAttacks, false, 0),
-                calculatePawnAdvanceBonus(blackPawns, allPieces, whiteAttacks, false, 256));
+                scaleByPhase(blackAdvanceBase, 0),
+                scaleByPhase(blackAdvanceBase, 256));
 
+        int whiteBlockedBase = calculateBlockedPawnPenaltyBase(whitePawns, allPieces, true);
         PhaseScore whiteBlocked = PhaseScore.of(
-                calculateBlockedPawnPenalty(whitePawns, allPieces, true, 0),
-                calculateBlockedPawnPenalty(whitePawns, allPieces, true, 256));
+                scaleByPhase(whiteBlockedBase, 0),
+                scaleByPhase(whiteBlockedBase, 256));
+        int blackBlockedBase = calculateBlockedPawnPenaltyBase(blackPawns, allPieces, false);
         PhaseScore blackBlocked = PhaseScore.of(
-                calculateBlockedPawnPenalty(blackPawns, allPieces, false, 0),
-                calculateBlockedPawnPenalty(blackPawns, allPieces, false, 256));
+                scaleByPhase(blackBlockedBase, 0),
+                scaleByPhase(blackBlockedBase, 256));
 
+        int whiteBackwardBase = calculateBackwardPawnPenaltyBase(whitePawns, blackPawns, allPieces, true);
         PhaseScore whiteBackward = PhaseScore.of(
-                calculateBackwardPawnPenalty(whitePawns, blackPawns, allPieces, true, 0),
-                calculateBackwardPawnPenalty(whitePawns, blackPawns, allPieces, true, 256));
+                scaleByPhase(whiteBackwardBase, 0),
+                scaleByPhase(whiteBackwardBase, 256));
+        int blackBackwardBase = calculateBackwardPawnPenaltyBase(blackPawns, whitePawns, allPieces, false);
         PhaseScore blackBackward = PhaseScore.of(
-                calculateBackwardPawnPenalty(blackPawns, whitePawns, allPieces, false, 0),
-                calculateBackwardPawnPenalty(blackPawns, whitePawns, allPieces, false, 256));
+                scaleByPhase(blackBackwardBase, 0),
+                scaleByPhase(blackBackwardBase, 256));
 
         PhaseScore[] whiteComponents = new PhaseScore[]{
                 whiteCenter,
@@ -371,7 +377,7 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         return STRUCTURE_CACHE.computeIfAbsent(key, _ -> new CachedStructure(whitePawns, blackPawns));
     }
 
-    private static int calculatePawnAdvanceBonus(long pawns, long allPieces, long enemyAttacks, boolean isWhite, int phase) {
+    private static int calculatePawnAdvanceBase(long pawns, long allPieces, long enemyAttacks, boolean isWhite) {
         int bonus = 0;
         long advancedRanks = isWhite
                 ? (RankMasks[3] | RankMasks[4] | RankMasks[5] | RankMasks[6])
@@ -387,10 +393,10 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
             }
             advancedPawns &= advancedPawns - 1;
         }
-        return scaleByPhase(bonus, phase);
+        return bonus;
     }
 
-    private static int calculateBlockedPawnPenalty(long pawns, long allPieces, boolean isWhite, int phase) {
+    private static int calculateBlockedPawnPenaltyBase(long pawns, long allPieces, boolean isWhite) {
         int penalty = 0;
         long remaining = pawns;
         while (remaining != 0) {
@@ -401,10 +407,10 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
             }
             remaining &= remaining - 1;
         }
-        return scaleByPhase(penalty, phase);
+        return penalty;
     }
 
-    private static int calculateBackwardPawnPenalty(long pawns, long enemyPawns, long allPieces, boolean isWhite, int phase) {
+    private static int calculateBackwardPawnPenaltyBase(long pawns, long enemyPawns, long allPieces, boolean isWhite) {
         int penalty = 0;
         long remaining = pawns;
         while (remaining != 0) {
@@ -419,7 +425,7 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
             }
             remaining &= remaining - 1;
         }
-        return scaleByPhase(penalty, phase);
+        return penalty;
     }
 
     private static int sumMidgame(PhaseScore... scores) {

--- a/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
@@ -5,6 +5,7 @@ import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.BishopHelper;
 import julius.game.chessengine.helper.RookHelper;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import static julius.game.chessengine.helper.PawnMoveTables.PAWN_ATTACKS;
@@ -46,6 +47,8 @@ public final class ThreatModule implements EvaluationModule {
         PAWN_THREAT_PENALTIES[QUEEN] = -25;
     }
 
+    private final int[][] squarePenalties = new int[2][64];
+    private final int[] totals = new int[2];
     private int midgameScoreCache;
     private int endgameScoreCache;
     private boolean dirty = true;
@@ -60,34 +63,17 @@ public final class ThreatModule implements EvaluationModule {
         if (!dirty) {
             return;
         }
-        Objects.requireNonNull(context, "context");
-        EvaluationContext.BoardView board = context.board();
-        if (board == null) {
-            midgameScoreCache = 0;
-            endgameScoreCache = 0;
-            dirty = false;
-            return;
-        }
-
-        long whiteAttacks = context.whiteAttackMap();
-        long blackAttacks = context.blackAttackMap();
-
-        int whitePenalty = evaluateSide(board, true, whiteAttacks, blackAttacks);
-        int blackPenalty = evaluateSide(board, false, blackAttacks, whiteAttacks);
-
-        midgameScoreCache = whitePenalty - blackPenalty;
-        endgameScoreCache = midgameScoreCache;
-        dirty = false;
+        rebuildFromContext(Objects.requireNonNull(context, "context"));
     }
 
     @Override
     public void applyMove(MoveContext moveContext) {
-        dirty = true;
+        updateForMove(moveContext);
     }
 
     @Override
     public void undoMove(MoveContext moveContext) {
-        dirty = true;
+        updateForMove(moveContext);
     }
 
     @Override
@@ -110,48 +96,243 @@ public final class ThreatModule implements EvaluationModule {
         dirty = true;
     }
 
-    private int evaluateSide(EvaluationContext.BoardView board, boolean isWhite, long friendlyAttacks, long enemyAttacks) {
+    private void rebuildFromContext(EvaluationContext context) {
+        EvaluationContext.BoardView board = context.board();
+        Arrays.fill(totals, 0);
+        for (int[] penalties : squarePenalties) {
+            Arrays.fill(penalties, 0);
+        }
+
+        if (board == null) {
+            midgameScoreCache = 0;
+            endgameScoreCache = 0;
+            dirty = false;
+            return;
+        }
+
+        long whiteAttacks = context.whiteAttackMap();
+        long blackAttacks = context.blackAttackMap();
+
+        rebuildSide(board, true, whiteAttacks, blackAttacks);
+        rebuildSide(board, false, blackAttacks, whiteAttacks);
+
+        midgameScoreCache = totals[WHITE] - totals[BLACK];
+        endgameScoreCache = midgameScoreCache;
+        dirty = false;
+    }
+
+    private void rebuildSide(EvaluationContext.BoardView board, boolean isWhite,
+                             long friendlyAttacks, long enemyAttacks) {
+        int color = isWhite ? WHITE : BLACK;
         long pieces = isWhite ? board.whitePieces() : board.blackPieces();
         long enemyPawns = isWhite ? board.blackPawns() : board.whitePawns();
         int enemyPawnColor = isWhite ? BLACK : WHITE;
         long enemyPawnAttacks = computePawnAttackMask(enemyPawns, enemyPawnColor);
 
-        int penalty = 0;
         long remaining = pieces;
         while (remaining != 0) {
             long bit = remaining & -remaining;
             int square = Long.numberOfTrailingZeros(bit);
-            PieceType type = board.getPieceTypeAtIndex(square);
-            if (type == null) {
-                remaining ^= bit;
-                continue;
-            }
-            int typeBits = MoveHelper.pieceTypeToInt(type);
-            if (typeBits == KING) {
-                remaining ^= bit;
-                continue;
-            }
-            long mask = 1L << square;
-            if ((enemyAttacks & mask) == 0) {
-                remaining ^= bit;
-                continue;
-            }
-            boolean defended = (friendlyAttacks & mask) != 0;
-            if (!defended) {
-                penalty += HANGING_PENALTIES[typeBits];
-            }
-            if (typeBits > PAWN && (enemyPawnAttacks & mask) != 0) {
-                int defenderValue = defended
-                        ? leastValuableDefenderValue(board, isWhite, square)
-                        : materialValueFor(typeBits);
-                if (defenderValue <= 0) {
-                    defenderValue = materialValueFor(typeBits);
-                }
-                penalty += scalePawnThreatPenalty(typeBits, defenderValue);
-            }
+            int penalty = computePiecePenalty(board, isWhite, square, friendlyAttacks,
+                    enemyAttacks, enemyPawnAttacks);
+            squarePenalties[color][square] = penalty;
+            totals[color] += penalty;
             remaining ^= bit;
         }
+    }
+
+    private int computePiecePenalty(EvaluationContext.BoardView board, boolean isWhite, int square,
+                                     long friendlyAttacks, long enemyAttacks, long enemyPawnAttacks) {
+        PieceType type = board.getPieceTypeAtIndex(square);
+        if (type == null) {
+            return 0;
+        }
+        int typeBits = MoveHelper.pieceTypeToInt(type);
+        if (typeBits == KING) {
+            return 0;
+        }
+        long mask = 1L << square;
+        if ((enemyAttacks & mask) == 0) {
+            return 0;
+        }
+        int penalty = 0;
+        boolean defended = (friendlyAttacks & mask) != 0;
+        if (!defended) {
+            penalty += HANGING_PENALTIES[typeBits];
+        }
+        if (typeBits > PAWN && (enemyPawnAttacks & mask) != 0) {
+            int defenderValue = defended
+                    ? leastValuableDefenderValue(board, isWhite, square)
+                    : materialValueFor(typeBits);
+            if (defenderValue <= 0) {
+                defenderValue = materialValueFor(typeBits);
+            }
+            penalty += scalePawnThreatPenalty(typeBits, defenderValue);
+        }
         return penalty;
+    }
+
+    private void updateForMove(MoveContext moveContext) {
+        EvaluationContext current = moveContext.currentContext();
+        if (current == null || current.board() == null) {
+            Arrays.fill(totals, 0);
+            for (int[] penalties : squarePenalties) {
+                Arrays.fill(penalties, 0);
+            }
+            midgameScoreCache = 0;
+            endgameScoreCache = 0;
+            dirty = false;
+            return;
+        }
+        EvaluationContext previous = moveContext.previousContext();
+        if (previous == null || previous.board() == null) {
+            rebuildFromContext(current);
+            return;
+        }
+
+        if (dirty) {
+            rebuildFromContext(current);
+            return;
+        }
+
+        boolean[] impactedWhite = new boolean[64];
+        boolean[] impactedBlack = new boolean[64];
+
+        markMoveSquares(moveContext.move(), impactedWhite, impactedBlack);
+        markAttackDifferences(previous, current, impactedWhite, impactedBlack);
+
+        if (!hasImpacted(impactedWhite) && !hasImpacted(impactedBlack)) {
+            return;
+        }
+
+        EvaluationContext.BoardView board = current.board();
+        long whiteFriendlyAttacks = current.whiteAttackMap();
+        long blackFriendlyAttacks = current.blackAttackMap();
+        long whiteEnemyAttacks = current.blackAttackMap();
+        long blackEnemyAttacks = current.whiteAttackMap();
+        long whiteEnemyPawnAttacks = computePawnAttackMask(board.blackPawns(), BLACK);
+        long blackEnemyPawnAttacks = computePawnAttackMask(board.whitePawns(), WHITE);
+
+        updateSidePenalties(true, board, whiteFriendlyAttacks, whiteEnemyAttacks,
+                whiteEnemyPawnAttacks, impactedWhite);
+        updateSidePenalties(false, board, blackFriendlyAttacks, blackEnemyAttacks,
+                blackEnemyPawnAttacks, impactedBlack);
+
+        midgameScoreCache = totals[WHITE] - totals[BLACK];
+        endgameScoreCache = midgameScoreCache;
+    }
+
+    private void markMoveSquares(int move, boolean[] impactedWhite, boolean[] impactedBlack) {
+        int from = MoveHelper.deriveFromIndex(move);
+        int to = MoveHelper.deriveToIndex(move);
+        boolean moverIsWhite = MoveHelper.isWhitesMove(move);
+        markSquare(moverIsWhite ? impactedWhite : impactedBlack, from);
+        markSquare(moverIsWhite ? impactedWhite : impactedBlack, to);
+
+        int capturedPiece = MoveHelper.deriveCapturedPieceTypeBits(move);
+        if (capturedPiece != 0) {
+            int captureSquare = MoveHelper.isEnPassantMove(move)
+                    ? (MoveHelper.isWhitesMove(move) ? to - 8 : to + 8)
+                    : to;
+            markSquare(moverIsWhite ? impactedBlack : impactedWhite, captureSquare);
+        }
+
+        if (MoveHelper.isCastlingMove(move)) {
+            markCastlingSquares(MoveHelper.isWhitesMove(move), to,
+                    moverIsWhite ? impactedWhite : impactedBlack);
+        }
+    }
+
+    private void markAttackDifferences(EvaluationContext previous, EvaluationContext current,
+                                       boolean[] impactedWhite, boolean[] impactedBlack) {
+        long prevWhiteAttacks = previous.whiteAttackMap();
+        long currWhiteAttacks = current.whiteAttackMap();
+        long prevBlackAttacks = previous.blackAttackMap();
+        long currBlackAttacks = current.blackAttackMap();
+
+        EvaluationContext.BoardView prevBoard = previous.board();
+        EvaluationContext.BoardView currBoard = current.board();
+
+        long whitePiecesCombined = prevBoard.whitePieces() | currBoard.whitePieces();
+        long blackPiecesCombined = prevBoard.blackPieces() | currBoard.blackPieces();
+
+        long attackDiffUnion = (prevBlackAttacks ^ currBlackAttacks) | (prevWhiteAttacks ^ currWhiteAttacks);
+
+        markSquaresFromMask(impactedWhite, whitePiecesCombined & attackDiffUnion);
+        markSquaresFromMask(impactedBlack, blackPiecesCombined & attackDiffUnion);
+
+        long prevBlackPawnAttacks = computePawnAttackMask(prevBoard.blackPawns(), BLACK);
+        long currBlackPawnAttacks = computePawnAttackMask(currBoard.blackPawns(), BLACK);
+        long prevWhitePawnAttacks = computePawnAttackMask(prevBoard.whitePawns(), WHITE);
+        long currWhitePawnAttacks = computePawnAttackMask(currBoard.whitePawns(), WHITE);
+
+        markSquaresFromMask(impactedWhite, whitePiecesCombined & (prevBlackPawnAttacks ^ currBlackPawnAttacks));
+        markSquaresFromMask(impactedBlack, blackPiecesCombined & (prevWhitePawnAttacks ^ currWhitePawnAttacks));
+    }
+
+    private void updateSidePenalties(boolean isWhite, EvaluationContext.BoardView board,
+                                     long friendlyAttacks, long enemyAttacks,
+                                     long enemyPawnAttacks, boolean[] impacted) {
+        int color = isWhite ? WHITE : BLACK;
+        long pieces = isWhite ? board.whitePieces() : board.blackPieces();
+        for (int square = 0; square < impacted.length; square++) {
+            if (!impacted[square]) {
+                continue;
+            }
+            int old = squarePenalties[color][square];
+            totals[color] -= old;
+            squarePenalties[color][square] = 0;
+            if ((pieces & (1L << square)) == 0) {
+                continue;
+            }
+            int penalty = computePiecePenalty(board, isWhite, square, friendlyAttacks,
+                    enemyAttacks, enemyPawnAttacks);
+            squarePenalties[color][square] = penalty;
+            totals[color] += penalty;
+        }
+    }
+
+    private static void markCastlingSquares(boolean whiteMove, int kingDestination, boolean[] impacted) {
+        if (whiteMove) {
+            if (kingDestination == 6) {
+                markSquare(impacted, 5);
+                markSquare(impacted, 7);
+            } else {
+                markSquare(impacted, 3);
+                markSquare(impacted, 0);
+            }
+        } else {
+            if (kingDestination == 62) {
+                markSquare(impacted, 61);
+                markSquare(impacted, 63);
+            } else {
+                markSquare(impacted, 59);
+                markSquare(impacted, 56);
+            }
+        }
+    }
+
+    private static void markSquare(boolean[] impacted, int square) {
+        if (square >= 0 && square < impacted.length) {
+            impacted[square] = true;
+        }
+    }
+
+    private static void markSquaresFromMask(boolean[] impacted, long mask) {
+        while (mask != 0) {
+            int square = Long.numberOfTrailingZeros(mask);
+            impacted[square] = true;
+            mask &= mask - 1;
+        }
+    }
+
+    private static boolean hasImpacted(boolean[] impacted) {
+        for (boolean flag : impacted) {
+            if (flag) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static int materialValueFor(int pieceType) {


### PR DESCRIPTION
## Summary
- make BatteryModule reuse per-slider caches and update only rays touched by a move
- teach ThreatModule to track per-piece penalties and update only impacted squares on a move
- narrow KingSafety invalidation logic by caching pawn/file metadata and attack masks per side
- avoid duplicate pawn scans by reusing base scores in PawnStructureModule
- cache slider attack and blocker masks in ActivityModule so ray rescans stay local

## Testing
- `./mvnw -q test` *(fails: network unreachable for Maven wrapper download)*
- `mvn -q -DskipTests package` *(fails: cannot resolve parent POM without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cf5f1670832aa4aa392ffb7a5bd0