### PR TITLE
Reuse pooled legal-move snapshots

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -195,7 +195,7 @@ public class Engine {
             } else if (legalMovesSnapshot == null) {
                 publishLegalMovesSnapshot(buffer);
             }
-            return legalMovesSnapshot != null ? legalMovesSnapshot : new MoveList(buffer);
+            return legalMovesSnapshot;
         }
     }
 
@@ -379,11 +379,20 @@ public class Engine {
 
     private void markLegalMovesStale() {
         legalMovesNeedUpdate = true;
-        legalMovesSnapshot = null;
+        if (legalMovesSnapshot != null) {
+            releaseSnapshot(legalMovesSnapshot);
+            legalMovesSnapshot = null;
+        }
     }
 
     private void publishLegalMovesSnapshot(MoveList buffer) {
-        legalMovesSnapshot = new MoveList(buffer);
+        if (legalMovesSnapshot != null) {
+            releaseSnapshot(legalMovesSnapshot);
+            legalMovesSnapshot = null;
+        }
+        MoveList snapshot = obtainSnapshot();
+        snapshot.copyFrom(buffer);
+        legalMovesSnapshot = snapshot;
     }
 
     private MoveList ensureLegalMovesBuffer() {


### PR DESCRIPTION
## Summary
- return stale legal-move snapshots to the pool before clearing references
- publish legal-move buffers through the pooled snapshot mechanism and reuse it from getAllLegalMoves

## Testing
- mvn test *(fails: release version 25 not supported by compiler)*

------
https://chatgpt.com/codex/tasks/task_e_68d7cb4452d8832aaa842b8c3c0e8531