### PR TITLE
Orient evaluations for side to move

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2472,11 +2472,10 @@ public class AI {
 
         if (simulatorEngine.getGameState().isInStateDraw()) {
             double scoreDiff = simulatorEngine.getGameState().getScore().getScoreDifference();
-            // stronger bias than ±0.01 to steer away from draws when ahead
             final double DRAW_BIAS = 0.20;
-            if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
+            if (scoreDiff > 0) {
                 return DRAW - DRAW_BIAS; // discourage draws when ahead
-            } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {
+            } else if (scoreDiff < 0) {
                 return DRAW + DRAW_BIAS; // prefer draws when behind
             }
             return DRAW;
@@ -2600,18 +2599,15 @@ public class AI {
         }
         if (gameState.isInStateDraw()) {
             double scoreDiff = gameState.getScore().getScoreDifference();
-            // stronger bias than ±0.01 to steer decisively
             final double DRAW_BIAS = 0.20;
-            if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
+            if (scoreDiff > 0) {
                 return DRAW - DRAW_BIAS; // avoid draws when ahead
-            } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {
+            } else if (scoreDiff < 0) {
                 return DRAW + DRAW_BIAS; // accept draws when behind
             }
             return DRAW;
         }
-        double scoreDifference = gameState.getScore().getScoreDifference();
-
-        return isWhitesTurn ? scoreDifference : -scoreDifference;
+        return gameState.getScore().getScoreDifference();
     }
 
     private MoveList getPossibleCapturesOrPromotions(Engine simulatorEngine) {

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -163,7 +163,16 @@ public class Score {
         if (!evaluationPipeline.isInitialized()) {
             return 0.0;
         }
-        return evaluationPipeline.getScoreDifference();
+        // Normalise the blended evaluation so that a positive value always
+        // indicates an advantage for the side to move.  This keeps the search
+        // logic (which evaluates positions from the mover's perspective) and
+        // heuristic fallbacks aligned with the evaluation pipeline.
+        double diff = evaluationPipeline.getScoreDifference();
+        EvaluationContext context = this.evaluationContext;
+        if (context != null && !context.whiteToMove()) {
+            diff = -diff;
+        }
+        return diff;
     }
 
     public int getMidgameScore() {

--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -874,7 +874,7 @@ public class BestMoveSearchTest {
     }
 
     private static double orientScoreForMover(boolean whiteToMove, double scoreDifference) {
-        return whiteToMove ? scoreDifference : -scoreDifference;
+        return scoreDifference;
     }
 
     private static String formatCentipawns(double centipawns) {

--- a/src/test/java/julius/game/chessengine/ai/DrawScoreOrientationTest.java
+++ b/src/test/java/julius/game/chessengine/ai/DrawScoreOrientationTest.java
@@ -21,15 +21,17 @@ class DrawScoreOrientationTest {
         Engine engine = new Engine();
         AI ai = new AI(engine);
 
-        GameState drawState = new GameState(engine.getGameState());
-        stubDrawState(drawState, 320.0);
-
         Method evaluateStatic = AI.class.getDeclaredMethod(
                 "evaluateStaticPosition", GameState.class, boolean.class, int.class);
         evaluateStatic.setAccessible(true);
 
-        double whiteToMoveScore = (double) evaluateStatic.invoke(ai, drawState, true, 0);
-        double blackToMoveScore = (double) evaluateStatic.invoke(ai, drawState, false, 0);
+        GameState whiteDrawState = new GameState(engine.getGameState());
+        stubDrawState(whiteDrawState, 320.0);
+        double whiteToMoveScore = (double) evaluateStatic.invoke(ai, whiteDrawState, true, 0);
+
+        GameState blackDrawState = new GameState(engine.getGameState());
+        stubDrawState(blackDrawState, -320.0);
+        double blackToMoveScore = (double) evaluateStatic.invoke(ai, blackDrawState, false, 0);
 
         assertTrue(whiteToMoveScore < Score.DRAW,
                 "White should dislike accepting a draw while ahead.");


### PR DESCRIPTION
## Summary
- flip blended evaluation scores when it's Black's turn so getScoreDifference always represents the mover's advantage
- simplify draw handling and leaf evaluations to use the mover-oriented scores directly
- align tests with the new score orientation semantics

## Testing
- ./mvnw test *(fails: Maven wrapper cannot download dependencies in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d46d233188832a95c0074ba4f5c202