### PR TITLE
Add PGNs for popular sound chess openings

### DIFF
--- a/src/main/resources/opening/caro_kann_defense.pgn
+++ b/src/main/resources/opening/caro_kann_defense.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Bf5 5. Ng3 Bg6 *

--- a/src/main/resources/opening/english_opening.pgn
+++ b/src/main/resources/opening/english_opening.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. c4 e5 2. Nc3 Nf6 3. g3 d5 4. cxd5 Nxd5 5. Bg2 Nb6 *

--- a/src/main/resources/opening/french_defense.pgn
+++ b/src/main/resources/opening/french_defense.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. e4 e6 2. d4 d5 3. Nc3 Nf6 4. Bg5 Be7 5. e5 Nfd7 *

--- a/src/main/resources/opening/kings_indian_defense.pgn
+++ b/src/main/resources/opening/kings_indian_defense.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. Nf3 O-O *

--- a/src/main/resources/opening/nimzo_indian_defense.pgn
+++ b/src/main/resources/opening/nimzo_indian_defense.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. e3 O-O 5. Bd3 d5 *

--- a/src/main/resources/opening/queens_gambit_declined.pgn
+++ b/src/main/resources/opening/queens_gambit_declined.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Bg5 Be7 5. e3 O-O *

--- a/src/main/resources/opening/sicilian_defense.pgn
+++ b/src/main/resources/opening/sicilian_defense.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 *

--- a/src/test/resources/opening/caro_kann_defense.pgn
+++ b/src/test/resources/opening/caro_kann_defense.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. e4 c6 2. d4 d5 3. Nc3 dxe4 4. Nxe4 Bf5 5. Ng3 Bg6 *

--- a/src/test/resources/opening/english_opening.pgn
+++ b/src/test/resources/opening/english_opening.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. c4 e5 2. Nc3 Nf6 3. g3 d5 4. cxd5 Nxd5 5. Bg2 Nb6 *

--- a/src/test/resources/opening/french_defense.pgn
+++ b/src/test/resources/opening/french_defense.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. e4 e6 2. d4 d5 3. Nc3 Nf6 4. Bg5 Be7 5. e5 Nfd7 *

--- a/src/test/resources/opening/kings_indian_defense.pgn
+++ b/src/test/resources/opening/kings_indian_defense.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. d4 Nf6 2. c4 g6 3. Nc3 Bg7 4. e4 d6 5. Nf3 O-O *

--- a/src/test/resources/opening/nimzo_indian_defense.pgn
+++ b/src/test/resources/opening/nimzo_indian_defense.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. d4 Nf6 2. c4 e6 3. Nc3 Bb4 4. e3 O-O 5. Bd3 d5 *

--- a/src/test/resources/opening/queens_gambit_declined.pgn
+++ b/src/test/resources/opening/queens_gambit_declined.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. d4 d5 2. c4 e6 3. Nc3 Nf6 4. Bg5 Be7 5. e3 O-O *

--- a/src/test/resources/opening/sicilian_defense.pgn
+++ b/src/test/resources/opening/sicilian_defense.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. e4 c5 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 *

--- a/src/test/resources/opening/vienna_gambit.pgn
+++ b/src/test/resources/opening/vienna_gambit.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e5 2. Nc3 Nc6 3. f4 d5 *


### PR DESCRIPTION
## Summary
- add PGNs for popular, theoretically sound openings to the main resources bundle
- mirror the new opening samples in the test resources for parity with the production data

## Testing
- ./mvnw test *(fails: network is unreachable when downloading Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68d7aa4fa8f4832a82e4a58e146a7796