### PR TITLE
Introduce immutable board snapshots for evaluation pipeline

### DIFF
--- a/src/main/java/julius/game/chessengine/board/ImmutableBoardView.java
+++ b/src/main/java/julius/game/chessengine/board/ImmutableBoardView.java
@@ -1,0 +1,260 @@
+package julius.game.chessengine.board;
+
+import julius.game.chessengine.figures.PieceType;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Lightweight, read-only projection of a {@link BitBoard}'s tactical state. The
+ * evaluation pipeline can reuse instances of this class to avoid repeatedly
+ * cloning {@link BitBoard} objects while still exposing all data required by the
+ * evaluation modules.
+ */
+public final class ImmutableBoardView {
+
+    private boolean whitesTurn;
+    private long whitePawns;
+    private long blackPawns;
+    private long whiteKnights;
+    private long blackKnights;
+    private long whiteBishops;
+    private long blackBishops;
+    private long whiteRooks;
+    private long blackRooks;
+    private long whiteQueens;
+    private long blackQueens;
+    private long whiteKing;
+    private long blackKing;
+    private long whitePieces;
+    private long blackPieces;
+    private long allPieces;
+    private long whiteAttackMap;
+    private long blackAttackMap;
+    private int lastMoveDoubleStepPawnIndex;
+    private boolean whiteKingMoved;
+    private boolean blackKingMoved;
+    private boolean whiteRookA1Moved;
+    private boolean whiteRookH1Moved;
+    private boolean blackRookA8Moved;
+    private boolean blackRookH8Moved;
+    private boolean whiteKingHasCastled;
+    private boolean blackKingHasCastled;
+    private int halfmoveClock;
+    private int fullmoveNumber;
+    private final PieceType[] pieceBoard = new PieceType[64];
+
+    private ImmutableBoardView() {
+    }
+
+    private ImmutableBoardView(ImmutableBoardView other) {
+        copyFrom(other);
+    }
+
+    public static ImmutableBoardView from(BitBoard source) {
+        Objects.requireNonNull(source, "source");
+        ImmutableBoardView view = new ImmutableBoardView();
+        view.copyFrom(source);
+        return view;
+    }
+
+    public ImmutableBoardView copy() {
+        return new ImmutableBoardView(this);
+    }
+
+    public void copyFrom(BitBoard source) {
+        Objects.requireNonNull(source, "source");
+        this.whitesTurn = source.isWhitesTurn();
+        this.whitePawns = source.getWhitePawns();
+        this.blackPawns = source.getBlackPawns();
+        this.whiteKnights = source.getWhiteKnights();
+        this.blackKnights = source.getBlackKnights();
+        this.whiteBishops = source.getWhiteBishops();
+        this.blackBishops = source.getBlackBishops();
+        this.whiteRooks = source.getWhiteRooks();
+        this.blackRooks = source.getBlackRooks();
+        this.whiteQueens = source.getWhiteQueens();
+        this.blackQueens = source.getBlackQueens();
+        this.whiteKing = source.getWhiteKing();
+        this.blackKing = source.getBlackKing();
+        this.whitePieces = source.getWhitePieces();
+        this.blackPieces = source.getBlackPieces();
+        this.allPieces = source.getAllPieces();
+        this.lastMoveDoubleStepPawnIndex = source.getLastMoveDoubleStepPawnIndex();
+        this.whiteKingMoved = source.isWhiteKingMoved();
+        this.blackKingMoved = source.isBlackKingMoved();
+        this.whiteRookA1Moved = source.isWhiteRookA1Moved();
+        this.whiteRookH1Moved = source.isWhiteRookH1Moved();
+        this.blackRookA8Moved = source.isBlackRookA8Moved();
+        this.blackRookH8Moved = source.isBlackRookH8Moved();
+        this.whiteKingHasCastled = source.isWhiteKingHasCastled();
+        this.blackKingHasCastled = source.isBlackKingHasCastled();
+        this.halfmoveClock = source.getHalfmoveClock();
+        this.fullmoveNumber = source.getFullmoveNumber();
+        PieceType[] sourcePieces = source.getPieceBoard();
+        System.arraycopy(sourcePieces, 0, this.pieceBoard, 0, this.pieceBoard.length);
+        this.whiteAttackMap = source.getAttackBitboard(true);
+        this.blackAttackMap = source.getAttackBitboard(false);
+    }
+
+    public void copyFrom(ImmutableBoardView other) {
+        Objects.requireNonNull(other, "other");
+        this.whitesTurn = other.whitesTurn;
+        this.whitePawns = other.whitePawns;
+        this.blackPawns = other.blackPawns;
+        this.whiteKnights = other.whiteKnights;
+        this.blackKnights = other.blackKnights;
+        this.whiteBishops = other.whiteBishops;
+        this.blackBishops = other.blackBishops;
+        this.whiteRooks = other.whiteRooks;
+        this.blackRooks = other.blackRooks;
+        this.whiteQueens = other.whiteQueens;
+        this.blackQueens = other.blackQueens;
+        this.whiteKing = other.whiteKing;
+        this.blackKing = other.blackKing;
+        this.whitePieces = other.whitePieces;
+        this.blackPieces = other.blackPieces;
+        this.allPieces = other.allPieces;
+        this.whiteAttackMap = other.whiteAttackMap;
+        this.blackAttackMap = other.blackAttackMap;
+        this.lastMoveDoubleStepPawnIndex = other.lastMoveDoubleStepPawnIndex;
+        this.whiteKingMoved = other.whiteKingMoved;
+        this.blackKingMoved = other.blackKingMoved;
+        this.whiteRookA1Moved = other.whiteRookA1Moved;
+        this.whiteRookH1Moved = other.whiteRookH1Moved;
+        this.blackRookA8Moved = other.blackRookA8Moved;
+        this.blackRookH8Moved = other.blackRookH8Moved;
+        this.whiteKingHasCastled = other.whiteKingHasCastled;
+        this.blackKingHasCastled = other.blackKingHasCastled;
+        this.halfmoveClock = other.halfmoveClock;
+        this.fullmoveNumber = other.fullmoveNumber;
+        System.arraycopy(other.pieceBoard, 0, this.pieceBoard, 0, this.pieceBoard.length);
+    }
+
+    public boolean isWhitesTurn() {
+        return whitesTurn;
+    }
+
+    public long getWhitePawns() {
+        return whitePawns;
+    }
+
+    public long getBlackPawns() {
+        return blackPawns;
+    }
+
+    public long getWhiteKnights() {
+        return whiteKnights;
+    }
+
+    public long getBlackKnights() {
+        return blackKnights;
+    }
+
+    public long getWhiteBishops() {
+        return whiteBishops;
+    }
+
+    public long getBlackBishops() {
+        return blackBishops;
+    }
+
+    public long getWhiteRooks() {
+        return whiteRooks;
+    }
+
+    public long getBlackRooks() {
+        return blackRooks;
+    }
+
+    public long getWhiteQueens() {
+        return whiteQueens;
+    }
+
+    public long getBlackQueens() {
+        return blackQueens;
+    }
+
+    public long getWhiteKing() {
+        return whiteKing;
+    }
+
+    public long getBlackKing() {
+        return blackKing;
+    }
+
+    public long getWhitePieces() {
+        return whitePieces;
+    }
+
+    public long getBlackPieces() {
+        return blackPieces;
+    }
+
+    public long getAllPieces() {
+        return allPieces;
+    }
+
+    public long getWhiteAttackMap() {
+        return whiteAttackMap;
+    }
+
+    public long getBlackAttackMap() {
+        return blackAttackMap;
+    }
+
+    public int getLastMoveDoubleStepPawnIndex() {
+        return lastMoveDoubleStepPawnIndex;
+    }
+
+    public boolean isWhiteKingMoved() {
+        return whiteKingMoved;
+    }
+
+    public boolean isBlackKingMoved() {
+        return blackKingMoved;
+    }
+
+    public boolean isWhiteRookA1Moved() {
+        return whiteRookA1Moved;
+    }
+
+    public boolean isWhiteRookH1Moved() {
+        return whiteRookH1Moved;
+    }
+
+    public boolean isBlackRookA8Moved() {
+        return blackRookA8Moved;
+    }
+
+    public boolean isBlackRookH8Moved() {
+        return blackRookH8Moved;
+    }
+
+    public boolean isWhiteKingHasCastled() {
+        return whiteKingHasCastled;
+    }
+
+    public boolean isBlackKingHasCastled() {
+        return blackKingHasCastled;
+    }
+
+    public int getHalfmoveClock() {
+        return halfmoveClock;
+    }
+
+    public int getFullmoveNumber() {
+        return fullmoveNumber;
+    }
+
+    public PieceType getPieceTypeAtIndex(int index) {
+        if (index < 0 || index >= pieceBoard.length) {
+            throw new IndexOutOfBoundsException("Square index out of range: " + index);
+        }
+        return pieceBoard[index];
+    }
+
+    public PieceType[] getPieceBoard() {
+        return Arrays.copyOf(pieceBoard, pieceBoard.length);
+    }
+}

--- a/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
@@ -1,7 +1,7 @@
 package julius.game.chessengine.evaluation;
 
-import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.BishopHelper;
 import julius.game.chessengine.helper.KingHelper;
@@ -9,6 +9,7 @@ import julius.game.chessengine.helper.KnightHelper;
 import julius.game.chessengine.helper.RookHelper;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Tracks piece activity (mobility plus center control) with separate midgame/endgame
@@ -134,7 +135,7 @@ public final class ActivityModule implements EvaluationModule {
 
     @Override
     public void initialize(EvaluationContext context) {
-        rebuildFromBoard(context.getBoard());
+        rebuildFromBoard(Objects.requireNonNull(context, "context").getBoardView());
         initialized = true;
     }
 
@@ -143,7 +144,7 @@ public final class ActivityModule implements EvaluationModule {
         if (!dirty) {
             return;
         }
-        rebuildFromBoard(context.getBoard());
+        rebuildFromBoard(Objects.requireNonNull(context, "context").getBoardView());
     }
 
     @Override
@@ -153,7 +154,7 @@ public final class ActivityModule implements EvaluationModule {
         }
         boolean forward = isForwardMove(moveContext);
         if (!updateForMove(moveContext.getMove(), forward)) {
-            rebuildFromBoard(moveContext.getCurrentContext().getBoard());
+            rebuildFromBoard(moveContext.getCurrentContext().getBoardView());
         }
     }
 
@@ -398,7 +399,7 @@ public final class ActivityModule implements EvaluationModule {
         return pieceType == BISHOP || pieceType == ROOK || pieceType == QUEEN;
     }
 
-    private void rebuildFromBoard(BitBoard board) {
+    private void rebuildFromBoard(ImmutableBoardView board) {
         Arrays.fill(midgameTotals, 0);
         Arrays.fill(endgameTotals, 0);
         for (PieceActivity activity : activities) {

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationContext.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationContext.java
@@ -1,7 +1,9 @@
 package julius.game.chessengine.evaluation;
 
 import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.figures.PieceType;
 
 import java.util.Objects;
 
@@ -12,34 +14,35 @@ import java.util.Objects;
  */
 public final class EvaluationContext {
 
-    private final BitBoard board;
-    private final GameStateEnum gameState;
-    private final int phase;
-    private final long whiteAttackMap;
-    private final long blackAttackMap;
-    private final boolean whiteToMove;
+    private final ImmutableBoardView boardView;
+    private GameStateEnum gameState;
+    private int phase;
+    private long whiteAttackMap;
+    private long blackAttackMap;
 
-    private EvaluationContext(BitBoard board, GameStateEnum gameState, int phase,
-                              long whiteAttackMap, long blackAttackMap, boolean whiteToMove) {
-        this.board = Objects.requireNonNull(board, "board");
+    private EvaluationContext(ImmutableBoardView boardView, GameStateEnum gameState, int phase,
+                              long whiteAttackMap, long blackAttackMap) {
+        this.boardView = Objects.requireNonNull(boardView, "boardView");
         this.gameState = gameState;
         this.phase = phase;
         this.whiteAttackMap = whiteAttackMap;
         this.blackAttackMap = blackAttackMap;
-        this.whiteToMove = whiteToMove;
     }
 
     public static EvaluationContext from(BitBoard bitBoard, GameStateEnum gameState) {
         Objects.requireNonNull(bitBoard, "bitBoard");
-        BitBoard snapshot = bitBoard.snapshotWithoutHistory();
-        long whiteAttacks = bitBoard.getAttackBitboard(true);
-        long blackAttacks = bitBoard.getAttackBitboard(false);
-        return new EvaluationContext(snapshot, gameState, bitBoard.getPhase(), whiteAttacks, blackAttacks,
-                bitBoard.isWhitesTurn());
+        ImmutableBoardView view = ImmutableBoardView.from(bitBoard);
+        return new EvaluationContext(view, gameState, bitBoard.getPhase(),
+                view.getWhiteAttackMap(), view.getBlackAttackMap());
     }
 
-    public BitBoard getBoard() {
-        return board;
+    public void updateFrom(BitBoard bitBoard, GameStateEnum gameState) {
+        Objects.requireNonNull(bitBoard, "bitBoard");
+        boardView.copyFrom(bitBoard);
+        this.gameState = gameState;
+        this.phase = bitBoard.getPhase();
+        this.whiteAttackMap = boardView.getWhiteAttackMap();
+        this.blackAttackMap = boardView.getBlackAttackMap();
     }
 
     public GameStateEnum getGameState() {
@@ -59,10 +62,122 @@ public final class EvaluationContext {
     }
 
     public boolean isWhiteToMove() {
-        return whiteToMove;
+        return boardView.isWhitesTurn();
+    }
+
+    public long getWhitePawns() {
+        return boardView.getWhitePawns();
+    }
+
+    public long getBlackPawns() {
+        return boardView.getBlackPawns();
+    }
+
+    public long getWhiteKnights() {
+        return boardView.getWhiteKnights();
+    }
+
+    public long getBlackKnights() {
+        return boardView.getBlackKnights();
+    }
+
+    public long getWhiteBishops() {
+        return boardView.getWhiteBishops();
+    }
+
+    public long getBlackBishops() {
+        return boardView.getBlackBishops();
+    }
+
+    public long getWhiteRooks() {
+        return boardView.getWhiteRooks();
+    }
+
+    public long getBlackRooks() {
+        return boardView.getBlackRooks();
+    }
+
+    public long getWhiteQueens() {
+        return boardView.getWhiteQueens();
+    }
+
+    public long getBlackQueens() {
+        return boardView.getBlackQueens();
+    }
+
+    public long getWhiteKing() {
+        return boardView.getWhiteKing();
+    }
+
+    public long getBlackKing() {
+        return boardView.getBlackKing();
+    }
+
+    public long getWhitePieces() {
+        return boardView.getWhitePieces();
+    }
+
+    public long getBlackPieces() {
+        return boardView.getBlackPieces();
+    }
+
+    public long getAllPieces() {
+        return boardView.getAllPieces();
+    }
+
+    public boolean isWhiteKingHasCastled() {
+        return boardView.isWhiteKingHasCastled();
+    }
+
+    public boolean isBlackKingHasCastled() {
+        return boardView.isBlackKingHasCastled();
+    }
+
+    public boolean isWhiteKingMoved() {
+        return boardView.isWhiteKingMoved();
+    }
+
+    public boolean isBlackKingMoved() {
+        return boardView.isBlackKingMoved();
+    }
+
+    public boolean isWhiteRookA1Moved() {
+        return boardView.isWhiteRookA1Moved();
+    }
+
+    public boolean isWhiteRookH1Moved() {
+        return boardView.isWhiteRookH1Moved();
+    }
+
+    public boolean isBlackRookA8Moved() {
+        return boardView.isBlackRookA8Moved();
+    }
+
+    public boolean isBlackRookH8Moved() {
+        return boardView.isBlackRookH8Moved();
+    }
+
+    public int getHalfmoveClock() {
+        return boardView.getHalfmoveClock();
+    }
+
+    public int getFullmoveNumber() {
+        return boardView.getFullmoveNumber();
+    }
+
+    public int getLastMoveDoubleStepPawnIndex() {
+        return boardView.getLastMoveDoubleStepPawnIndex();
+    }
+
+    public PieceType getPieceTypeAtIndex(int index) {
+        return boardView.getPieceTypeAtIndex(index);
+    }
+
+    public ImmutableBoardView getBoardView() {
+        return boardView;
     }
 
     public EvaluationContext copy() {
-        return new EvaluationContext(board.snapshotWithoutHistory(), gameState, phase, whiteAttackMap, blackAttackMap, whiteToMove);
+        return new EvaluationContext(boardView.copy(), gameState, phase, whiteAttackMap, blackAttackMap);
     }
 }

--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -1,7 +1,7 @@
 package julius.game.chessengine.evaluation;
 
-import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.BishopHelper;
 import julius.game.chessengine.helper.RookHelper;
@@ -138,10 +138,11 @@ public final class KingSafetyModule implements EvaluationModule {
             dirty = false;
             return currentView;
         }
-        long whiteAttacks = board.getAttackBitboard(true);
-        long blackAttacks = board.getAttackBitboard(false);
-        rebuildSideState(sideStates[WHITE], board, true, whiteAttacks, blackAttacks);
-        rebuildSideState(sideStates[BLACK], board, false, blackAttacks, whiteAttacks);
+        ImmutableBoardView view = ImmutableBoardView.from(board);
+        long whiteAttacks = view.getWhiteAttackMap();
+        long blackAttacks = view.getBlackAttackMap();
+        rebuildSideState(sideStates[WHITE], view, true, whiteAttacks, blackAttacks);
+        rebuildSideState(sideStates[BLACK], view, false, blackAttacks, whiteAttacks);
         refreshScoreCaches();
         dirty = false;
         return currentView;
@@ -152,7 +153,7 @@ public final class KingSafetyModule implements EvaluationModule {
     }
 
     private void rebuildFromContext(EvaluationContext context) {
-        BitBoard board = context.getBoard();
+        ImmutableBoardView board = Objects.requireNonNull(context, "context").getBoardView();
         long whiteAttacks = context.getWhiteAttackMap();
         long blackAttacks = context.getBlackAttackMap();
         rebuildSideState(sideStates[WHITE], board, true, whiteAttacks, blackAttacks);
@@ -214,8 +215,8 @@ public final class KingSafetyModule implements EvaluationModule {
                 return true;
             }
         }
-        BitBoard previousBoard = previous.getBoard();
-        BitBoard currentBoard = current.getBoard();
+        ImmutableBoardView previousBoard = previous.getBoardView();
+        ImmutableBoardView currentBoard = current.getBoardView();
         long prevQueens = side == WHITE ? previousBoard.getWhiteQueens() : previousBoard.getBlackQueens();
         long currQueens = side == WHITE ? currentBoard.getWhiteQueens() : currentBoard.getBlackQueens();
         if (prevQueens != currQueens) {
@@ -235,7 +236,8 @@ public final class KingSafetyModule implements EvaluationModule {
         return false;
     }
 
-    private void rebuildSideState(SideState state, BitBoard board, boolean isWhite, long friendlyAttacks, long enemyAttacks) {
+    private void rebuildSideState(SideState state, ImmutableBoardView board, boolean isWhite,
+                                  long friendlyAttacks, long enemyAttacks) {
         state.reset();
         long kingBits = isWhite ? board.getWhiteKing() : board.getBlackKing();
         if (kingBits == 0) {
@@ -305,7 +307,7 @@ public final class KingSafetyModule implements EvaluationModule {
         state.endgameQueenPenalty = queenEnd;
     }
 
-    private void computeBackrankWeaknessPenalty(SideState state, BitBoard board, boolean isWhite) {
+    private void computeBackrankWeaknessPenalty(SideState state, ImmutableBoardView board, boolean isWhite) {
         state.backrankWeaknessMidgame = 0;
         state.backrankWeaknessEndgame = 0;
         if (state.kingSquare < 0) {
@@ -371,7 +373,7 @@ public final class KingSafetyModule implements EvaluationModule {
         return mask;
     }
 
-    private long computeFriendlyNonKingAttacks(BitBoard board, boolean isWhite) {
+    private long computeFriendlyNonKingAttacks(ImmutableBoardView board, boolean isWhite) {
         long attacks = 0L;
         long occupancy = board.getAllPieces();
 

--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -1,5 +1,6 @@
 package julius.game.chessengine.evaluation;
 
+import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;

--- a/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
@@ -1,8 +1,8 @@
 package julius.game.chessengine.evaluation;
 
 import java.util.Arrays;
+import java.util.Objects;
 
-import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.figures.PieceType;
 /**
@@ -61,7 +61,7 @@ public final class MaterialModule implements EvaluationModule {
 
     @Override
     public void initialize(EvaluationContext context) {
-        rebuildFromBoard(context.getBoard());
+        rebuildFromContext(Objects.requireNonNull(context, "context"));
     }
 
     @Override
@@ -69,7 +69,7 @@ public final class MaterialModule implements EvaluationModule {
         if (!dirty) {
             return;
         }
-        rebuildFromBoard(context.getBoard());
+        rebuildFromContext(Objects.requireNonNull(context, "context"));
     }
 
     @Override
@@ -158,22 +158,22 @@ public final class MaterialModule implements EvaluationModule {
         updateScoreCaches();
     }
 
-    private void rebuildFromBoard(BitBoard board) {
+    private void rebuildFromContext(EvaluationContext context) {
         Arrays.fill(midgameMaterial, 0);
         Arrays.fill(endgameMaterial, 0);
         Arrays.fill(bishopCounts, 0);
 
-        accumulatePieces(WHITE, PAWN, Long.bitCount(board.getWhitePawns()));
-        accumulatePieces(WHITE, KNIGHT, Long.bitCount(board.getWhiteKnights()));
-        accumulatePieces(WHITE, BISHOP, Long.bitCount(board.getWhiteBishops()));
-        accumulatePieces(WHITE, ROOK, Long.bitCount(board.getWhiteRooks()));
-        accumulatePieces(WHITE, QUEEN, Long.bitCount(board.getWhiteQueens()));
+        accumulatePieces(WHITE, PAWN, Long.bitCount(context.getWhitePawns()));
+        accumulatePieces(WHITE, KNIGHT, Long.bitCount(context.getWhiteKnights()));
+        accumulatePieces(WHITE, BISHOP, Long.bitCount(context.getWhiteBishops()));
+        accumulatePieces(WHITE, ROOK, Long.bitCount(context.getWhiteRooks()));
+        accumulatePieces(WHITE, QUEEN, Long.bitCount(context.getWhiteQueens()));
 
-        accumulatePieces(BLACK, PAWN, Long.bitCount(board.getBlackPawns()));
-        accumulatePieces(BLACK, KNIGHT, Long.bitCount(board.getBlackKnights()));
-        accumulatePieces(BLACK, BISHOP, Long.bitCount(board.getBlackBishops()));
-        accumulatePieces(BLACK, ROOK, Long.bitCount(board.getBlackRooks()));
-        accumulatePieces(BLACK, QUEEN, Long.bitCount(board.getBlackQueens()));
+        accumulatePieces(BLACK, PAWN, Long.bitCount(context.getBlackPawns()));
+        accumulatePieces(BLACK, KNIGHT, Long.bitCount(context.getBlackKnights()));
+        accumulatePieces(BLACK, BISHOP, Long.bitCount(context.getBlackBishops()));
+        accumulatePieces(BLACK, ROOK, Long.bitCount(context.getBlackRooks()));
+        accumulatePieces(BLACK, QUEEN, Long.bitCount(context.getBlackQueens()));
 
         updateScoreCaches();
         dirty = false;

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -1,7 +1,7 @@
 package julius.game.chessengine.evaluation;
 
-import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.PawnHelper;
 
@@ -60,17 +60,25 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
 
     @Override
     public void initialize(EvaluationContext context) {
-        BitBoard board = Objects.requireNonNull(context, "context").getBoard();
         markAllFilesDirty();
-        evaluate(board);
+        evaluateContext(Objects.requireNonNull(context, "context"));
     }
 
     @Override
     public void evaluate(EvaluationContext context) {
-        evaluate(Objects.requireNonNull(context, "context").getBoard());
+        evaluateContext(Objects.requireNonNull(context, "context"));
     }
 
-    public PawnStructureView evaluate(BitBoard board) {
+    private PawnStructureView evaluateContext(EvaluationContext context) {
+        if (context == null) {
+            currentView = PawnStructureView.empty();
+            midgameScoreCache = 0;
+            endgameScoreCache = 0;
+            dirty = false;
+            metadataDirty = false;
+            return currentView;
+        }
+        ImmutableBoardView board = context.getBoardView();
         if (board == null) {
             currentView = PawnStructureView.empty();
             midgameScoreCache = 0;
@@ -89,8 +97,8 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         long allPieces = board.getAllPieces();
         long whiteRooks = board.getWhiteRooks();
         long blackRooks = board.getBlackRooks();
-        long whiteAttacks = board.getAttackBitboard(true);
-        long blackAttacks = board.getAttackBitboard(false);
+        long whiteAttacks = context.getWhiteAttackMap();
+        long blackAttacks = context.getBlackAttackMap();
         long whiteKing = board.getWhiteKing();
         long blackKing = board.getBlackKing();
 
@@ -255,10 +263,21 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     }
 
     public PawnStructureView getView(BitBoard board) {
-        return evaluate(board);
+        if (board == null) {
+            return evaluateContext(null);
+        }
+        EvaluationContext context = EvaluationContext.from(board, null);
+        return evaluateContext(context);
     }
 
     public int countHalfOpenFilesWithRooks(BitBoard board, long rooksBitboard, boolean isWhite) {
+        if (board == null) {
+            return 0;
+        }
+        return countHalfOpenFilesWithRooks(ImmutableBoardView.from(board), rooksBitboard, isWhite);
+    }
+
+    private int countHalfOpenFilesWithRooks(ImmutableBoardView board, long rooksBitboard, boolean isWhite) {
         if (rooksBitboard == 0L) {
             return 0;
         }
@@ -283,6 +302,13 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     }
 
     public int countOpenFilesWithRooks(BitBoard board, long rooksBitboard) {
+        if (board == null) {
+            return 0;
+        }
+        return countOpenFilesWithRooks(ImmutableBoardView.from(board), rooksBitboard);
+    }
+
+    private int countOpenFilesWithRooks(ImmutableBoardView board, long rooksBitboard) {
         if (rooksBitboard == 0L) {
             return 0;
         }
@@ -326,7 +352,7 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         }
     }
 
-    private void refreshFileMetadata(BitBoard board) {
+    private void refreshFileMetadata(ImmutableBoardView board) {
         if (!metadataDirty || board == null) {
             return;
         }

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -1,5 +1,6 @@
 package julius.game.chessengine.evaluation;
 
+import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;

--- a/src/main/java/julius/game/chessengine/evaluation/PieceSquareModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PieceSquareModule.java
@@ -1,9 +1,10 @@
 package julius.game.chessengine.evaluation;
 
 import java.util.Arrays;
+import java.util.Objects;
 
-import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
 
 import static julius.game.chessengine.evaluation.MaterialModule.BISHOP_VALUE;
@@ -145,10 +146,11 @@ public final class PieceSquareModule implements EvaluationModule {
 
     @Override
     public void initialize(EvaluationContext context) {
-        rebuildFromBoard(context.getBoard());
+        ImmutableBoardView board = Objects.requireNonNull(context, "context").getBoardView();
+        rebuildFromBoard(board);
         currentPhase = clampPhase(context.getPhase());
         recalculateDevelopmentContribution();
-        recalculateCastlingContribution(context.getBoard(), currentPhase);
+        recalculateCastlingContribution(board, currentPhase);
         dirty = false;
         initialized = true;
     }
@@ -158,10 +160,11 @@ public final class PieceSquareModule implements EvaluationModule {
         if (!dirty) {
             return;
         }
-        rebuildFromBoard(context.getBoard());
+        ImmutableBoardView board = Objects.requireNonNull(context, "context").getBoardView();
+        rebuildFromBoard(board);
         currentPhase = clampPhase(context.getPhase());
         recalculateDevelopmentContribution();
-        recalculateCastlingContribution(context.getBoard(), currentPhase);
+        recalculateCastlingContribution(board, currentPhase);
         dirty = false;
     }
 
@@ -173,7 +176,7 @@ public final class PieceSquareModule implements EvaluationModule {
         boolean forward = isForwardMove(moveContext);
         castlingDirty = true;
         if (!updateForMove(moveContext.getMove(), forward)) {
-            rebuildFromBoard(moveContext.getCurrentContext().getBoard());
+            rebuildFromBoard(moveContext.getCurrentContext().getBoardView());
         }
         int phase = clampPhase(moveContext.getCurrentContext().getPhase());
         if (phase != currentPhase) {
@@ -184,7 +187,7 @@ public final class PieceSquareModule implements EvaluationModule {
             recalculateDevelopmentContribution();
         }
         if (castlingDirty) {
-            recalculateCastlingContribution(moveContext.getCurrentContext().getBoard(), currentPhase);
+            recalculateCastlingContribution(moveContext.getCurrentContext().getBoardView(), currentPhase);
         }
         dirty = false;
     }
@@ -494,7 +497,7 @@ public final class PieceSquareModule implements EvaluationModule {
         developmentDirty = false;
     }
 
-    private void recalculateCastlingContribution(BitBoard board, int phase) {
+    private void recalculateCastlingContribution(ImmutableBoardView board, int phase) {
         if (!castlingDirty) {
             return;
         }
@@ -513,7 +516,7 @@ public final class PieceSquareModule implements EvaluationModule {
         castlingDirty = false;
     }
 
-    private int computeCastlingContribution(BitBoard board, int phase) {
+    private int computeCastlingContribution(ImmutableBoardView board, int phase) {
         int materialBalance = computeMaterialBalance(board);
         int whiteAdjustment = computeCastlingAdjustment(
                 board.getWhiteKing(),
@@ -609,7 +612,7 @@ public final class PieceSquareModule implements EvaluationModule {
         return adjustment;
     }
 
-    private static int computeMaterialBalance(BitBoard board) {
+    private static int computeMaterialBalance(ImmutableBoardView board) {
         int whiteMaterial = Long.bitCount(board.getWhitePawns()) * PAWN_VALUE
                 + Long.bitCount(board.getWhiteKnights()) * KNIGHT_VALUE
                 + Long.bitCount(board.getWhiteBishops()) * BISHOP_VALUE
@@ -623,7 +626,7 @@ public final class PieceSquareModule implements EvaluationModule {
         return whiteMaterial - blackMaterial;
     }
 
-    private void rebuildFromBoard(BitBoard board) {
+    private void rebuildFromBoard(ImmutableBoardView board) {
         Arrays.fill(occupantColor, -1);
         Arrays.fill(occupantPiece, 0);
         Arrays.fill(midgameContributionBySquare, 0);

--- a/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
@@ -1,7 +1,7 @@
 package julius.game.chessengine.evaluation;
 
-import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
 
 import java.util.Objects;
@@ -56,7 +56,7 @@ public final class ThreatModule implements EvaluationModule {
             return;
         }
         Objects.requireNonNull(context, "context");
-        BitBoard board = context.getBoard();
+        ImmutableBoardView board = context.getBoardView();
         if (board == null) {
             midgameScoreCache = 0;
             endgameScoreCache = 0;
@@ -105,7 +105,7 @@ public final class ThreatModule implements EvaluationModule {
         dirty = true;
     }
 
-    private int evaluateSide(BitBoard board, boolean isWhite, long friendlyAttacks, long enemyAttacks) {
+    private int evaluateSide(ImmutableBoardView board, boolean isWhite, long friendlyAttacks, long enemyAttacks) {
         long pieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
         long enemyPawns = isWhite ? board.getBlackPawns() : board.getWhitePawns();
         int enemyPawnColor = isWhite ? BLACK : WHITE;

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -40,6 +40,8 @@ public class Score {
     private final EvaluationPipeline evaluationPipeline;
     @JsonIgnore
     private EvaluationContext evaluationContext;
+    @JsonIgnore
+    private EvaluationContext spareEvaluationContext;
 
     public Score() {
         materialModule.setPawnChangeListener(pawnStructureModule);
@@ -57,6 +59,9 @@ public class Score {
         this();
         if (other != null && other.evaluationContext != null) {
             this.evaluationContext = other.evaluationContext.copy();
+            if (other.spareEvaluationContext != null) {
+                this.spareEvaluationContext = other.spareEvaluationContext.copy();
+            }
             if (other.evaluationPipeline.isInitialized()) {
                 evaluationPipeline.initialize(this.evaluationContext);
             }
@@ -73,13 +78,18 @@ public class Score {
         Objects.requireNonNull(bitBoard, "bitBoard");
         EvaluationContext context = EvaluationContext.from(bitBoard, null);
         this.evaluationContext = context;
+        this.spareEvaluationContext = null;
         evaluationPipeline.initialize(context);
     }
 
     public void refresh(BitBoard bitBoard, GameStateEnum state) {
         Objects.requireNonNull(bitBoard, "bitBoard");
-        EvaluationContext updated = EvaluationContext.from(bitBoard, state);
-        this.evaluationContext = updated;
+        if (evaluationContext == null) {
+            evaluationContext = EvaluationContext.from(bitBoard, state);
+        } else {
+            evaluationContext.updateFrom(bitBoard, state);
+        }
+        EvaluationContext updated = evaluationContext;
 
         if (!evaluationPipeline.isInitialized()) {
             evaluationPipeline.initialize(updated);
@@ -94,32 +104,44 @@ public class Score {
     public void applyMove(BitBoard bitBoard, int move, GameStateEnum state) {
         Objects.requireNonNull(bitBoard, "bitBoard");
         EvaluationContext previous = this.evaluationContext;
-        EvaluationContext updated = EvaluationContext.from(bitBoard, state);
-        this.evaluationContext = updated;
+        EvaluationContext next = spareEvaluationContext;
+        if (next == null) {
+            next = EvaluationContext.from(bitBoard, state);
+        } else {
+            next.updateFrom(bitBoard, state);
+        }
+        this.evaluationContext = next;
+        this.spareEvaluationContext = previous;
 
-        if (previous == null || !evaluationPipeline.isInitialized()) {
-            evaluationPipeline.initialize(updated);
+        if (next == null || !evaluationPipeline.isInitialized()) {
+            evaluationPipeline.initialize(next);
             return;
         }
 
-        synchronizePipeline(updated);
-        MoveContext moveContext = new MoveContext(move, previous, updated);
+        synchronizePipeline(next);
+        MoveContext moveContext = new MoveContext(move, previous, next);
         evaluationPipeline.applyMove(moveContext);
     }
 
     public void undoMove(BitBoard bitBoard, int move, GameStateEnum state) {
         Objects.requireNonNull(bitBoard, "bitBoard");
         EvaluationContext previous = this.evaluationContext;
-        EvaluationContext updated = EvaluationContext.from(bitBoard, state);
-        this.evaluationContext = updated;
+        EvaluationContext next = spareEvaluationContext;
+        if (next == null) {
+            next = EvaluationContext.from(bitBoard, state);
+        } else {
+            next.updateFrom(bitBoard, state);
+        }
+        this.evaluationContext = next;
+        this.spareEvaluationContext = previous;
 
-        if (previous == null || !evaluationPipeline.isInitialized()) {
-            evaluationPipeline.initialize(updated);
+        if (next == null || !evaluationPipeline.isInitialized()) {
+            evaluationPipeline.initialize(next);
             return;
         }
 
-        synchronizePipeline(updated);
-        MoveContext moveContext = new MoveContext(move, previous, updated);
+        synchronizePipeline(next);
+        MoveContext moveContext = new MoveContext(move, previous, next);
         evaluationPipeline.undoMove(moveContext);
     }
 


### PR DESCRIPTION
## Summary
- add an `ImmutableBoardView` snapshot that mirrors the primitive bitboards and metadata without cloning `BitBoard`
- refactor `EvaluationContext` and evaluation modules to consume the lightweight snapshot accessors instead of `BitBoard` clones
- reuse `EvaluationContext` instances inside `Score` when applying or undoing moves

## Testing
- ./mvnw test *(fails: Maven wrapper cannot download dependencies because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6caf14798832a921a77127fbb1a1f