### PR TITLE
Expose heuristic tables and mask

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1638,7 +1638,7 @@ public class AI {
         final boolean inCheckAtNode = isSideInCheck(simulatorEngine, true);
         final WorkerContext worker = searchContext.worker();
         final SearchContext.Heuristics heuristics = worker.heuristics();
-        final int[][] historyTable = heuristics.history;
+        final int[][] historyTable = heuristics.history();
 
         MoveList orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove, simulatorEngine);
         final Map<Integer, Integer> seeCache = worker.seeCache();
@@ -1863,7 +1863,7 @@ public class AI {
         final boolean inCheckAtNode = isSideInCheck(simulatorEngine, false);
         final WorkerContext worker = searchContext.worker();
         final SearchContext.Heuristics heuristics = worker.heuristics();
-        final int[][] historyTable = heuristics.history;
+        final int[][] historyTable = heuristics.history();
 
         MoveList orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove, simulatorEngine);
         final Map<Integer, Integer> seeCache = worker.seeCache();
@@ -2111,9 +2111,10 @@ public class AI {
         final long[] sortKeys = worker.sortKeyBuffer();
 
         final SearchContext.Heuristics heuristics = worker.heuristics();
-        final int[][] killerMoves = heuristics.killers;
-        final int[][] historyTable = heuristics.history;
-        final int[][] counterMove = heuristics.counter;
+        final int[][] killerMoves = heuristics.killers();
+        final int[][] historyTable = heuristics.history();
+        final int[][] counterMove = heuristics.counter();
+        final int[][] continuationTable = heuristics.continuation();
 
         final int depthIndex = Math.max(0, Math.min(currentDepth, killerMoves.length - 1));
 
@@ -2247,7 +2248,7 @@ public class AI {
                 category = CAT_CHECK_QUIET;
                 score = historyTable[from][to] + CHECK_QUIET_BONUS + checkPriorityBonus;
                 if (prevTo >= 0) {
-                    int continuationScore = heuristics.continuation[prevTo][to];
+                    int continuationScore = continuationTable[prevTo][to];
                     score += continuationScore / CONTINUATION_HISTORY_DIVISOR;
                 }
                 if (moveInt == cm) {
@@ -2264,7 +2265,7 @@ public class AI {
                 category = CAT_QUIET;
                 score = historyTable[from][to]; // butterfly history
                 if (prevTo >= 0) {
-                    int continuationScore = heuristics.continuation[prevTo][to];
+                    int continuationScore = continuationTable[prevTo][to];
                     score += continuationScore / CONTINUATION_HISTORY_DIVISOR;
                 }
                 if (moveInt == cm) score += COUNTER_MOVE_BONUS;

--- a/src/main/java/julius/game/chessengine/engine/search/context/SearchContext.java
+++ b/src/main/java/julius/game/chessengine/engine/search/context/SearchContext.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 public final class SearchContext {
 
     static final int SEE_CACHE_SIZE = 1 << 10; // 1024 entries
-    static final int SEE_CACHE_MASK = SEE_CACHE_SIZE - 1;
+    public static final int SEE_CACHE_MASK = SEE_CACHE_SIZE - 1;
 
     static final int NUM_KILLER_MOVES = 2;
     static final int MAX_MOVE_LIST_SIZE = 218; // legal move upper bound
@@ -488,6 +488,22 @@ public final class SearchContext {
                 snapshot[i] = Arrays.copyOf(killers[i], killers[i].length);
             }
             return snapshot;
+        }
+
+        public int[][] killers() {
+            return killers;
+        }
+
+        public int[][] history() {
+            return history;
+        }
+
+        public int[][] continuation() {
+            return continuation;
+        }
+
+        public int[][] counter() {
+            return counter;
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose the SEE cache mask so other packages can reuse it
- provide accessor methods for heuristic tables in SearchContext
- update AI move ordering code to use the new heuristic accessors

## Testing
- mvn -q -DskipTests package *(fails: missing parent POM due to offline Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d41c31dabc832aaac4fb16211da132