### PR TITLE
Add TimeManager utility for deterministic search timing

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/search/time/TimeManager.java
+++ b/src/main/java/julius/game/chessengine/engine/search/time/TimeManager.java
@@ -1,0 +1,195 @@
+package julius.game.chessengine.engine.search.time;
+
+import julius.game.chessengine.engine.search.config.SearchLimits;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongSupplier;
+
+/**
+ * Centralises all time-control responsibilities for a single search invocation.
+ *
+ * <p>The manager is initialised with the limits that apply to the next search and
+ * exposes helpers to query elapsed time, per-iteration deadlines and stop flags.
+ * It can be supplied with a custom time source which makes the behaviour fully
+ * deterministic in tests.</p>
+ */
+public final class TimeManager {
+
+    private static final int MAX_ASPIRATION_SHIFT = 30;
+
+    private final LongSupplier nanoSource;
+    private final AtomicBoolean stopRequested = new AtomicBoolean(false);
+
+    private volatile SearchLimits limits = SearchLimits.unlimited();
+    private volatile long searchStartTimeNanos = 0L;
+    private volatile long softDeadlineNanos = Long.MAX_VALUE;
+    private volatile long hardDeadlineNanos = Long.MAX_VALUE;
+
+    public TimeManager() {
+        this(System::nanoTime);
+    }
+
+    public TimeManager(LongSupplier nanoSource) {
+        this.nanoSource = Objects.requireNonNull(nanoSource, "nanoSource");
+    }
+
+    /**
+     * Begin a new search using the supplied limits.  The start time and absolute
+     * deadlines are computed lazily from the provided time source which allows
+     * tests to supply a deterministic clock.
+     */
+    public synchronized void beginSearch(SearchLimits limits) {
+        this.limits = limits != null ? limits : SearchLimits.unlimited();
+        this.searchStartTimeNanos = nanoSource.getAsLong();
+        this.stopRequested.set(false);
+        computeDeadlines();
+    }
+
+    private void computeDeadlines() {
+        long start = searchStartTimeNanos;
+        if (start <= 0L) {
+            softDeadlineNanos = Long.MAX_VALUE;
+            hardDeadlineNanos = Long.MAX_VALUE;
+            return;
+        }
+
+        SearchLimits active = this.limits;
+        hardDeadlineNanos = active.hardDeadlineNanos(start);
+
+        long relativeSoft = active.getSoftDeadlineNanos();
+        if (relativeSoft <= 0L) {
+            softDeadlineNanos = hardDeadlineNanos;
+        } else if (relativeSoft == Long.MAX_VALUE) {
+            softDeadlineNanos = Long.MAX_VALUE;
+        } else {
+            softDeadlineNanos = saturatingAdd(start, relativeSoft, Long.MAX_VALUE);
+            if (softDeadlineNanos > hardDeadlineNanos) {
+                softDeadlineNanos = hardDeadlineNanos;
+            }
+        }
+    }
+
+    private long saturatingAdd(long base, long delta, long maxFallback) {
+        try {
+            return Math.addExact(base, delta);
+        } catch (ArithmeticException ex) {
+            return maxFallback;
+        }
+    }
+
+    public long getSearchStartTimeNanos() {
+        return searchStartTimeNanos;
+    }
+
+    public long getSoftDeadlineNanos() {
+        return softDeadlineNanos;
+    }
+
+    public long getHardDeadlineNanos() {
+        return hardDeadlineNanos;
+    }
+
+    /**
+     * Returns {@code true} if the current search should stop according to the
+     * configured limits or because a stop was explicitly requested.
+     */
+    public boolean shouldStop(long nodesSoFar, int plyFromRoot) {
+        if (stopRequested.get()) {
+            return true;
+        }
+
+        SearchLimits active = this.limits;
+
+        long nodesLimit = active.getNodesLimit();
+        if (nodesLimit > 0 && nodesSoFar >= nodesLimit) {
+            return true;
+        }
+
+        int fixedDepth = active.getFixedDepth();
+        if (fixedDepth > 0 && plyFromRoot >= fixedDepth) {
+            return true;
+        }
+
+        long hard = hardDeadlineNanos;
+        if (hard != Long.MAX_VALUE) {
+            long now = nanoSource.getAsLong();
+            if (now >= hard) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the deadline (absolute nanoseconds) for the given aspiration
+     * re-search attempt within the current iterative-deepening iteration.
+     *
+     * <p>The first attempt uses the soft deadline so that a failing aspiration
+     * window can be retried while keeping enough slack to honour the overall
+     * hard deadline.  Subsequent attempts approach the hard deadline using a
+     * geometric distribution which keeps the progression deterministic while
+     * reserving diminishing slices of the remaining slack.</p>
+     */
+    public long deadlineForAspirationAttempt(int attemptIndex) {
+        if (attemptIndex <= 0) {
+            return softDeadlineNanos;
+        }
+
+        long hard = hardDeadlineNanos;
+        long soft = softDeadlineNanos;
+        if (hard == Long.MAX_VALUE || soft == Long.MAX_VALUE) {
+            return hard;
+        }
+
+        if (soft >= hard) {
+            return hard;
+        }
+
+        long slack = hard - soft;
+        int shift = Math.min(attemptIndex, MAX_ASPIRATION_SHIFT);
+        long remainder = slack >>> shift; // geometric decay: 1/2^attempt
+        long delta = slack - remainder;
+        return Math.min(hard, saturatingAdd(soft, delta, hard));
+    }
+
+    /**
+     * @return elapsed time in milliseconds since {@link #beginSearch(SearchLimits)}
+     * was invoked. Returns {@code 0} if the search has not started yet or the
+     * elapsed time would be negative due to the supplied clock.
+     */
+    public long getSearchElapsedMillis() {
+        long start = searchStartTimeNanos;
+        if (start <= 0L) {
+            return 0L;
+        }
+        long now = nanoSource.getAsLong();
+        if (now <= start) {
+            return 0L;
+        }
+        long elapsed = now - start;
+        if (elapsed <= 0L) {
+            return 0L;
+        }
+        return TimeUnit.NANOSECONDS.toMillis(elapsed);
+    }
+
+    public void requestStop() {
+        stopRequested.set(true);
+    }
+
+    public AtomicBoolean stopSignal() {
+        return stopRequested;
+    }
+
+    public synchronized void reset() {
+        stopRequested.set(false);
+        limits = SearchLimits.unlimited();
+        searchStartTimeNanos = 0L;
+        softDeadlineNanos = Long.MAX_VALUE;
+        hardDeadlineNanos = Long.MAX_VALUE;
+    }
+}
+

--- a/src/test/java/julius/game/chessengine/engine/search/time/TimeManagerTest.java
+++ b/src/test/java/julius/game/chessengine/engine/search/time/TimeManagerTest.java
@@ -1,0 +1,134 @@
+package julius.game.chessengine.engine.search.time;
+
+import julius.game.chessengine.engine.search.config.SearchLimits;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TimeManagerTest {
+
+    private static final long ONE_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
+
+    private TestClock clock;
+    private TimeManager manager;
+
+    @BeforeEach
+    void setUp() {
+        clock = new TestClock();
+        manager = new TimeManager(clock);
+    }
+
+    @Test
+    void beginSearchInitialisesDeadlinesFromMoveTime() {
+        SearchLimits limits = SearchLimits.builder().moveTimeMillis(250).build();
+        clock.set(1_000_000L);
+
+        manager.beginSearch(limits);
+
+        long expectedDeadline = clock.now() + TimeUnit.MILLISECONDS.toNanos(250);
+        assertEquals(clock.now(), manager.getSearchStartTimeNanos());
+        assertEquals(expectedDeadline, manager.getHardDeadlineNanos());
+        assertEquals(expectedDeadline, manager.getSoftDeadlineNanos());
+
+        assertFalse(manager.shouldStop(0L, 0));
+        clock.advance(TimeUnit.MILLISECONDS.toNanos(300));
+        assertTrue(manager.shouldStop(0L, 0));
+    }
+
+    @Test
+    void aspirationAttemptsApproachHardDeadline() {
+        SearchLimits limits = SearchLimits.builder()
+                .softDeadlineNanos(TimeUnit.MILLISECONDS.toNanos(100))
+                .hardDeadlineNanos(TimeUnit.MILLISECONDS.toNanos(200))
+                .build();
+        clock.set(5_000_000L);
+
+        manager.beginSearch(limits);
+
+        long soft = manager.getSoftDeadlineNanos();
+        long hard = manager.getHardDeadlineNanos();
+        assertEquals(clock.now() + TimeUnit.MILLISECONDS.toNanos(100), soft);
+        assertEquals(clock.now() + TimeUnit.MILLISECONDS.toNanos(200), hard);
+
+        assertEquals(soft, manager.deadlineForAspirationAttempt(0));
+        long attemptOne = manager.deadlineForAspirationAttempt(1);
+        assertTrue(attemptOne > soft && attemptOne < hard);
+        long attemptTwo = manager.deadlineForAspirationAttempt(2);
+        assertTrue(attemptTwo >= attemptOne && attemptTwo < hard);
+        long laterAttempt = manager.deadlineForAspirationAttempt(10);
+        assertEquals(hard, laterAttempt);
+    }
+
+    @Test
+    void nodesAndDepthLimitsTriggerStop() {
+        SearchLimits limits = SearchLimits.builder()
+                .nodesLimit(1000)
+                .fixedDepth(5)
+                .build();
+        clock.set(10_000_000L);
+        manager.beginSearch(limits);
+
+        assertFalse(manager.shouldStop(999, 4));
+        assertTrue(manager.shouldStop(1000, 4));
+        assertTrue(manager.shouldStop(999, 5));
+    }
+
+    @Test
+    void requestStopOverridesLimits() {
+        manager.beginSearch(SearchLimits.unlimited());
+        assertFalse(manager.shouldStop(0L, 0));
+        manager.requestStop();
+        assertTrue(manager.shouldStop(0L, 0));
+        assertTrue(manager.stopSignal().get());
+    }
+
+    @Test
+    void elapsedMillisUsesProvidedClock() {
+        manager.beginSearch(SearchLimits.unlimited());
+        assertEquals(0L, manager.getSearchElapsedMillis());
+
+        clock.advance(42 * ONE_MILLISECOND);
+        assertEquals(42L, manager.getSearchElapsedMillis());
+    }
+
+    @Test
+    void resetClearsState() {
+        clock.set(100L);
+        manager.beginSearch(SearchLimits.builder().moveTimeMillis(10).build());
+        manager.requestStop();
+
+        manager.reset();
+
+        assertEquals(0L, manager.getSearchStartTimeNanos());
+        assertEquals(Long.MAX_VALUE, manager.getSoftDeadlineNanos());
+        assertEquals(Long.MAX_VALUE, manager.getHardDeadlineNanos());
+        assertFalse(manager.stopSignal().get());
+        assertFalse(manager.shouldStop(0L, 0));
+    }
+
+    private static final class TestClock implements LongSupplier {
+        private long now;
+
+        @Override
+        public long getAsLong() {
+            return now;
+        }
+
+        void set(long value) {
+            now = value;
+        }
+
+        void advance(long delta) {
+            now += delta;
+        }
+
+        long now() {
+            return now;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated `TimeManager` to encapsulate search deadlines, elapsed time, and shared stop signalling
- support aspiration attempt deadline progression with deterministic slices driven by the configured soft/hard limits
- cover the new behaviour with unit tests using a controllable clock

## Testing
- `mvn -q test` *(fails: parent POM cannot be resolved without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d4133b4f70832aabbf62ed4f20d624