### PR TITLE
Fix razor pruning evaluation sign

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1538,6 +1538,9 @@ public class AI {
             double mateBand = CHECKMATE - (plyFromRoot + 2);  // stay away from mate scores
             if (alpha > -mateBand && beta < mateBand) {       // not in mate race
                 double st = evaluateStaticPosition(simulatorEngine.getGameState(), isWhite, plyFromRoot);
+                if (!isWhite) {
+                    st = -st;
+                }
                 double razorMargin = (depth == 1) ? 150.0 : 250.0;
                 if (st + razorMargin <= alpha) {
                     double q = evaluateBoard(simulatorEngine, isWhite, deadline);


### PR DESCRIPTION
## Summary
- ensure the razor-pruning static evaluation is converted to the white-oriented score before it is compared to alpha
- prevents pruning mistakes that caused the search to miss recaptures and other tactical replies when it was black to move

## Testing
- `mvn -q -DskipTests compile` *(fails: parent POM requires internet access)*

------
https://chatgpt.com/codex/tasks/task_e_68d46d233188832a95c0074ba4f5c202