### PR TITLE
Implement MoveList pooling to reduce GC pressure

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -4,6 +4,7 @@ import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.Move;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.MoveList;
+import julius.game.chessengine.board.MoveListPool;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.engine.GameStateEnum;
@@ -2049,44 +2050,51 @@ public class AI {
 
         // Generate moves: evasions if in check, else captures/promotions
         MoveList moves = inCheck ? simulatorEngine.getAllLegalMoves() : getPossibleCapturesOrPromotions(simulatorEngine);
+        final boolean borrowedMoves = !inCheck;
 
-        // Order them (captures first via MVV-LVA/promotion bonus, killers/history still help)
-        MoveList ordered = sortMovesByEfficiency(moves, 0, simulatorEngine.getBoardStateHash(), -1,
-                simulatorEngine);
+        try {
+            // Order them (captures first via MVV-LVA/promotion bonus, killers/history still help)
+            MoveList ordered = sortMovesByEfficiency(moves, 0, simulatorEngine.getBoardStateHash(), -1,
+                    simulatorEngine);
 
-        for (int i = 0; i < ordered.size(); i++) {
-            int m = ordered.getMove(i);
-            boolean isCapture = MoveHelper.isCapture(m);
-            boolean isPromotion = MoveHelper.isPawnPromotionMove(m);
-            boolean isQuiet = !isCapture && !isPromotion;
+            for (int i = 0; i < ordered.size(); i++) {
+                int m = ordered.getMove(i);
+                boolean isCapture = MoveHelper.isCapture(m);
+                boolean isPromotion = MoveHelper.isPawnPromotionMove(m);
+                boolean isQuiet = !isCapture && !isPromotion;
 
-            // --- SEE pruning: drop clearly losing captures or quiet moves (keeps promotions) ---
-            if ((!inCheck && isCapture && !isPromotion) || isQuiet) {
-                int see = simulatorEngine.see(m);
-                if (see < 0) {
-                    simulatorEngine.performMove(m);
-                    boolean givesCheck = isSideInCheck(simulatorEngine, !isWhitesTurn);
-                    simulatorEngine.undoLastMove();
-                    if (!givesCheck) continue;
+                // --- SEE pruning: drop clearly losing captures or quiet moves (keeps promotions) ---
+                if ((!inCheck && isCapture && !isPromotion) || isQuiet) {
+                    int see = simulatorEngine.see(m);
+                    if (see < 0) {
+                        simulatorEngine.performMove(m);
+                        boolean givesCheck = isSideInCheck(simulatorEngine, !isWhitesTurn);
+                        simulatorEngine.undoLastMove();
+                        if (!givesCheck) continue;
+                    }
+                }
+                simulatorEngine.performMove(m);
+                // Propagate timeout BEFORE negation
+                double child = quiescenceSearch(simulatorEngine, !isWhitesTurn, -beta, -alpha, deadline, depth + 1);
+                simulatorEngine.undoLastMove();
+
+                if (child == EXIT_FLAG) return EXIT_FLAG;
+
+                double score = -child;
+
+                if (score >= beta) {
+                    return beta;
+                }
+                if (score > alpha) {
+                    alpha = score;
                 }
             }
-            simulatorEngine.performMove(m);
-            // Propagate timeout BEFORE negation
-            double child = quiescenceSearch(simulatorEngine, !isWhitesTurn, -beta, -alpha, deadline, depth + 1);
-            simulatorEngine.undoLastMove();
-
-            if (child == EXIT_FLAG) return EXIT_FLAG;
-
-            double score = -child;
-
-            if (score >= beta) {
-                return beta;
-            }
-            if (score > alpha) {
-                alpha = score;
+            return alpha;
+        } finally {
+            if (borrowedMoves) {
+                MoveListPool.release(moves);
             }
         }
-        return alpha;
     }
 
     private double evaluateStaticPosition(GameState gameState, boolean isWhitesTurn, int depthOrPly) {
@@ -2120,7 +2128,7 @@ public class AI {
 
     private MoveList getPossibleCapturesOrPromotions(Engine simulatorEngine) {
         MoveList allLegalMoves = simulatorEngine.getAllLegalMoves();
-        MoveList capturesAndPromotions = new MoveList();
+        MoveList capturesAndPromotions = MoveListPool.borrow();
         for (int i = 0; i < allLegalMoves.size(); i++) {
             int m = allLegalMoves.getMove(i);
             if (MoveHelper.isCapture(m) || MoveHelper.isPawnPromotionMove(m)) {

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -61,9 +61,6 @@ public class BitBoard {
     private boolean blackAttackDirty = true;
     private PieceType[] pieceBoard = new PieceType[64];
 
-    // Reusable buffer for move generation to avoid frequent allocations.
-    private final MoveList moveGenerationBuffer = new MoveList();
-
     @Getter(AccessLevel.NONE)
     private final Deque<Integer> halfmoveHistory = new ArrayDeque<>();
     @Getter(AccessLevel.NONE)
@@ -265,8 +262,8 @@ public class BitBoard {
         return (whiteMinorPieces <= 1) && (blackMinorPieces <= 1);
     }
 
-    public MoveList getAllCurrentPossibleMoves() {
-        return generateAllPossibleMoves(whitesTurn);
+    public void getAllCurrentPossibleMoves(MoveList target) {
+        generateAllPossibleMoves(whitesTurn, target);
     }
 
     // Method to set up the initial position
@@ -782,9 +779,7 @@ public class BitBoard {
         }
     }
 
-    public MoveList generateAllPossibleMoves(boolean whitesTurn) {
-        // Reuse the internal buffer to cut down on object creation and GC pressure.
-        MoveList moves = moveGenerationBuffer;
+    public void generateAllPossibleMoves(boolean whitesTurn, MoveList moves) {
         moves.clear();
 
         // Do NOT recompute white/black attack maps here.
@@ -799,7 +794,6 @@ public class BitBoard {
         generateQueenMoves(whitesTurn, moves);
         generateKingMoves(whitesTurn, moves);
 
-        return moves;
     }
 
 

--- a/src/main/java/julius/game/chessengine/board/MoveList.java
+++ b/src/main/java/julius/game/chessengine/board/MoveList.java
@@ -2,13 +2,12 @@ package julius.game.chessengine.board;
 
 import lombok.extern.log4j.Log4j2;
 
-import java.util.Arrays;
 
 @Log4j2
 public class MoveList {
     private int[] moves;
     private int moveCount;
-    private static final int MAX_SIZE = 218; // Maximum number of legal moves
+    public static final int MAX_SIZE = 218; // Maximum number of legal moves
 
     private String stringRepresentation;
     private boolean isStringRepresentationStale = true;
@@ -52,10 +51,6 @@ public class MoveList {
         return moves[index];
     }
 
-    public int[] toArray() {
-        return Arrays.copyOf(moves, moveCount);
-    }
-
     public int[] get() {
         return this.moves;
     }
@@ -63,6 +58,22 @@ public class MoveList {
     public void clear() {
         moveCount = 0;
         isStringRepresentationStale = true;
+    }
+
+    /**
+     * Copy the contents of this list into the provided target list. The target list is cleared
+     * and populated without allocating a new backing array.
+     *
+     * @param target the list to receive the copy
+     * @throws IllegalArgumentException if the target cannot accommodate {@link #MAX_SIZE} moves
+     */
+    public void copyInto(MoveList target) {
+        if (target.moves.length < MAX_SIZE) {
+            throw new IllegalArgumentException("Target MoveList capacity is insufficient");
+        }
+        System.arraycopy(this.moves, 0, target.moves, 0, this.moveCount);
+        target.moveCount = this.moveCount;
+        target.isStringRepresentationStale = true;
     }
 
     /**

--- a/src/main/java/julius/game/chessengine/board/MoveListPool.java
+++ b/src/main/java/julius/game/chessengine/board/MoveListPool.java
@@ -1,0 +1,49 @@
+package julius.game.chessengine.board;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Thread-local pool for {@link MoveList} instances. Each list is pre-sized once to the
+ * {@link MoveList#MAX_SIZE} capacity and cleared on checkout to avoid repeated allocations in
+ * hot paths such as move generation and quiescence search.
+ */
+public final class MoveListPool {
+
+    private static final int MAX_POOL_SIZE = 32;
+    private static final ThreadLocal<Deque<MoveList>> POOL =
+            ThreadLocal.withInitial(ArrayDeque::new);
+
+    private MoveListPool() {
+    }
+
+    public static MoveList borrow() {
+        Deque<MoveList> deque = POOL.get();
+        MoveList list = deque.pollLast();
+        if (list == null) {
+            list = new MoveList();
+        } else {
+            list.clear();
+        }
+        return list;
+    }
+
+    public static void release(MoveList list) {
+        if (list == null) {
+            return;
+        }
+        list.clear();
+        Deque<MoveList> deque = POOL.get();
+        if (deque.size() < MAX_POOL_SIZE) {
+            deque.addLast(list);
+        }
+    }
+
+    static int available() {
+        return POOL.get().size();
+    }
+
+    static void reset() {
+        POOL.remove();
+    }
+}

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -136,6 +136,34 @@ public class Engine {
         startNewGame();
     }
 
+    private void replaceLegalMoves(MoveList next) {
+        if (this.legalMoves != null && this.legalMoves != next) {
+            MoveListPool.release(this.legalMoves);
+        }
+        this.legalMoves = next;
+    }
+
+    private void discardLegalMoves() {
+        if (this.legalMoves != null) {
+            MoveListPool.release(this.legalMoves);
+            this.legalMoves = null;
+        }
+    }
+
+    private static MoveList snapshotOf(MoveList source) {
+        MoveList snapshot = new MoveList();
+        source.copyInto(snapshot);
+        return snapshot;
+    }
+
+    private void ensureCacheWithinBounds() {
+        int size = legalMovesCache.size();
+        if (size > CACHE_CFG.maxSize) {
+            throw new RuntimeException(String.format(
+                    "LegalMovesCache size %s is larger than configured MAX_SIZE %s", size, CACHE_CFG.maxSize));
+        }
+    }
+
     public Engine(Engine other) {
         synchronized (other.boardLock) {
             this.bitBoard = new BitBoard(other.bitBoard);
@@ -178,13 +206,7 @@ public class Engine {
 
     public MoveList getAllLegalMoves() {
         synchronized (boardLock) {
-            if (gameState.isGameOver()) {
-                if (legalMoves == null) {
-                    legalMoves = new MoveList();  // Create only if null
-                } else {
-                    legalMoves.clear();  // Clear existing list instead of creating a new one
-                }
-            } else if (legalMovesNeedUpdate) {
+            if (legalMovesNeedUpdate || legalMoves == null) {
                 generateLegalMoves();
             }
             return legalMoves;
@@ -220,6 +242,7 @@ public class Engine {
 
     public void importBoardFromFen(String fen) {
         synchronized (boardLock) {
+            discardLegalMoves();
             this.bitBoard = FEN.translateFENtoBitBoard(fen);
             this.gameState = new GameState(bitBoard);
 
@@ -236,11 +259,7 @@ public class Engine {
             // For terminal draw states (e.g., fifty-move rule) skip move generation entirely so
             // callers observe an empty legal move list.
             if (gameState.isFiftyMoveRule() || gameState.isThreefoldRepetition()) {
-                if (legalMoves == null) {
-                    legalMoves = new MoveList();
-                } else {
-                    legalMoves.clear();
-                }
+                replaceLegalMoves(MoveListPool.borrow());
                 legalMovesNeedUpdate = false;
                 gameState.setState(GameStateEnum.DRAW);
             } else {
@@ -262,6 +281,7 @@ public class Engine {
         Objects.requireNonNull(other, "other engine");
         synchronized (boardLock) {
             synchronized (other.boardLock) {
+                discardLegalMoves();
                 this.bitBoard = new BitBoard(other.bitBoard);
                 this.gameState = new GameState(other.gameState);
                 this.line = new ArrayList<>(other.line);
@@ -276,6 +296,7 @@ public class Engine {
 
     public void startNewGame() {
         synchronized (boardLock) {
+            discardLegalMoves();
             bitBoard = new BitBoard();
             gameState = new GameState(bitBoard);
             legalMovesNeedUpdate = true;
@@ -296,43 +317,53 @@ public class Engine {
             // Use cached result if available
             MoveList cached = legalMovesCache.get(boardStateHash);
             if (cached != null) {
-                this.legalMoves = new MoveList(cached);
+                MoveList snapshot = MoveListPool.borrow();
+                cached.copyInto(snapshot);
+                replaceLegalMoves(snapshot);
                 legalMovesNeedUpdate = false;
                 return;
             }
 
             if (gameState.isGameOver()) {
-                this.legalMoves = new MoveList();
+                MoveList empty = MoveListPool.borrow();
+                replaceLegalMoves(empty);
                 legalMovesNeedUpdate = false;
+                legalMovesCache.put(boardStateHash, snapshotOf(empty));
+                ensureCacheWithinBounds();
                 return;
             }
 
             // Generate pseudo-legal moves on the current board
-            MoveList moves = bitBoard.getAllCurrentPossibleMoves();
+            MoveList pseudoLegal = null;
+            MoveList legal = MoveListPool.borrow();
+            try {
+                pseudoLegal = MoveListPool.borrow();
+                bitBoard.getAllCurrentPossibleMoves(pseudoLegal);
 
-            // Filter in-place by making/unmaking on the SAME bitBoard (no BitBoard copy)
-            MoveList legal = new MoveList();
-            for (int i = 0; i < moves.size(); i++) {
-                int move = moves.getMove(i);
+                // Filter in-place by making/unmaking on the SAME bitBoard (no BitBoard copy)
+                for (int i = 0; i < pseudoLegal.size(); i++) {
+                    int move = pseudoLegal.getMove(i);
 
-                bitBoard.performMove(move);
-                // If the mover's king is not left in check, the move is legal
-                if (!bitBoard.isInCheck(MoveHelper.isWhitesMove(move))) {
-                    legal.add(move);
+                    bitBoard.performMove(move);
+                    // If the mover's king is not left in check, the move is legal
+                    if (!bitBoard.isInCheck(MoveHelper.isWhitesMove(move))) {
+                        legal.add(move);
+                    }
+                    bitBoard.undoMove(move);
                 }
-                bitBoard.undoMove(move);
-            }
 
-            this.legalMoves = legal;
-            legalMovesNeedUpdate = false;
-            // Store a clone to keep the cache immutable from callers' perspective.
-            legalMovesCache.put(boardStateHash, new MoveList(legal));
-
-            int size = legalMovesCache.size();
-            if (size > CACHE_CFG.maxSize) {
-                // This should be rare due to eviction, but keep the guard to surface misconfigurations.
-                throw new RuntimeException(String.format(
-                        "LegalMovesCache size %s is larger than configured MAX_SIZE %s", size, CACHE_CFG.maxSize));
+                replaceLegalMoves(legal);
+                legalMovesNeedUpdate = false;
+                // Store a clone to keep the cache immutable from callers' perspective.
+                legalMovesCache.put(boardStateHash, snapshotOf(legal));
+                ensureCacheWithinBounds();
+            } finally {
+                if (legal != this.legalMoves) {
+                    MoveListPool.release(legal);
+                }
+                if (pseudoLegal != null) {
+                    MoveListPool.release(pseudoLegal);
+                }
             }
         }
     }

--- a/src/test/java/julius/game/chessengine/board/MoveListPoolTest.java
+++ b/src/test/java/julius/game/chessengine/board/MoveListPoolTest.java
@@ -1,0 +1,69 @@
+package julius.game.chessengine.board;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MoveListPoolTest {
+
+    @BeforeEach
+    void setUp() {
+        MoveListPool.reset();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MoveListPool.reset();
+    }
+
+    @Test
+    void borrowedListsAreCleared() {
+        MoveList list = MoveListPool.borrow();
+        try {
+            assertEquals(0, list.size(), "Newly borrowed list should start empty");
+        } finally {
+            MoveListPool.release(list);
+        }
+    }
+
+    @Test
+    void releasedListsAreReusedAndCleared() {
+        MoveList first = MoveListPool.borrow();
+        first.add(123);
+        MoveListPool.release(first);
+
+        MoveList second = MoveListPool.borrow();
+        try {
+            assertSame(first, second, "Pool should reuse released instances");
+            assertEquals(0, second.size(), "Reused instance must be cleared");
+        } finally {
+            MoveListPool.release(second);
+        }
+    }
+
+    @Test
+    void copyIntoProducesIndependentSnapshot() {
+        MoveList source = MoveListPool.borrow();
+        try {
+            source.add(1);
+            source.add(2);
+            source.add(3);
+
+            MoveList snapshot = new MoveList();
+            source.copyInto(snapshot);
+
+            assertEquals(source.size(), snapshot.size());
+            for (int i = 0; i < source.size(); i++) {
+                assertEquals(source.getMove(i), snapshot.getMove(i));
+            }
+
+            snapshot.setMove(0, 99);
+            assertNotEquals(source.getMove(0), snapshot.getMove(0),
+                    "Snapshots should not alias the source backing array");
+        } finally {
+            MoveListPool.release(source);
+        }
+    }
+}

--- a/src/test/java/julius/game/chessengine/engine/EngineMoveGenerationGcTest.java
+++ b/src/test/java/julius/game/chessengine/engine/EngineMoveGenerationGcTest.java
@@ -1,0 +1,70 @@
+package julius.game.chessengine.engine;
+
+import julius.game.chessengine.board.MoveList;
+import org.junit.jupiter.api.Test;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EngineMoveGenerationGcTest {
+
+    @Test
+    void cachedSnapshotsRemainStableAfterUndo() {
+        Engine engine = new Engine();
+        MoveList initialMoves = engine.getAllLegalMoves();
+        int size = initialMoves.size();
+        int[] snapshot = new int[size];
+        for (int i = 0; i < size; i++) {
+            snapshot[i] = initialMoves.getMove(i);
+        }
+
+        if (size == 0) {
+            return; // trivial starting position with no moves
+        }
+
+        int move = snapshot[0];
+        engine.performMove(move);
+        engine.undoLastMove();
+
+        MoveList fromCache = engine.getAllLegalMoves();
+        assertEquals(size, fromCache.size(), "Cached list should preserve move count");
+        for (int i = 0; i < size; i++) {
+            assertEquals(snapshot[i], fromCache.getMove(i), "Cached snapshot should match original ordering");
+        }
+    }
+
+    @Test
+    void stressMoveGenerationAvoidsGcChurn() {
+        Engine engine = new Engine();
+        long before = totalGcCollections();
+
+        for (int i = 0; i < 256; i++) {
+            MoveList moves = engine.getAllLegalMoves();
+            if (moves.size() == 0) {
+                break;
+            }
+            int move = moves.getMove(i % moves.size());
+            engine.performMove(move);
+            engine.undoLastMove();
+        }
+
+        long after = totalGcCollections();
+        assertTrue(after - before <= 1, "Move generation pooling should eliminate GC churn");
+    }
+
+    private static long totalGcCollections() {
+        long total = 0;
+        List<GarbageCollectorMXBean> beans = ManagementFactory.getGarbageCollectorMXBeans();
+        for (GarbageCollectorMXBean bean : beans) {
+            long count = bean.getCollectionCount();
+            if (count > 0) {
+                total += count;
+            }
+        }
+        return total;
+    }
+}

--- a/src/test/java/julius/game/chessengine/evaluation/LightweightSnapshotEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/evaluation/LightweightSnapshotEvaluationTest.java
@@ -3,6 +3,7 @@ package julius.game.chessengine.evaluation;
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.FEN;
 import julius.game.chessengine.board.MoveList;
+import julius.game.chessengine.board.MoveListPool;
 import julius.game.chessengine.utils.Score;
 import org.junit.jupiter.api.Test;
 
@@ -36,12 +37,17 @@ class LightweightSnapshotEvaluationTest {
         Deque<Integer> played = new ArrayDeque<>();
 
         for (int ply = 0; ply < 6; ply++) {
-            MoveList moves = board.getAllCurrentPossibleMoves();
-            assertTrue(moves.size() > 0, "No legal move available at ply " + ply);
-            int move = moves.getMove(0);
-            played.push(move);
-            board.performMove(move);
-            score.applyMove(board, move, null);
+            MoveList moves = MoveListPool.borrow();
+            try {
+                board.getAllCurrentPossibleMoves(moves);
+                assertTrue(moves.size() > 0, "No legal move available at ply " + ply);
+                int move = moves.getMove(0);
+                played.push(move);
+                board.performMove(move);
+                score.applyMove(board, move, null);
+            } finally {
+                MoveListPool.release(moves);
+            }
         }
 
         score.refresh(board, null);


### PR DESCRIPTION
## Summary
- introduce a thread-local MoveListPool and a copyInto helper so lists keep a single MAX_SIZE backing array
- refactor Engine, BitBoard, and AI hot paths to borrow/release pooled MoveLists while caching immutable snapshots
- add unit and stress-style tests that exercise pooling, GC churn, and existing evaluation flows

## Testing
- ./mvnw -q test *(fails: Maven wrapper download blocked by network sandbox)*
- mvn -q test *(fails: container JDK does not support --release 25)*

------
https://chatgpt.com/codex/tasks/task_e_68d6de585594832aa507523294e8c66c