### PR TITLE
Avoid pruning necessary recaptures

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1817,10 +1817,12 @@ public class AI {
             // SEE pruning for losing captures/quiets (keep checks/promotions).
             // Only consider when NOT in check.
             boolean seePruneCandidate = !inCheckAtNode && !isPromotion;
+            boolean isRecapture = isCapture && prevMove >= 0
+                    && MoveHelper.deriveToIndex(prevMove) == to;
             if (seePruneCandidate) {
                 seeGain = seeCache.computeIfAbsent(move, simulatorEngine::see);
                 seeEvaluated = true;
-                if (seeGain < 0) {
+                if (seeGain < 0 && !isRecapture) {
                     simulatorEngine.performMove(move);
                     boolean givesCheckTmp = isSideInCheck(simulatorEngine, false);
                     simulatorEngine.undoLastMove();
@@ -2043,10 +2045,12 @@ public class AI {
             // SEE pruning for losing captures/quiets (keep checks/promotions).
             // Only consider when NOT in check.
             boolean seePruneCandidate = !inCheckAtNode && !isPromotion;
+            boolean isRecapture = isCapture && prevMove >= 0
+                    && MoveHelper.deriveToIndex(prevMove) == to;
             if (seePruneCandidate) {
                 seeGain = seeCache.computeIfAbsent(move, simulatorEngine::see);
                 seeEvaluated = true;
-                if (seeGain < 0) {
+                if (seeGain < 0 && !isRecapture) {
                     simulatorEngine.performMove(move);
                     boolean givesCheckTmp = isSideInCheck(simulatorEngine, true);
                     simulatorEngine.undoLastMove();


### PR DESCRIPTION
## Summary
- keep SEE-based pruning from discarding recaptures in both maximizer and minimizer search branches
- ensure losing recaptures are still examined so tactical material balances are preserved

## Testing
- `./mvnw -q -DskipTests -o package` *(fails: Maven wrapper requires network access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d46d233188832a95c0074ba4f5c202