### PR TITLE
Hardcode bishop and rook magic numbers

### DIFF
--- a/src/main/java/julius/game/chessengine/helper/BishopHelper.java
+++ b/src/main/java/julius/game/chessengine/helper/BishopHelper.java
@@ -3,7 +3,6 @@ package julius.game.chessengine.helper;
 import lombok.extern.log4j.Log4j2;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -13,6 +12,73 @@ public class BishopHelper {
 
     private static final String BISHOP_MAGIC_NUMBERS_PATH = "/magic/bishop_magic_numbers.txt";
     private static final String BISHOP_MAGIC_NUMBERS_PATH_write = "src/main/resources" + BISHOP_MAGIC_NUMBERS_PATH;
+
+    private static final long[] PRECOMPUTED_BISHOP_MAGICS = new long[] {
+            4539888478322752L, // 0
+            4764905863112581644L, // 1
+            2346394106149881856L, // 2
+            9201284531881216L, // 3
+            -8528687258843217920L, // 4
+            54192868830478404L, // 5
+            36736951798238208L, // 6
+            -9223229097927178218L, // 7
+            76567859522175104L, // 8
+            -2161021897880305152L, // 9
+            3602888532958413828L, // 10
+            8815538078144L, // 11
+            1152922673911840896L, // 12
+            301743379494993920L, // 13
+            660824238735362L, // 14
+            2262799771373602L, // 15
+            1738399927429638156L, // 16
+            4644826776079106L, // 17
+            281543700417792L, // 18
+            -4025092004760223744L, // 19
+            -8925851302307037168L, // 20
+            70480549643265L, // 21
+            72146124522129432L, // 22
+            1162220220482356228L, // 23
+            9024791579330704L, // 24
+            -9218577616124901340L, // 25
+            2260595925712928L, // 26
+            148909063135051792L, // 27
+            1189232876115214342L, // 28
+            735212914180882944L, // 29
+            7494553005111648768L, // 30
+            -9183959765850183544L, // 31
+            20302001170842624L, // 32
+            288379944162034317L, // 33
+            2743255708212396616L, // 34
+            145152723648800L, // 35
+            1161092868874368L, // 36
+            117674133524973578L, // 37
+            2598022904152675328L, // 38
+            4616331601092035080L, // 39
+            4612821969632047136L, // 40
+            5188437625983344769L, // 41
+            47605564616280064L, // 42
+            1153239280932620291L, // 43
+            1161093011473408L, // 44
+            666541575305743426L, // 45
+            -8646327916256198144L, // 46
+            289356843279450692L, // 47
+            3456942140817416L, // 48
+            4807374275870738L, // 49
+            288301097217689168L, // 50
+            580964387397967880L, // 51
+            616993443700412417L, // 52
+            2306213016486027392L, // 53
+            2427863609444608L, // 54
+            4623091287206150146L, // 55
+            -8924722687374120939L, // 56
+            279307616768L, // 57
+            153122475713005568L, // 58
+            35304639824930L, // 59
+            83582479630856L, // 60
+            34393821697L, // 61
+            1152956845762562304L, // 62
+            -9218867268978982656L // 63
+    };
 
     public static final int[] BISHOP_MIDGAME_POSITIONAL_VALUES = {
             // R1
@@ -199,24 +265,8 @@ public class BishopHelper {
     }
 
     public void loadMagicNumbers() {
-        try (InputStream is = getClass().getResourceAsStream(BISHOP_MAGIC_NUMBERS_PATH)) {
-            assert is != null;
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    String[] parts = line.split(":");
-                    if (parts.length == 2) {
-                        int square = Integer.parseInt(parts[0]);
-                        squareMagicFound[square] = true;
-
-                        long magicNumber = Long.parseLong(parts[1]);
-                        bishopMagics[square] = magicNumber;
-                    }
-                }
-            }
-        } catch (IOException | NullPointerException e) {
-            log.error("Error reading magic numbers from file", e);
-        }
+        System.arraycopy(PRECOMPUTED_BISHOP_MAGICS, 0, bishopMagics, 0, bishopMagics.length);
+        Arrays.fill(squareMagicFound, true);
     }
 
     public long calculateMovesUsingBishopMagic(int square, long occupancy) {

--- a/src/main/java/julius/game/chessengine/helper/RookHelper.java
+++ b/src/main/java/julius/game/chessengine/helper/RookHelper.java
@@ -3,7 +3,6 @@ package julius.game.chessengine.helper;
 import lombok.extern.log4j.Log4j2;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -13,6 +12,73 @@ public class RookHelper {
 
     private static final String ROOK_MAGIC_NUMBERS_PATH = "/magic/rook_magic_numbers.txt";
     private static final String ROOK_MAGIC_NUMBERS_PATH_write = "src/main/resources" + ROOK_MAGIC_NUMBERS_PATH;
+
+    private static final long[] PRECOMPUTED_ROOK_MAGICS = new long[] {
+            36028936609595408L, // 0
+            2323857476446855168L, // 1
+            144124259317448836L, // 2
+            612498345683846272L, // 3
+            144120823207297040L, // 4
+            4647715932146237952L, // 5
+            180144534867411456L, // 6
+            72057732559143168L, // 7
+            5189694884176757796L, // 8
+            1297107062502723588L, // 9
+            2392674742042752L, // 10
+            72339107670392864L, // 11
+            1267189432714240L, // 12
+            9570157798361105L, // 13
+            6991979167579373824L, // 14
+            1153203118171884800L, // 15
+            576497586019385344L, // 16
+            150083874340875L, // 17
+            141287512612868L, // 18
+            2305879293365911560L, // 19
+            141287311280128L, // 20
+            1268286729748992L, // 21
+            5192654768538980354L, // 22
+            144117387109138500L, // 23
+            108086684188418048L, // 24
+            288318338155683844L, // 25
+            4904420065081827328L, // 26
+            281513633648640L, // 27
+            5771362939722285088L, // 28
+            1153488854762652160L, // 29
+            1152939148343509274L, // 30
+            2598577268460650788L, // 31
+            -8070309519839723488L, // 32
+            189151734650650630L, // 33
+            4647855621729689601L, // 34
+            18032274196924448L, // 35
+            72199465439593472L, // 36
+            703704630034944L, // 37
+            2305851809668817424L, // 38
+            290597520801961L, // 39
+            576531157557215232L, // 40
+            2305930970680803328L, // 41
+            5908746902551265312L, // 42
+            20266267043201152L, // 43
+            -9220833264371957744L, // 44
+            579275536497508368L, // 45
+            146371394526052608L, // 46
+            45109681949638660L, // 47
+            -6016737633340714496L, // 48
+            70370944091264L, // 49
+            -8646770409622994816L, // 50
+            567485577302528L, // 51
+            -9078129827751362432L, // 52
+            38562106202915072L, // 53
+            18031998077633536L, // 54
+            -9218582405214354944L, // 55
+            3314667467707720961L, // 56
+            2306133831112987683L, // 57
+            450432667944096001L, // 58
+            4503741364455525L, // 59
+            564066913886210L, // 60
+            3171097671754846210L, // 61
+            576536627467780228L, // 62
+            290482315568628738L // 63
+    };
 
     // Rook directions
 
@@ -270,24 +336,8 @@ public class RookHelper {
     }
 
     public void loadMagicNumbers() {
-        try (InputStream is = getClass().getResourceAsStream(ROOK_MAGIC_NUMBERS_PATH)) {
-            assert is != null;
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    String[] parts = line.split(":");
-                    if (parts.length == 2) {
-                        int square = Integer.parseInt(parts[0]);
-                        squareMagicFound[square] = true;
-
-                        long magicNumber = Long.parseLong(parts[1]);
-                        rookMagics[square] = magicNumber;
-                    }
-                }
-            }
-        } catch (IOException | NullPointerException e) {
-            log.error("Error reading magic numbers from file", e);
-        }
+        System.arraycopy(PRECOMPUTED_ROOK_MAGICS, 0, rookMagics, 0, rookMagics.length);
+        Arrays.fill(squareMagicFound, true);
     }
 
     private void writeMagicNumbersToFile(ConcurrentHashMap<Integer, Long> magicNumbers) {


### PR DESCRIPTION
## Summary
- embed the existing bishop and rook magic numbers directly in their helper classes
- initialize the magic arrays from the new constants while preserving square status flags

## Testing
- mvn -q -DskipTests package *(fails: release version 25 not supported in container JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68d716aebb24832a86a1346cbfb65bad