### PR TITLE
Reuse MoveList buffers in legal move generation

### DIFF
--- a/src/main/java/julius/game/chessengine/board/MoveList.java
+++ b/src/main/java/julius/game/chessengine/board/MoveList.java
@@ -3,6 +3,7 @@ package julius.game.chessengine.board;
 import lombok.extern.log4j.Log4j2;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 @Log4j2
 public class MoveList {
@@ -62,6 +63,25 @@ public class MoveList {
 
     public void clear() {
         moveCount = 0;
+        isStringRepresentationStale = true;
+    }
+
+    /**
+     * Copy the contents of {@code src} into this list in-place.
+     *
+     * <p>The backing array is reused, avoiding an additional allocation. The
+     * string representation cache is invalidated so callers see the updated
+     * state on the next {@link #toString()} call.</p>
+     *
+     * @param src source list to copy from
+     */
+    public void copyFrom(MoveList src) {
+        Objects.requireNonNull(src, "src");
+        if (src == this) {
+            return;
+        }
+        this.moveCount = src.moveCount;
+        System.arraycopy(src.moves, 0, this.moves, 0, src.moveCount);
         isStringRepresentationStale = true;
     }
 

--- a/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
+++ b/src/main/java/julius/game/chessengine/cache/TimedLRUCache.java
@@ -5,9 +5,11 @@ import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 /**
  * A lightweight LRU cache with optional time-based eviction. Keys are
@@ -44,6 +46,7 @@ public class TimedLRUCache<V> {
     private final LongArrayFIFOQueue keyQueue = new LongArrayFIFOQueue();
     private final LongArrayFIFOQueue timeQueue = new LongArrayFIFOQueue();
     private final Object lock = new Object();
+    private volatile Consumer<V> evictionListener = v -> {};
 
     /**
      * @param maxSize maximum number of entries to retain (LRU when exceeded)
@@ -59,6 +62,8 @@ public class TimedLRUCache<V> {
     }
 
     public V get(long key) {
+        List<V> evicted = Collections.emptyList();
+        V value;
         synchronized (lock) {
             Entry<V> entry = map.get(key);
             if (entry == null) {
@@ -68,19 +73,27 @@ public class TimedLRUCache<V> {
             entry.time = now;               // touch (refresh recency)
             keyQueue.enqueue(key);
             timeQueue.enqueue(now);
-            evictLocked(now);
-            return entry.value;
+            evicted = evictLocked(now);
+            value = entry.value;
         }
+        notifyEvicted(evicted);
+        return value;
     }
 
     public void put(long key, V value) {
         long now = System.currentTimeMillis();
+        Entry<V> previous;
+        List<V> evicted = Collections.emptyList();
         synchronized (lock) {
-            map.put(key, new Entry<>(value, now));
+            previous = map.put(key, new Entry<>(value, now));
             keyQueue.enqueue(key);
             timeQueue.enqueue(now);
-            evictLocked(now);
+            evicted = evictLocked(now);
         }
+        if (previous != null) {
+            notifyEvicted(previous.value);
+        }
+        notifyEvicted(evicted);
     }
 
     public boolean containsKey(long key) {
@@ -97,9 +110,11 @@ public class TimedLRUCache<V> {
 
     /** Manually trigger eviction pass (e.g., on timers in higher layers). */
     public void cleanup() {
+        List<V> evicted;
         synchronized (lock) {
-            evictLocked(System.currentTimeMillis());
+            evicted = evictLocked(System.currentTimeMillis());
         }
+        notifyEvicted(evicted);
     }
 
     /** Remove all entries. */
@@ -119,7 +134,8 @@ public class TimedLRUCache<V> {
         return maxAgeMs;
     }
 
-    private void evictLocked(long now) {
+    private List<V> evictLocked(long now) {
+        List<V> evicted = Collections.emptyList();
         // Ensure both queues contain data before accessing their heads to avoid
         // NoSuchElementException when they become unsynchronized.
         while (!keyQueue.isEmpty() && !timeQueue.isEmpty()) {
@@ -141,6 +157,12 @@ public class TimedLRUCache<V> {
                 map.remove(k);
                 keyQueue.dequeueLong();
                 timeQueue.dequeueLong();
+                if (entry != null) {
+                    if (evicted.isEmpty()) {
+                        evicted = new ArrayList<>();
+                    }
+                    evicted.add(entry.value);
+                }
             } else {
                 // Head is current and not expired; LRU is satisfied.
                 break;
@@ -152,6 +174,37 @@ public class TimedLRUCache<V> {
             keyQueue.clear();
             timeQueue.clear();
         }
+        return evicted;
+    }
+
+    private void notifyEvicted(List<V> evicted) {
+        if (evicted == null || evicted.isEmpty()) {
+            return;
+        }
+        Consumer<V> listener = evictionListener;
+        for (V value : evicted) {
+            try {
+                listener.accept(value);
+            } catch (RuntimeException ignored) {
+                // Listener exceptions should not break cache behaviour.
+            }
+        }
+    }
+
+    private void notifyEvicted(V value) {
+        if (value == null) {
+            return;
+        }
+        Consumer<V> listener = evictionListener;
+        try {
+            listener.accept(value);
+        } catch (RuntimeException ignored) {
+            // Listener exceptions should not break cache behaviour.
+        }
+    }
+
+    public void setEvictionListener(Consumer<V> evictionListener) {
+        this.evictionListener = (evictionListener != null) ? evictionListener : v -> {};
     }
 
     public void forEach(BiConsumer<Long, V> action) {

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -10,6 +10,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.LongConsumer;
 import java.util.stream.Collectors;
 
@@ -112,7 +113,8 @@ public class Engine {
 
     // --- Cache instance based on computed configuration ---
     private static final CacheConfig CACHE_CFG = computeCacheConfig();
-    private TimedLRUCache<MoveList> legalMovesCache = new TimedLRUCache<>(CACHE_CFG.maxSize, CACHE_CFG.maxAgeMs);
+    private final ConcurrentLinkedDeque<MoveList> legalMovesSnapshotPool = new ConcurrentLinkedDeque<>();
+    private TimedLRUCache<MoveList> legalMovesCache = createLegalMovesCache();
 
     private final Object boardLock = new Object();
 
@@ -152,7 +154,8 @@ public class Engine {
             // ✅ light: fresh empty state for the clone; compute lazily when needed
             this.legalMoves = null;
             this.legalMovesNeedUpdate = true;
-            this.legalMovesCache = new TimedLRUCache<>(CACHE_CFG.maxSize, CACHE_CFG.maxAgeMs);
+            recycleCacheEntries();
+            this.legalMovesCache = createLegalMovesCache();
 
             this.openingBook = other.openingBook;
         }
@@ -178,16 +181,14 @@ public class Engine {
 
     public MoveList getAllLegalMoves() {
         synchronized (boardLock) {
+            MoveList buffer = ensureLegalMovesBuffer();
             if (gameState.isGameOver()) {
-                if (legalMoves == null) {
-                    legalMoves = new MoveList();  // Create only if null
-                } else {
-                    legalMoves.clear();  // Clear existing list instead of creating a new one
-                }
+                buffer.clear();
+                legalMovesNeedUpdate = false;
             } else if (legalMovesNeedUpdate) {
                 generateLegalMoves();
             }
-            return legalMoves;
+            return buffer;
         }
     }
 
@@ -236,11 +237,8 @@ public class Engine {
             // For terminal draw states (e.g., fifty-move rule) skip move generation entirely so
             // callers observe an empty legal move list.
             if (gameState.isFiftyMoveRule() || gameState.isThreefoldRepetition()) {
-                if (legalMoves == null) {
-                    legalMoves = new MoveList();
-                } else {
-                    legalMoves.clear();
-                }
+                MoveList buffer = ensureLegalMovesBuffer();
+                buffer.clear();
                 legalMovesNeedUpdate = false;
                 gameState.setState(GameStateEnum.DRAW);
             } else {
@@ -268,7 +266,8 @@ public class Engine {
                 this.redoLine = new ArrayList<>(other.redoLine);
                 this.legalMoves = null;
                 this.legalMovesNeedUpdate = true;
-                this.legalMovesCache = new TimedLRUCache<>(CACHE_CFG.maxSize, CACHE_CFG.maxAgeMs);
+                recycleCacheEntries();
+                this.legalMovesCache = createLegalMovesCache();
                 this.openingBook = other.openingBook;
             }
         }
@@ -282,7 +281,8 @@ public class Engine {
             line = new ArrayList<>();
             redoLine = new ArrayList<>();
             this.openingBook = OpeningBook.getInstance();
-            legalMovesCache = new TimedLRUCache<>(CACHE_CFG.maxSize, CACHE_CFG.maxAgeMs);
+            recycleCacheEntries();
+            legalMovesCache = createLegalMovesCache();
             // Optional: one cleanup to ensure fresh state
             legalMovesCache.cleanup();
             notifyPositionChanged();
@@ -291,18 +291,20 @@ public class Engine {
 
     private void generateLegalMoves() {
         synchronized (boardLock) {
+            MoveList buffer = ensureLegalMovesBuffer();
+            buffer.clear();
+
             final long boardStateHash = getBoardStateHash();
 
             // Use cached result if available
             MoveList cached = legalMovesCache.get(boardStateHash);
             if (cached != null) {
-                this.legalMoves = new MoveList(cached);
+                buffer.copyFrom(cached);
                 legalMovesNeedUpdate = false;
                 return;
             }
 
             if (gameState.isGameOver()) {
-                this.legalMoves = new MoveList();
                 legalMovesNeedUpdate = false;
                 return;
             }
@@ -311,22 +313,22 @@ public class Engine {
             MoveList moves = bitBoard.getAllCurrentPossibleMoves();
 
             // Filter in-place by making/unmaking on the SAME bitBoard (no BitBoard copy)
-            MoveList legal = new MoveList();
             for (int i = 0; i < moves.size(); i++) {
                 int move = moves.getMove(i);
 
                 bitBoard.performMove(move);
                 // If the mover's king is not left in check, the move is legal
                 if (!bitBoard.isInCheck(MoveHelper.isWhitesMove(move))) {
-                    legal.add(move);
+                    buffer.add(move);
                 }
                 bitBoard.undoMove(move);
             }
 
-            this.legalMoves = legal;
             legalMovesNeedUpdate = false;
-            // Store a clone to keep the cache immutable from callers' perspective.
-            legalMovesCache.put(boardStateHash, new MoveList(legal));
+
+            MoveList snapshot = obtainSnapshot();
+            snapshot.copyFrom(buffer);
+            legalMovesCache.put(boardStateHash, snapshot);
 
             int size = legalMovesCache.size();
             if (size > CACHE_CFG.maxSize) {
@@ -335,6 +337,43 @@ public class Engine {
                         "LegalMovesCache size %s is larger than configured MAX_SIZE %s", size, CACHE_CFG.maxSize));
             }
         }
+    }
+
+    private MoveList ensureLegalMovesBuffer() {
+        if (legalMoves == null) {
+            legalMoves = new MoveList();
+        }
+        return legalMoves;
+    }
+
+    private MoveList obtainSnapshot() {
+        MoveList snapshot = legalMovesSnapshotPool.pollFirst();
+        if (snapshot == null) {
+            snapshot = new MoveList();
+        }
+        return snapshot;
+    }
+
+    private void releaseSnapshot(MoveList snapshot) {
+        if (snapshot == null) {
+            return;
+        }
+        snapshot.clear();
+        legalMovesSnapshotPool.offer(snapshot);
+    }
+
+    private void recycleCacheEntries() {
+        if (legalMovesCache == null) {
+            return;
+        }
+        legalMovesCache.forEach((hash, list) -> releaseSnapshot(list));
+        legalMovesCache.clear();
+    }
+
+    private TimedLRUCache<MoveList> createLegalMovesCache() {
+        TimedLRUCache<MoveList> cache = new TimedLRUCache<>(CACHE_CFG.maxSize, CACHE_CFG.maxAgeMs);
+        cache.setEvictionListener(this::releaseSnapshot);
+        return cache;
     }
 
     // Each of these methods would need to be implemented to handle the specific move generation for each piece type.

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -123,6 +123,7 @@ public class Engine {
 
     private boolean legalMovesNeedUpdate = true;
     private MoveList legalMoves;
+    private MoveList legalMovesSnapshot;
 
     @Getter
     private ArrayList<Integer> line = new ArrayList<>();
@@ -153,7 +154,7 @@ public class Engine {
 
             // ✅ light: fresh empty state for the clone; compute lazily when needed
             this.legalMoves = null;
-            this.legalMovesNeedUpdate = true;
+            markLegalMovesStale();
             recycleCacheEntries();
             this.legalMovesCache = createLegalMovesCache();
 
@@ -185,10 +186,13 @@ public class Engine {
             if (gameState.isGameOver()) {
                 buffer.clear();
                 legalMovesNeedUpdate = false;
+                publishLegalMovesSnapshot(buffer);
             } else if (legalMovesNeedUpdate) {
                 generateLegalMoves();
+            } else if (legalMovesSnapshot == null) {
+                publishLegalMovesSnapshot(buffer);
             }
-            return buffer;
+            return legalMovesSnapshot != null ? legalMovesSnapshot : new MoveList(buffer);
         }
     }
 
@@ -240,6 +244,7 @@ public class Engine {
                 MoveList buffer = ensureLegalMovesBuffer();
                 buffer.clear();
                 legalMovesNeedUpdate = false;
+                publishLegalMovesSnapshot(buffer);
                 gameState.setState(GameStateEnum.DRAW);
             } else {
                 generateLegalMoves();
@@ -265,7 +270,7 @@ public class Engine {
                 this.line = new ArrayList<>(other.line);
                 this.redoLine = new ArrayList<>(other.redoLine);
                 this.legalMoves = null;
-                this.legalMovesNeedUpdate = true;
+                markLegalMovesStale();
                 recycleCacheEntries();
                 this.legalMovesCache = createLegalMovesCache();
                 this.openingBook = other.openingBook;
@@ -277,7 +282,7 @@ public class Engine {
         synchronized (boardLock) {
             bitBoard = new BitBoard();
             gameState = new GameState(bitBoard);
-            legalMovesNeedUpdate = true;
+            markLegalMovesStale();
             line = new ArrayList<>();
             redoLine = new ArrayList<>();
             this.openingBook = OpeningBook.getInstance();
@@ -301,11 +306,13 @@ public class Engine {
             if (cached != null) {
                 buffer.copyFrom(cached);
                 legalMovesNeedUpdate = false;
+                publishLegalMovesSnapshot(buffer);
                 return;
             }
 
             if (gameState.isGameOver()) {
                 legalMovesNeedUpdate = false;
+                publishLegalMovesSnapshot(buffer);
                 return;
             }
 
@@ -326,6 +333,8 @@ public class Engine {
 
             legalMovesNeedUpdate = false;
 
+            publishLegalMovesSnapshot(buffer);
+
             MoveList snapshot = obtainSnapshot();
             snapshot.copyFrom(buffer);
             legalMovesCache.put(boardStateHash, snapshot);
@@ -337,6 +346,15 @@ public class Engine {
                         "LegalMovesCache size %s is larger than configured MAX_SIZE %s", size, CACHE_CFG.maxSize));
             }
         }
+    }
+
+    private void markLegalMovesStale() {
+        legalMovesNeedUpdate = true;
+        legalMovesSnapshot = null;
+    }
+
+    private void publishLegalMovesSnapshot(MoveList buffer) {
+        legalMovesSnapshot = new MoveList(buffer);
     }
 
     private MoveList ensureLegalMovesBuffer() {
@@ -493,7 +511,7 @@ public class Engine {
             bitBoard.flipSideToMove();
 
             // Mark move list stale so the next search ply regenerates for the new side.
-            legalMovesNeedUpdate = true;
+            markLegalMovesStale();
 
             gameState.refreshScore(bitBoard);
 
@@ -511,7 +529,7 @@ public class Engine {
             bitBoard.setLastMoveDoubleStepPawnIndex(previousDoubleStep);
 
             // Mark stale again so we rebuild for the restored side.
-            legalMovesNeedUpdate = true;
+            markLegalMovesStale();
 
             gameState.refreshScore(bitBoard);
         }


### PR DESCRIPTION
## Summary
- add an in-place `MoveList.copyFrom` helper that keeps the preallocated buffer intact
- enhance `TimedLRUCache` with eviction callbacks so cached move lists can be recycled
- refactor the engine to reuse its legal move buffer and snapshot pool when reading from or writing to the cache

## Testing
- `mvn -q test` *(fails: Fatal error compiling: error: release version 25 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68d70f536970832aaaa0816d84635941