### PR TITLE
Use lightweight BitBoard snapshots in evaluation

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -171,6 +171,10 @@ public class BitBoard {
     }
 
     public BitBoard(BitBoard other) {
+        this(other, true);
+    }
+
+    private BitBoard(BitBoard other, boolean includeHistory) {
         // Copying all the long fields representing the pieces
         this.bishopHelper = other.bishopHelper;
         this.rookHelper = other.rookHelper;
@@ -215,8 +219,15 @@ public class BitBoard {
         this.pieceBoard = Arrays.copyOf(other.pieceBoard, other.pieceBoard.length);
         this.halfmoveClock = other.halfmoveClock;
         this.fullmoveNumber = other.fullmoveNumber;
-        this.halfmoveHistory.addAll(other.halfmoveHistory);
-        this.fullmoveHistory.addAll(other.fullmoveHistory);
+
+        if (includeHistory) {
+            this.halfmoveHistory.addAll(other.halfmoveHistory);
+            this.fullmoveHistory.addAll(other.fullmoveHistory);
+        }
+    }
+
+    public BitBoard snapshotWithoutHistory() {
+        return new BitBoard(this, false);
     }
     public void setLastMoveDoubleStepPawnIndex(int index) {
         int oldEp = getEnPassantTargetIndex();

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationContext.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationContext.java
@@ -31,7 +31,7 @@ public final class EvaluationContext {
 
     public static EvaluationContext from(BitBoard bitBoard, GameStateEnum gameState) {
         Objects.requireNonNull(bitBoard, "bitBoard");
-        BitBoard snapshot = new BitBoard(bitBoard);
+        BitBoard snapshot = bitBoard.snapshotWithoutHistory();
         long whiteAttacks = bitBoard.getAttackBitboard(true);
         long blackAttacks = bitBoard.getAttackBitboard(false);
         return new EvaluationContext(snapshot, gameState, bitBoard.getPhase(), whiteAttacks, blackAttacks,
@@ -63,6 +63,6 @@ public final class EvaluationContext {
     }
 
     public EvaluationContext copy() {
-        return new EvaluationContext(new BitBoard(board), gameState, phase, whiteAttackMap, blackAttackMap, whiteToMove);
+        return new EvaluationContext(board.snapshotWithoutHistory(), gameState, phase, whiteAttackMap, blackAttackMap, whiteToMove);
     }
 }

--- a/src/test/java/julius/game/chessengine/evaluation/LightweightSnapshotEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/evaluation/LightweightSnapshotEvaluationTest.java
@@ -1,0 +1,70 @@
+package julius.game.chessengine.evaluation;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.board.MoveList;
+import julius.game.chessengine.utils.Score;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LightweightSnapshotEvaluationTest {
+
+    private static final String COMPLEX_FEN = "r3k2r/pppb1ppp/2n1bn2/2Pp4/3P4/2N1PN2/PPPB1PPP/R3K2R w KQkq d6 7 12";
+
+    @Test
+    void evaluationSnapshotsRemainLightweightAndAccurate() {
+        BitBoard board = FEN.translateFENtoBitBoard(COMPLEX_FEN);
+        BitBoard baseline = new BitBoard(board);
+
+        Score score = Score.initializeScore(board);
+        Score baselineScore = Score.initializeScore(baseline);
+
+        int baselineMidgame = baselineScore.getMidgameScore();
+        int baselineEndgame = baselineScore.getEndgameScore();
+        int baselineBlended = baselineScore.getBlendedScore();
+
+        long baselineWhiteAttacks = baseline.getAttackBitboard(true);
+        long baselineBlackAttacks = baseline.getAttackBitboard(false);
+        int baselinePhase = baseline.getPhase();
+        long baselineHash = baseline.getBoardStateHash();
+
+        Deque<Integer> played = new ArrayDeque<>();
+
+        for (int ply = 0; ply < 6; ply++) {
+            MoveList moves = board.getAllCurrentPossibleMoves();
+            assertTrue(moves.size() > 0, "No legal move available at ply " + ply);
+            int move = moves.getMove(0);
+            played.push(move);
+            board.performMove(move);
+            score.applyMove(board, move, null);
+        }
+
+        score.refresh(board, null);
+
+        while (!played.isEmpty()) {
+            int move = played.pop();
+            board.undoMove(move);
+            score.undoMove(board, move, null);
+        }
+
+        score.refresh(board, null);
+
+        long finalWhiteAttacks = board.getAttackBitboard(true);
+        long finalBlackAttacks = board.getAttackBitboard(false);
+
+        assertEquals(baseline, board, "Board state differs after undo sequence");
+        assertEquals(baselinePhase, board.getPhase(), "Phase mismatch after undo");
+        assertEquals(baselineWhiteAttacks, finalWhiteAttacks, "White attack map mismatch");
+        assertEquals(baselineBlackAttacks, finalBlackAttacks, "Black attack map mismatch");
+        assertEquals(baselineHash, board.getBoardStateHash(), "Zobrist hash mismatch after undo");
+
+        assertEquals(baselineMidgame, score.getMidgameScore(), "Midgame score changed after refresh/undo cycle");
+        assertEquals(baselineEndgame, score.getEndgameScore(), "Endgame score changed after refresh/undo cycle");
+        assertEquals(baselineBlended, score.getBlendedScore(), "Blended score changed after refresh/undo cycle");
+    }
+}


### PR DESCRIPTION
## Summary
- add a BitBoard snapshot path that skips copying historical move stacks
- update EvaluationContext cloning to rely on the lightweight snapshots
- add a regression test to ensure score refresh/apply/undo cycles remain consistent after multiple moves

## Testing
- ./mvnw -q test *(fails: Maven wrapper cannot download due to network restrictions)*
- mvn -q test *(fails: local JDK does not support release 25 target)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c32669c4832ab52088b5f0a6ad36