### PR TITLE
Replace move history ArrayList with primitive stack

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -5,6 +5,7 @@ import julius.game.chessengine.board.*;
 import julius.game.chessengine.cache.TimedLRUCache;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.utils.Color;
+import julius.game.chessengine.utils.MoveStack;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
@@ -126,8 +127,8 @@ public class Engine {
     private MoveList legalMovesSnapshot;
 
     @Getter
-    private ArrayList<Integer> line = new ArrayList<>();
-    private ArrayList<Integer> redoLine = new ArrayList<>();
+    private MoveStack line = new MoveStack();
+    private MoveStack redoLine = new MoveStack();
     private BitBoard bitBoard = new BitBoard();
     @Getter
     private GameState gameState = new GameState(bitBoard);
@@ -143,8 +144,8 @@ public class Engine {
         synchronized (other.boardLock) {
             this.bitBoard = new BitBoard(other.bitBoard);
             this.gameState = new GameState(other.gameState);
-            this.line = new ArrayList<>(other.line);
-            this.redoLine = new ArrayList<>(other.redoLine);
+            this.line = new MoveStack(other.line);
+            this.redoLine = new MoveStack(other.redoLine);
 
             // ❌ heavy: cloning the current legal list and cache
             // this.legalMoves = other.legalMoves == null ? null : new MoveList(other.legalMoves);
@@ -217,7 +218,7 @@ public class Engine {
                 gameState.pushHalfmoveClock();
                 gameState.update(bitBoard, legalMoves, move, isOpeningMove);
                 gameState.getScore().applyMove(bitBoard, move, gameState.getState());
-                line.add(move);
+                line.push(move);
                 notifyPositionChanged();
             }
         }
@@ -267,8 +268,8 @@ public class Engine {
             synchronized (other.boardLock) {
                 this.bitBoard = new BitBoard(other.bitBoard);
                 this.gameState = new GameState(other.gameState);
-                this.line = new ArrayList<>(other.line);
-                this.redoLine = new ArrayList<>(other.redoLine);
+                this.line = new MoveStack(other.line);
+                this.redoLine = new MoveStack(other.redoLine);
                 this.legalMoves = null;
                 markLegalMovesStale();
                 recycleCacheEntries();
@@ -283,8 +284,8 @@ public class Engine {
             bitBoard = new BitBoard();
             gameState = new GameState(bitBoard);
             markLegalMovesStale();
-            line = new ArrayList<>();
-            redoLine = new ArrayList<>();
+            line = new MoveStack();
+            redoLine = new MoveStack();
             this.openingBook = OpeningBook.getInstance();
             recycleCacheEntries();
             legalMovesCache = createLegalMovesCache();
@@ -539,7 +540,7 @@ public class Engine {
         synchronized (boardLock) {
             if (line.isEmpty()) throw new IllegalStateException("undoLastMoveWasNotPossible, line is empty");
 
-            Integer undoMove = line.getLast();
+            int undoMove = line.pop();
 
             long currentHash = getBoardStateHash();
             gameState.removeHash(currentHash);
@@ -554,8 +555,7 @@ public class Engine {
             gameState.getScore().undoMove(bitBoard, undoMove, gameState.getState());
 
             // 3) Bookkeeping
-            redoLine.add(undoMove);
-            line.removeLast();
+            redoLine.push(undoMove);
             notifyPositionChanged();
         }
     }
@@ -564,8 +564,7 @@ public class Engine {
     public void redoMove() {
         synchronized (boardLock) {
             if (!redoLine.isEmpty()) {
-                performMove(redoLine.getLast());
-                redoLine.removeLast();
+                performMove(redoLine.pop());
                 notifyPositionChanged();
             } else {
                 throw new IllegalStateException("redoLastMoveWasNotPossible, redoLine is empty");
@@ -573,9 +572,9 @@ public class Engine {
         }
     }
 
-    public Integer getLastMove() {
+    public int getLastMove() {
         if (!line.isEmpty()) {
-            return line.getLast();
+            return line.peek();
         } else {
             return -1;
         }

--- a/src/main/java/julius/game/chessengine/pgn/PgnParser.java
+++ b/src/main/java/julius/game/chessengine/pgn/PgnParser.java
@@ -4,9 +4,9 @@ import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.MoveList;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.figures.PieceType;
+import julius.game.chessengine.utils.MoveStack;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
 
 public class PgnParser {
 
@@ -18,7 +18,7 @@ public class PgnParser {
         BOTH  // Ambiguity in both file and rank
     }
     private final Engine engine = new Engine();
-    private final ArrayList<Integer> line;
+    private final MoveStack line;
 
     private String event = "Alieknek testing";
     private String site = "Neulengbach";
@@ -32,7 +32,7 @@ public class PgnParser {
     boolean sameFile = false;
     boolean sameRank = false;
 
-    public PgnParser(ArrayList<Integer> line) {
+    public PgnParser(MoveStack line) {
         this.line = line;
     }
 
@@ -44,11 +44,12 @@ public class PgnParser {
         int moveCounter = 1;
 
         for (int i = 0; i < line.size(); i++) {
-            engine.performMove(line.get(i)); // Update the engine's state for the next move
+            int move = line.get(i);
+            engine.performMove(move); // Update the engine's state for the next move
             if (i % 2 == 0) {
                 pgn.append(moveCounter++).append(". ");
             }
-            String movePgn = convertMoveToPgn(line.get(i));
+            String movePgn = convertMoveToPgn(move);
             pgn.append(movePgn).append(" ");
 
         }

--- a/src/main/java/julius/game/chessengine/utils/MoveStack.java
+++ b/src/main/java/julius/game/chessengine/utils/MoveStack.java
@@ -1,0 +1,98 @@
+package julius.game.chessengine.utils;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
+
+/**
+ * A lightweight primitive stack optimised for chess move history tracking.
+ * It stores moves in a growable {@code int[]} without boxing so callers can
+ * push/pop frequently without triggering {@link Integer#valueOf(int)}.
+ */
+public final class MoveStack {
+
+    private static final int DEFAULT_CAPACITY = 32;
+
+    private int[] buffer;
+    private int size;
+
+    public MoveStack() {
+        this(DEFAULT_CAPACITY);
+    }
+
+    public MoveStack(int initialCapacity) {
+        if (initialCapacity <= 0) {
+            initialCapacity = DEFAULT_CAPACITY;
+        }
+        this.buffer = new int[initialCapacity];
+        this.size = 0;
+    }
+
+    public MoveStack(MoveStack other) {
+        this.size = other.size;
+        this.buffer = Arrays.copyOf(other.buffer, other.size);
+    }
+
+    public void copyFrom(MoveStack other) {
+        if (this == other) {
+            return;
+        }
+        ensureCapacity(other.size);
+        System.arraycopy(other.buffer, 0, this.buffer, 0, other.size);
+        this.size = other.size;
+    }
+
+    public void push(int value) {
+        ensureCapacity(size + 1);
+        buffer[size++] = value;
+    }
+
+    public int pop() {
+        if (size == 0) {
+            throw new NoSuchElementException("MoveStack is empty");
+        }
+        return buffer[--size];
+    }
+
+    public int peek() {
+        if (size == 0) {
+            throw new NoSuchElementException("MoveStack is empty");
+        }
+        return buffer[size - 1];
+    }
+
+    public boolean isEmpty() {
+        return size == 0;
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public void clear() {
+        size = 0;
+    }
+
+    public int get(int index) {
+        if (index < 0 || index >= size) {
+            throw new IndexOutOfBoundsException(index + " outside of size " + size);
+        }
+        return buffer[index];
+    }
+
+    public int[] toArray() {
+        return Arrays.copyOf(buffer, size);
+    }
+
+    public IntStream stream() {
+        return Arrays.stream(buffer, 0, size);
+    }
+
+    private void ensureCapacity(int capacity) {
+        if (capacity <= buffer.length) {
+            return;
+        }
+        int newCapacity = Math.max(capacity, buffer.length << 1);
+        buffer = Arrays.copyOf(buffer, newCapacity);
+    }
+}


### PR DESCRIPTION
## Summary
- add a lightweight MoveStack utility for primitive move history management
- update Engine history bookkeeping to use MoveStack and expose primitive accessors
- adapt PGN parsing to iterate over the primitive move stack without boxing

## Testing
- ./mvnw -q test *(fails: network is unreachable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68d7340bad74832aaa781951aeb0e1d6