### PR TITLE
Use primitive long buffer for GameState repetition tracking

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -2,6 +2,7 @@ package julius.game.chessengine.engine;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.MoveList;
@@ -10,15 +11,11 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-
-
 @Data
 @Log4j2
 public class GameState {
 
-    private final Deque<Long> hashHistory = new ArrayDeque<>(256);
+    private final LongArrayList hashHistory = new LongArrayList(256);
     private final Long2IntOpenHashMap repetition;
     private final IntArrayList halfmoveStack = new IntArrayList();
     private final IntArrayList fullmoveStack = new IntArrayList();
@@ -155,7 +152,7 @@ public class GameState {
      * Threefold Repetition Logic
      */
     public void recordHash(long zKey) {
-        hashHistory.addLast(zKey);
+        hashHistory.add(zKey);
         repetition.addTo(zKey, 1);
         lastZobrist = zKey;
     }
@@ -168,8 +165,10 @@ public class GameState {
             else repetition.put(zKey, count - 1);
         }
         // We only ever remove the most recent
-        if (!hashHistory.isEmpty()) hashHistory.removeLast();
-        lastZobrist = hashHistory.isEmpty() ? 0L : hashHistory.getLast();
+        if (!hashHistory.isEmpty()) {
+            hashHistory.removeLong(hashHistory.size() - 1);
+        }
+        lastZobrist = hashHistory.isEmpty() ? 0L : hashHistory.getLong(hashHistory.size() - 1);
     }
 
     public boolean isThreefoldRepetition() {
@@ -197,12 +196,23 @@ public class GameState {
 
     @Override
     public String toString() {
+        StringBuilder hashHistoryBuilder = new StringBuilder("[");
+        for (int i = 0; i < hashHistory.size(); i++) {
+            if (i > 0) {
+                hashHistoryBuilder.append(',').append(' ');
+            }
+            hashHistoryBuilder.append(hashHistory.getLong(i));
+        }
+        hashHistoryBuilder.append(']');
+
         return "GameState {" +
                 "\n  State: " + state +
                 "\n  Midgame Score: " + score.getMidgameScore() +
                 "\n  Endgame Score: " + score.getEndgameScore() +
                 "\n  Blended Score: " + score.getBlendedScore() +
                 "\n  Score Difference: " + score.getScoreDifference() +
+                "\n  Last Zobrist: " + lastZobrist +
+                "\n  Hash History: " + hashHistoryBuilder +
                 "\n  Repetition Count: " + repetition +
                 "\n}";
     }

--- a/src/test/java/julius/game/chessengine/engine/GameStateThreefoldRepetitionTest.java
+++ b/src/test/java/julius/game/chessengine/engine/GameStateThreefoldRepetitionTest.java
@@ -1,0 +1,71 @@
+package julius.game.chessengine.engine;
+
+import julius.game.chessengine.board.BitBoard;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class GameStateThreefoldRepetitionTest {
+
+    @Test
+    void detectsThreefoldRepetitionUsingPrimitiveHistory() {
+        BitBoard board = new BitBoard();
+        GameState state = new GameState(board);
+
+        long baseHash = board.getBoardStateHash();
+        state.recordHash(baseHash);
+        state.recordHash(baseHash);
+
+        Assertions.assertTrue(state.isThreefoldRepetition(),
+                "Three identical Zobrist keys should trigger a repetition draw candidate.");
+        Assertions.assertEquals(baseHash, state.getLastZobrist(),
+                "Last Zobrist hash should match the head of the primitive history buffer.");
+    }
+
+    @Test
+    void removingHashUpdatesRepetitionAndHistoryHead() {
+        BitBoard board = new BitBoard();
+        GameState state = new GameState(board);
+
+        long baseHash = board.getBoardStateHash();
+        long nextHash = baseHash ^ 0x1FL;
+
+        state.recordHash(nextHash);
+        Assertions.assertEquals(nextHash, state.getLastZobrist(),
+                "Last Zobrist should reflect the most recently pushed hash.");
+
+        state.removeHash(nextHash);
+
+        Assertions.assertEquals(baseHash, state.getLastZobrist(),
+                "Removing the latest hash should reveal the previous head without boxing.");
+        Assertions.assertEquals(1, state.getRepetition().get(baseHash),
+                "Base hash count should remain intact after removing a different head value.");
+    }
+
+    @Test
+    void clonedGameStateRetainsIndependentPrimitiveHistory() {
+        BitBoard board = new BitBoard();
+        GameState original = new GameState(board);
+
+        long baseHash = board.getBoardStateHash();
+        long alternateHash = baseHash ^ 0xAAFFL;
+
+        original.recordHash(alternateHash);
+
+        GameState clone = new GameState(original);
+
+        long thirdHash = baseHash ^ 0xFF00L;
+        original.recordHash(thirdHash);
+
+        Assertions.assertEquals(alternateHash, clone.getLastZobrist(),
+                "Clone should preserve the head hash present at clone time.");
+        Assertions.assertEquals(thirdHash, original.getLastZobrist(),
+                "Original should advance to the newly recorded hash.");
+
+        original.removeHash(thirdHash);
+        Assertions.assertEquals(alternateHash, original.getLastZobrist(),
+                "After undoing, the original should revert to the previous primitive head.");
+        Assertions.assertEquals(alternateHash, clone.getLastZobrist(),
+                "Clone history should remain independent from mutations on the original.");
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace the GameState hash history deque with a fastutil LongArrayList to avoid boxing
- update hash recording/removal and string serialization to track the primitive history head
- add threefold repetition unit coverage for primitive history operations and cloning

## Testing
- mvn -Dtest=GameStateThreefoldRepetitionTest test *(fails: container JDK does not support release 25)*

------
https://chatgpt.com/codex/tasks/task_e_68d6de5c7034832a844f28b3f8b41920