### PR TITLE
Decouple heuristics snapshots from shared lock

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -16,9 +16,11 @@ import org.springframework.stereotype.Component;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.locks.StampedLock;
 
 import static julius.game.chessengine.helper.BitHelper.FileMasks;
 import static julius.game.chessengine.helper.KingHelper.KING_ATTACKS;
@@ -133,7 +135,8 @@ public class AI {
      */
     private final ThreadLocal<Heuristics> threadHeuristics;
 
-    private final Object heuristicsLock = new Object();
+    private final StampedLock heuristicsLock = new StampedLock();
+    private final LockMetrics heuristicsLockMetrics = new LockMetrics();
 
     // Buffers used for move ordering. Reused across calls to avoid repeated
     // allocations when ordering moves.
@@ -267,6 +270,52 @@ public class AI {
         this.mainEngine.setOnPositionChanged(h -> updateBoardStateHash());
     }
 
+    private long acquireWriteLock() {
+        long start = System.nanoTime();
+        long stamp = heuristicsLock.writeLock();
+        heuristicsLockMetrics.recordWriteAcquisition(System.nanoTime() - start);
+        return stamp;
+    }
+
+    private long acquireReadLock() {
+        long start = System.nanoTime();
+        long stamp = heuristicsLock.readLock();
+        heuristicsLockMetrics.recordReadAcquisition(System.nanoTime() - start);
+        return stamp;
+    }
+
+    private void releaseWriteLock(long stamp) {
+        heuristicsLock.unlockWrite(stamp);
+    }
+
+    private void releaseReadLock(long stamp) {
+        heuristicsLock.unlockRead(stamp);
+    }
+
+    private Heuristics.Snapshot captureHeuristicsSnapshot(int requiredDepth) {
+        while (true) {
+            long stamp = heuristicsLock.tryOptimisticRead();
+            if (stamp != 0L) {
+                Heuristics.Snapshot optimistic = globalHeuristics.snapshot(requiredDepth);
+                if (heuristicsLock.validate(stamp)) {
+                    heuristicsLockMetrics.recordOptimisticSnapshot();
+                    return optimistic;
+                }
+            }
+            long readStamp = acquireReadLock();
+            try {
+                heuristicsLockMetrics.recordOptimisticFallback();
+                return globalHeuristics.snapshot(requiredDepth);
+            } finally {
+                releaseReadLock(readStamp);
+            }
+        }
+    }
+
+    LockMetricsSnapshot snapshotHeuristicsLockMetrics() {
+        return heuristicsLockMetrics.snapshot();
+    }
+
     private void rebuildTranspositionTables() {
         boolean concurrent = Math.max(searchThreads, lazySmpThreads) > 1;
         long totalBytes = Math.max(1L, (long) hashSizeMb * 1024L * 1024L);
@@ -371,8 +420,11 @@ public class AI {
      */
     public synchronized void setMaxDepth(int depth) {
         int requestedDepth = Math.max(1, depth);
-        synchronized (heuristicsLock) {
+        long stamp = acquireWriteLock();
+        try {
             globalHeuristics.ensureCapacity(requestedDepth);
+        } finally {
+            releaseWriteLock(stamp);
         }
         threadHeuristics.get().ensureCapacity(requestedDepth);
         this.maxDepth = requestedDepth;
@@ -561,7 +613,8 @@ public class AI {
     }
 
     private void prepareIterationState(SearchTask task, Heuristics heuristics, int currentDepth, boolean firstAtDepth) {
-        synchronized (heuristicsLock) {
+        long stamp = acquireWriteLock();
+        try {
             globalHeuristics.ensureCapacity(maxDepth);
             if (firstAtDepth) {
                 if (transpositionTable != null) {
@@ -572,14 +625,20 @@ public class AI {
                 }
                 globalHeuristics.decayHistory();
             }
-            heuristics.beginIteration(globalHeuristics, maxDepth);
-            heuristics.markPrepared(task.getId(), currentDepth);
+        } finally {
+            releaseWriteLock(stamp);
         }
+        Heuristics.Snapshot snapshot = captureHeuristicsSnapshot(maxDepth);
+        heuristics.beginIteration(snapshot, maxDepth);
+        heuristics.markPrepared(task.getId(), currentDepth);
     }
 
     private void mergeThreadHeuristics(Heuristics heuristics) {
-        synchronized (heuristicsLock) {
+        long stamp = acquireWriteLock();
+        try {
             heuristics.mergeInto(globalHeuristics);
+        } finally {
+            releaseWriteLock(stamp);
         }
         heuristics.resetUpdates();
     }
@@ -587,11 +646,15 @@ public class AI {
     private Heuristics prepareHelperHeuristics(SearchTask task, int depth) {
         Heuristics heuristics = threadHeuristics.get();
         if (!heuristics.isPreparedFor(task.getId(), depth)) {
-            synchronized (heuristicsLock) {
+            long stamp = acquireWriteLock();
+            try {
                 globalHeuristics.ensureCapacity(maxDepth);
-                heuristics.beginIteration(globalHeuristics, maxDepth);
-                heuristics.markPrepared(task.getId(), depth);
+            } finally {
+                releaseWriteLock(stamp);
             }
+            Heuristics.Snapshot snapshot = captureHeuristicsSnapshot(maxDepth);
+            heuristics.beginIteration(snapshot, maxDepth);
+            heuristics.markPrepared(task.getId(), depth);
         }
         return heuristics;
     }
@@ -2162,21 +2225,30 @@ public class AI {
     }
 
     private void decayHistoryTable() {
-        synchronized (heuristicsLock) {
+        long stamp = acquireWriteLock();
+        try {
             globalHeuristics.decayHistory();
+        } finally {
+            releaseWriteLock(stamp);
         }
     }
 
     private void clearHistoryTable() {
-        synchronized (heuristicsLock) {
+        long stamp = acquireWriteLock();
+        try {
             globalHeuristics.clearHistory();
             globalHeuristics.clearCounter();
+        } finally {
+            releaseWriteLock(stamp);
         }
     }
 
     int[][] snapshotKillerMoves() {
-        synchronized (heuristicsLock) {
+        long stamp = acquireReadLock();
+        try {
             return globalHeuristics.snapshotKillers();
+        } finally {
+            releaseReadLock(stamp);
         }
     }
 
@@ -2187,6 +2259,95 @@ public class AI {
         int victimValue = Score.getPieceValue(MoveHelper.deriveCapturedPieceTypeBits(move));
         int attackerValue = Score.getPieceValue(MoveHelper.derivePieceTypeBits(move));
         return victimValue - attackerValue;
+    }
+
+    static final class LockMetricsSnapshot {
+        private final long maxReadWaitNanos;
+        private final long maxWriteWaitNanos;
+        private final long readAcquisitions;
+        private final long writeAcquisitions;
+        private final long optimisticSnapshots;
+        private final long optimisticFallbacks;
+
+        LockMetricsSnapshot(long maxReadWaitNanos,
+                            long maxWriteWaitNanos,
+                            long readAcquisitions,
+                            long writeAcquisitions,
+                            long optimisticSnapshots,
+                            long optimisticFallbacks) {
+            this.maxReadWaitNanos = maxReadWaitNanos;
+            this.maxWriteWaitNanos = maxWriteWaitNanos;
+            this.readAcquisitions = readAcquisitions;
+            this.writeAcquisitions = writeAcquisitions;
+            this.optimisticSnapshots = optimisticSnapshots;
+            this.optimisticFallbacks = optimisticFallbacks;
+        }
+
+        long getMaxReadWaitNanos() {
+            return maxReadWaitNanos;
+        }
+
+        long getMaxWriteWaitNanos() {
+            return maxWriteWaitNanos;
+        }
+
+        long getReadAcquisitions() {
+            return readAcquisitions;
+        }
+
+        long getWriteAcquisitions() {
+            return writeAcquisitions;
+        }
+
+        long getOptimisticSnapshots() {
+            return optimisticSnapshots;
+        }
+
+        long getOptimisticFallbacks() {
+            return optimisticFallbacks;
+        }
+    }
+
+    private static final class LockMetrics {
+        private final AtomicLong maxReadWait = new AtomicLong();
+        private final AtomicLong maxWriteWait = new AtomicLong();
+        private final LongAdder readAcquisitions = new LongAdder();
+        private final LongAdder writeAcquisitions = new LongAdder();
+        private final LongAdder optimisticSnapshots = new LongAdder();
+        private final LongAdder optimisticFallbacks = new LongAdder();
+
+        void recordReadAcquisition(long waitNanos) {
+            readAcquisitions.increment();
+            updateMax(maxReadWait, waitNanos);
+        }
+
+        void recordWriteAcquisition(long waitNanos) {
+            writeAcquisitions.increment();
+            updateMax(maxWriteWait, waitNanos);
+        }
+
+        void recordOptimisticSnapshot() {
+            optimisticSnapshots.increment();
+        }
+
+        void recordOptimisticFallback() {
+            optimisticFallbacks.increment();
+        }
+
+        LockMetricsSnapshot snapshot() {
+            return new LockMetricsSnapshot(
+                    maxReadWait.get(),
+                    maxWriteWait.get(),
+                    readAcquisitions.sum(),
+                    writeAcquisitions.sum(),
+                    optimisticSnapshots.sum(),
+                    optimisticFallbacks.sum()
+            );
+        }
+
+        private static void updateMax(AtomicLong target, long value) {
+            target.accumulateAndGet(value, (cur, v) -> Math.max(cur, v));
+        }
     }
 
     private static final class Heuristics {
@@ -2253,17 +2414,46 @@ public class AI {
             killerDirtyList = Arrays.copyOf(killerDirtyList, depth);
         }
 
-        void beginIteration(Heuristics base, int requiredDepth) {
+        void beginIteration(Snapshot snapshot, int requiredDepth) {
             resetUpdates();
             ensureCapacity(requiredDepth);
-            base.ensureCapacity(requiredDepth);
-            int limit = Math.min(requiredDepth, base.killers.length);
+            int limit = Math.min(requiredDepth, snapshot.killers.length);
             for (int d = 0; d < limit; d++) {
-                System.arraycopy(base.killers[d], 0, killers[d], 0, NUM_KILLER_MOVES);
+                System.arraycopy(snapshot.killers[d], 0, killers[d], 0, NUM_KILLER_MOVES);
+            }
+            for (int d = limit; d < requiredDepth; d++) {
+                Arrays.fill(killers[d], -1);
             }
             for (int f = 0; f < BOARD_SQUARES; f++) {
-                System.arraycopy(base.history[f], 0, history[f], 0, BOARD_SQUARES);
-                System.arraycopy(base.counter[f], 0, counter[f], 0, BOARD_SQUARES);
+                System.arraycopy(snapshot.history[f], 0, history[f], 0, BOARD_SQUARES);
+                System.arraycopy(snapshot.counter[f], 0, counter[f], 0, BOARD_SQUARES);
+            }
+        }
+
+        Snapshot snapshot(int requiredDepth) {
+            int killerDepth = Math.min(requiredDepth, killers.length);
+            int[][] killerCopy = new int[killerDepth][];
+            for (int d = 0; d < killerDepth; d++) {
+                killerCopy[d] = Arrays.copyOf(killers[d], NUM_KILLER_MOVES);
+            }
+            int[][] historyCopy = new int[BOARD_SQUARES][];
+            int[][] counterCopy = new int[BOARD_SQUARES][];
+            for (int f = 0; f < BOARD_SQUARES; f++) {
+                historyCopy[f] = Arrays.copyOf(history[f], BOARD_SQUARES);
+                counterCopy[f] = Arrays.copyOf(counter[f], BOARD_SQUARES);
+            }
+            return new Snapshot(killerCopy, historyCopy, counterCopy);
+        }
+
+        static final class Snapshot {
+            final int[][] killers;
+            final int[][] history;
+            final int[][] counter;
+
+            Snapshot(int[][] killers, int[][] history, int[][] counter) {
+                this.killers = killers;
+                this.history = history;
+                this.counter = counter;
             }
         }
 

--- a/src/test/java/julius/game/chessengine/ai/HeuristicsLockStressTest.java
+++ b/src/test/java/julius/game/chessengine/ai/HeuristicsLockStressTest.java
@@ -1,0 +1,125 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.engine.Engine;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.SplittableRandom;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+class HeuristicsLockStressTest {
+
+    private static final String SEARCH_THREADS_PROP = "chessengine.searchThreads";
+    private static final String LAZY_SMP_THREADS_PROP = "chessengine.lazySmpThreads";
+
+    @BeforeEach
+    void configureThreads() {
+        System.setProperty(SEARCH_THREADS_PROP, "24");
+        System.setProperty(LAZY_SMP_THREADS_PROP, "24");
+    }
+
+    @AfterEach
+    void clearThreadProperties() {
+        System.clearProperty(SEARCH_THREADS_PROP);
+        System.clearProperty(LAZY_SMP_THREADS_PROP);
+    }
+
+    @Test
+    void iterativeDeepeningKeepsHeuristicsLockContentionLow() throws Exception {
+        Engine engine = new Engine();
+        AI ai = new AI(engine);
+        ai.setMaxDepth(4);
+
+        Engine rootSnapshot = engine.createSimulation();
+        long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(300);
+        SearchTask task = new SearchTask(1L, engine.getBoardStateHash(), engine.whitesTurn(), deadline, 24, rootSnapshot);
+
+        Method iterativeDeepening = AI.class.getDeclaredMethod(
+                "iterativeDeepening", SearchTask.class, Engine.class, SplittableRandom.class);
+        iterativeDeepening.setAccessible(true);
+
+        Field threadSearchTaskField = AI.class.getDeclaredField("threadSearchTask");
+        threadSearchTaskField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        ThreadLocal<SearchTask> threadSearchTask = (ThreadLocal<SearchTask>) threadSearchTaskField.get(ai);
+
+        ExecutorService pool = Executors.newFixedThreadPool(24);
+        CountDownLatch ready = new CountDownLatch(24);
+        CountDownLatch start = new CountDownLatch(1);
+
+        for (int workerIndex = 0; workerIndex < 24; workerIndex++) {
+            final int index = workerIndex;
+            pool.submit(() -> {
+                Engine workerEngine = task.getRootSnapshot().createSimulation();
+                SplittableRandom rng = new SplittableRandom(
+                        task.getBoardHash() ^ (0x9E3779B97F4A7C15L * (index + 1L)));
+                ready.countDown();
+                try {
+                    start.await();
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+
+                threadSearchTask.set(task);
+                try {
+                    invokeIterativeDeepening(iterativeDeepening, ai, task, workerEngine, rng);
+                } finally {
+                    threadSearchTask.remove();
+                    task.workerDone();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+
+        task.awaitCompletion();
+        task.requestStop();
+
+        pool.shutdownNow();
+        pool.awaitTermination(2, TimeUnit.SECONDS);
+
+        AI.LockMetricsSnapshot metrics = ai.snapshotHeuristicsLockMetrics();
+        Assertions.assertTrue(metrics.getWriteAcquisitions() > 0,
+                "expected at least one write lock acquisition");
+        Assertions.assertTrue(metrics.getReadAcquisitions() > 0,
+                "expected at least one read lock acquisition");
+
+        long maxWriteMillis = TimeUnit.NANOSECONDS.toMillis(metrics.getMaxWriteWaitNanos());
+        long maxReadMillis = TimeUnit.NANOSECONDS.toMillis(metrics.getMaxReadWaitNanos());
+        Assertions.assertTrue(maxWriteMillis < 100,
+                "write lock wait exceeded threshold: " + maxWriteMillis + "ms");
+        Assertions.assertTrue(maxReadMillis < 100,
+                "read lock wait exceeded threshold: " + maxReadMillis + "ms");
+    }
+
+    private static void invokeIterativeDeepening(Method method,
+                                                 AI ai,
+                                                 SearchTask task,
+                                                 Engine engine,
+                                                 SplittableRandom rng) {
+        try {
+            method.invoke(ai, task, engine, rng);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError("Failed to access iterativeDeepening", e);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException runtime) {
+                throw runtime;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw new AssertionError("Unexpected exception", cause);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the global heuristics monitor with a stamped lock and record acquisition metrics
- copy killer/history/counter data from optimistic snapshots outside the write phase
- add a 24-thread iterative-deepening stress test that checks heuristics lock contention stays low

## Testing
- ./mvnw test *(fails: Maven wrapper could not download dependencies because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d719523128832aaad65cb64cf15ca1