### PR TITLE
Add automated profiling batch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,44 @@ java -jar target/chess-engine-<version>-uci.jar
 The process listens on standard input and speaks the UCI protocol on standard
 output.
 
+## Profiling the engine on Windows
+
+To automate the build, self-play session, and profiling capture, run the
+`profile-engine.bat` helper from a Windows terminal:
+
+```cmd
+profile-engine.bat
+```
+
+The script performs the following steps:
+
+1. Builds the project with `mvnw.cmd -DskipTests package`.
+2. Locates the latest `*-uci.jar` artifact in `target/`.
+3. Launches the UCI engine with Java Flight Recorder (JFR) profiling enabled
+   while the engine plays both sides of a game for a configurable number of
+   plies and move time.
+4. Stores the resulting artifacts under `profiles/`:
+   * `uci-<timestamp>.jfr` &mdash; the JFR capture that you can inspect with
+     Java Mission Control.
+   * `uci-<timestamp>.log` &mdash; the raw UCI transcript, including the
+     commands sent to the engine and the `info`/`bestmove` responses.
+   * `uci-<timestamp>-summary.json` &mdash; metadata about the run, including
+     the moves that were played and the effective configuration.
+
+You can tweak the duration and game characteristics by exporting environment
+variables before running the batch file:
+
+```cmd
+set PROFILE_MOVE_TIME_MS=1500
+set PROFILE_PLY_COUNT=120
+set PROFILE_JFR_DURATION=240s
+profile-engine.bat
+```
+
+Adjust `PROFILE_JFR_DURATION` to ensure the recording lasts long enough to
+cover the requested number of plies. The batch file automatically validates that
+Java is available on the `PATH` and reports any build or runtime errors.
+
 ## Running the web UI
 
 The browser UI talks to the engine through a WebSocket that is hosted by the

--- a/profile-engine.bat
+++ b/profile-engine.bat
@@ -1,0 +1,74 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+
+set "PROFILE_DIR=%SCRIPT_DIR%\profiles"
+if not exist "%PROFILE_DIR%" (
+    mkdir "%PROFILE_DIR%"
+    if errorlevel 1 (
+        echo [ERROR] Failed to create profile output directory at "%PROFILE_DIR%".
+        exit /b 1
+    )
+)
+
+where java >nul 2>&1
+if errorlevel 1 (
+    echo [ERROR] Java runtime not found. Please ensure Java 17 or later is installed and available on PATH.
+    exit /b 1
+)
+
+set "MVNW_CMD=%SCRIPT_DIR%\mvnw.cmd"
+if not exist "%MVNW_CMD%" (
+    echo [ERROR] Unable to locate mvnw.cmd at "%MVNW_CMD%".
+    exit /b 1
+)
+
+if not defined PROFILE_MOVE_TIME_MS set "PROFILE_MOVE_TIME_MS=2000"
+if not defined PROFILE_PLY_COUNT set "PROFILE_PLY_COUNT=80"
+if not defined PROFILE_JFR_DURATION set "PROFILE_JFR_DURATION=180s"
+
+pushd "%SCRIPT_DIR%" >nul
+call "%MVNW_CMD%" -DskipTests package
+if errorlevel 1 (
+    echo [ERROR] Maven build failed. See the log above for details.
+    popd >nul
+    exit /b 1
+)
+
+set "UCI_JAR="
+for /f "delims=" %%F in ('dir /b /o:-n "target\chess-engine-*-uci.jar" 2^>nul') do (
+    set "UCI_JAR=%SCRIPT_DIR%\target\%%F"
+    goto :JarFound
+)
+
+echo [ERROR] Unable to locate the chess engine UCI jar in target\.
+popd >nul
+exit /b 1
+
+:JarFound
+popd >nul
+
+echo ------------------------------------------------------------
+echo Launching self-play profiling session...
+echo   Engine jar   : %UCI_JAR%
+echo   Move time    : %PROFILE_MOVE_TIME_MS% ms
+echo   Ply count    : %PROFILE_PLY_COUNT%
+echo   JFR duration : %PROFILE_JFR_DURATION%
+echo Output will be written under %PROFILE_DIR%
+echo ------------------------------------------------------------
+
+powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%\scripts\profile-engine.ps1" ^
+    -JarPath "%UCI_JAR%" ^
+    -ProfileDir "%PROFILE_DIR%" ^
+    -MoveTimeMs %PROFILE_MOVE_TIME_MS% ^
+    -PlyCount %PROFILE_PLY_COUNT% ^
+    -JfrDuration "%PROFILE_JFR_DURATION%"
+if errorlevel 1 (
+    echo [ERROR] Profiling session failed.
+    exit /b 1
+)
+
+echo Profiling artifacts generated in: %PROFILE_DIR%
+exit /b 0

--- a/scripts/profile-engine.ps1
+++ b/scripts/profile-engine.ps1
@@ -1,0 +1,234 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$JarPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ProfileDir,
+
+    [int]$MoveTimeMs = 2000,
+
+    [int]$PlyCount = 80,
+
+    [string]$JfrDuration = "180s"
+)
+
+Set-StrictMode -Version Latest
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-FullPath {
+    param([string]$PathValue)
+    return [System.IO.Path]::GetFullPath((Resolve-Path -LiteralPath $PathValue).ProviderPath)
+}
+
+if (-not (Test-Path -LiteralPath $JarPath)) {
+    throw "The UCI engine jar '$JarPath' was not found. Build the project before running the profiler."
+}
+
+if (-not (Test-Path -LiteralPath $ProfileDir)) {
+    New-Item -ItemType Directory -Path $ProfileDir -Force | Out-Null
+}
+
+$jarFullPath = Resolve-FullPath -PathValue $JarPath
+$profileFullPath = Resolve-FullPath -PathValue $ProfileDir
+
+if ($MoveTimeMs -le 0) {
+    throw "MoveTimeMs must be greater than zero."
+}
+
+if ($PlyCount -le 0) {
+    throw "PlyCount must be greater than zero."
+}
+
+$timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$jfrFile = Join-Path $profileFullPath "uci-$timestamp.jfr"
+$logFile = Join-Path $profileFullPath "uci-$timestamp.log"
+$summaryFile = Join-Path $profileFullPath "uci-$timestamp-summary.json"
+
+$logWriter = New-Object System.IO.StreamWriter($logFile, $false, [System.Text.Encoding]::UTF8)
+$logWriter.AutoFlush = $true
+
+Write-Host "Launching engine for profiling..."
+Write-Host "  Engine jar    : $jarFullPath"
+Write-Host "  JFR duration  : $JfrDuration"
+Write-Host "  Move time (ms): $MoveTimeMs"
+Write-Host "  Ply count     : $PlyCount"
+
+$startFlightRecording = "-XX:StartFlightRecording=name=uci,settings=profile,duration=$JfrDuration,filename=\"$jfrFile\""
+$argumentList = @($startFlightRecording, '-jar', $jarFullPath)
+
+$processStartInfo = New-Object System.Diagnostics.ProcessStartInfo
+$processStartInfo.FileName = 'java'
+foreach ($arg in $argumentList) {
+    [void]$processStartInfo.ArgumentList.Add($arg)
+}
+$processStartInfo.RedirectStandardInput = $true
+$processStartInfo.RedirectStandardOutput = $true
+$processStartInfo.RedirectStandardError = $true
+$processStartInfo.UseShellExecute = $false
+$processStartInfo.CreateNoWindow = $true
+
+$process = New-Object System.Diagnostics.Process
+$process.StartInfo = $processStartInfo
+$null = $process.Start()
+
+$stderrThread = [System.Threading.Thread]::new([System.Threading.ThreadStart]{
+    while (-not $process.StandardError.EndOfStream) {
+        $line = $process.StandardError.ReadLine()
+        if ($null -ne $line) {
+            $logWriter.WriteLine("[stderr] $line")
+        }
+    }
+})
+$stderrThread.IsBackground = $true
+$stderrThread.Start()
+
+$stdin = $process.StandardInput
+
+function Write-Log {
+    param(
+        [string]$Channel,
+        [string]$Message
+    )
+    $logWriter.WriteLine("[{0}] {1}" -f $Channel, $Message)
+}
+
+function Send-UciCommand {
+    param([string]$Command)
+    Write-Log -Channel 'stdin' -Message $Command
+    $stdin.WriteLine($Command)
+    $stdin.Flush()
+}
+
+function Wait-ForLine {
+    param(
+        [string]$Pattern,
+        [string]$Context
+    )
+
+    while ($true) {
+        $line = $process.StandardOutput.ReadLine()
+        if ($null -eq $line) {
+            if ($process.HasExited) {
+                throw "Engine terminated unexpectedly while waiting for $Context ($Pattern)."
+            }
+            continue
+        }
+
+        Write-Log -Channel 'stdout' -Message $line
+
+        if ([string]::IsNullOrWhiteSpace($Pattern)) {
+            return [PSCustomObject]@{ Line = $line }
+        }
+
+        $match = [regex]::Match($line, $Pattern)
+        if ($match.Success) {
+            return [PSCustomObject]@{ Line = $line; Match = $match }
+        }
+    }
+}
+
+$moveHistory = New-Object System.Collections.Generic.List[string]
+$quitIssued = $false
+$bestMovePattern = '^bestmove\s+(\S+)' 
+
+try {
+    Send-UciCommand -Command 'uci'
+    [void](Wait-ForLine -Pattern '^uciok$' -Context 'uci handshake')
+
+    Send-UciCommand -Command 'isready'
+    [void](Wait-ForLine -Pattern '^readyok$' -Context 'engine readiness')
+
+    Send-UciCommand -Command 'ucinewgame'
+    Send-UciCommand -Command 'isready'
+    [void](Wait-ForLine -Pattern '^readyok$' -Context 'new game readiness')
+
+    for ($ply = 1; $ply -le $PlyCount; $ply++) {
+        $positionCommand = 'position startpos'
+        if ($moveHistory.Count -gt 0) {
+            $positionCommand += ' moves ' + ($moveHistory -join ' ')
+        }
+
+        Send-UciCommand -Command $positionCommand
+        Send-UciCommand -Command ("go movetime {0}" -f $MoveTimeMs)
+
+        $bestMoveResult = Wait-ForLine -Pattern $bestMovePattern -Context ("bestmove response for ply $ply")
+        $bestMove = $bestMoveResult.Match.Groups[1].Value
+
+        if ([string]::IsNullOrWhiteSpace($bestMove) -or $bestMove -eq '(none)') {
+            Write-Host "Engine reported no legal moves on ply $ply. Stopping self-play loop."
+            break
+        }
+
+        Write-Host ("Ply {0,2}: {1}" -f $ply, $bestMove)
+        $moveHistory.Add($bestMove)
+
+        Send-UciCommand -Command 'isready'
+        [void](Wait-ForLine -Pattern '^readyok$' -Context ("post-move readiness for ply $ply"))
+    }
+
+    Send-UciCommand -Command 'quit'
+    $quitIssued = $true
+    $stdin.Close()
+
+    if (-not $process.WaitForExit(10000)) {
+        Write-Warning 'Engine did not exit within 10 seconds after quit; terminating the process.'
+        $process.Kill()
+        $process.WaitForExit()
+    }
+}
+catch {
+    Write-Error $_
+    if (-not $process.HasExited) {
+        try {
+            if (-not $quitIssued) {
+                $stdin.WriteLine('quit')
+                $stdin.Flush()
+            }
+        } catch {}
+        try { $stdin.Close() } catch {}
+        try {
+            if (-not $process.WaitForExit(2000)) {
+                $process.Kill()
+                $process.WaitForExit()
+            }
+        } catch {}
+    }
+    throw
+}
+finally {
+    try {
+        if ($stderrThread -and $stderrThread.IsAlive) {
+            $stderrThread.Join()
+        }
+    } catch {}
+
+    $logWriter.Dispose()
+}
+
+$exitCode = $process.ExitCode
+
+$summary = [ordered]@{
+    timestampUtc = (Get-Date).ToUniversalTime().ToString('u')
+    engineJar = $jarFullPath
+    jfrDuration = $JfrDuration
+    moveTimeMs = $MoveTimeMs
+    requestedPlyCount = $PlyCount
+    completedPlyCount = $moveHistory.Count
+    bestMoves = $moveHistory
+    jfrFile = $jfrFile
+    logFile = $logFile
+    exitCode = $exitCode
+}
+
+$summary | ConvertTo-Json -Depth 4 | Set-Content -Path $summaryFile -Encoding UTF8
+
+Write-Host ''
+Write-Host 'Profiling run complete.'
+Write-Host "  Best moves played : $($moveHistory.Count) plies"
+Write-Host "  Engine exit code  : $exitCode"
+Write-Host "  JFR capture       : $jfrFile"
+Write-Host "  Engine log        : $logFile"
+Write-Host "  Run summary       : $summaryFile"
+Write-Host ''
+Write-Host 'Open the JFR file in Java Mission Control to inspect hotspots.'


### PR DESCRIPTION
## Summary
- add a Windows batch helper that builds the engine, launches a self-play session, and captures a JFR recording
- add a supporting PowerShell driver that feeds UCI commands, records output, and saves profiling artifacts
- document the profiling workflow and configuration options in the README

## Testing
- ./mvnw -DskipTests package *(fails: Network is unreachable while downloading Maven Wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d6918e6eb4832aaf77f04d6ef5bd03