### PR TITLE
Reuse pooled legal move snapshots and add regression tests

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -195,7 +195,12 @@ public class Engine {
             } else if (legalMovesSnapshot == null) {
                 publishLegalMovesSnapshot(buffer);
             }
-            return legalMovesSnapshot != null ? legalMovesSnapshot : new MoveList(buffer);
+
+            if (legalMovesSnapshot == null) {
+                publishLegalMovesSnapshot(buffer);
+            }
+
+            return legalMovesSnapshot;
         }
     }
 
@@ -379,11 +384,19 @@ public class Engine {
 
     private void markLegalMovesStale() {
         legalMovesNeedUpdate = true;
+        releaseSnapshot(legalMovesSnapshot);
         legalMovesSnapshot = null;
     }
 
     private void publishLegalMovesSnapshot(MoveList buffer) {
-        legalMovesSnapshot = new MoveList(buffer);
+        MoveList previousSnapshot = legalMovesSnapshot;
+        if (previousSnapshot != null) {
+            releaseSnapshot(previousSnapshot);
+        }
+
+        MoveList snapshot = obtainSnapshot();
+        snapshot.copyFrom(buffer);
+        legalMovesSnapshot = snapshot;
     }
 
     private MoveList ensureLegalMovesBuffer() {

--- a/src/test/java/julius/game/chessengine/engine/EngineLegalMovesSnapshotTest.java
+++ b/src/test/java/julius/game/chessengine/engine/EngineLegalMovesSnapshotTest.java
@@ -1,0 +1,47 @@
+package julius.game.chessengine.engine;
+
+import julius.game.chessengine.board.MoveList;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EngineLegalMovesSnapshotTest {
+
+    @Test
+    void getAllLegalMovesReturnsSnapshotInstance() {
+        Engine engine = new Engine();
+
+        MoveList first = engine.getAllLegalMoves();
+        MoveList second = engine.getAllLegalMoves();
+
+        assertSame(first, second, "Expected cached snapshot instance to be reused");
+        assertTrue(first.size() > 0, "Initial position should expose legal moves");
+    }
+
+    @Test
+    void snapshotIsReusedAndUpdatedAfterMove() {
+        Engine engine = new Engine();
+
+        MoveList initialSnapshot = engine.getAllLegalMoves();
+        assertTrue(initialSnapshot.size() > 0, "Initial snapshot must contain moves");
+
+        int[] initialMoves = initialSnapshot.toArray();
+        int move = initialMoves[0];
+
+        engine.performMove(move);
+
+        MoveList afterMoveSnapshot = engine.getAllLegalMoves();
+
+        assertSame(initialSnapshot, afterMoveSnapshot,
+                "Snapshot instance should be recycled via the pool");
+        assertTrue(afterMoveSnapshot.size() > 0, "Updated snapshot should also contain moves");
+        assertFalse(Arrays.equals(initialMoves, afterMoveSnapshot.toArray()),
+                "Legal moves should change after performing a move");
+
+        MoveList cachedView = engine.getAllLegalMoves();
+        assertSame(afterMoveSnapshot, cachedView,
+                "Subsequent calls should return the published snapshot");
+    }
+}


### PR DESCRIPTION
## Summary
- release stale legal move snapshots back to the pool before clearing references
- rebuild legal move snapshots from pooled instances and avoid ad-hoc copies in `getAllLegalMoves`
- add regression tests to ensure snapshots are reused and updated across move generation

## Testing
- mvn test *(fails: Fatal error compiling: error: release version 25 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68d7cb4452d8832aaa842b8c3c0e8531