### PR TITLE
Optimize evaluation modules for incremental updates

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
@@ -43,6 +43,8 @@ public final class ActivityModule implements EvaluationModule {
     private static final int SOUTH_WEST = 7;
 
     private static final long[][] DIRECTION_RAYS = new long[8][64];
+    private static final int[] DIRECTION_RANK_DELTAS = {1, -1, 0, 0, 1, 1, -1, -1};
+    private static final int[] DIRECTION_FILE_DELTAS = {0, 0, 1, -1, 1, -1, 1, -1};
 
     private static final BishopHelper BISHOP_HELPER = BishopHelper.getInstance();
     private static final RookHelper ROOK_HELPER = RookHelper.getInstance();
@@ -329,25 +331,51 @@ public final class ActivityModule implements EvaluationModule {
     }
 
     private void recalculateAffectedSliders(long affectedMask, long excludeMask) {
-        long sliders = sliderSquares;
-        while (sliders != 0) {
-            int square = Long.numberOfTrailingZeros(sliders);
-            sliders &= sliders - 1;
-
-            if (((excludeMask >>> square) & 1L) != 0) {
-                continue;
-            }
-
+        long slidersToUpdate = collectAffectedSliders(affectedMask) & sliderSquares & ~excludeMask;
+        while (slidersToUpdate != 0) {
+            int square = Long.numberOfTrailingZeros(slidersToUpdate);
+            slidersToUpdate &= slidersToUpdate - 1;
             PieceActivity activity = activities[square];
             if (activity.color < 0) {
                 continue;
             }
+            recalculatePiece(square);
+        }
+    }
 
-            long rayMask = sliderRayMask(activity.pieceType, square);
-            if ((rayMask & affectedMask) != 0) {
-                recalculatePiece(square);
+    private long collectAffectedSliders(long affectedMask) {
+        long sliders = 0L;
+        long mask = affectedMask;
+        while (mask != 0) {
+            int square = Long.numberOfTrailingZeros(mask);
+            mask &= mask - 1;
+            sliders |= (sliderSquares & (1L << square));
+            for (int direction = 0; direction < DIRECTION_RAYS.length; direction++) {
+                sliders |= firstSliderInDirection(square, direction);
             }
         }
+        return sliders;
+    }
+
+    private long firstSliderInDirection(int square, int direction) {
+        int rankDelta = DIRECTION_RANK_DELTAS[direction];
+        int fileDelta = DIRECTION_FILE_DELTAS[direction];
+        int rank = square / 8 + rankDelta;
+        int file = square % 8 + fileDelta;
+        while (rank >= 0 && rank < 8 && file >= 0 && file < 8) {
+            int target = rank * 8 + file;
+            long mask = 1L << target;
+            if ((allPieces & mask) != 0) {
+                PieceActivity activity = activities[target];
+                if (activity.color >= 0 && isSlider(activity.pieceType)) {
+                    return mask;
+                }
+                break;
+            }
+            rank += rankDelta;
+            file += fileDelta;
+        }
+        return 0L;
     }
 
     private long sliderRayMask(int pieceType, int square) {

--- a/src/main/java/julius/game/chessengine/evaluation/BatteryModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/BatteryModule.java
@@ -55,13 +55,33 @@ public final class BatteryModule implements EvaluationModule {
         BATTERY_ATTACK_ENDGAME[KING] = 28;
     }
 
+    private static final int WHITE = 0;
+    private static final int BLACK = 1;
+
+    private static final Direction[] ALL_DIRECTIONS = {
+            new Direction(1, 0),
+            new Direction(-1, 0),
+            new Direction(0, 1),
+            new Direction(0, -1),
+            new Direction(1, 1),
+            new Direction(1, -1),
+            new Direction(-1, 1),
+            new Direction(-1, -1)
+    };
+
+    private final int[][] midgameContributions = new int[2][64];
+    private final int[][] endgameContributions = new int[2][64];
+    private final int[] sideMidgameTotals = new int[2];
+    private final int[] sideEndgameTotals = new int[2];
+    private final boolean[] touchedSquares = new boolean[64];
+
     private int midgameScoreCache;
     private int endgameScoreCache;
     private boolean dirty = true;
 
     @Override
     public void initialize(EvaluationContext context) {
-        evaluate(context);
+        rebuildFromBoard(context == null ? null : context.board());
     }
 
     @Override
@@ -69,30 +89,21 @@ public final class BatteryModule implements EvaluationModule {
         if (!dirty) {
             return;
         }
-        if (context == null) {
-            midgameScoreCache = 0;
-            endgameScoreCache = 0;
-            dirty = false;
-            return;
-        }
-        EvaluationContext.BoardView board = context.board();
-
-        BatteryScore white = evaluateSide(board, true);
-        BatteryScore black = evaluateSide(board, false);
-
-        midgameScoreCache = white.midgame - black.midgame;
-        endgameScoreCache = white.endgame - black.endgame;
-        dirty = false;
+        rebuildFromBoard(context == null ? null : context.board());
     }
 
     @Override
     public void applyMove(MoveContext moveContext) {
-        dirty = true;
+        if (!incrementalUpdate(moveContext)) {
+            rebuildFromBoard(moveContext.currentContext() == null
+                    ? null
+                    : moveContext.currentContext().board());
+        }
     }
 
     @Override
     public void undoMove(MoveContext moveContext) {
-        dirty = true;
+        applyMove(moveContext);
     }
 
     @Override
@@ -115,84 +126,261 @@ public final class BatteryModule implements EvaluationModule {
         dirty = true;
     }
 
-    private BatteryScore evaluateSide(EvaluationContext.BoardView board, boolean isWhite) {
-        BatteryScore score = new BatteryScore();
+    private void rebuildFromBoard(EvaluationContext.BoardView board) {
+        clearContributions();
+        if (board == null) {
+            midgameScoreCache = 0;
+            endgameScoreCache = 0;
+            dirty = false;
+            return;
+        }
         long occupancy = board.allPieces();
-        long friendlyPieces = isWhite ? board.whitePieces() : board.blackPieces();
-        long enemyPieces = isWhite ? board.blackPieces() : board.whitePieces();
-
-        long l = isWhite ? board.whiteQueens() : board.blackQueens();
-        long diagonalCandidates = (isWhite ? board.whiteBishops() : board.blackBishops())
-                | l;
-        accumulateBatteries(board, diagonalCandidates, DIAGONAL_DIRECTIONS, occupancy,
-                friendlyPieces, enemyPieces, true, score);
-
-        long orthogonalCandidates = (isWhite ? board.whiteRooks() : board.blackRooks())
-                | l;
-        accumulateBatteries(board, orthogonalCandidates, ORTHOGONAL_DIRECTIONS, occupancy,
-                friendlyPieces, enemyPieces, false, score);
-
-        return score;
+        long whitePieces = board.whitePieces();
+        long blackPieces = board.blackPieces();
+        for (int square = 0; square < 64; square++) {
+            PieceType type = board.getPieceTypeAtIndex(square);
+            if (type == null) {
+                continue;
+            }
+            boolean isWhite = ((whitePieces >>> square) & 1L) != 0;
+            int side = isWhite ? WHITE : BLACK;
+            ScorePair scores = computeScores(board, square, type, occupancy,
+                    isWhite ? whitePieces : blackPieces,
+                    isWhite ? blackPieces : whitePieces);
+            midgameContributions[side][square] = scores.midgame;
+            endgameContributions[side][square] = scores.endgame;
+            sideMidgameTotals[side] += scores.midgame;
+            sideEndgameTotals[side] += scores.endgame;
+        }
+        refreshScoreCaches();
+        dirty = false;
     }
 
-    private void accumulateBatteries(EvaluationContext.BoardView board, long candidates,
-                                     Direction[] directions, long occupancy, long friendlyPieces,
-                                     long enemyPieces, boolean diagonal, BatteryScore score) {
-        long remaining = candidates;
-        while (remaining != 0) {
-            long bit = remaining & -remaining;
-            int square = Long.numberOfTrailingZeros(bit);
-            accumulateFromSquare(board, square, directions, occupancy, friendlyPieces,
-                    enemyPieces, diagonal, score);
-            remaining ^= bit;
+    private boolean incrementalUpdate(MoveContext moveContext) {
+        EvaluationContext current = moveContext.currentContext();
+        EvaluationContext previous = moveContext.previousContext();
+        if (current == null) {
+            clearContributions();
+            midgameScoreCache = 0;
+            endgameScoreCache = 0;
+            dirty = false;
+            return true;
+        }
+        if (previous == null) {
+            rebuildFromBoard(current.board());
+            return true;
+        }
+        EvaluationContext.BoardView previousBoard = previous.board();
+        EvaluationContext.BoardView currentBoard = current.board();
+        if (previousBoard == null || currentBoard == null) {
+            rebuildFromBoard(currentBoard);
+            return true;
+        }
+
+        clearTouched();
+
+        int move = moveContext.move();
+        int from = MoveHelper.deriveFromIndex(move);
+        int to = MoveHelper.deriveToIndex(move);
+        markAffected(previousBoard, from);
+        markAffected(previousBoard, to);
+        markAffected(currentBoard, from);
+        markAffected(currentBoard, to);
+
+        if (MoveHelper.isEnPassantMove(move)) {
+            int capture = MoveHelper.isWhitesMove(move) ? to - 8 : to + 8;
+            markAffected(previousBoard, capture);
+            markAffected(currentBoard, capture);
+        }
+
+        if (MoveHelper.isCastlingMove(move)) {
+            boolean whiteMove = MoveHelper.isWhitesMove(move);
+            boolean kingside = to > from;
+            int rookFrom = whiteMove ? (kingside ? 7 : 0) : (kingside ? 63 : 56);
+            int rookTo = whiteMove ? (kingside ? 5 : 3) : (kingside ? 61 : 59);
+            markAffected(previousBoard, rookFrom);
+            markAffected(currentBoard, rookFrom);
+            markAffected(previousBoard, rookTo);
+            markAffected(currentBoard, rookTo);
+        }
+
+        int capturedPiece = MoveHelper.deriveCapturedPieceTypeBits(move);
+        if (capturedPiece != 0) {
+            markAffected(previousBoard, to);
+        }
+
+        applyUpdates(currentBoard);
+        dirty = false;
+        return true;
+    }
+
+    private void clearContributions() {
+        for (int side = 0; side < midgameContributions.length; side++) {
+            java.util.Arrays.fill(midgameContributions[side], 0);
+            java.util.Arrays.fill(endgameContributions[side], 0);
+            sideMidgameTotals[side] = 0;
+            sideEndgameTotals[side] = 0;
         }
     }
 
-    private void accumulateFromSquare(EvaluationContext.BoardView board, int square,
-                                      Direction[] directions, long occupancy, long friendlyPieces,
-                                      long enemyPieces, boolean diagonal, BatteryScore score) {
+    private void applyUpdates(EvaluationContext.BoardView board) {
+        long whitePieces = board.whitePieces();
+        long blackPieces = board.blackPieces();
+        long occupancy = board.allPieces();
+        for (int square = 0; square < touchedSquares.length; square++) {
+            if (!touchedSquares[square]) {
+                continue;
+            }
+            for (int side = 0; side < 2; side++) {
+                int prevMid = midgameContributions[side][square];
+                int prevEnd = endgameContributions[side][square];
+                if (prevMid != 0 || prevEnd != 0) {
+                    sideMidgameTotals[side] -= prevMid;
+                    sideEndgameTotals[side] -= prevEnd;
+                    midgameContributions[side][square] = 0;
+                    endgameContributions[side][square] = 0;
+                }
+            }
+            long mask = 1L << square;
+            boolean isWhite = (whitePieces & mask) != 0;
+            boolean isBlack = (blackPieces & mask) != 0;
+            if (!isWhite && !isBlack) {
+                continue;
+            }
+            PieceType type = board.getPieceTypeAtIndex(square);
+            if (type == null) {
+                continue;
+            }
+            int side = isWhite ? WHITE : BLACK;
+            ScorePair scores = computeScores(board, square, type, occupancy,
+                    isWhite ? whitePieces : blackPieces,
+                    isWhite ? blackPieces : whitePieces);
+            midgameContributions[side][square] = scores.midgame;
+            endgameContributions[side][square] = scores.endgame;
+            sideMidgameTotals[side] += scores.midgame;
+            sideEndgameTotals[side] += scores.endgame;
+        }
+        refreshScoreCaches();
+    }
+
+    private void refreshScoreCaches() {
+        midgameScoreCache = sideMidgameTotals[WHITE] - sideMidgameTotals[BLACK];
+        endgameScoreCache = sideEndgameTotals[WHITE] - sideEndgameTotals[BLACK];
+    }
+
+    private void clearTouched() {
+        java.util.Arrays.fill(touchedSquares, false);
+    }
+
+    private void markAffected(EvaluationContext.BoardView board, int square) {
+        if (square < 0 || square >= 64 || board == null) {
+            return;
+        }
+        touchedSquares[square] = true;
+        for (Direction direction : ALL_DIRECTIONS) {
+            markDirectionalImpact(board, square, direction);
+        }
+    }
+
+    private void markDirectionalImpact(EvaluationContext.BoardView board, int square, Direction direction) {
+        int rank = square / 8 + direction.rankDelta;
+        int file = square % 8 + direction.fileDelta;
+        while (rank >= 0 && rank < 8 && file >= 0 && file < 8) {
+            int target = rank * 8 + file;
+            PieceType type = board.getPieceTypeAtIndex(target);
+            if (type != null && supportsDirection(type, isDiagonal(direction))) {
+                touchedSquares[target] = true;
+                break;
+            }
+            if (type != null) {
+                break;
+            }
+            rank += direction.rankDelta;
+            file += direction.fileDelta;
+        }
+    }
+
+    private static boolean isDiagonal(Direction direction) {
+        return direction.rankDelta != 0 && direction.fileDelta != 0;
+    }
+
+    private ScorePair computeScores(EvaluationContext.BoardView board,
+                                    int square,
+                                    PieceType pieceType,
+                                    long occupancy,
+                                    long friendlyPieces,
+                                    long enemyPieces) {
+        if (!isDiagonalSlider(pieceType) && !isOrthogonalSlider(pieceType)) {
+            return ScorePair.ZERO;
+        }
+        ScorePair total = new ScorePair();
+        if (isDiagonalSlider(pieceType)) {
+            add(total, accumulateDirections(board, square, DIAGONAL_DIRECTIONS,
+                    occupancy, friendlyPieces, enemyPieces, true));
+        }
+        if (isOrthogonalSlider(pieceType)) {
+            add(total, accumulateDirections(board, square, ORTHOGONAL_DIRECTIONS,
+                    occupancy, friendlyPieces, enemyPieces, false));
+        }
+        return total;
+    }
+
+    private ScorePair accumulateDirections(EvaluationContext.BoardView board,
+                                           int square,
+                                           Direction[] directions,
+                                           long occupancy,
+                                           long friendlyPieces,
+                                           long enemyPieces,
+                                           boolean diagonal) {
+        ScorePair total = new ScorePair();
         for (Direction direction : directions) {
-            accumulateInDirection(board, square, direction, occupancy, friendlyPieces,
-                    enemyPieces, diagonal, score);
+            add(total, accumulateDirection(board, square, direction, occupancy,
+                    friendlyPieces, enemyPieces, diagonal));
         }
+        return total;
     }
 
-    private void accumulateInDirection(EvaluationContext.BoardView board, int square,
-                                       Direction direction, long occupancy, long friendlyPieces,
-                                       long enemyPieces, boolean diagonal, BatteryScore score) {
-        int rank = square / 8;
-        int file = square % 8;
-        int r = rank + direction.rankDelta;
-        int f = file + direction.fileDelta;
-        while (r >= 0 && r < 8 && f >= 0 && f < 8) {
-            int targetSquare = r * 8 + f;
-            long mask = 1L << targetSquare;
+    private ScorePair accumulateDirection(EvaluationContext.BoardView board,
+                                          int square,
+                                          Direction direction,
+                                          long occupancy,
+                                          long friendlyPieces,
+                                          long enemyPieces,
+                                          boolean diagonal) {
+        int rank = square / 8 + direction.rankDelta;
+        int file = square % 8 + direction.fileDelta;
+        while (rank >= 0 && rank < 8 && file >= 0 && file < 8) {
+            int target = rank * 8 + file;
+            long mask = 1L << target;
             if ((occupancy & mask) != 0) {
                 if ((friendlyPieces & mask) != 0) {
-                    PieceType friendlyType = board.getPieceTypeAtIndex(targetSquare);
+                    PieceType friendlyType = board.getPieceTypeAtIndex(target);
                     if (friendlyType != null && supportsDirection(friendlyType, diagonal)) {
-                        score.midgame += BATTERY_FORMATION_MIDGAME;
-                        score.endgame += BATTERY_FORMATION_ENDGAME;
-                        accumulateRayThreats(board, targetSquare, direction, friendlyPieces,
-                                enemyPieces, score);
+                        ScorePair scores = accumulateRayThreats(board, target, direction,
+                                friendlyPieces, enemyPieces);
+                        scores.midgame += BATTERY_FORMATION_MIDGAME;
+                        scores.endgame += BATTERY_FORMATION_ENDGAME;
+                        return scores;
                     }
                 }
                 break;
             }
-            r += direction.rankDelta;
-            f += direction.fileDelta;
+            rank += direction.rankDelta;
+            file += direction.fileDelta;
         }
+        return ScorePair.ZERO;
     }
 
-    private void accumulateRayThreats(EvaluationContext.BoardView board, int fromSquare,
-                                      Direction direction, long friendlyPieces, long enemyPieces,
-                                      BatteryScore score) {
-        int rank = fromSquare / 8;
-        int file = fromSquare % 8;
-        int r = rank + direction.rankDelta;
-        int f = file + direction.fileDelta;
-        while (r >= 0 && r < 8 && f >= 0 && f < 8) {
-            int targetSquare = r * 8 + f;
+    private ScorePair accumulateRayThreats(EvaluationContext.BoardView board,
+                                           int fromSquare,
+                                           Direction direction,
+                                           long friendlyPieces,
+                                           long enemyPieces) {
+        ScorePair score = new ScorePair();
+        int rank = fromSquare / 8 + direction.rankDelta;
+        int file = fromSquare % 8 + direction.fileDelta;
+        while (rank >= 0 && rank < 8 && file >= 0 && file < 8) {
+            int targetSquare = rank * 8 + file;
             long mask = 1L << targetSquare;
             if ((friendlyPieces & mask) != 0) {
                 break;
@@ -208,9 +396,15 @@ public final class BatteryModule implements EvaluationModule {
             }
             score.midgame += BATTERY_RAY_CONTROL_MIDGAME;
             score.endgame += BATTERY_RAY_CONTROL_ENDGAME;
-            r += direction.rankDelta;
-            f += direction.fileDelta;
+            rank += direction.rankDelta;
+            file += direction.fileDelta;
         }
+        return score;
+    }
+
+    private static void add(ScorePair target, ScorePair delta) {
+        target.midgame += delta.midgame;
+        target.endgame += delta.endgame;
     }
 
     private static boolean supportsDirection(PieceType type, boolean diagonal) {
@@ -228,8 +422,12 @@ public final class BatteryModule implements EvaluationModule {
     private record Direction(int rankDelta, int fileDelta) {
     }
 
-    private static final class BatteryScore {
+    private static final class ScorePair {
+        private static final ScorePair ZERO = new ScorePair();
         private int midgame;
         private int endgame;
+
+        private ScorePair() {
+        }
     }
 }

--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -183,13 +183,15 @@ public final class KingSafetyModule implements EvaluationModule {
         int from = MoveHelper.deriveFromIndex(move);
         int to = MoveHelper.deriveToIndex(move);
         long moveMask = (1L << from) | (1L << to);
-        if ((moveMask & (state.kingZone | state.shieldMask | state.fileMask)) != 0) {
+        if ((moveMask & (state.kingZone | state.shieldMask)) != 0) {
             return true;
         }
         int movedPiece = MoveHelper.derivePieceTypeBits(move);
+        boolean isWhiteSide = side == WHITE;
         if (movedPiece == PAWN) {
-            if (((1L << from) & state.fileMask) != 0 || ((1L << to) & state.fileMask) != 0) {
-                return true;
+            long fileMask = state.fileMask;
+            if (fileMask != 0 && (((1L << from) | (1L << to)) & fileMask) != 0) {
+                return fileOccupancyChanged(state, previous.board(), current.board(), isWhiteSide);
             }
         }
         int capturedPiece = MoveHelper.deriveCapturedPieceTypeBits(move);
@@ -198,8 +200,11 @@ public final class KingSafetyModule implements EvaluationModule {
             if (MoveHelper.isEnPassantMove(move)) {
                 captureMask = side == WHITE ? (1L << (to - 8)) : (1L << (to + 8));
             }
-            if ((captureMask & (state.shieldMask | state.fileMask)) != 0) {
+            if ((captureMask & state.shieldMask) != 0) {
                 return true;
+            }
+            if ((captureMask & state.fileMask) != 0) {
+                return fileOccupancyChanged(state, previous.board(), current.board(), isWhiteSide);
             }
         }
         EvaluationContext.BoardView previousBoard = previous.board();
@@ -218,6 +223,27 @@ public final class KingSafetyModule implements EvaluationModule {
             queenMask ^= q;
         }
         return state.backrankMask != 0 && ((prevFriendlyAttacks ^ currFriendlyAttacks) & state.backrankMask) != 0;
+    }
+
+    private boolean fileOccupancyChanged(SideState state,
+                                         EvaluationContext.BoardView previousBoard,
+                                         EvaluationContext.BoardView currentBoard,
+                                         boolean sideIsWhite) {
+        if (previousBoard == null || currentBoard == null) {
+            return true;
+        }
+        long fileMask = state.fileMask;
+        if (fileMask == 0) {
+            return false;
+        }
+        long prevFriendly = sideIsWhite ? previousBoard.whitePawns() : previousBoard.blackPawns();
+        long currFriendly = sideIsWhite ? currentBoard.whitePawns() : currentBoard.blackPawns();
+        if (Long.bitCount(prevFriendly & fileMask) != Long.bitCount(currFriendly & fileMask)) {
+            return true;
+        }
+        long prevEnemy = sideIsWhite ? previousBoard.blackPawns() : previousBoard.whitePawns();
+        long currEnemy = sideIsWhite ? currentBoard.blackPawns() : currentBoard.whitePawns();
+        return Long.bitCount(prevEnemy & fileMask) != Long.bitCount(currEnemy & fileMask);
     }
 
     private void rebuildSideState(SideState state, EvaluationContext.BoardView board, boolean isWhite,

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -371,6 +371,52 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         return STRUCTURE_CACHE.computeIfAbsent(key, _ -> new CachedStructure(whitePawns, blackPawns));
     }
 
+    private static int[] computeFileCounts(long pawns) {
+        int[] counts = new int[8];
+        for (int file = 0; file < 8; file++) {
+            counts[file] = Long.bitCount(pawns & FileMasks[file]);
+        }
+        return counts;
+    }
+
+    private static int countDoubled(int[] counts) {
+        int doubled = 0;
+        for (int file = 0; file < counts.length; file++) {
+            if (counts[file] > 1) {
+                doubled++;
+            }
+        }
+        return doubled;
+    }
+
+    private static int countIsolated(int[] counts) {
+        int isolated = 0;
+        for (int file = 0; file < counts.length; file++) {
+            if (counts[file] == 0) {
+                continue;
+            }
+            boolean leftEmpty = file == 0 || counts[file - 1] == 0;
+            boolean rightEmpty = file == counts.length - 1 || counts[file + 1] == 0;
+            if (leftEmpty && rightEmpty) {
+                isolated++;
+            }
+        }
+        return isolated;
+    }
+
+    private static int countIslands(int[] counts) {
+        int islands = 0;
+        boolean previousHasPawn = false;
+        for (int file = 0; file < counts.length; file++) {
+            boolean hasPawn = counts[file] > 0;
+            if (hasPawn && !previousHasPawn) {
+                islands++;
+            }
+            previousHasPawn = hasPawn;
+        }
+        return islands;
+    }
+
     private static int calculatePawnAdvanceBonus(long pawns, long allPieces, long enemyAttacks, boolean isWhite, int phase) {
         int bonus = 0;
         long advancedRanks = isWhite
@@ -525,16 +571,18 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         private final int blackPawnIslandPenalty;
 
         private CachedStructure(long whitePawns, long blackPawns) {
+            int[] whiteCounts = computeFileCounts(whitePawns);
+            int[] blackCounts = computeFileCounts(blackPawns);
             this.whiteCenterPawnBonus = PawnHelper.countCenterPawns(whitePawns) * CENTER_PAWN_BONUS;
             this.blackCenterPawnBonus = PawnHelper.countCenterPawns(blackPawns) * CENTER_PAWN_BONUS;
-            this.whiteDoubledPawnPenalty = PawnHelper.countDoubledPawns(whitePawns) * DOUBLED_PAWN_PENALTY;
-            this.blackDoubledPawnPenalty = PawnHelper.countDoubledPawns(blackPawns) * DOUBLED_PAWN_PENALTY;
-            this.whiteIsolatedPawnPenalty = PawnHelper.countIsolatedPawns(whitePawns) * ISOLATED_PAWN_PENALTY;
-            this.blackIsolatedPawnPenalty = PawnHelper.countIsolatedPawns(blackPawns) * ISOLATED_PAWN_PENALTY;
+            this.whiteDoubledPawnPenalty = countDoubled(whiteCounts) * DOUBLED_PAWN_PENALTY;
+            this.blackDoubledPawnPenalty = countDoubled(blackCounts) * DOUBLED_PAWN_PENALTY;
+            this.whiteIsolatedPawnPenalty = countIsolated(whiteCounts) * ISOLATED_PAWN_PENALTY;
+            this.blackIsolatedPawnPenalty = countIsolated(blackCounts) * ISOLATED_PAWN_PENALTY;
             this.whiteConnectedPawnBonus = PawnHelper.countConnectedPawns(whitePawns) * CONNECTED_PAWN_BONUS;
             this.blackConnectedPawnBonus = PawnHelper.countConnectedPawns(blackPawns) * CONNECTED_PAWN_BONUS;
-            this.whitePawnIslandPenalty = Math.max(0, PawnHelper.countPawnIslands(whitePawns) - 1) * PAWN_ISLAND_PENALTY;
-            this.blackPawnIslandPenalty = Math.max(0, PawnHelper.countPawnIslands(blackPawns) - 1) * PAWN_ISLAND_PENALTY;
+            this.whitePawnIslandPenalty = Math.max(0, countIslands(whiteCounts) - 1) * PAWN_ISLAND_PENALTY;
+            this.blackPawnIslandPenalty = Math.max(0, countIslands(blackCounts) - 1) * PAWN_ISLAND_PENALTY;
         }
     }
 

--- a/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
@@ -5,6 +5,7 @@ import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.BishopHelper;
 import julius.game.chessengine.helper.RookHelper;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import static julius.game.chessengine.helper.PawnMoveTables.PAWN_ATTACKS;
@@ -12,8 +13,8 @@ import static julius.game.chessengine.helper.KingHelper.KING_ATTACKS;
 
 /**
  * Evaluates tactical vulnerabilities such as hanging pieces and pawn attacks on higher valued
- * pieces. The module recomputes its contribution when marked dirty rather than maintaining
- * incremental state.
+ * pieces. The module keeps per-piece caches so it can adjust only the squares whose tactical
+ * status changes after a move.
  */
 public final class ThreatModule implements EvaluationModule {
 
@@ -46,13 +47,18 @@ public final class ThreatModule implements EvaluationModule {
         PAWN_THREAT_PENALTIES[QUEEN] = -25;
     }
 
+    private final int[][] squarePenalties = new int[2][64];
+    private final int[] sideTotals = new int[2];
+    private final boolean[] whiteTouched = new boolean[64];
+    private final boolean[] blackTouched = new boolean[64];
+
     private int midgameScoreCache;
     private int endgameScoreCache;
     private boolean dirty = true;
 
     @Override
     public void initialize(EvaluationContext context) {
-        evaluate(context);
+        rebuildFromContext(context);
     }
 
     @Override
@@ -60,34 +66,19 @@ public final class ThreatModule implements EvaluationModule {
         if (!dirty) {
             return;
         }
-        Objects.requireNonNull(context, "context");
-        EvaluationContext.BoardView board = context.board();
-        if (board == null) {
-            midgameScoreCache = 0;
-            endgameScoreCache = 0;
-            dirty = false;
-            return;
-        }
-
-        long whiteAttacks = context.whiteAttackMap();
-        long blackAttacks = context.blackAttackMap();
-
-        int whitePenalty = evaluateSide(board, true, whiteAttacks, blackAttacks);
-        int blackPenalty = evaluateSide(board, false, blackAttacks, whiteAttacks);
-
-        midgameScoreCache = whitePenalty - blackPenalty;
-        endgameScoreCache = midgameScoreCache;
-        dirty = false;
+        rebuildFromContext(Objects.requireNonNull(context, "context"));
     }
 
     @Override
     public void applyMove(MoveContext moveContext) {
-        dirty = true;
+        if (!handleMove(moveContext)) {
+            rebuildFromContext(moveContext.currentContext());
+        }
     }
 
     @Override
     public void undoMove(MoveContext moveContext) {
-        dirty = true;
+        applyMove(moveContext);
     }
 
     @Override
@@ -110,48 +101,191 @@ public final class ThreatModule implements EvaluationModule {
         dirty = true;
     }
 
-    private int evaluateSide(EvaluationContext.BoardView board, boolean isWhite, long friendlyAttacks, long enemyAttacks) {
+    private void rebuildFromContext(EvaluationContext context) {
+        if (context == null) {
+            resetState();
+            dirty = false;
+            return;
+        }
+        rebuildFromSnapshot(context.board(), context.whiteAttackMap(), context.blackAttackMap());
+    }
+
+    private void rebuildFromSnapshot(EvaluationContext.BoardView board, long whiteAttacks, long blackAttacks) {
+        resetState();
+        if (board == null) {
+            dirty = false;
+            return;
+        }
+        applyFullSide(board, true, whiteAttacks, blackAttacks);
+        applyFullSide(board, false, blackAttacks, whiteAttacks);
+        refreshScoreCaches();
+        dirty = false;
+    }
+
+    private void resetState() {
+        for (int side = 0; side < squarePenalties.length; side++) {
+            Arrays.fill(squarePenalties[side], 0);
+            sideTotals[side] = 0;
+        }
+        midgameScoreCache = 0;
+        endgameScoreCache = 0;
+    }
+
+    private boolean handleMove(MoveContext moveContext) {
+        EvaluationContext current = moveContext.currentContext();
+        if (current == null) {
+            resetState();
+            dirty = false;
+            return true;
+        }
+        EvaluationContext previous = moveContext.previousContext();
+        if (previous == null) {
+            rebuildFromContext(current);
+            return true;
+        }
+        EvaluationContext.BoardView currentBoard = current.board();
+        EvaluationContext.BoardView previousBoard = previous.board();
+        if (currentBoard == null || previousBoard == null) {
+            rebuildFromContext(current);
+            return true;
+        }
+
+        Arrays.fill(whiteTouched, false);
+        Arrays.fill(blackTouched, false);
+
+        markSideChanges(true, previous, current);
+        markSideChanges(false, previous, current);
+
+        long whiteAttacks = current.whiteAttackMap();
+        long blackAttacks = current.blackAttackMap();
+        applySideUpdates(currentBoard, true, whiteAttacks, blackAttacks, whiteTouched);
+        applySideUpdates(currentBoard, false, blackAttacks, whiteAttacks, blackTouched);
+        refreshScoreCaches();
+        dirty = false;
+        return true;
+    }
+
+    private void markSideChanges(boolean whiteSide, EvaluationContext previous, EvaluationContext current) {
+        EvaluationContext.BoardView previousBoard = previous.board();
+        EvaluationContext.BoardView currentBoard = current.board();
+        if (previousBoard == null || currentBoard == null) {
+            return;
+        }
+        boolean[] touched = whiteSide ? whiteTouched : blackTouched;
+        long prevPieces = whiteSide ? previousBoard.whitePieces() : previousBoard.blackPieces();
+        long currPieces = whiteSide ? currentBoard.whitePieces() : currentBoard.blackPieces();
+        long movedSquares = prevPieces ^ currPieces;
+        markBits(movedSquares, touched);
+
+        long enemyPrevAttacks = whiteSide ? previous.blackAttackMap() : previous.whiteAttackMap();
+        long enemyCurrAttacks = whiteSide ? current.blackAttackMap() : current.whiteAttackMap();
+        long friendlyPrevAttacks = whiteSide ? previous.whiteAttackMap() : previous.blackAttackMap();
+        long friendlyCurrAttacks = whiteSide ? current.whiteAttackMap() : current.blackAttackMap();
+
+        long piecesNow = currPieces;
+        markBits((enemyPrevAttacks ^ enemyCurrAttacks) & piecesNow, touched);
+        markBits((friendlyPrevAttacks ^ friendlyCurrAttacks) & piecesNow, touched);
+    }
+
+    private void markBits(long bitboard, boolean[] touched) {
+        while (bitboard != 0) {
+            int square = Long.numberOfTrailingZeros(bitboard);
+            touched[square] = true;
+            bitboard &= bitboard - 1;
+        }
+    }
+
+    private void applySideUpdates(EvaluationContext.BoardView board,
+                                  boolean isWhite,
+                                  long friendlyAttacks,
+                                  long enemyAttacks,
+                                  boolean[] touchedSquares) {
+        int side = isWhite ? WHITE : BLACK;
         long pieces = isWhite ? board.whitePieces() : board.blackPieces();
         long enemyPawns = isWhite ? board.blackPawns() : board.whitePawns();
-        int enemyPawnColor = isWhite ? BLACK : WHITE;
-        long enemyPawnAttacks = computePawnAttackMask(enemyPawns, enemyPawnColor);
+        long enemyPawnAttacks = computePawnAttackMask(enemyPawns, isWhite ? BLACK : WHITE);
+        for (int square = 0; square < touchedSquares.length; square++) {
+            if (!touchedSquares[square]) {
+                continue;
+            }
+            sideTotals[side] -= squarePenalties[side][square];
+            squarePenalties[side][square] = 0;
+            long mask = 1L << square;
+            if ((pieces & mask) == 0) {
+                continue;
+            }
+            PieceType type = board.getPieceTypeAtIndex(square);
+            if (type == null) {
+                continue;
+            }
+            int penalty = evaluateSquare(board, isWhite, square, type,
+                    friendlyAttacks, enemyAttacks, enemyPawnAttacks);
+            squarePenalties[side][square] = penalty;
+            sideTotals[side] += penalty;
+        }
+    }
 
-        int penalty = 0;
+    private void applyFullSide(EvaluationContext.BoardView board,
+                               boolean isWhite,
+                               long friendlyAttacks,
+                               long enemyAttacks) {
+        int side = isWhite ? WHITE : BLACK;
+        long pieces = isWhite ? board.whitePieces() : board.blackPieces();
+        long enemyPawns = isWhite ? board.blackPawns() : board.whitePawns();
+        long enemyPawnAttacks = computePawnAttackMask(enemyPawns, isWhite ? BLACK : WHITE);
         long remaining = pieces;
         while (remaining != 0) {
             long bit = remaining & -remaining;
             int square = Long.numberOfTrailingZeros(bit);
             PieceType type = board.getPieceTypeAtIndex(square);
-            if (type == null) {
-                remaining ^= bit;
-                continue;
-            }
-            int typeBits = MoveHelper.pieceTypeToInt(type);
-            if (typeBits == KING) {
-                remaining ^= bit;
-                continue;
-            }
-            long mask = 1L << square;
-            if ((enemyAttacks & mask) == 0) {
-                remaining ^= bit;
-                continue;
-            }
-            boolean defended = (friendlyAttacks & mask) != 0;
-            if (!defended) {
-                penalty += HANGING_PENALTIES[typeBits];
-            }
-            if (typeBits > PAWN && (enemyPawnAttacks & mask) != 0) {
-                int defenderValue = defended
-                        ? leastValuableDefenderValue(board, isWhite, square)
-                        : materialValueFor(typeBits);
-                if (defenderValue <= 0) {
-                    defenderValue = materialValueFor(typeBits);
-                }
-                penalty += scalePawnThreatPenalty(typeBits, defenderValue);
+            if (type != null) {
+                int penalty = evaluateSquare(board, isWhite, square, type,
+                        friendlyAttacks, enemyAttacks, enemyPawnAttacks);
+                squarePenalties[side][square] = penalty;
+                sideTotals[side] += penalty;
             }
             remaining ^= bit;
         }
+    }
+
+    private int evaluateSquare(EvaluationContext.BoardView board,
+                               boolean isWhite,
+                               int square,
+                               PieceType type,
+                               long friendlyAttacks,
+                               long enemyAttacks,
+                               long enemyPawnAttacks) {
+        if (type == null) {
+            return 0;
+        }
+        int typeBits = MoveHelper.pieceTypeToInt(type);
+        if (typeBits == KING) {
+            return 0;
+        }
+        long mask = 1L << square;
+        if ((enemyAttacks & mask) == 0) {
+            return 0;
+        }
+        boolean defended = (friendlyAttacks & mask) != 0;
+        int penalty = 0;
+        if (!defended) {
+            penalty += HANGING_PENALTIES[typeBits];
+        }
+        if (typeBits > PAWN && (enemyPawnAttacks & mask) != 0) {
+            int defenderValue = defended
+                    ? leastValuableDefenderValue(board, isWhite, square)
+                    : materialValueFor(typeBits);
+            if (defenderValue <= 0) {
+                defenderValue = materialValueFor(typeBits);
+            }
+            penalty += scalePawnThreatPenalty(typeBits, defenderValue);
+        }
         return penalty;
+    }
+
+    private void refreshScoreCaches() {
+        midgameScoreCache = sideTotals[WHITE] - sideTotals[BLACK];
+        endgameScoreCache = midgameScoreCache;
     }
 
     private static int materialValueFor(int pieceType) {


### PR DESCRIPTION
## Summary
- teach the battery evaluation to cache per-square contributions and refresh only the sliders touched by a move
- cache per-piece threat penalties so incremental updates use attack-map deltas instead of full rescans
- tighten king-safety pawn-file invalidations, reuse pawn file counts for structure heuristics, and limit activity slider rescans to affected rays

## Testing
- ./mvnw -q test *(fails: Maven wrapper could not download dependencies because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cf5f1670832aa4aa392ffb7a5bd0