### PR TITLE
Fix profiler script output handling

### DIFF
--- a/scripts/profile-engine.ps1
+++ b/scripts/profile-engine.ps1
@@ -184,18 +184,27 @@ if ($DryRun) {
 
 # ---------- Globals for process + async queues ----------
 $process = $null
-$stdoutSubscription = $null
-$stderrSubscription = $null
-$script:stdoutQueue = $null
+$stdoutHandler = $null
+$stderrHandler = $null
+$stdoutQueue = $null
 
 # ---------- Async wait helper ----------
 function Wait-ForRegexWithTimeout {
-    param([string]$Pattern,[string]$Context,[int]$TimeoutMs = 0)
+    param(
+        [string]$Pattern,
+        [string]$Context,
+        [int]$TimeoutMs = 0,
+        [System.Collections.Concurrent.ConcurrentQueue[string]]$Queue
+    )
+
+    if (-not $Queue) {
+        throw 'Wait-ForRegexWithTimeout requires a queue instance.'
+    }
     $regex = if ([string]::IsNullOrWhiteSpace($Pattern)) { $null } else { [regex]$Pattern }
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     while ($true) {
         $line = $null
-        if ($script:stdoutQueue -and $script:stdoutQueue.TryDequeue([ref]$line)) {
+        if ($Queue.TryDequeue([ref]$line)) {
             if ($null -eq $regex) { return [PSCustomObject]@{ Line = $line } }
             $m = $regex.Match($line)
             if ($m.Success) { return [PSCustomObject]@{ Line = $line; Match = $m } }
@@ -236,40 +245,43 @@ try {
     if (-not $process.Start()) { throw "Failed to start 'java' process. Is Java on PATH?" }
 
     # Wire up async handlers for stdout/stderr
-    $script:stdoutQueue = [System.Collections.Concurrent.ConcurrentQueue[string]]::new()
+    $stdoutQueue = New-Object System.Collections.Concurrent.ConcurrentQueue[string]
 
-    $stdoutSubscription = Register-ObjectEvent -InputObject $process -EventName OutputDataReceived -Action {
+    $stdoutHandler = [System.Diagnostics.DataReceivedEventHandler]{
         param($sender,$eventArgs)
         $line = $eventArgs.Data
         if ($null -eq $line) { return }
-        $script:stdoutQueue.Enqueue($line) | Out-Null
+        $stdoutQueue.Enqueue($line) | Out-Null
         Write-LogAndMaybeConsole -Channel 'stdout' -Message $line
     }
 
-    $stderrSubscription = Register-ObjectEvent -InputObject $process -EventName ErrorDataReceived -Action {
+    $stderrHandler = [System.Diagnostics.DataReceivedEventHandler]{
         param($sender,$eventArgs)
         $line = $eventArgs.Data
         if ($null -eq $line) { return }
         Write-LogAndMaybeConsole -Channel 'stderr' -Message $line
     }
 
+    $process.add_OutputDataReceived($stdoutHandler)
+    $process.add_ErrorDataReceived($stderrHandler)
+
     $process.BeginOutputReadLine()
     $process.BeginErrorReadLine()
 
     # ---- Handshake using async queue ----
     Send-UciCommand -Command 'uci'
-    if (-not (Wait-ForRegexWithTimeout -Pattern '^uciok$' -Context 'uci handshake' -TimeoutMs 10000)) {
+    if (-not (Wait-ForRegexWithTimeout -Pattern '^uciok$' -Context 'uci handshake' -TimeoutMs 10000 -Queue $stdoutQueue)) {
         throw "Timeout waiting for uciok."
     }
 
     Send-UciCommand -Command 'isready'
-    if (-not (Wait-ForRegexWithTimeout -Pattern '^readyok$' -Context 'engine readiness' -TimeoutMs 10000)) {
+    if (-not (Wait-ForRegexWithTimeout -Pattern '^readyok$' -Context 'engine readiness' -TimeoutMs 10000 -Queue $stdoutQueue)) {
         throw "Timeout waiting for readyok."
     }
 
     Send-UciCommand -Command 'ucinewgame'
     Send-UciCommand -Command 'isready'
-    if (-not (Wait-ForRegexWithTimeout -Pattern '^readyok$' -Context 'new game readiness' -TimeoutMs 10000)) {
+    if (-not (Wait-ForRegexWithTimeout -Pattern '^readyok$' -Context 'new game readiness' -TimeoutMs 10000 -Queue $stdoutQueue)) {
         throw "Timeout waiting for readyok after ucinewgame."
     }
 
@@ -283,13 +295,15 @@ try {
 
         $bestMoveResult = Wait-ForRegexWithTimeout -Pattern $bestMovePattern `
             -Context ("bestmove response for ply $ply") `
-            -TimeoutMs ([Math]::Max($MoveTimeMs * 5, 5000))
+            -TimeoutMs ([Math]::Max($MoveTimeMs * 5, 5000)) `
+            -Queue $stdoutQueue
 
         if ($null -eq $bestMoveResult) {
             Send-UciCommand -Command 'stop'
             $bestMoveResult = Wait-ForRegexWithTimeout -Pattern $bestMovePattern `
                 -Context ("bestmove (post-stop) for ply $ply") `
-                -TimeoutMs 3000
+                -TimeoutMs 3000 `
+                -Queue $stdoutQueue
         }
 
         if ($null -eq $bestMoveResult) {
@@ -308,7 +322,7 @@ try {
         $moveHistory.Add($bestMove)
 
         Send-UciCommand -Command 'isready'
-        if (-not (Wait-ForRegexWithTimeout -Pattern '^readyok$' -Context ("post-move readiness for ply $ply") -TimeoutMs 10000)) {
+        if (-not (Wait-ForRegexWithTimeout -Pattern '^readyok$' -Context ("post-move readiness for ply $ply") -TimeoutMs 10000 -Queue $stdoutQueue)) {
             throw "Timeout waiting for readyok after ply $ply."
         }
     }
@@ -346,18 +360,8 @@ catch {
 finally {
     try { if ($process) { $process.CancelOutputRead() } } catch {}
     try { if ($process) { $process.CancelErrorRead() } } catch {}
-    try {
-        if ($stdoutSubscription) {
-            Unregister-Event -SubscriptionId $stdoutSubscription.Id -ErrorAction SilentlyContinue
-            Remove-Event -SourceIdentifier $stdoutSubscription.SourceIdentifier -ErrorAction SilentlyContinue
-        }
-    } catch {}
-    try {
-        if ($stderrSubscription) {
-            Unregister-Event -SubscriptionId $stderrSubscription.Id -ErrorAction SilentlyContinue
-            Remove-Event -SourceIdentifier $stderrSubscription.SourceIdentifier -ErrorAction SilentlyContinue
-        }
-    } catch {}
+    try { if ($process -and $stdoutHandler) { $process.remove_OutputDataReceived($stdoutHandler) } } catch {}
+    try { if ($process -and $stderrHandler) { $process.remove_ErrorDataReceived($stderrHandler) } } catch {}
     $logWriter.Dispose()
 }
 


### PR DESCRIPTION
## Summary
- replace `Register-ObjectEvent` usage in `profile-engine.ps1` with explicit `DataReceivedEventHandler` delegates so the UCI output queue is populated reliably
- require the wait helper to receive the shared stdout queue and pass it through each call to avoid losing events
- clean up the registered handlers during disposal

## Testing
- Not run (PowerShell is unavailable in the container environment)

------
https://chatgpt.com/codex/tasks/task_e_68d6b0e5095c832abb48f6a22eaa45e9