### PR TITLE
Fix profiling script logging from background thread

### DIFF
--- a/scripts/profile-engine.ps1
+++ b/scripts/profile-engine.ps1
@@ -10,6 +10,7 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+$script:mainThreadId = [System.Threading.Thread]::CurrentThread.ManagedThreadId
 
 function Resolve-FullPath {
     param([string]$PathValue)
@@ -88,14 +89,39 @@ function Write-Log {
     $logWriter.WriteLine(("[{0}] {1}" -f @($Channel, $Message)))
 }
 
+function Write-ConsoleLine {
+    param(
+        [string]$Message,
+        [switch]$ErrorStream
+    )
+
+    $currentThreadId = [System.Threading.Thread]::CurrentThread.ManagedThreadId
+    $isMainThread    = ($currentThreadId -eq $script:mainThreadId)
+
+    if ($ErrorStream) {
+        if ($isMainThread) {
+            Write-Warning $Message
+        } else {
+            [Console]::Error.WriteLine($Message)
+        }
+    }
+    else {
+        if ($isMainThread) {
+            Write-Host $Message
+        } else {
+            [Console]::WriteLine($Message)
+        }
+    }
+}
+
 function Write-LogAndMaybeConsole {
     param([string]$Channel,[string]$Message)
     Write-Log -Channel $Channel -Message $Message
     # Always echo UCI traffic by default (less surprising)
-    if ($Channel -eq 'stderr') { Write-Warning $Message; return }
-    if ($Channel -eq 'stdout') { Write-Host    $Message; return }
-    if ($Channel -eq 'stdin')  { Write-Host    $Message; return }
-    if ($EchoEngine) { Write-Host $Message }
+    if ($Channel -eq 'stderr') { Write-ConsoleLine -Message $Message -ErrorStream; return }
+    if ($Channel -eq 'stdout') { Write-ConsoleLine -Message $Message; return }
+    if ($Channel -eq 'stdin')  { Write-ConsoleLine -Message $Message; return }
+    if ($EchoEngine) { Write-ConsoleLine -Message $Message }
 }
 
 Write-Host "Launching engine for profiling..."


### PR DESCRIPTION
## Summary
- track the main thread id in profile-engine.ps1 so background workers can detect when they are off the PowerShell runspace
- replace direct Write-Host/Write-Warning calls with a helper that uses Console.WriteLine when invoked from background threads to keep logging alive during profiling runs

## Testing
- Not run (PowerShell script change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6a3148ffc832a85872cb757221e82