### PR TITLE
Fix mate evaluation orientation

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2595,23 +2595,30 @@ public class AI {
     private double evaluateStaticPosition(GameState gameState, boolean isWhitesTurn, int depthOrPly) {
         instrumentation().recordStaticEvalCall();
 
-        if (gameState.isInStateCheckMate()) {
-            return -(CHECKMATE - depthOrPly);
-        }
-        if (gameState.isInStateDraw()) {
-            double scoreDiff = gameState.getScore().getScoreDifference();
-            // stronger bias than ±0.01 to steer decisively
-            final double DRAW_BIAS = 0.20;
-            if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
-                return DRAW - DRAW_BIAS; // avoid draws when ahead
-            } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {
-                return DRAW + DRAW_BIAS; // accept draws when behind
-            }
-            return DRAW;
-        }
-        double scoreDifference = gameState.getScore().getScoreDifference();
+        double whitePerspective;
 
-        return isWhitesTurn ? scoreDifference : -scoreDifference;
+        if (gameState.isInStateCheckMate()) {
+            double mateScore = CHECKMATE - depthOrPly;
+            whitePerspective = switch (gameState.getState()) {
+                case WHITE_WON -> mateScore;
+                case BLACK_WON -> -mateScore;
+                default -> -mateScore; // fallback: side to move has no moves and loses
+            };
+        } else if (gameState.isInStateDraw()) {
+            double scoreDiff = gameState.getScore().getScoreDifference();
+            final double DRAW_BIAS = 0.20; // stronger bias than ±0.01 to steer decisively
+            if (scoreDiff > 0) {
+                whitePerspective = DRAW - DRAW_BIAS; // white is ahead, avoid the draw
+            } else if (scoreDiff < 0) {
+                whitePerspective = DRAW + DRAW_BIAS; // white is behind, take the draw
+            } else {
+                whitePerspective = DRAW;
+            }
+        } else {
+            whitePerspective = gameState.getScore().getScoreDifference();
+        }
+
+        return isWhitesTurn ? whitePerspective : -whitePerspective;
     }
 
     private MoveList getPossibleCapturesOrPromotions(Engine simulatorEngine) {

--- a/src/test/java/julius/game/chessengine/utils/ScoreSignTest.java
+++ b/src/test/java/julius/game/chessengine/utils/ScoreSignTest.java
@@ -1,0 +1,31 @@
+package julius.game.chessengine.utils;
+
+import julius.game.chessengine.engine.Engine;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the material evaluation sign matches the side that is ahead.
+ */
+class ScoreSignTest {
+
+    private static final String WHITE_UP_QUEEN = "8/8/8/8/8/8/4k3/3QK3 %s - - 0 1";
+
+    @Test
+    void scoreDifferenceIsPositiveWhenWhiteHasExtraQueenWhiteToMove() {
+        Engine engine = new Engine();
+        engine.importBoardFromFen(WHITE_UP_QUEEN.formatted("w"));
+        double score = engine.getGameState().getScore().getScoreDifference();
+        assertTrue(score > 0.0, "Score should be positive when white leads materially");
+    }
+
+    @Test
+    void scoreDifferenceIsPositiveWhenWhiteHasExtraQueenBlackToMove() {
+        Engine engine = new Engine();
+        engine.importBoardFromFen(WHITE_UP_QUEEN.formatted("b"));
+        double score = engine.getGameState().getScore().getScoreDifference();
+        assertTrue(score > 0.0, "Score should be positive for white regardless of side to move");
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure static evaluation derives a white-perspective score for mate/draw states before converting for the side to move
- add a regression test that verifies positive score values when White has an extra queen regardless of side to move

## Testing
- `mvn -q -Dtest=ScoreSignTest test` *(fails: unable to download Spring Boot parent due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d46d233188832a95c0074ba4f5c202