### PR TITLE
Remove synchronization from AI position change detection

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2131,7 +2131,14 @@ public class AI {
         return capturesAndPromotions;
     }
 
-    private synchronized boolean positionChanged() {
+    /**
+     * Checks whether the board hash has changed since the current search task started.
+     *
+     * <p>The hashes live in {@code volatile} fields, so this is a lock-free visibility check that
+     * avoids serialising worker threads on a monitor. The volatile semantics already provide the
+     * required cross-thread visibility.</p>
+     */
+    private boolean positionChanged() {
         return currentBoardState != beforeCalculationBoardState;
     }
 


### PR DESCRIPTION
## Summary
- drop the synchronized modifier from AI.positionChanged() to avoid monitor contention
- document that the method is a lock-free visibility check based on volatile board hash fields

## Testing
- `mvn -Dtest=MateSearchTest -Dchessengine.searchThreads=4 -Dchessengine.lazySmpThreads=2 -Dchessengine.rootParallelLimit=8 test` *(fails: build requires JDK 25, environment provides JDK 21)*

------
https://chatgpt.com/codex/tasks/task_e_68d6de3c966c832a94d00477a8c8d202