### PR TITLE
Cache opening book entries in memory

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/OpeningBook.java
+++ b/src/main/java/julius/game/chessengine/ai/OpeningBook.java
@@ -7,27 +7,35 @@ import org.springframework.stereotype.Component;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Component
 @Log4j2
 public class OpeningBook {
     private static final String OPENINGS_FILE_PATH = "/opening/openings.txt";
-    private final Map<Long, List<Integer>> openings = new HashMap<>();
+    private static final Map<Long, List<Integer>> openings = new ConcurrentHashMap<>();
 
-    private static OpeningBook instance;
-    
+    private static final class Holder {
+        static final OpeningBook INSTANCE = new OpeningBook();
+    }
+
     private OpeningBook() {
         loadOpenings();
     }
 
-    public static synchronized OpeningBook getInstance() {
-        if (instance == null) {
-            instance = new OpeningBook();
-        }
-        return instance;
+    public static OpeningBook getInstance() {
+        return Holder.INSTANCE;
     }
 
     private void loadOpenings() {
+        // When running from a packaged JAR the resource is immutable, so we only
+        // populate the in-memory cache once at start-up.
+        if (!openings.isEmpty()) {
+            return;
+        }
+
         try (InputStream is = getClass().getResourceAsStream(OPENINGS_FILE_PATH);
              BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
 
@@ -37,7 +45,7 @@ public class OpeningBook {
                 if (parts.length == 2) {
                     int move = Integer.parseInt(parts[0].trim());
                     long boardStateHash = Long.parseLong(parts[1].trim());
-                    openings.computeIfAbsent(boardStateHash, k -> new ArrayList<>()).add(move);
+                    openings.computeIfAbsent(boardStateHash, k -> new CopyOnWriteArrayList<>()).add(move);
                 }
             }
         } catch (IOException | NullPointerException e) {
@@ -46,7 +54,7 @@ public class OpeningBook {
     }
 
     public void addOpening(int move, long boardStateHash) {
-        List<Integer> existingMoves = openings.computeIfAbsent(boardStateHash, k -> new ArrayList<>());
+        List<Integer> existingMoves = openings.computeIfAbsent(boardStateHash, k -> new CopyOnWriteArrayList<>());
         if (!existingMoves.contains(move)) {
             existingMoves.add(move);
             writeOpening(move, boardStateHash); // Writes to the file
@@ -74,9 +82,7 @@ public class OpeningBook {
         if (moves.isEmpty()) {
             return -1; // or a default move, depending on how you want to handle this scenario
         }
-        Random random = new Random();
-        int randomMove = moves.get(random.nextInt(moves.size()));
-        return randomMove;
+        return moves.get(ThreadLocalRandom.current().nextInt(moves.size()));
     }
 
     public boolean containsMoveAndBoardStateHash(long boardStateHashBeforeMove, int move) {


### PR DESCRIPTION
## Summary
- populate the opening book data once into a concurrent in-memory cache via a holder-backed singleton
- reuse the cached moves for lookups and rely on ThreadLocalRandom for selecting a book move

## Testing
- ./mvnw -q -DskipTests package *(fails: network is unreachable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68d70fe04fc4832aafe483f5e30315da