### PR TITLE
Refactor search configuration into dedicated classes

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -4,12 +4,14 @@ import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.Move;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.MoveList;
-import julius.game.chessengine.helper.BishopHelper;
-import julius.game.chessengine.helper.PawnMoveTables;
-import julius.game.chessengine.helper.RookHelper;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.engine.search.config.SearchConfig;
+import julius.game.chessengine.engine.search.config.SearchLimits;
+import julius.game.chessengine.helper.BishopHelper;
+import julius.game.chessengine.helper.PawnMoveTables;
+import julius.game.chessengine.helper.RookHelper;
 import julius.game.chessengine.utils.Score;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
@@ -34,12 +36,7 @@ public class AI {
     @Getter
     private final Engine mainEngine;
 
-    /**
-     * Number of threads used for searching. Defaults to single-threaded search but
-     * can be adjusted at runtime via the UCI "Threads" option.
-     */
-    @Getter
-    private int searchThreads = Integer.getInteger("chessengine.searchThreads", 1);
+    private final SearchConfig searchConfig;
 
     // number of Lazy SMP workers (≥1)
     @Getter
@@ -54,13 +51,7 @@ public class AI {
     private final AtomicReference<SearchTask> activeSearch = new AtomicReference<>();
     private final ThreadLocal<SearchTask> threadSearchTask = new ThreadLocal<>();
     private final AtomicLong searchIdGenerator = new AtomicLong();
-    /**
-     * Requested size of the transposition table in megabytes. The current
-     * implementation does not dynamically resize the table, but the value is
-     * tracked so that future improvements can honour it.
-     */
-    @Getter
-    private int hashSizeMb = 16;
+    private volatile SearchLimits searchLimits = SearchLimits.unlimited();
 
     /**
      * Estimated footprint per stored entry in the main and capture transposition tables.
@@ -85,8 +76,9 @@ public class AI {
     private static final double MAIN_TT_WEIGHT = 2.0;
     private static final double CAPTURE_TT_WEIGHT = 1.0;
 
-    public static final int MIN_HASH_SIZE_MB = 1;
-    public static final int MAX_HASH_SIZE_MB = 4096;
+    public static final int MIN_HASH_SIZE_MB = SearchConfig.MIN_HASH_SIZE_MB;
+    public static final int MAX_HASH_SIZE_MB = SearchConfig.MAX_HASH_SIZE_MB;
+    public static final long INFINITE_TIME_LIMIT = Long.MAX_VALUE;
 
     /**
      * Thread pool for root-split parallel search (created only if searchThreads > 1).
@@ -188,20 +180,6 @@ public class AI {
         return lastCompletedPrincipalVariation;
     }
 
-    // Game configuration parameters
-
-    @Getter
-    private int maxDepth = 64; // Adjust the level of depth according to your requirements
-
-    @Getter
-    private long timeLimit; // milliseconds
-
-    public static final long INFINITE_TIME_LIMIT = Long.MAX_VALUE;
-
-    private final boolean useNullMovePruning = Boolean.parseBoolean(
-            System.getProperty("chessengine.nullMove", "true")
-    );
-
     @Getter
     private long nodesVisited = 0;
     private volatile long searchStartTimeNanos = 0L;
@@ -211,16 +189,46 @@ public class AI {
     private volatile SearchDiagnostics lastDiagnostics = SearchDiagnostics.EMPTY;
 
     public AI(Engine mainEngine) {
-        log.info("### SearchThreads = {}, LazySmpThreads = {}", searchThreads, lazySmpThreads);
+        this(mainEngine, SearchConfig.defaults());
+    }
+
+    public AI(Engine mainEngine, SearchConfig config) {
+        Objects.requireNonNull(mainEngine, "mainEngine");
         this.mainEngine = mainEngine;
-        this.timeLimit = 50;
+        this.searchConfig = config != null ? config : SearchConfig.defaults();
 
-        this.globalHeuristics = new Heuristics(maxDepth);
-        this.threadHeuristics = ThreadLocal.withInitial(() -> new Heuristics(maxDepth));
+        int initialThreads = Integer.getInteger("chessengine.searchThreads", searchConfig.getThreads());
+        searchConfig.setThreads(initialThreads);
 
-        rebuildSearchPool(this.searchThreads);
+        log.info("### SearchThreads = {}, LazySmpThreads = {}", searchConfig.getThreads(), lazySmpThreads);
+
+        int depthCapacity = searchConfig.effectiveMaxDepth();
+        this.globalHeuristics = new Heuristics(depthCapacity);
+        this.threadHeuristics = ThreadLocal.withInitial(() -> new Heuristics(depthCapacity));
+
+        rebuildSearchPool(searchConfig.getThreads());
 
         this.mainEngine.setOnPositionChanged(_ -> updateBoardStateHash());
+    }
+
+    public int getSearchThreads() {
+        return searchConfig.getThreads();
+    }
+
+    public int getHashSizeMb() {
+        return searchConfig.getHashSizeMb();
+    }
+
+    public int getMaxDepth() {
+        return searchConfig.getMaxDepth();
+    }
+
+    public SearchConfig getSearchConfig() {
+        return searchConfig;
+    }
+
+    public SearchLimits getSearchLimits() {
+        return searchLimits;
     }
 
     private void updatePrincipalVariation(List<MoveAndScore> principalVariation) {
@@ -240,16 +248,17 @@ public class AI {
     }
 
     private void rebuildTranspositionTables() {
-        boolean concurrent = Math.max(searchThreads, lazySmpThreads) > 1;
-        long totalBytes = Math.max(1L, (long) hashSizeMb * 1024L * 1024L);
+        int threads = searchConfig.getThreads();
+        boolean concurrent = Math.max(threads, lazySmpThreads) > 1;
+        long totalBytes = Math.max(1L, (long) searchConfig.getHashSizeMb() * 1024L * 1024L);
 
         double totalWeight = MAIN_TT_WEIGHT + CAPTURE_TT_WEIGHT;
         long mainBudget = Math.max(1L, (long) (totalBytes * (MAIN_TT_WEIGHT / totalWeight)));
         long captureBudget = Math.max(1L, totalBytes - mainBudget);
 
-        int mainCapacity = computeTableCapacity(mainBudget, MAIN_TT_ENTRY_BYTES,
+        int mainCapacity = SearchConfig.computeHashCapacity(mainBudget, MAIN_TT_ENTRY_BYTES,
                 MIN_MAIN_TT_ENTRIES, MAX_MAIN_TT_ENTRIES);
-        int captureCapacity = computeTableCapacity(captureBudget, CAPTURE_TT_ENTRY_BYTES,
+        int captureCapacity = SearchConfig.computeHashCapacity(captureBudget, CAPTURE_TT_ENTRY_BYTES,
                 MIN_CAPTURE_TT_ENTRIES, MAX_CAPTURE_TT_ENTRIES);
 
         this.transpositionTableCapacity = mainCapacity;
@@ -264,57 +273,17 @@ public class AI {
                 : new PlainFixedSizeTranspositionTable<>(captureCapacity);
     }
 
-    private static int computeTableCapacity(long budgetBytes, int entryBytes, int minEntries, int maxEntries) {
-        if (entryBytes <= 0) {
-            throw new IllegalArgumentException("Entry byte estimate must be positive");
-        }
-
-        long estimatedEntries = Math.max(1L, budgetBytes / entryBytes);
-        if (estimatedEntries > Integer.MAX_VALUE) {
-            estimatedEntries = Integer.MAX_VALUE;
-        }
-
-        int candidate = (int) estimatedEntries;
-        if (candidate < minEntries) {
-            candidate = minEntries;
-        } else if (candidate > maxEntries) {
-            candidate = maxEntries;
-        }
-
-        int rounded = roundUpToPowerOfTwo(candidate);
-        if (rounded < minEntries) {
-            rounded = minEntries;
-        }
-        while (rounded > maxEntries && rounded > 1) {
-            rounded >>= 1;
-        }
-        return rounded;
-    }
-
-    private static int roundUpToPowerOfTwo(int value) {
-        if (value <= 1) {
-            return 1;
-        }
-        int highest = Integer.highestOneBit(value);
-        if (highest == value) {
-            return value;
-        }
-        if (highest > (1 << 30)) {
-            return 1 << 30;
-        }
-        return highest << 1;
-    }
-
     /**
      * Adjust the requested hash size (in megabytes) and rebuild the transposition tables.
-     * Values outside the supported range are clamped between {@value MIN_HASH_SIZE_MB} MB
-     * and {@value MAX_HASH_SIZE_MB} MB. The resulting table capacities are also limited
-     * to {@value MIN_MAIN_TT_ENTRIES}/{@value MAX_MAIN_TT_ENTRIES} for the main table and
+     * Values outside the supported range are clamped between
+     * {@value julius.game.chessengine.engine.search.config.SearchConfig#MIN_HASH_SIZE_MB} MB
+     * and {@value julius.game.chessengine.engine.search.config.SearchConfig#MAX_HASH_SIZE_MB} MB.
+     * The resulting table capacities are also limited to
+     * {@value MIN_MAIN_TT_ENTRIES}/{@value MAX_MAIN_TT_ENTRIES} for the main table and
      * {@value MIN_CAPTURE_TT_ENTRIES}/{@value MAX_CAPTURE_TT_ENTRIES} for the capture table.
      */
     public synchronized void setHashSizeMb(int hashSizeMb) {
-        int clamped = Math.max(MIN_HASH_SIZE_MB, Math.min(hashSizeMb, MAX_HASH_SIZE_MB));
-        if (clamped == this.hashSizeMb) {
+        if (!searchConfig.setHashSizeMb(hashSizeMb)) {
             return;
         }
 
@@ -325,11 +294,10 @@ public class AI {
             captureTranspositionTable.clear();
         }
 
-        this.hashSizeMb = clamped;
         rebuildTranspositionTables();
 
         log.info("Hash size set to {} MB (main TT capacity: {}, capture TT capacity: {})",
-                this.hashSizeMb, transpositionTableCapacity, captureTranspositionTableCapacity);
+                searchConfig.getHashSizeMb(), transpositionTableCapacity, captureTranspositionTableCapacity);
     }
 
     /**
@@ -338,25 +306,42 @@ public class AI {
      * previous allocation. The requested depth is always respected (minimum 1).
      */
     public synchronized void setMaxDepth(int depth) {
-        int requestedDepth = Math.max(1, depth);
+        searchConfig.setMaxDepth(depth);
+        int requestedDepth = searchConfig.getMaxDepth();
         synchronized (heuristicsLock) {
             globalHeuristics.ensureCapacity(requestedDepth);
         }
         threadHeuristics.get().ensureCapacity(requestedDepth);
-        this.maxDepth = requestedDepth;
     }
 
 
+    public void setSearchLimits(SearchLimits limits) {
+        this.searchLimits = limits != null ? limits : SearchLimits.unlimited();
+    }
+
     public void setTimeLimit(long timeLimitMillis) {
-        if (timeLimitMillis <= 0L) {
-            this.timeLimit = INFINITE_TIME_LIMIT;
+        if (timeLimitMillis <= 0L || timeLimitMillis >= INFINITE_TIME_LIMIT) {
+            setSearchLimits(SearchLimits.unlimited());
             return;
         }
-        if (timeLimitMillis >= INFINITE_TIME_LIMIT) {
-            this.timeLimit = INFINITE_TIME_LIMIT;
-            return;
+        setSearchLimits(SearchLimits.builder().moveTimeMillis(timeLimitMillis).build());
+    }
+
+    public long getTimeLimit() {
+        SearchLimits limits = this.searchLimits;
+        long moveTime = limits.getMoveTimeMillis();
+        if (moveTime > 0L) {
+            return moveTime;
         }
-        this.timeLimit = timeLimitMillis;
+        long hard = limits.getHardDeadlineNanos();
+        if (hard > 0L && hard < Long.MAX_VALUE) {
+            return TimeUnit.NANOSECONDS.toMillis(hard);
+        }
+        long soft = limits.getSoftDeadlineNanos();
+        if (soft > 0L && soft < Long.MAX_VALUE) {
+            return TimeUnit.NANOSECONDS.toMillis(soft);
+        }
+        return INFINITE_TIME_LIMIT;
     }
 
 
@@ -452,7 +437,8 @@ public class AI {
         Heuristics heuristics = threadHeuristics.get();
         SearchInstrumentation instr = task.getInstrumentation();
 
-        for (int currentDepth = 1; currentDepth <= maxDepth; currentDepth++) {
+        int depthLimit = searchConfig.getMaxDepth();
+        for (int currentDepth = 1; currentDepth <= depthLimit; currentDepth++) {
             if (shouldStopCalculating(task.getDeadline())) break;
 
             boolean firstAtDepth = task.beginIteration(currentDepth);
@@ -515,6 +501,7 @@ public class AI {
 
     private void prepareIterationState(SearchTask task, Heuristics heuristics, int currentDepth, boolean firstAtDepth) {
         synchronized (heuristicsLock) {
+            int maxDepth = searchConfig.getMaxDepth();
             globalHeuristics.ensureCapacity(maxDepth);
             if (firstAtDepth) {
                 if (transpositionTable != null) {
@@ -543,8 +530,9 @@ public class AI {
             oldPool.shutdownNow();
         }
 
-        if (searchThreads > 1) {
-            this.searchPool = Executors.newFixedThreadPool(searchThreads, r -> {
+        int threads = searchConfig.getThreads();
+        if (threads > 1) {
+            this.searchPool = Executors.newFixedThreadPool(threads, r -> {
                 Thread t = new Thread(r, "AI-Search-" + System.identityHashCode(r));
                 t.setDaemon(true);
                 return t;
@@ -554,35 +542,29 @@ public class AI {
         }
 
         boolean previousConcurrent = Math.max(previousSearchThreads, lazySmpThreads) > 1;
-        boolean newConcurrent = Math.max(searchThreads, lazySmpThreads) > 1;
+        boolean newConcurrent = Math.max(threads, lazySmpThreads) > 1;
         if (transpositionTable == null || previousConcurrent != newConcurrent) {
             rebuildTranspositionTables();
         }
     }
 
     public void setSearchThreads(int requestedThreads) {
-        int clamped = Math.max(1, requestedThreads);
-        int previous;
-        synchronized (this) {
-            if (clamped == this.searchThreads) {
-                return;
-            }
+        int previous = searchConfig.getThreads();
+        if (!searchConfig.setThreads(requestedThreads)) {
+            return;
         }
 
         stopCalculation();
 
-        synchronized (this) {
-            previous = this.searchThreads;
-            this.searchThreads = clamped;
-        }
         rebuildSearchPool(previous);
-        log.info("Search thread count updated to {}", clamped);
+        log.info("Search thread count updated to {}", searchConfig.getThreads());
     }
 
     private Heuristics prepareHelperHeuristics(SearchTask task, int depth) {
         Heuristics heuristics = threadHeuristics.get();
         if (!heuristics.isPreparedFor(task.getId(), depth)) {
             synchronized (heuristicsLock) {
+                int maxDepth = searchConfig.getMaxDepth();
                 globalHeuristics.ensureCapacity(maxDepth);
                 heuristics.beginIteration(globalHeuristics, maxDepth);
                 heuristics.markPrepared(task.getId(), depth);
@@ -592,7 +574,7 @@ public class AI {
     }
 
     protected MoveAndScore searchRootMoves(Engine sim, SearchTask task, int depth, double alpha, double beta, SplittableRandom rng) {
-        if (searchThreads > 1) {
+        if (searchConfig.getThreads() > 1) {
             return getBestMoveParallel(sim, task, depth, task.getDeadline(), alpha, beta, rng);
         }
         return getBestMove(sim, task.isWhiteToMove(), depth, task.getDeadline(), alpha, beta, rng);
@@ -788,24 +770,8 @@ public class AI {
 
 
     private long computeDeadlineNanos() {
-        if (timeLimit >= INFINITE_TIME_LIMIT) {
-            return Long.MAX_VALUE;
-        }
-        long millis = timeLimit;
-        if (millis <= 0L) {
-            return Long.MAX_VALUE;
-        }
-        long nanos;
-        try {
-            nanos = Math.multiplyExact(millis, 1_000_000L);
-        } catch (ArithmeticException ex) {
-            return Long.MAX_VALUE;
-        }
-        long now = System.nanoTime();
-        if (nanos > 0L && now > Long.MAX_VALUE - nanos) {
-            return Long.MAX_VALUE;
-        }
-        return now + nanos;
+        long start = System.nanoTime();
+        return searchLimits.hardDeadlineNanos(start);
     }
 
     private void performCalculation() {
@@ -1046,7 +1012,7 @@ public class AI {
             return bestMove != -1 ? new MoveAndScore(bestMove, bestScore) : fallback;
         }
 
-        final int fanout = Math.min(Math.min(ROOT_PARALLEL_LIMIT, searchThreads * 2), orderedMoves.size() - 1);
+        final int fanout = Math.min(Math.min(ROOT_PARALLEL_LIMIT, searchConfig.getThreads() * 2), orderedMoves.size() - 1);
         final CompletionService<MoveAndScore> ecs = new ExecutorCompletionService<>(searchPool);
         final List<Future<MoveAndScore>> futures = new ArrayList<>(Math.max(fanout, 0));
         final java.util.concurrent.locks.ReentrantLock fullResLock = new java.util.concurrent.locks.ReentrantLock();
@@ -1293,7 +1259,7 @@ public class AI {
         if (transpositionTable == null) {
             return;
         }
-        int depthForEntry = Math.max(maxDepth, Math.max(0, depthRemaining) + 6);
+        int depthForEntry = Math.max(searchConfig.getMaxDepth(), Math.max(0, depthRemaining) + 6);
         TranspositionTableEntry existing = transpositionTable.get(childHash);
         if (existing != null
                 && existing.nodeType == NodeType.EXACT
@@ -1457,7 +1423,7 @@ public class AI {
 
         if (abortRequested(deadline)) return EXIT_FLAG;
 
-        if (plyFromRoot >= maxDepth + ABS_PLY_LIMIT_MARGIN) {
+        if (plyFromRoot >= searchConfig.getMaxDepth() + ABS_PLY_LIMIT_MARGIN) {
             double eval = evaluateBoard(simulatorEngine, isWhite, deadline);
             if (eval == EXIT_FLAG) return EXIT_FLAG;
             if (!isWhite) eval = -eval;
@@ -1514,7 +1480,7 @@ public class AI {
         MoveList moves = simulatorEngine.getAllLegalMoves();
         int mobility = moves.size();
         BitBoard bitBoard = simulatorEngine.getBitBoard();
-        boolean allowNullMove = useNullMovePruning
+        boolean allowNullMove = searchConfig.isNullMovePruningEnabled()
                 && !inCheck
                 && !simulatorEngine.isEndgame()
                 && prevMove != -1;

--- a/src/main/java/julius/game/chessengine/engine/search/config/SearchConfig.java
+++ b/src/main/java/julius/game/chessengine/engine/search/config/SearchConfig.java
@@ -1,0 +1,261 @@
+package julius.game.chessengine.engine.search.config;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.IntConsumer;
+
+/**
+ * Mutable configuration shared across search invocations.  The engine exposes the
+ * configuration through UCI options so front-ends can tune the search behaviour at
+ * runtime.  Validation and clamping rules live here so the searcher only needs to
+ * consume the sanitized values.
+ */
+public final class SearchConfig {
+
+    public static final int MIN_HASH_SIZE_MB = 1;
+    public static final int MAX_HASH_SIZE_MB = 4096;
+
+    private volatile int maxDepth = 64;
+    private volatile int hashSizeMb = 16;
+    private volatile int threads = 1;
+    private volatile boolean aspirationEnabled = true;
+    private volatile boolean nullMovePruningEnabled = Boolean.parseBoolean(
+            System.getProperty("chessengine.nullMove", "true"));
+    private volatile boolean lateMoveReductionsEnabled = true;
+    private volatile boolean internalIterativeReductionsEnabled = true;
+    private volatile boolean futilityPruningEnabled = true;
+    private volatile double contempt = 0.0;
+    private volatile boolean ttConcurrency = true;
+    private volatile int ttBucketsPerSet = 1;
+
+    private final Map<String, Double> evalParams = new ConcurrentHashMap<>();
+
+    private final Map<String, UciSpinOption> uciSpinOptions;
+
+    public SearchConfig() {
+        Map<String, UciSpinOption> options = new LinkedHashMap<>();
+        options.put("Threads", new UciSpinOption(1, 1, 512, this::updateThreads));
+        options.put("Hash", new UciSpinOption(hashSizeMb, MIN_HASH_SIZE_MB, MAX_HASH_SIZE_MB, this::updateHashSizeMb));
+        this.uciSpinOptions = Collections.unmodifiableMap(options);
+    }
+
+    public static SearchConfig defaults() {
+        return new SearchConfig();
+    }
+
+    public synchronized boolean setMaxDepth(int requestedDepth) {
+        int clamped = Math.max(1, requestedDepth);
+        if (clamped == this.maxDepth) {
+            return false;
+        }
+        this.maxDepth = clamped;
+        return true;
+    }
+
+    public int getMaxDepth() {
+        return maxDepth;
+    }
+
+    public int effectiveMaxDepth() {
+        return Math.max(1, maxDepth);
+    }
+
+    public synchronized boolean setThreads(int requestedThreads) {
+        return updateThreads(requestedThreads);
+    }
+
+    private boolean updateThreads(int requestedThreads) {
+        int clamped = Math.max(1, requestedThreads);
+        if (clamped == this.threads) {
+            return false;
+        }
+        this.threads = clamped;
+        return true;
+    }
+
+    public int getThreads() {
+        return threads;
+    }
+
+    public synchronized boolean setHashSizeMb(int requestedMb) {
+        return updateHashSizeMb(requestedMb);
+    }
+
+    private boolean updateHashSizeMb(int requestedMb) {
+        int clamped = Math.max(MIN_HASH_SIZE_MB, Math.min(MAX_HASH_SIZE_MB, requestedMb));
+        if (clamped == this.hashSizeMb) {
+            return false;
+        }
+        this.hashSizeMb = clamped;
+        return true;
+    }
+
+    public int getHashSizeMb() {
+        return hashSizeMb;
+    }
+
+    public boolean isAspirationEnabled() {
+        return aspirationEnabled;
+    }
+
+    public void setAspirationEnabled(boolean aspirationEnabled) {
+        this.aspirationEnabled = aspirationEnabled;
+    }
+
+    public boolean isNullMovePruningEnabled() {
+        return nullMovePruningEnabled;
+    }
+
+    public void setNullMovePruningEnabled(boolean nullMovePruningEnabled) {
+        this.nullMovePruningEnabled = nullMovePruningEnabled;
+    }
+
+    public boolean isLateMoveReductionsEnabled() {
+        return lateMoveReductionsEnabled;
+    }
+
+    public void setLateMoveReductionsEnabled(boolean lateMoveReductionsEnabled) {
+        this.lateMoveReductionsEnabled = lateMoveReductionsEnabled;
+    }
+
+    public boolean isInternalIterativeReductionsEnabled() {
+        return internalIterativeReductionsEnabled;
+    }
+
+    public void setInternalIterativeReductionsEnabled(boolean internalIterativeReductionsEnabled) {
+        this.internalIterativeReductionsEnabled = internalIterativeReductionsEnabled;
+    }
+
+    public boolean isFutilityPruningEnabled() {
+        return futilityPruningEnabled;
+    }
+
+    public void setFutilityPruningEnabled(boolean futilityPruningEnabled) {
+        this.futilityPruningEnabled = futilityPruningEnabled;
+    }
+
+    public double getContempt() {
+        return contempt;
+    }
+
+    public void setContempt(double contempt) {
+        this.contempt = contempt;
+    }
+
+    public boolean isTtConcurrencyEnabled() {
+        return ttConcurrency;
+    }
+
+    public void setTtConcurrencyEnabled(boolean ttConcurrency) {
+        this.ttConcurrency = ttConcurrency;
+    }
+
+    public int getTtBucketsPerSet() {
+        return ttBucketsPerSet;
+    }
+
+    public void setTtBucketsPerSet(int ttBucketsPerSet) {
+        this.ttBucketsPerSet = Math.max(1, ttBucketsPerSet);
+    }
+
+    public Map<String, Double> getEvalParams() {
+        return Collections.unmodifiableMap(evalParams);
+    }
+
+    public void setEvalParam(String key, double value) {
+        Objects.requireNonNull(key, "key");
+        evalParams.put(key, value);
+    }
+
+    public void clearEvalParam(String key) {
+        if (key != null) {
+            evalParams.remove(key);
+        }
+    }
+
+    public Map<String, UciSpinOption> getUciSpinOptions() {
+        return uciSpinOptions;
+    }
+
+    public static int computeHashCapacity(long budgetBytes, int entryBytes, int minEntries, int maxEntries) {
+        if (entryBytes <= 0) {
+            throw new IllegalArgumentException("Entry byte estimate must be positive");
+        }
+        if (minEntries <= 0 || maxEntries < minEntries) {
+            throw new IllegalArgumentException("Invalid entry bounds");
+        }
+
+        long estimatedEntries = Math.max(1L, budgetBytes / entryBytes);
+        if (estimatedEntries > Integer.MAX_VALUE) {
+            estimatedEntries = Integer.MAX_VALUE;
+        }
+
+        int candidate = (int) estimatedEntries;
+        if (candidate < minEntries) {
+            candidate = minEntries;
+        } else if (candidate > maxEntries) {
+            candidate = maxEntries;
+        }
+
+        int rounded = roundUpToPowerOfTwo(candidate);
+        if (rounded < minEntries) {
+            rounded = minEntries;
+        }
+        while (rounded > maxEntries && rounded > 1) {
+            rounded >>= 1;
+        }
+        return rounded;
+    }
+
+    private static int roundUpToPowerOfTwo(int value) {
+        if (value <= 1) {
+            return 1;
+        }
+        int highest = Integer.highestOneBit(value);
+        if (highest == value) {
+            return value;
+        }
+        if (highest > (1 << 30)) {
+            return 1 << 30;
+        }
+        return highest << 1;
+    }
+
+    public static final class UciSpinOption {
+        private final int defaultValue;
+        private final int min;
+        private final int max;
+        private final IntConsumer updater;
+
+        private UciSpinOption(int defaultValue, int min, int max, IntConsumer updater) {
+            this.defaultValue = defaultValue;
+            this.min = min;
+            this.max = max;
+            this.updater = Objects.requireNonNull(updater, "updater");
+        }
+
+        public int defaultValue() {
+            return defaultValue;
+        }
+
+        public int min() {
+            return min;
+        }
+
+        public int max() {
+            return max;
+        }
+
+        public void apply(int value) {
+            if (value < min) {
+                value = min;
+            } else if (value > max) {
+                value = max;
+            }
+            updater.accept(value);
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/engine/search/config/SearchLimits.java
+++ b/src/main/java/julius/game/chessengine/engine/search/config/SearchLimits.java
@@ -1,0 +1,217 @@
+package julius.game.chessengine.engine.search.config;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Per-search limits that control when the search should stop.  The limits are immutable
+ * so callers can safely share instances across threads.
+ */
+public final class SearchLimits {
+
+    private final TimeControl timeControl;
+    private final int fixedDepth;
+    private final long nodesLimit;
+    private final long moveTimeMillis;
+    private final boolean ponder;
+    private final long softDeadlineNanos;
+    private final long hardDeadlineNanos;
+
+    private SearchLimits(Builder builder) {
+        this.timeControl = builder.timeControl;
+        this.fixedDepth = builder.fixedDepth;
+        this.nodesLimit = builder.nodesLimit;
+        this.moveTimeMillis = builder.moveTimeMillis;
+        this.ponder = builder.ponder;
+        this.softDeadlineNanos = builder.softDeadlineNanos;
+        this.hardDeadlineNanos = builder.hardDeadlineNanos;
+    }
+
+    public static SearchLimits unlimited() {
+        return new Builder().build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public TimeControl getTimeControl() {
+        return timeControl;
+    }
+
+    public int getFixedDepth() {
+        return fixedDepth;
+    }
+
+    public long getNodesLimit() {
+        return nodesLimit;
+    }
+
+    public long getMoveTimeMillis() {
+        return moveTimeMillis;
+    }
+
+    public boolean isPonder() {
+        return ponder;
+    }
+
+    public long getSoftDeadlineNanos() {
+        return softDeadlineNanos;
+    }
+
+    public long getHardDeadlineNanos() {
+        return hardDeadlineNanos;
+    }
+
+    public boolean hasTimeLimit() {
+        if (moveTimeMillis > 0) {
+            return true;
+        }
+        if (softDeadlineNanos > 0 || hardDeadlineNanos > 0) {
+            return true;
+        }
+        if (timeControl == null) {
+            return false;
+        }
+        return timeControl.whiteTimeMillis > 0
+                || timeControl.blackTimeMillis > 0
+                || timeControl.whiteIncrementMillis > 0
+                || timeControl.blackIncrementMillis > 0;
+    }
+
+    public long hardDeadlineNanos(long startNanos) {
+        long limit = hardDeadlineNanos > 0 ? hardDeadlineNanos : softDeadlineNanos;
+        if (limit <= 0 && moveTimeMillis > 0) {
+            limit = safeMultiply(moveTimeMillis, TimeUnit.MILLISECONDS.toNanos(1));
+        }
+        if (limit <= 0) {
+            return Long.MAX_VALUE;
+        }
+        if (limit >= Long.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+        try {
+            return Math.addExact(startNanos, limit);
+        } catch (ArithmeticException ex) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    private long safeMultiply(long value, long factor) {
+        try {
+            return Math.multiplyExact(value, factor);
+        } catch (ArithmeticException ex) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    public static final class Builder {
+        private TimeControl timeControl;
+        private int fixedDepth;
+        private long nodesLimit;
+        private long moveTimeMillis;
+        private boolean ponder;
+        private long softDeadlineNanos;
+        private long hardDeadlineNanos;
+
+        private Builder() {
+        }
+
+        public Builder timeControl(long wtime, long btime, long winc, long binc, int movesToGo) {
+            this.timeControl = new TimeControl(wtime, btime, winc, binc, movesToGo);
+            return this;
+        }
+
+        public Builder fixedDepth(int depth) {
+            if (depth > 0) {
+                this.fixedDepth = Math.max(1, depth);
+            } else {
+                this.fixedDepth = 0;
+            }
+            return this;
+        }
+
+        public Builder nodesLimit(long nodes) {
+            if (nodes < 0) {
+                this.nodesLimit = 0;
+            } else {
+                this.nodesLimit = nodes;
+            }
+            return this;
+        }
+
+        public Builder moveTimeMillis(long moveTimeMillis) {
+            if (moveTimeMillis < 0) {
+                this.moveTimeMillis = 0;
+            } else {
+                this.moveTimeMillis = moveTimeMillis;
+            }
+            return this;
+        }
+
+        public Builder ponder(boolean ponder) {
+            this.ponder = ponder;
+            return this;
+        }
+
+        public Builder softDeadlineNanos(long nanos) {
+            this.softDeadlineNanos = clampNonNegative(nanos);
+            return this;
+        }
+
+        public Builder hardDeadlineNanos(long nanos) {
+            this.hardDeadlineNanos = clampNonNegative(nanos);
+            return this;
+        }
+
+        public SearchLimits build() {
+            if (hardDeadlineNanos > 0 && softDeadlineNanos > hardDeadlineNanos) {
+                softDeadlineNanos = hardDeadlineNanos;
+            }
+            return new SearchLimits(this);
+        }
+
+        private long clampNonNegative(long value) {
+            return Math.max(0L, value);
+        }
+    }
+
+    public static final class TimeControl {
+        private final long whiteTimeMillis;
+        private final long blackTimeMillis;
+        private final long whiteIncrementMillis;
+        private final long blackIncrementMillis;
+        private final int movesToGo;
+
+        private TimeControl(long wtime, long btime, long winc, long binc, int movesToGo) {
+            this.whiteTimeMillis = clampNonNegative(wtime);
+            this.blackTimeMillis = clampNonNegative(btime);
+            this.whiteIncrementMillis = clampNonNegative(winc);
+            this.blackIncrementMillis = clampNonNegative(binc);
+            this.movesToGo = Math.max(0, movesToGo);
+        }
+
+        public long whiteTimeMillis() {
+            return whiteTimeMillis;
+        }
+
+        public long blackTimeMillis() {
+            return blackTimeMillis;
+        }
+
+        public long whiteIncrementMillis() {
+            return whiteIncrementMillis;
+        }
+
+        public long blackIncrementMillis() {
+            return blackIncrementMillis;
+        }
+
+        public int movesToGo() {
+            return movesToGo;
+        }
+
+        private long clampNonNegative(long value) {
+            return Math.max(0L, value);
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -7,6 +7,7 @@ import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.MoveList;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
+import julius.game.chessengine.engine.search.config.SearchLimits;
 import julius.game.chessengine.utils.Score;
 import julius.game.chessengine.utils.VersionInfo;
 
@@ -132,16 +133,20 @@ public class UciHandler {
     }
 
     private void registerOptions() {
-        options.put("Threads", new UciOption("Threads", "spin", "1", 1, 128,
-                v -> {
-                    int requested = Integer.parseInt(v);
-                    ai.setSearchThreads(requested);
-                    output.accept("info string Threads requested " + requested
-                            + " active " + ai.getSearchThreads());
-                }));
-        options.put("Hash", new UciOption("Hash", "spin", "16",
-                AI.MIN_HASH_SIZE_MB, AI.MAX_HASH_SIZE_MB,
-                v -> ai.setHashSizeMb(Integer.parseInt(v))));
+        ai.getSearchConfig().getUciSpinOptions().forEach((name, opt) ->
+                options.put(name, new UciOption(name, "spin", String.valueOf(opt.defaultValue()),
+                        opt.min(), opt.max(), v -> {
+                            int requested = Integer.parseInt(v);
+                            if ("Threads".equals(name)) {
+                                ai.setSearchThreads(requested);
+                                output.accept("info string Threads requested " + requested
+                                        + " active " + ai.getSearchThreads());
+                            } else if ("Hash".equals(name)) {
+                                ai.setHashSizeMb(requested);
+                            } else {
+                                opt.apply(requested);
+                            }
+                        })));
         options.put("Move Overhead", new UciOption("Move Overhead", "spin", "0", 0, 5000,
                 v -> moveOverheadMs = Integer.parseInt(v)));
     }
@@ -380,11 +385,13 @@ public class UciHandler {
         long timeLeft = whitesTurn ? wtime : btime;
         long inc = whitesTurn ? winc : binc;
         long limit = computeTimeLimit(timeLeft, inc, movetime, movestogo, moveOverheadMs);
-        if (ponder && movetime == 0) {
-            ai.setTimeLimit(AI.INFINITE_TIME_LIMIT);
-        } else {
-            ai.setTimeLimit(limit);
+        SearchLimits.Builder limitsBuilder = SearchLimits.builder()
+                .timeControl(wtime, btime, winc, binc, movestogo)
+                .ponder(ponder);
+        if (!ponder || movetime > 0) {
+            limitsBuilder.moveTimeMillis(limit);
         }
+        ai.setSearchLimits(limitsBuilder.build());
 
         ponderActive = ponder;
         ponderShouldOutputMove = false;

--- a/src/test/java/julius/game/chessengine/engine/search/config/SearchConfigTest.java
+++ b/src/test/java/julius/game/chessengine/engine/search/config/SearchConfigTest.java
@@ -1,0 +1,48 @@
+package julius.game.chessengine.engine.search.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SearchConfigTest {
+
+    @Test
+    void effectiveMaxDepthClampsToAtLeastOne() {
+        SearchConfig config = new SearchConfig();
+        assertEquals(64, config.effectiveMaxDepth());
+        assertTrue(config.setMaxDepth(-5));
+        assertEquals(1, config.getMaxDepth());
+        assertEquals(1, config.effectiveMaxDepth());
+    }
+
+    @Test
+    void hashSizeIsClampedBetweenBounds() {
+        SearchConfig config = new SearchConfig();
+        assertTrue(config.setHashSizeMb(0));
+        assertEquals(SearchConfig.MIN_HASH_SIZE_MB, config.getHashSizeMb());
+        assertTrue(config.setHashSizeMb(SearchConfig.MAX_HASH_SIZE_MB + 1024));
+        assertEquals(SearchConfig.MAX_HASH_SIZE_MB, config.getHashSizeMb());
+    }
+
+    @Test
+    void computeHashCapacityRoundsToNearestPowerOfTwoWithinBounds() {
+        int capacity = SearchConfig.computeHashCapacity(300L, 8, 4, 64);
+        assertEquals(64, capacity);
+
+        int minCapacity = SearchConfig.computeHashCapacity(8L, 64, 4, 64);
+        assertEquals(4, minCapacity);
+
+        int capped = SearchConfig.computeHashCapacity(1_000_000L, 1, 4, 32);
+        assertEquals(32, capped);
+    }
+
+    @Test
+    void threadsAreClampedToAtLeastOne() {
+        SearchConfig config = new SearchConfig();
+        assertTrue(config.setThreads(0));
+        assertEquals(1, config.getThreads());
+        assertTrue(config.setThreads(4));
+        assertEquals(4, config.getThreads());
+    }
+}

--- a/src/test/java/julius/game/chessengine/engine/search/config/SearchLimitsTest.java
+++ b/src/test/java/julius/game/chessengine/engine/search/config/SearchLimitsTest.java
@@ -1,0 +1,62 @@
+package julius.game.chessengine.engine.search.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SearchLimitsTest {
+
+    @Test
+    void builderClampsNonNegativeValues() {
+        SearchLimits limits = SearchLimits.builder()
+                .timeControl(-1, -2, -3, -4, -5)
+                .nodesLimit(-10)
+                .moveTimeMillis(-20)
+                .softDeadlineNanos(-30)
+                .hardDeadlineNanos(-40)
+                .build();
+
+        assertFalse(limits.hasTimeLimit());
+        assertEquals(0, limits.getNodesLimit());
+        assertEquals(0, limits.getMoveTimeMillis());
+        assertEquals(0, limits.getSoftDeadlineNanos());
+        assertEquals(0, limits.getHardDeadlineNanos());
+        assertEquals(0, limits.getTimeControl().movesToGo());
+        assertEquals(0, limits.getTimeControl().whiteTimeMillis());
+    }
+
+    @Test
+    void hasTimeLimitConsidersMoveTimeAndTimeControl() {
+        SearchLimits withMoveTime = SearchLimits.builder().moveTimeMillis(150).build();
+        assertTrue(withMoveTime.hasTimeLimit());
+
+        SearchLimits withTimeControl = SearchLimits.builder()
+                .timeControl(1_000, 0, 0, 0, 0)
+                .build();
+        assertTrue(withTimeControl.hasTimeLimit());
+
+        SearchLimits unlimited = SearchLimits.unlimited();
+        assertFalse(unlimited.hasTimeLimit());
+    }
+
+    @Test
+    void hardDeadlineUsesMoveTimeWhenPresent() {
+        SearchLimits limits = SearchLimits.builder().moveTimeMillis(250).build();
+        long start = 500L;
+        long expected = start + TimeUnit.MILLISECONDS.toNanos(250);
+        assertEquals(expected, limits.hardDeadlineNanos(start));
+    }
+
+    @Test
+    void hardDeadlinePrefersExplicitDeadline() {
+        SearchLimits limits = SearchLimits.builder()
+                .moveTimeMillis(250)
+                .hardDeadlineNanos(1_500)
+                .build();
+        assertEquals(2_000, limits.hardDeadlineNanos(500));
+    }
+}


### PR DESCRIPTION
## Summary
- add `SearchConfig` and `SearchLimits` classes to encapsulate static search options and per-search limits
- refactor `AI` to consume the new configuration/limit objects and keep legacy accessors available
- update the UCI handler to route option updates through `SearchConfig` and introduce unit tests covering the new helpers

## Testing
- `mvn test` *(fails: unable to download parent POM because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d40d501e64832a8b1aa22a7ca73585