### PR TITLE
Fix time manager deadlines and thread clamping

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/search/config/SearchConfig.java
+++ b/src/main/java/julius/game/chessengine/engine/search/config/SearchConfig.java
@@ -85,11 +85,9 @@ public final class SearchConfig {
 
     private boolean updateThreads(int requestedThreads) {
         int clamped = Math.max(1, requestedThreads);
-        if (clamped == this.threads) {
-            return false;
-        }
+        boolean changed = clamped != this.threads;
         this.threads = clamped;
-        return true;
+        return changed || requestedThreads < 1;
     }
 
     public synchronized boolean setHashSizeMb(int requestedMb) {

--- a/src/main/java/julius/game/chessengine/engine/search/time/TimeManager.java
+++ b/src/main/java/julius/game/chessengine/engine/search/time/TimeManager.java
@@ -17,13 +17,13 @@ import java.util.function.LongSupplier;
  */
 public final class TimeManager {
 
-    private static final int MAX_ASPIRATION_SHIFT = 30;
+    private static final int MAX_ASPIRATION_ATTEMPTS = 10;
 
     private final LongSupplier nanoSource;
     private final AtomicBoolean stopRequested = new AtomicBoolean(false);
 
     private volatile SearchLimits limits = SearchLimits.unlimited();
-    private volatile long searchStartTimeNanos = 0L;
+    private volatile long searchStartTimeNanos = -1L;
     private volatile long softDeadlineNanos = Long.MAX_VALUE;
     private volatile long hardDeadlineNanos = Long.MAX_VALUE;
 
@@ -49,7 +49,7 @@ public final class TimeManager {
 
     private void computeDeadlines() {
         long start = searchStartTimeNanos;
-        if (start <= 0L) {
+        if (start < 0L) {
             softDeadlineNanos = Long.MAX_VALUE;
             hardDeadlineNanos = Long.MAX_VALUE;
             return;
@@ -148,8 +148,12 @@ public final class TimeManager {
             return hard;
         }
 
+        if (attemptIndex >= MAX_ASPIRATION_ATTEMPTS) {
+            return hard;
+        }
+
         long slack = hard - soft;
-        int shift = Math.min(attemptIndex, MAX_ASPIRATION_SHIFT);
+        int shift = attemptIndex;
         long remainder = slack >>> shift; // geometric decay: 1/2^attempt
         long delta = slack - remainder;
         return Math.min(hard, saturatingAdd(soft, delta, hard));
@@ -162,7 +166,7 @@ public final class TimeManager {
      */
     public long getSearchElapsedMillis() {
         long start = searchStartTimeNanos;
-        if (start <= 0L) {
+        if (start < 0L) {
             return 0L;
         }
         long now = nanoSource.getAsLong();
@@ -187,7 +191,7 @@ public final class TimeManager {
     public synchronized void reset() {
         stopRequested.set(false);
         limits = SearchLimits.unlimited();
-        searchStartTimeNanos = 0L;
+        searchStartTimeNanos = -1L;
         softDeadlineNanos = Long.MAX_VALUE;
         hardDeadlineNanos = Long.MAX_VALUE;
     }


### PR DESCRIPTION
## Summary
- ensure SearchConfig thread setter reports clamping of invalid values
- allow TimeManager to measure elapsed time from zero-based clocks and cap late aspiration attempts at the hard deadline

## Testing
- mvn test *(fails: requires downloading dependencies and network access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68d41d7e4b00832ab9a8ff29454aba3b