### PR TITLE
Avoid allocations in fast move legality checks

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -65,6 +65,16 @@ public class BitBoard {
     // Reusable buffer for move generation to avoid frequent allocations.
     private final MoveList moveGenerationBuffer = new MoveList();
 
+    /**
+     * Scratch buffers for {@link #isMoveLegalFast(int, PinState)}.
+     *
+     * <p>The buffers are mutable and therefore must only be accessed while holding the engine's
+     * {@code boardLock}. Callers are expected to register that monitor via
+     * {@link #setMoveLegalityScratchGuard(Object)} before invoking the fast legality checks.</p>
+     */
+    private final long[][] moveLegalityScratch = {new long[7], new long[7]};
+    private volatile Object moveLegalityScratchGuard;
+
     public static final class PinState {
         private final boolean whiteSide;
         private final int kingSquare;
@@ -277,10 +287,24 @@ public class BitBoard {
             this.halfmoveHistory.addAll(other.halfmoveHistory);
             this.fullmoveHistory.addAll(other.fullmoveHistory);
         }
+        this.moveLegalityScratchGuard = other.moveLegalityScratchGuard;
+    }
+
+    /**
+     * Registers the monitor that must be held while accessing {@link #moveLegalityScratch}.
+     * The provided object should be the same {@code boardLock} used by {@code Engine} to guard
+     * move generation, ensuring these mutable buffers are never mutated concurrently.
+     *
+     * @param boardLock the monitor protecting move generation, or {@code null} to clear the guard
+     */
+    public void setMoveLegalityScratchGuard(Object boardLock) {
+        this.moveLegalityScratchGuard = boardLock;
     }
 
     public BitBoard snapshotWithoutHistory() {
-        return new BitBoard(this, false);
+        BitBoard snapshot = new BitBoard(this, false);
+        snapshot.moveLegalityScratchGuard = this.moveLegalityScratchGuard;
+        return snapshot;
     }
     public void setLastMoveDoubleStepPawnIndex(int index) {
         int oldEp = getEnPassantTargetIndex();
@@ -1511,6 +1535,11 @@ public class BitBoard {
     }
 
     public boolean isMoveLegalFast(int move, PinState pinState) {
+        Object scratchGuard = this.moveLegalityScratchGuard;
+        if (scratchGuard != null && !Thread.holdsLock(scratchGuard)) {
+            throw new IllegalStateException("isMoveLegalFast must be called while holding the registered board lock");
+        }
+
         boolean whiteMove = MoveHelper.isWhitesMove(move);
         if (pinState == null || pinState.isWhiteSide() != whiteMove) {
             pinState = computePinState(whiteMove);
@@ -1541,8 +1570,22 @@ public class BitBoard {
             }
         }
 
-        long[] whiteByType = {0L, whitePawns, whiteKnights, whiteBishops, whiteRooks, whiteQueens, whiteKing};
-        long[] blackByType = {0L, blackPawns, blackKnights, blackBishops, blackRooks, blackQueens, blackKing};
+        long[] whiteByType = moveLegalityScratch[0];
+        long[] blackByType = moveLegalityScratch[1];
+        Arrays.fill(whiteByType, 0L);
+        Arrays.fill(blackByType, 0L);
+        whiteByType[1] = whitePawns;
+        whiteByType[2] = whiteKnights;
+        whiteByType[3] = whiteBishops;
+        whiteByType[4] = whiteRooks;
+        whiteByType[5] = whiteQueens;
+        whiteByType[6] = whiteKing;
+        blackByType[1] = blackPawns;
+        blackByType[2] = blackKnights;
+        blackByType[3] = blackBishops;
+        blackByType[4] = blackRooks;
+        blackByType[5] = blackQueens;
+        blackByType[6] = blackKing;
         long occ = allPieces;
 
         if (isCapture) {

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -131,7 +131,7 @@ public class Engine {
     @Getter
     private MoveStack line = new MoveStack();
     private MoveStack redoLine = new MoveStack();
-    private BitBoard bitBoard = new BitBoard();
+    private BitBoard bitBoard = attachBoard(new BitBoard());
     @Getter
     private GameState gameState = new GameState(bitBoard);
 
@@ -144,7 +144,7 @@ public class Engine {
 
     public Engine(Engine other) {
         synchronized (other.boardLock) {
-            this.bitBoard = new BitBoard(other.bitBoard);
+            this.bitBoard = attachBoard(new BitBoard(other.bitBoard));
             this.gameState = new GameState(other.gameState);
             this.line = new MoveStack(other.line);
             this.redoLine = new MoveStack(other.redoLine);
@@ -229,7 +229,7 @@ public class Engine {
 
     public void importBoardFromFen(String fen) {
         synchronized (boardLock) {
-            this.bitBoard = FEN.translateFENtoBitBoard(fen);
+            this.bitBoard = attachBoard(FEN.translateFENtoBitBoard(fen));
             this.gameState = new GameState(bitBoard);
 
             // Ensure the imported state reflects the parsed halfmove/fullmove counters and
@@ -269,7 +269,7 @@ public class Engine {
         Objects.requireNonNull(other, "other engine");
         synchronized (boardLock) {
             synchronized (other.boardLock) {
-                this.bitBoard = new BitBoard(other.bitBoard);
+                this.bitBoard = attachBoard(new BitBoard(other.bitBoard));
                 this.gameState = new GameState(other.gameState);
                 this.line = new MoveStack(other.line);
                 this.redoLine = new MoveStack(other.redoLine);
@@ -284,7 +284,7 @@ public class Engine {
 
     public void startNewGame() {
         synchronized (boardLock) {
-            bitBoard = new BitBoard();
+            bitBoard = attachBoard(new BitBoard());
             gameState = new GameState(bitBoard);
             markLegalMovesStale();
             line = new MoveStack();
@@ -421,6 +421,12 @@ public class Engine {
         TimedLRUCache<MoveList> cache = new TimedLRUCache<>(CACHE_CFG.maxSize, CACHE_CFG.maxAgeMs);
         cache.setEvictionListener(this::releaseSnapshot);
         return cache;
+    }
+
+    private BitBoard attachBoard(BitBoard board) {
+        Objects.requireNonNull(board, "board");
+        board.setMoveLegalityScratchGuard(boardLock);
+        return board;
     }
 
     private boolean moveListsEqual(MoveList a, MoveList b) {


### PR DESCRIPTION
## Summary
- add reusable scratch buffers inside `BitBoard` for fast move legality calculations and copy the guard metadata between clones
- reuse the scratch buffers inside `isMoveLegalFast` while asserting the engine's board lock is held
- register the board lock on every `BitBoard` instance constructed by the engine to prevent concurrent mutation of the shared buffers

## Testing
- mvn -q -DskipTests package *(fails: Fatal error compiling: error: release version 25 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c75b17dc832aac79517af982a9cd