### PR TITLE
Build opening book from PGNs with caching

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/OpeningBook.java
+++ b/src/main/java/julius/game/chessengine/ai/OpeningBook.java
@@ -1,27 +1,24 @@
 package julius.game.chessengine.ai;
 
-import julius.game.chessengine.board.Move;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Component
 @Log4j2
 public class OpeningBook {
-    private static final String OPENINGS_FILE_PATH = "/opening/openings.txt";
-    private static final Map<Long, List<Integer>> openings = new ConcurrentHashMap<>();
+    private static final Map<Long, List<OpeningEntry>> openings = new ConcurrentHashMap<>();
+    private final OpeningBookLoader loader;
 
     private static final class Holder {
         static final OpeningBook INSTANCE = new OpeningBook();
     }
 
     private OpeningBook() {
+        this.loader = new OpeningBookLoader();
         loadOpenings();
     }
 
@@ -30,67 +27,46 @@ public class OpeningBook {
     }
 
     private void loadOpenings() {
-        // When running from a packaged JAR the resource is immutable, so we only
-        // populate the in-memory cache once at start-up.
         if (!openings.isEmpty()) {
             return;
         }
-
-        try (InputStream is = getClass().getResourceAsStream(OPENINGS_FILE_PATH);
-             BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
-
-            String line;
-            while ((line = reader.readLine()) != null) {
-                String[] parts = line.split(",");
-                if (parts.length == 2) {
-                    int move = Integer.parseInt(parts[0].trim());
-                    long boardStateHash = Long.parseLong(parts[1].trim());
-                    openings.computeIfAbsent(boardStateHash, k -> new CopyOnWriteArrayList<>()).add(move);
-                }
-            }
-        } catch (IOException | NullPointerException e) {
-            // Handle exceptions or log errors
-        }
-    }
-
-    public void addOpening(int move, long boardStateHash) {
-        List<Integer> existingMoves = openings.computeIfAbsent(boardStateHash, k -> new CopyOnWriteArrayList<>());
-        if (!existingMoves.contains(move)) {
-            existingMoves.add(move);
-            writeOpening(move, boardStateHash); // Writes to the file
-        }
-    }
-
-
-    public void writeOpening(int move, long boardStateHash) {
-        // This method writes a new opening move to the file
-        File file = new File("src/main/resources" + OPENINGS_FILE_PATH);
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, true))) {
-            writer.write(move + "," + boardStateHash + "\n");
-        } catch (IOException e) {
-            // Handle exceptions or log errors
-        }
+        OpeningBookLoader.Result result = loader.load();
+        openings.clear();
+        openings.putAll(result.entries());
+        log.info("Opening book initialised with {} unique positions{}", openings.size(),
+                result.fromCache() ? " (cache hit)" : "");
     }
 
     public List<Integer> getMovesForBoardStateHash(long boardStateHash) {
-        return openings.getOrDefault(boardStateHash, Collections.emptyList());
+        List<OpeningEntry> entries = openings.get(boardStateHash);
+        if (entries == null || entries.isEmpty()) {
+            return Collections.emptyList();
+        }
+        LinkedHashSet<Integer> unique = new LinkedHashSet<>();
+        for (OpeningEntry entry : entries) {
+            unique.add(entry.move());
+        }
+        return List.copyOf(unique);
     }
 
     public int getRandomMoveForBoardStateHash(long boardStateHash) {
-        List<Integer> moves = getMovesForBoardStateHash(boardStateHash);
-
-        if (moves.isEmpty()) {
+        List<OpeningEntry> entries = openings.get(boardStateHash);
+        if (entries == null || entries.isEmpty()) {
             return -1; // or a default move, depending on how you want to handle this scenario
         }
-        return moves.get(ThreadLocalRandom.current().nextInt(moves.size()));
+        OpeningEntry entry = entries.get(ThreadLocalRandom.current().nextInt(entries.size()));
+        return entry.move();
     }
 
     public boolean containsMoveAndBoardStateHash(long boardStateHashBeforeMove, int move) {
-
-        List<Integer> moves = openings.get(boardStateHashBeforeMove);
-        if (moves == null) {
+        List<OpeningEntry> entries = openings.get(boardStateHashBeforeMove);
+        if (entries == null) {
             return false;
         }
-        return moves.contains(move);
+        return entries.stream().anyMatch(entry -> entry.move() == move);
+    }
+
+    public List<OpeningEntry> getEntriesForHash(long boardStateHash) {
+        return openings.getOrDefault(boardStateHash, Collections.emptyList());
     }
 }

--- a/src/main/java/julius/game/chessengine/ai/OpeningBookCache.java
+++ b/src/main/java/julius/game/chessengine/ai/OpeningBookCache.java
@@ -1,0 +1,95 @@
+package julius.game.chessengine.ai;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.log4j.Log4j2;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Small helper responsible for serialising/deserialising the opening book to a
+ * JSON cache on disk.  The cache is keyed by a content fingerprint so callers
+ * can safely reuse precomputed data across restarts until the underlying PGNs
+ * change.
+ */
+@Log4j2
+final class OpeningBookCache {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+
+    private final Path cachePath;
+
+    OpeningBookCache(Path cachePath) {
+        this.cachePath = Objects.requireNonNull(cachePath, "cachePath");
+    }
+
+    record CachePayload(String fingerprint, List<CachedEntry> entries) {}
+
+    record CachedEntry(long hash, int move, String openingName, int ply, List<Integer> continuation) {
+        CachedEntry {
+            continuation = continuation == null ? List.of() : List.copyOf(continuation);
+        }
+    }
+
+    CachePayload readIfPresent() {
+        if (!Files.exists(cachePath)) {
+            return null;
+        }
+        try (InputStream is = Files.newInputStream(cachePath)) {
+            return OBJECT_MAPPER.readValue(is, new TypeReference<>() {});
+        } catch (IOException ex) {
+            log.warn("Failed to read opening book cache from {}. Falling back to regeneration.", cachePath, ex);
+            return null;
+        }
+    }
+
+    void write(CachePayload payload) {
+        Objects.requireNonNull(payload, "payload");
+        try {
+            Path parent = cachePath.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+        } catch (IOException ex) {
+            log.warn("Unable to create cache directory for {}", cachePath, ex);
+        }
+        try (OutputStream os = Files.newOutputStream(cachePath)) {
+            OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValue(os, payload);
+        } catch (IOException ex) {
+            log.warn("Failed to write opening book cache to {}", cachePath, ex);
+        }
+    }
+
+    static Map<Long, List<OpeningEntry>> toMap(CachePayload payload) {
+        if (payload == null || payload.entries == null) {
+            return Collections.emptyMap();
+        }
+        Map<Long, List<OpeningEntry>> map = new HashMap<>();
+        for (CachedEntry cached : payload.entries) {
+            OpeningEntry entry = new OpeningEntry(cached.move, cached.openingName, cached.ply, cached.continuation);
+            map.computeIfAbsent(cached.hash, k -> new ArrayList<>()).add(entry);
+        }
+        map.replaceAll((k, v) -> Collections.unmodifiableList(new ArrayList<>(v)));
+        return map;
+    }
+
+    static CachePayload fromMap(String fingerprint, Map<Long, List<OpeningEntry>> openings) {
+        List<CachedEntry> entries = new ArrayList<>();
+        openings.forEach((hash, entryList) -> entryList.forEach(entry ->
+                entries.add(new CachedEntry(hash, entry.move(), entry.openingName(), entry.ply(), entry.continuation()))));
+        return new CachePayload(fingerprint, entries);
+    }
+}

--- a/src/main/java/julius/game/chessengine/ai/OpeningBookLoader.java
+++ b/src/main/java/julius/game/chessengine/ai/OpeningBookLoader.java
@@ -1,0 +1,188 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.pgn.OpeningPgnReader;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Handles discovery of PGN resources, parsing and construction of the
+ * {@link OpeningEntry} map used by {@link OpeningBook}.  The loader also takes
+ * care of persisting a cache to speed-up subsequent startups.
+ */
+@Log4j2
+final class OpeningBookLoader {
+
+    private static final String DEFAULT_RESOURCE_PATTERN = "classpath*:opening/*.pgn";
+    private static final String OPENING_DIR_PROP = "chess.opening.dir";
+    private static final String OPENING_DIR_ENV = "CHESS_OPENING_DIR";
+    private static final String CACHE_PATH_PROP = "chess.opening.cache";
+    private static final String CACHE_PATH_ENV = "CHESS_OPENING_CACHE";
+
+    private final OpeningPgnReader reader = new OpeningPgnReader();
+
+    record Result(Map<Long, List<OpeningEntry>> entries, boolean fromCache) {}
+
+    Result load() {
+        List<OpeningResource> resources = locateResources();
+        if (resources.isEmpty()) {
+            log.info("No PGN files discovered for opening book");
+            return new Result(Collections.emptyMap(), false);
+        }
+        resources.sort(Comparator.comparing(OpeningResource::openingName));
+        String fingerprint = computeFingerprint(resources);
+        OpeningBookCache cache = new OpeningBookCache(resolveCachePath());
+        OpeningBookCache.CachePayload cached = cache.readIfPresent();
+        if (cached != null && Objects.equals(cached.fingerprint(), fingerprint)) {
+            log.info("Loaded opening book from cache ({} entries)", cached.entries().size());
+            return new Result(OpeningBookCache.toMap(cached), true);
+        }
+        Map<Long, List<OpeningEntry>> parsed = parseResources(resources);
+        cache.write(OpeningBookCache.fromMap(fingerprint, parsed));
+        log.info("Parsed {} PGN resources into {} unique hashes", resources.size(), parsed.size());
+        return new Result(parsed, false);
+    }
+
+    private Map<Long, List<OpeningEntry>> parseResources(List<OpeningResource> resources) {
+        Map<Long, List<OpeningEntry>> aggregated = new HashMap<>();
+        for (OpeningResource resource : resources) {
+            List<OpeningPgnReader.ParsedGame> games = reader.parse(resource.data());
+            for (OpeningPgnReader.ParsedGame game : games) {
+                applyGame(resource.openingName(), game, aggregated);
+            }
+        }
+        aggregated.replaceAll((hash, entries) -> Collections.unmodifiableList(new ArrayList<>(entries)));
+        return Collections.unmodifiableMap(new ConcurrentHashMap<>(aggregated));
+    }
+
+    private void applyGame(String openingName, OpeningPgnReader.ParsedGame game, Map<Long, List<OpeningEntry>> aggregated) {
+        List<Integer> moves = game.moves();
+        List<Long> hashes = game.hashes();
+        for (int i = 0; i < moves.size() && i < hashes.size(); i++) {
+            long hash = hashes.get(i);
+            int move = moves.get(i);
+            List<Integer> continuation = moves.subList(i + 1, moves.size());
+            OpeningEntry entry = new OpeningEntry(move, openingName, i + 1, continuation);
+            aggregated.computeIfAbsent(hash, k -> new ArrayList<>()).add(entry);
+        }
+    }
+
+    private String computeFingerprint(List<OpeningResource> resources) {
+        List<byte[]> blobs = resources.stream()
+                .map(res -> combineNameAndData(res.openingName(), res.data()))
+                .collect(Collectors.toList());
+        return reader.fingerprint(blobs);
+    }
+
+    private byte[] combineNameAndData(String name, byte[] data) {
+        byte[] nameBytes = name.getBytes(StandardCharsets.UTF_8);
+        byte[] combined = new byte[nameBytes.length + 1 + data.length];
+        System.arraycopy(nameBytes, 0, combined, 0, nameBytes.length);
+        combined[nameBytes.length] = 0;
+        System.arraycopy(data, 0, combined, nameBytes.length + 1, data.length);
+        return combined;
+    }
+
+    private List<OpeningResource> locateResources() {
+        String configuredPath = firstNonBlank(System.getProperty(OPENING_DIR_PROP), System.getenv(OPENING_DIR_ENV));
+        if (configuredPath != null) {
+            Path directory = Paths.get(configuredPath);
+            if (Files.isDirectory(directory)) {
+                return readFromDirectory(directory);
+            }
+            log.warn("Configured opening directory {} does not exist", directory);
+        }
+        return readFromClasspath();
+    }
+
+    private List<OpeningResource> readFromDirectory(Path directory) {
+        try {
+            List<OpeningResource> resources = new ArrayList<>();
+            try (var stream = Files.walk(directory)) {
+                stream.filter(Files::isRegularFile)
+                        .filter(path -> path.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".pgn"))
+                        .forEach(path -> resources.add(loadPath(path)));
+            }
+            return resources;
+        } catch (IOException ex) {
+            throw new UncheckedIOException("Failed to read directory " + directory, ex);
+        }
+    }
+
+    private OpeningResource loadPath(Path path) {
+        try {
+            byte[] data = Files.readAllBytes(path);
+            return new OpeningResource(openingNameFromFile(path.getFileName().toString()), data);
+        } catch (IOException ex) {
+            throw new UncheckedIOException("Failed to read PGN file " + path, ex);
+        }
+    }
+
+    private List<OpeningResource> readFromClasspath() {
+        try {
+            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            Resource[] resources = resolver.getResources(DEFAULT_RESOURCE_PATTERN);
+            List<OpeningResource> result = new ArrayList<>();
+            for (Resource resource : resources) {
+                if (!resource.exists()) {
+                    continue;
+                }
+                byte[] data = resource.getContentAsByteArray();
+                String filename = Optional.ofNullable(resource.getFilename()).orElse("opening");
+                result.add(new OpeningResource(openingNameFromFile(filename), data));
+            }
+            return result;
+        } catch (IOException ex) {
+            log.warn("Unable to read classpath PGNs", ex);
+            return Collections.emptyList();
+        }
+    }
+
+    private Path resolveCachePath() {
+        String configured = firstNonBlank(System.getProperty(CACHE_PATH_PROP), System.getenv(CACHE_PATH_ENV));
+        if (configured != null) {
+            return Paths.get(configured);
+        }
+        return Paths.get("target", "opening-book-cache.json");
+    }
+
+    private String openingNameFromFile(String filename) {
+        int dot = filename.lastIndexOf('.');
+        String base = dot == -1 ? filename : filename.substring(0, dot);
+        return base.replace('_', ' ').trim();
+    }
+
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private record OpeningResource(String openingName, byte[] data) {
+        OpeningResource {
+            Objects.requireNonNull(openingName, "openingName");
+            Objects.requireNonNull(data, "data");
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/ai/OpeningEntry.java
+++ b/src/main/java/julius/game/chessengine/ai/OpeningEntry.java
@@ -1,0 +1,19 @@
+package julius.game.chessengine.ai;
+
+import java.util.List;
+
+/**
+ * Represents a single move in the opening book linked to the position it
+ * originated from.  Metadata like the originating opening name and the
+ * remaining line (continuation) allows callers to surface book information
+ * or bias selection towards deeper preparation.
+ */
+public record OpeningEntry(int move, String openingName, int ply, List<Integer> continuation) {
+
+    public OpeningEntry {
+        if (openingName == null || openingName.isBlank()) {
+            openingName = "Unknown";
+        }
+        continuation = continuation == null ? List.of() : List.copyOf(continuation);
+    }
+}

--- a/src/main/java/julius/game/chessengine/pgn/OpeningPgnReader.java
+++ b/src/main/java/julius/game/chessengine/pgn/OpeningPgnReader.java
@@ -1,0 +1,346 @@
+package julius.game.chessengine.pgn;
+
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.board.MoveList;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.figures.PieceType;
+import lombok.extern.log4j.Log4j2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Lightweight PGN reader tailored for opening book generation.  The reader
+ * supports multiple games per file, extracts tag pairs and converts SAN tokens
+ * into engine moves, recording the Zobrist hash for each ply.
+ */
+@Log4j2
+public class OpeningPgnReader {
+
+    private static final Pattern TAG_PATTERN = Pattern.compile("\\[(\\w+)\\s+\"([^\"]*)\"\\]");
+    private static final List<String> RESULT_TOKENS = List.of("1-0", "0-1", "1/2-1/2", "*");
+
+    public record ParsedGame(Map<String, String> headers, List<Integer> moves, List<Long> hashes) {}
+
+    public List<ParsedGame> parse(byte[] data) {
+        Objects.requireNonNull(data, "data");
+        String raw = new String(data, StandardCharsets.UTF_8);
+        return parse(raw);
+    }
+
+    public List<ParsedGame> parse(String rawPgn) {
+        Objects.requireNonNull(rawPgn, "rawPgn");
+        List<ParsedGame> games = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new StringReader(rawPgn))) {
+            while (true) {
+                Map<String, String> headers = readHeaders(reader);
+                if (headers == null) {
+                    break;
+                }
+                List<String> tokens = readMoves(reader);
+                if (tokens.isEmpty()) {
+                    continue;
+                }
+                games.add(convertToGame(headers, tokens));
+            }
+        } catch (IOException ex) {
+            log.warn("Failed reading PGN stream", ex);
+        }
+        return games;
+    }
+
+    private Map<String, String> readHeaders(BufferedReader reader) throws IOException {
+        Map<String, String> headers = new LinkedHashMap<>();
+        reader.mark(1);
+        int ch = reader.read();
+        while (ch != -1) {
+            if (Character.isWhitespace(ch)) {
+                reader.mark(1);
+                ch = reader.read();
+                continue;
+            }
+            if (ch != '[') {
+                reader.reset();
+                return headers.isEmpty() ? null : headers;
+            }
+            String line = reader.readLine();
+            if (line == null) {
+                break;
+            }
+            Matcher matcher = TAG_PATTERN.matcher("[" + line);
+            if (matcher.matches()) {
+                headers.put(matcher.group(1), matcher.group(2));
+            }
+            reader.mark(1);
+            ch = reader.read();
+        }
+        return headers.isEmpty() ? null : headers;
+    }
+
+    private List<String> readMoves(BufferedReader reader) throws IOException {
+        List<String> tokens = new LinkedList<>();
+        StringBuilder currentToken = new StringBuilder();
+        boolean inBraceComment = false;
+        boolean inSemicolonComment = false;
+        int parenthesesDepth = 0;
+        int intCh;
+        while (true) {
+            reader.mark(1);
+            intCh = reader.read();
+            if (intCh == -1) {
+                break;
+            }
+            char ch = (char) intCh;
+            if (inBraceComment) {
+                if (ch == '}') {
+                    inBraceComment = false;
+                }
+                continue;
+            }
+            if (inSemicolonComment) {
+                if (ch == '\n') {
+                    inSemicolonComment = false;
+                }
+                continue;
+            }
+            if (ch == '{') {
+                inBraceComment = true;
+                continue;
+            }
+            if (ch == ';') {
+                inSemicolonComment = true;
+                continue;
+            }
+            if (ch == '(') {
+                parenthesesDepth++;
+                continue;
+            }
+            if (ch == ')') {
+                if (parenthesesDepth > 0) {
+                    parenthesesDepth--;
+                }
+                continue;
+            }
+            if (parenthesesDepth > 0) {
+                continue;
+            }
+            if (ch == '[') {
+                reader.reset();
+                break;
+            }
+            if (Character.isWhitespace(ch)) {
+                addTokenIfPresent(tokens, currentToken);
+                if (ch == '\n') {
+                    reader.mark(1);
+                }
+                if (!tokens.isEmpty() && RESULT_TOKENS.contains(tokens.get(tokens.size() - 1))) {
+                    break;
+                }
+                continue;
+            }
+            currentToken.append(ch);
+        }
+        addTokenIfPresent(tokens, currentToken);
+        tokens.removeIf(token -> token.isBlank() || token.equals("...") || token.matches("\\d+\\.+"));
+        if (!tokens.isEmpty() && RESULT_TOKENS.contains(tokens.get(tokens.size() - 1))) {
+            tokens.remove(tokens.size() - 1);
+        }
+        return tokens;
+    }
+
+    private void addTokenIfPresent(List<String> tokens, StringBuilder currentToken) {
+        if (currentToken.length() > 0) {
+            tokens.add(currentToken.toString());
+            currentToken.setLength(0);
+        }
+    }
+
+    private ParsedGame convertToGame(Map<String, String> headers, List<String> tokens) {
+        Engine engine = new Engine();
+        engine.startNewGame();
+        List<Integer> moves = new ArrayList<>();
+        List<Long> hashes = new ArrayList<>();
+        for (String token : tokens) {
+            hashes.add(engine.getBoardStateHash());
+            int move = translateSanToMove(engine, token);
+            moves.add(move);
+            engine.performMove(move);
+        }
+        return new ParsedGame(headers, List.copyOf(moves), List.copyOf(hashes));
+    }
+
+    private int translateSanToMove(Engine engine, String sanToken) {
+        String san = normaliseSan(sanToken);
+        if (san.equals("O-O") || san.equals("0-0")) {
+            return locateCastling(engine, true);
+        }
+        if (san.equals("O-O-O") || san.equals("0-0-0")) {
+            return locateCastling(engine, false);
+        }
+
+        String promotionPart = null;
+        int promotionIndex = san.indexOf('=');
+        if (promotionIndex != -1) {
+            promotionPart = san.substring(promotionIndex + 1);
+            san = san.substring(0, promotionIndex);
+        }
+        if (san.length() < 2) {
+            throw new IllegalArgumentException("Invalid SAN token: " + sanToken);
+        }
+        String destination = san.substring(san.length() - 2);
+        String prefix = san.substring(0, san.length() - 2);
+        boolean capture = prefix.contains("x");
+        prefix = prefix.replace("x", "");
+
+        PieceType pieceType = PieceType.PAWN;
+        if (!prefix.isEmpty() && Character.isUpperCase(prefix.charAt(0))) {
+            pieceType = sanPiece(prefix.charAt(0));
+            prefix = prefix.substring(1);
+        }
+        Character disambiguationFile = null;
+        Character disambiguationRank = null;
+        if (!prefix.isEmpty()) {
+            if (prefix.length() == 2) {
+                disambiguationFile = fileChar(prefix.charAt(0));
+                disambiguationRank = rankChar(prefix.charAt(1));
+            } else if (prefix.length() == 1) {
+                disambiguationFile = fileChar(prefix.charAt(0));
+                disambiguationRank = rankChar(prefix.charAt(0));
+                if (disambiguationFile != null && disambiguationRank != null) {
+                    disambiguationRank = null; // prefer file when ambiguous
+                }
+            }
+        }
+
+        PieceType promotionPiece = promotionPart == null ? null : sanPiece(promotionPart.charAt(0));
+        int destinationIndex = MoveHelper.convertStringToIndex(destination);
+        Integer fromFile = disambiguationFile == null ? null : disambiguationFile - 'a';
+        Integer fromRank = disambiguationRank == null ? null : Character.getNumericValue(disambiguationRank) - 1;
+
+        MoveList legalMoves = engine.getAllLegalMoves();
+        for (int i = 0; i < legalMoves.size(); i++) {
+            int move = legalMoves.getMove(i);
+            if (!matchesMove(move, pieceType, destinationIndex, capture, fromFile, fromRank, promotionPiece)) {
+                continue;
+            }
+            return move;
+        }
+        throw new IllegalArgumentException("Unable to resolve SAN token: " + sanToken);
+    }
+
+    private PieceType sanPiece(char pieceChar) {
+        return switch (Character.toUpperCase(pieceChar)) {
+            case 'K' -> PieceType.KING;
+            case 'Q' -> PieceType.QUEEN;
+            case 'R' -> PieceType.ROOK;
+            case 'B' -> PieceType.BISHOP;
+            case 'N' -> PieceType.KNIGHT;
+            default -> PieceType.PAWN;
+        };
+    }
+
+    private Character fileChar(char value) {
+        char lower = Character.toLowerCase(value);
+        if (lower >= 'a' && lower <= 'h') {
+            return lower;
+        }
+        return null;
+    }
+
+    private Character rankChar(char value) {
+        if (value >= '1' && value <= '8') {
+            return value;
+        }
+        return null;
+    }
+
+    private int locateCastling(Engine engine, boolean kingSide) {
+        MoveList legal = engine.getAllLegalMoves();
+        for (int i = 0; i < legal.size(); i++) {
+            int move = legal.getMove(i);
+            if (!MoveHelper.isCastlingMove(move)) {
+                continue;
+            }
+            int from = MoveHelper.deriveFromIndex(move);
+            int to = MoveHelper.deriveToIndex(move);
+            if (kingSide && to > from) {
+                return move;
+            }
+            if (!kingSide && to < from) {
+                return move;
+            }
+        }
+        throw new IllegalArgumentException("Castling move not legal in current position");
+    }
+
+    private boolean matchesMove(int move, PieceType expectedPiece, int destinationIndex, boolean capture,
+                                Integer fromFile, Integer fromRank, PieceType promotionPiece) {
+        if (MoveHelper.deriveToIndex(move) != destinationIndex) {
+            return false;
+        }
+        PieceType actualPiece = MoveHelper.intToPieceType(MoveHelper.derivePieceTypeBits(move));
+        if (actualPiece != expectedPiece) {
+            return false;
+        }
+        if (capture != MoveHelper.isCapture(move)) {
+            return false;
+        }
+        if (promotionPiece != null) {
+            if (MoveHelper.derivePromotionPieceTypeBits(move) == 0) {
+                return false;
+            }
+            PieceType actualPromotion = MoveHelper.intToPieceType(MoveHelper.derivePromotionPieceTypeBits(move));
+            if (actualPromotion != promotionPiece) {
+                return false;
+            }
+        } else if (MoveHelper.derivePromotionPieceTypeBits(move) != 0) {
+            return false;
+        }
+        int fromIndex = MoveHelper.deriveFromIndex(move);
+        if (fromFile != null && fromFile != fromIndex % 8) {
+            return false;
+        }
+        if (fromRank != null && fromRank != fromIndex / 8) {
+            return false;
+        }
+        return true;
+    }
+
+    private String normaliseSan(String sanToken) {
+        String san = sanToken.trim();
+        while (!san.isEmpty() && "+#!?".indexOf(san.charAt(san.length() - 1)) >= 0) {
+            san = san.substring(0, san.length() - 1);
+        }
+        return san.replace('0', 'O');
+    }
+
+    public String fingerprint(List<byte[]> resources) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            for (byte[] resource : resources) {
+                digest.update(resource);
+            }
+            byte[] hash = digest.digest();
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(String.format(Locale.ROOT, "%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("Missing SHA-256 algorithm", ex);
+        }
+    }
+}

--- a/src/main/resources/opening/gioco_piano.pgn
+++ b/src/main/resources/opening/gioco_piano.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 *

--- a/src/main/resources/opening/ruy_lopez.pgn
+++ b/src/main/resources/opening/ruy_lopez.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 *

--- a/src/test/java/julius/game/chessengine/ai/OpeningBookLoaderTest.java
+++ b/src/test/java/julius/game/chessengine/ai/OpeningBookLoaderTest.java
@@ -1,0 +1,90 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.engine.Engine;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OpeningBookLoaderTest {
+
+    private static final String OPENING_DIR_PROP = "chess.opening.dir";
+    private static final String CACHE_PROP = "chess.opening.cache";
+    private static final Path CACHE_PATH = Paths.get("target", "test-opening-cache.json");
+
+    @AfterEach
+    void cleanUp() throws IOException {
+        System.clearProperty(OPENING_DIR_PROP);
+        System.clearProperty(CACHE_PROP);
+        Files.deleteIfExists(CACHE_PATH);
+    }
+
+    @Test
+    void indexesPgnDirectoryAndKeepsTranspositions() throws IOException {
+        Path openingDir = Paths.get("src/test/resources/opening").toAbsolutePath();
+        Files.deleteIfExists(CACHE_PATH);
+        System.setProperty(OPENING_DIR_PROP, openingDir.toString());
+        System.setProperty(CACHE_PROP, CACHE_PATH.toString());
+
+        OpeningBookLoader loader = new OpeningBookLoader();
+        OpeningBookLoader.Result first = loader.load();
+
+        assertFalse(first.entries().isEmpty(), "expected PGNs to populate the book");
+        assertFalse(first.fromCache());
+
+        Engine engine = new Engine();
+        long startHash = engine.getBoardStateHash();
+
+        List<OpeningEntry> startEntries = first.entries().get(startHash);
+        assertNotNull(startEntries);
+        assertEquals(2, startEntries.size());
+
+        Map<String, OpeningEntry> byName = startEntries.stream()
+                .collect(Collectors.toMap(OpeningEntry::openingName, entry -> entry));
+
+        OpeningEntry ruy = byName.get("ruy lopez");
+        OpeningEntry piano = byName.get("gioco piano");
+        assertNotNull(ruy);
+        assertNotNull(piano);
+        assertEquals(1, ruy.ply());
+        assertEquals(1, piano.ply());
+        assertMoveEquals(ruy.move(), "e2", "e4");
+        assertMoveEquals(piano.move(), "e2", "e4");
+        assertFalse(ruy.continuation().isEmpty());
+        assertMoveEquals(ruy.continuation().get(0), "e7", "e5");
+
+        // Play the shared moves to reach the third-move position (white to move)
+        engine.performMove(ruy.move());
+        engine.performMove(ruy.continuation().get(0));
+        engine.performMove(ruy.continuation().get(1));
+        engine.performMove(ruy.continuation().get(2));
+        long sharedHash = engine.getBoardStateHash();
+
+        List<OpeningEntry> sharedEntries = first.entries().get(sharedHash);
+        assertNotNull(sharedEntries);
+        assertEquals(2, sharedEntries.size());
+
+        Map<String, OpeningEntry> sharedByName = sharedEntries.stream()
+                .collect(Collectors.toMap(OpeningEntry::openingName, entry -> entry));
+        assertMoveEquals(sharedByName.get("ruy lopez").move(), "f1", "b5");
+        assertMoveEquals(sharedByName.get("gioco piano").move(), "f1", "c4");
+
+        OpeningBookLoader.Result second = loader.load();
+        assertTrue(second.fromCache());
+        assertEquals(first.entries(), second.entries());
+    }
+
+    private void assertMoveEquals(int move, String expectedFrom, String expectedTo) {
+        assertEquals(expectedFrom, MoveHelper.convertIndexToString(MoveHelper.deriveFromIndex(move)));
+        assertEquals(expectedTo, MoveHelper.convertIndexToString(MoveHelper.deriveToIndex(move)));
+    }
+}

--- a/src/test/resources/opening/gioco_piano.pgn
+++ b/src/test/resources/opening/gioco_piano.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 *

--- a/src/test/resources/opening/ruy_lopez.pgn
+++ b/src/test/resources/opening/ruy_lopez.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 *


### PR DESCRIPTION
## Summary
- load the opening book by scanning PGN resources, building entries per Zobrist hash and caching them on disk
- add a PGN reader that converts SAN tokens to engine moves so each opening line can be replayed
- cover the loader with sample PGNs that verify move indexing, opening names and duplicate hashes

## Testing
- `./mvnw test` *(fails: network is unreachable when Maven wrapper tries to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d73a9c8ba4832a8f3f5f7c1b36c78d