### PR TITLE
Refactor attack snapshot handling

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -63,6 +63,12 @@ public class BitBoard {
     private boolean blackAttackDirty = true;
     private PieceType[] pieceBoard = new PieceType[64];
 
+    private final MoveSnapshot moveSnapshot = new MoveSnapshot();
+    private final PieceBitboards attackScratchWhite = new PieceBitboards();
+    private final PieceBitboards attackScratchBlack = new PieceBitboards();
+    private final PieceBitboards seeWhiteScratch = new PieceBitboards();
+    private final PieceBitboards seeBlackScratch = new PieceBitboards();
+
     private static final int MAX_PSEUDO_LEGAL_MOVES = 218;
 
     public static final class PinState {
@@ -114,6 +120,80 @@ public class BitBoard {
 
         public int getPinnerSquare() {
             return pinnerSquare;
+        }
+    }
+
+    private static final class PieceBitboards {
+        long pawns;
+        long knights;
+        long bishops;
+        long rooks;
+        long queens;
+        long king;
+
+        PieceBitboards() {
+        }
+
+        PieceBitboards(long pawns, long knights, long bishops, long rooks, long queens, long king) {
+            load(pawns, knights, bishops, rooks, queens, king);
+        }
+
+        void load(long pawns, long knights, long bishops, long rooks, long queens, long king) {
+            this.pawns = pawns;
+            this.knights = knights;
+            this.bishops = bishops;
+            this.rooks = rooks;
+            this.queens = queens;
+            this.king = king;
+        }
+
+        long get(int pieceBits) {
+            return switch (pieceBits) {
+                case 1 -> pawns;
+                case 2 -> knights;
+                case 3 -> bishops;
+                case 4 -> rooks;
+                case 5 -> queens;
+                case 6 -> king;
+                default -> 0L;
+            };
+        }
+
+        void set(int pieceBits, long value) {
+            switch (pieceBits) {
+                case 1 -> pawns = value;
+                case 2 -> knights = value;
+                case 3 -> bishops = value;
+                case 4 -> rooks = value;
+                case 5 -> queens = value;
+                case 6 -> king = value;
+                default -> {
+                }
+            }
+        }
+
+        void clearBit(int pieceBits, long mask) {
+            if (pieceBits >= 1 && pieceBits <= 6) {
+                set(pieceBits, get(pieceBits) & ~mask);
+            }
+        }
+
+        void addBit(int pieceBits, long mask) {
+            if (pieceBits >= 1 && pieceBits <= 6) {
+                set(pieceBits, get(pieceBits) | mask);
+            }
+        }
+    }
+
+    private static final class MoveSnapshot {
+        final PieceBitboards white = new PieceBitboards();
+        final PieceBitboards black = new PieceBitboards();
+        long occ;
+
+        void load(BitBoard board) {
+            white.load(board.whitePawns, board.whiteKnights, board.whiteBishops, board.whiteRooks, board.whiteQueens, board.whiteKing);
+            black.load(board.blackPawns, board.blackKnights, board.blackBishops, board.blackRooks, board.blackQueens, board.blackKing);
+            occ = board.allPieces;
         }
     }
 
@@ -584,28 +664,32 @@ public class BitBoard {
         long toMask = 1L << to;
         long fromMask = 1L << from;
 
-        // Local mutable copies of per-piece bitboards (index 1..6)
-        long[] W = new long[7];
-        long[] B = new long[7];
-        W[1]=whitePawns; W[2]=whiteKnights; W[3]=whiteBishops; W[4]=whiteRooks; W[5]=whiteQueens; W[6]=whiteKing;
-        B[1]=blackPawns; B[2]=blackKnights; B[3]=blackBishops; B[4]=blackRooks; B[5]=blackQueens; B[6]=blackKing;
+        PieceBitboards whiteState = seeWhiteScratch;
+        PieceBitboards blackState = seeBlackScratch;
+        whiteState.load(whitePawns, whiteKnights, whiteBishops, whiteRooks, whiteQueens, whiteKing);
+        blackState.load(blackPawns, blackKnights, blackBishops, blackRooks, blackQueens, blackKing);
 
         // Remove captured piece from its set/occ
         int capIndex = isEp ? (whiteMove ? (to - 8) : (to + 8)) : to;
         if (isCapture) {
             long capMask = 1L << capIndex;
             if (whiteMove) {
-                if (capturedBits >= 1 && capturedBits <= 6) B[capturedBits] &= ~capMask;
+                blackState.clearBit(capturedBits, capMask);
             } else {
-                if (capturedBits >= 1 && capturedBits <= 6) W[capturedBits] &= ~capMask;
+                whiteState.clearBit(capturedBits, capMask);
             }
             occ &= ~capMask;
         }
 
         // Move the attacking piece onto 'to' (promotion changes its type/value)
         int placedBits = (promoBits != 0 ? promoBits : moverBits);
-        if (whiteMove) { W[moverBits] &= ~fromMask; W[placedBits] |= toMask; }
-        else           { B[moverBits] &= ~fromMask; B[placedBits] |= toMask; }
+        if (whiteMove) {
+            whiteState.clearBit(moverBits, fromMask);
+            whiteState.addBit(placedBits, toMask);
+        } else {
+            blackState.clearBit(moverBits, fromMask);
+            blackState.addBit(placedBits, toMask);
+        }
         occ &= ~fromMask;
         occ |= toMask;
 
@@ -628,14 +712,14 @@ public class BitBoard {
 
         while (true) {
             // Build attackers for the side to move now
-            long pawns   = sideWhite ? W[1] : B[1];
-            long knights = sideWhite ? W[2] : B[2];
-            long bishops = sideWhite ? W[3] : B[3];
-            long rooks   = sideWhite ? W[4] : B[4];
-            long queens  = sideWhite ? W[5] : B[5];
-            long king    = sideWhite ? W[6] : B[6];
+            long pawns   = sideWhite ? whiteState.pawns : blackState.pawns;
+            long knights = sideWhite ? whiteState.knights : blackState.knights;
+            long bishops = sideWhite ? whiteState.bishops : blackState.bishops;
+            long rooks   = sideWhite ? whiteState.rooks : blackState.rooks;
+            long queens  = sideWhite ? whiteState.queens : blackState.queens;
+            long king    = sideWhite ? whiteState.king : blackState.king;
 
-            long attPawns   = pawnAttackersToSquare(to, sideWhite, W[1], B[1]);
+            long attPawns   = pawnAttackersToSquare(to, sideWhite, whiteState.pawns, blackState.pawns);
             long attKnights = KnightHelper.knightMoveTable[to] & knights;
             long bRay = bishopAttacksFromWithOcc(to, occ);
             long rRay = rookAttacksFromWithOcc(to, occ);
@@ -651,7 +735,7 @@ public class BitBoard {
 
             while (true) {
                 if (attPawns != 0) {
-                    int candidate = selectLegalAttacker(attPawns, 1, sideWhite, W, B, occ, to, toPieceWhite, toPieceBits);
+                    int candidate = selectLegalAttacker(attPawns, 1, sideWhite, whiteState, blackState, occ, to, toPieceWhite, toPieceBits);
                     if (candidate != -1) {
                         fromBB = 1L << candidate;
                         attBits = 1;
@@ -661,7 +745,7 @@ public class BitBoard {
                     }
                     attPawns = 0;
                 } else if (attKnights != 0) {
-                    int candidate = selectLegalAttacker(attKnights, 2, sideWhite, W, B, occ, to, toPieceWhite, toPieceBits);
+                    int candidate = selectLegalAttacker(attKnights, 2, sideWhite, whiteState, blackState, occ, to, toPieceWhite, toPieceBits);
                     if (candidate != -1) {
                         fromBB = 1L << candidate;
                         attBits = 2;
@@ -671,7 +755,7 @@ public class BitBoard {
                     }
                     attKnights = 0;
                 } else if (attBishops != 0) {
-                    int candidate = selectLegalAttacker(attBishops, 3, sideWhite, W, B, occ, to, toPieceWhite, toPieceBits);
+                    int candidate = selectLegalAttacker(attBishops, 3, sideWhite, whiteState, blackState, occ, to, toPieceWhite, toPieceBits);
                     if (candidate != -1) {
                         fromBB = 1L << candidate;
                         attBits = 3;
@@ -681,7 +765,7 @@ public class BitBoard {
                     }
                     attBishops = 0;
                 } else if (attRooks != 0) {
-                    int candidate = selectLegalAttacker(attRooks, 4, sideWhite, W, B, occ, to, toPieceWhite, toPieceBits);
+                    int candidate = selectLegalAttacker(attRooks, 4, sideWhite, whiteState, blackState, occ, to, toPieceWhite, toPieceBits);
                     if (candidate != -1) {
                         fromBB = 1L << candidate;
                         attBits = 4;
@@ -691,7 +775,7 @@ public class BitBoard {
                     }
                     attRooks = 0;
                 } else if (attQueens != 0) {
-                    int candidate = selectLegalAttacker(attQueens, 5, sideWhite, W, B, occ, to, toPieceWhite, toPieceBits);
+                    int candidate = selectLegalAttacker(attQueens, 5, sideWhite, whiteState, blackState, occ, to, toPieceWhite, toPieceBits);
                     if (candidate != -1) {
                         fromBB = 1L << candidate;
                         attBits = 5;
@@ -702,7 +786,7 @@ public class BitBoard {
                     attQueens = 0;
                 } else if (attKing != 0) {
                     int kingFrom = Long.numberOfTrailingZeros(attKing);
-                    if (!isKingCaptureLegal(sideWhite, kingFrom, to, W, B, occ, toPieceWhite, toPieceBits)) {
+                    if (!isKingCaptureLegal(sideWhite, kingFrom, to, whiteState, blackState, occ, toPieceWhite, toPieceBits)) {
                         attKing = 0;
                         continue;
                     }
@@ -721,49 +805,24 @@ public class BitBoard {
             }
 
             // Remove previous occupant of 'to' (it is being captured now)
-            if (toPieceWhite) W[toPieceBits] &= ~toMask;
-            else              B[toPieceBits] &= ~toMask;
+            if (toPieceWhite) {
+                whiteState.clearBit(toPieceBits, toMask);
+            } else {
+                blackState.clearBit(toPieceBits, toMask);
+            }
 
             // Move this attacker onto 'to'
             if (sideWhite) {
-                switch (attBits) {
-                    case 1 -> W[1] &= ~attMask;
-                    case 2 -> W[2] &= ~attMask;
-                    case 3 -> W[3] &= ~attMask;
-                    case 4 -> W[4] &= ~attMask;
-                    case 5 -> W[5] &= ~attMask;
-                    case 6 -> W[6] &= ~attMask;
-                }
+                whiteState.clearBit(attBits, attMask);
             } else {
-                switch (attBits) {
-                    case 1 -> B[1] &= ~attMask;
-                    case 2 -> B[2] &= ~attMask;
-                    case 3 -> B[3] &= ~attMask;
-                    case 4 -> B[4] &= ~attMask;
-                    case 5 -> B[5] &= ~attMask;
-                    case 6 -> B[6] &= ~attMask;
-                }
+                blackState.clearBit(attBits, attMask);
             }
             occ &= ~attMask; // from-square cleared
             // place on 'to' (keep occupancy accurate for slider lookups)
             if (sideWhite) {
-                switch (attBits) {
-                    case 1 -> W[1] |= toMask;
-                    case 2 -> W[2] |= toMask;
-                    case 3 -> W[3] |= toMask;
-                    case 4 -> W[4] |= toMask;
-                    case 5 -> W[5] |= toMask;
-                    case 6 -> W[6] |= toMask;
-                }
+                whiteState.addBit(attBits, toMask);
             } else {
-                switch (attBits) {
-                    case 1 -> B[1] |= toMask;
-                    case 2 -> B[2] |= toMask;
-                    case 3 -> B[3] |= toMask;
-                    case 4 -> B[4] |= toMask;
-                    case 5 -> B[5] |= toMask;
-                    case 6 -> B[6] |= toMask;
-                }
+                blackState.addBit(attBits, toMask);
             }
             occ |= toMask; // ensure destination remains occupied for future attack discovery
 
@@ -784,43 +843,57 @@ public class BitBoard {
     }
 
     private boolean isKingCaptureLegal(boolean kingIsWhite, int kingFrom, int target,
-                                       long[] whiteByType, long[] blackByType, long occ,
+                                       PieceBitboards whiteState, PieceBitboards blackState, long occ,
                                        boolean toPieceWhite, int toPieceBits) {
-        long[] wCopy = whiteByType.clone();
-        long[] bCopy = blackByType.clone();
-        long occCopy = occ;
-
         long toMask = 1L << target;
         long fromMask = 1L << kingFrom;
 
+        long originalWhite = whiteState.king;
+        long originalBlack = blackState.king;
+        long originalCaptured = 0L;
+
         if (toPieceBits >= 1 && toPieceBits <= 6) {
             if (toPieceWhite) {
-                wCopy[toPieceBits] &= ~toMask;
+                originalCaptured = whiteState.get(toPieceBits);
+                whiteState.set(toPieceBits, originalCaptured & ~toMask);
             } else {
-                bCopy[toPieceBits] &= ~toMask;
+                originalCaptured = blackState.get(toPieceBits);
+                blackState.set(toPieceBits, originalCaptured & ~toMask);
             }
         }
 
         if (kingIsWhite) {
-            wCopy[6] &= ~fromMask;
-            wCopy[6] |= toMask;
+            whiteState.king = (originalWhite & ~fromMask) | toMask;
         } else {
-            bCopy[6] &= ~fromMask;
-            bCopy[6] |= toMask;
+            blackState.king = (originalBlack & ~fromMask) | toMask;
         }
 
-        occCopy &= ~fromMask;
-        occCopy |= toMask;
+        long occCopy = (occ & ~fromMask) | toMask;
 
-        return !isSquareAttackedInSee(target, !kingIsWhite, wCopy, bCopy, occCopy);
+        boolean safe = !isSquareAttackedInSee(target, !kingIsWhite, whiteState, blackState, occCopy);
+
+        if (kingIsWhite) {
+            whiteState.king = originalWhite;
+        } else {
+            blackState.king = originalBlack;
+        }
+        if (toPieceBits >= 1 && toPieceBits <= 6) {
+            if (toPieceWhite) {
+                whiteState.set(toPieceBits, originalCaptured);
+            } else {
+                blackState.set(toPieceBits, originalCaptured);
+            }
+        }
+
+        return safe;
     }
 
     private int selectLegalAttacker(long attackers, int attBits, boolean sideWhite,
-                                    long[] whiteByType, long[] blackByType, long occ, int target,
+                                    PieceBitboards whiteState, PieceBitboards blackState, long occ, int target,
                                     boolean toPieceWhite, int toPieceBits) {
         while (attackers != 0) {
             int from = Long.numberOfTrailingZeros(attackers);
-            if (attBits == 6 || isNonKingCaptureLegal(sideWhite, from, target, attBits, whiteByType, blackByType, occ,
+            if (attBits == 6 || isNonKingCaptureLegal(sideWhite, from, target, attBits, whiteState, blackState, occ,
                                                      toPieceWhite, toPieceBits)) {
                 return from;
             }
@@ -830,46 +903,73 @@ public class BitBoard {
     }
 
     private boolean isNonKingCaptureLegal(boolean attackerWhite, int attackerFrom, int target, int attackerBits,
-                                          long[] whiteByType, long[] blackByType, long occ,
+                                          PieceBitboards whiteState, PieceBitboards blackState, long occ,
                                           boolean toPieceWhite, int toPieceBits) {
-        long[] wCopy = whiteByType.clone();
-        long[] bCopy = blackByType.clone();
-        long occCopy = occ;
-
         long toMask = 1L << target;
         long fromMask = 1L << attackerFrom;
 
+        long originalAttacker = attackerWhite ? whiteState.get(attackerBits) : blackState.get(attackerBits);
+        long originalCaptured = 0L;
+        long occCopy = occ;
+
         if (toPieceBits >= 1 && toPieceBits <= 6) {
             if (toPieceWhite) {
-                wCopy[toPieceBits] &= ~toMask;
+                originalCaptured = whiteState.get(toPieceBits);
+                whiteState.set(toPieceBits, originalCaptured & ~toMask);
             } else {
-                bCopy[toPieceBits] &= ~toMask;
+                originalCaptured = blackState.get(toPieceBits);
+                blackState.set(toPieceBits, originalCaptured & ~toMask);
             }
             occCopy &= ~toMask;
         }
 
         if (attackerWhite) {
-            wCopy[attackerBits] &= ~fromMask;
-            wCopy[attackerBits] |= toMask;
+            whiteState.set(attackerBits, (originalAttacker & ~fromMask) | toMask);
         } else {
-            bCopy[attackerBits] &= ~fromMask;
-            bCopy[attackerBits] |= toMask;
+            blackState.set(attackerBits, (originalAttacker & ~fromMask) | toMask);
         }
 
         occCopy &= ~fromMask;
         occCopy |= toMask;
 
-        long kingBB = attackerWhite ? wCopy[6] : bCopy[6];
+        long kingBB = attackerWhite ? whiteState.king : blackState.king;
         if (kingBB == 0) {
+            if (attackerWhite) {
+                whiteState.set(attackerBits, originalAttacker);
+            } else {
+                blackState.set(attackerBits, originalAttacker);
+            }
+            if (toPieceBits >= 1 && toPieceBits <= 6) {
+                if (toPieceWhite) {
+                    whiteState.set(toPieceBits, originalCaptured);
+                } else {
+                    blackState.set(toPieceBits, originalCaptured);
+                }
+            }
             return false;
         }
         int kingSquare = Long.numberOfTrailingZeros(kingBB);
-        return !isSquareAttackedInSee(kingSquare, !attackerWhite, wCopy, bCopy, occCopy);
+        boolean safe = !isSquareAttackedInSee(kingSquare, !attackerWhite, whiteState, blackState, occCopy);
+
+        if (attackerWhite) {
+            whiteState.set(attackerBits, originalAttacker);
+        } else {
+            blackState.set(attackerBits, originalAttacker);
+        }
+        if (toPieceBits >= 1 && toPieceBits <= 6) {
+            if (toPieceWhite) {
+                whiteState.set(toPieceBits, originalCaptured);
+            } else {
+                blackState.set(toPieceBits, originalCaptured);
+            }
+        }
+
+        return safe;
     }
 
     private boolean isSquareAttackedInSee(int square, boolean attackerWhite,
-                                          long[] whiteByType, long[] blackByType, long occ) {
-        return isSquareUnderAttack(square, !attackerWhite, occ, whiteByType, blackByType);
+                                          PieceBitboards whiteState, PieceBitboards blackState, long occ) {
+        return isSquareUnderAttack(square, !attackerWhite, occ, whiteState, blackState);
     }
 
 
@@ -1501,29 +1601,39 @@ public class BitBoard {
 
     // Replace your current isSquareUnderAttack with this version
     private boolean isSquareUnderAttack(int index, boolean colorWhite) {
-        long[] whiteByType = {0L, whitePawns, whiteKnights, whiteBishops, whiteRooks, whiteQueens, whiteKing};
-        long[] blackByType = {0L, blackPawns, blackKnights, blackBishops, blackRooks, blackQueens, blackKing};
-        return isSquareUnderAttack(index, colorWhite, allPieces, whiteByType, blackByType);
+        attackScratchWhite.load(whitePawns, whiteKnights, whiteBishops, whiteRooks, whiteQueens, whiteKing);
+        attackScratchBlack.load(blackPawns, blackKnights, blackBishops, blackRooks, blackQueens, blackKing);
+        return isSquareUnderAttack(index, colorWhite, allPieces, attackScratchWhite, attackScratchBlack);
     }
 
     private boolean isSquareUnderAttack(int index, boolean colorWhite, long occ,
-                                        long[] whiteByType, long[] blackByType) {
+                                        PieceBitboards whiteState, PieceBitboards blackState) {
+        return isSquareUnderAttack(index, colorWhite, occ,
+                whiteState.pawns, whiteState.knights, whiteState.bishops, whiteState.rooks, whiteState.queens, whiteState.king,
+                blackState.pawns, blackState.knights, blackState.bishops, blackState.rooks, blackState.queens, blackState.king);
+    }
+
+    private boolean isSquareUnderAttack(int index, boolean colorWhite, long occ,
+                                        long whitePawnsBB, long whiteKnightsBB, long whiteBishopsBB,
+                                        long whiteRooksBB, long whiteQueensBB, long whiteKingBB,
+                                        long blackPawnsBB, long blackKnightsBB, long blackBishopsBB,
+                                        long blackRooksBB, long blackQueensBB, long blackKingBB) {
         if (colorWhite) {
-            if (pawnAttackersToSquare(index, false, whiteByType[1], blackByType[1]) != 0) return true;
-            if ((KnightHelper.knightMoveTable[index] & blackByType[2]) != 0) return true;
-            if ((KING_ATTACKS[index] & blackByType[6]) != 0) return true;
+            if (pawnAttackersToSquare(index, false, whitePawnsBB, blackPawnsBB) != 0) return true;
+            if ((KnightHelper.knightMoveTable[index] & blackKnightsBB) != 0) return true;
+            if ((KING_ATTACKS[index] & blackKingBB) != 0) return true;
             long bishopRays = bishopAttacksFromWithOcc(index, occ);
-            if ((bishopRays & (blackByType[3] | blackByType[5])) != 0) return true;
+            if ((bishopRays & (blackBishopsBB | blackQueensBB)) != 0) return true;
             long rookRays = rookAttacksFromWithOcc(index, occ);
-            return (rookRays & (blackByType[4] | blackByType[5])) != 0;
+            return (rookRays & (blackRooksBB | blackQueensBB)) != 0;
         } else {
-            if (pawnAttackersToSquare(index, true, whiteByType[1], blackByType[1]) != 0) return true;
-            if ((KnightHelper.knightMoveTable[index] & whiteByType[2]) != 0) return true;
-            if ((KING_ATTACKS[index] & whiteByType[6]) != 0) return true;
+            if (pawnAttackersToSquare(index, true, whitePawnsBB, blackPawnsBB) != 0) return true;
+            if ((KnightHelper.knightMoveTable[index] & whiteKnightsBB) != 0) return true;
+            if ((KING_ATTACKS[index] & whiteKingBB) != 0) return true;
             long bishopRays = bishopAttacksFromWithOcc(index, occ);
-            if ((bishopRays & (whiteByType[3] | whiteByType[5])) != 0) return true;
+            if ((bishopRays & (whiteBishopsBB | whiteQueensBB)) != 0) return true;
             long rookRays = rookAttacksFromWithOcc(index, occ);
-            return (rookRays & (whiteByType[4] | whiteByType[5])) != 0;
+            return (rookRays & (whiteRooksBB | whiteQueensBB)) != 0;
         }
     }
 
@@ -1558,38 +1668,36 @@ public class BitBoard {
             }
         }
 
-        long[] whiteByType = {0L, whitePawns, whiteKnights, whiteBishops, whiteRooks, whiteQueens, whiteKing};
-        long[] blackByType = {0L, blackPawns, blackKnights, blackBishops, blackRooks, blackQueens, blackKing};
-        long occ = allPieces;
+        MoveSnapshot snapshot = moveSnapshot;
+        snapshot.load(this);
+        PieceBitboards whiteState = snapshot.white;
+        PieceBitboards blackState = snapshot.black;
+        long occ = snapshot.occ;
 
         if (isCapture) {
             int capturedBits = MoveHelper.deriveCapturedPieceTypeBits(move);
             int captureSquare = isEnPassant ? (whiteMove ? to - 8 : to + 8) : to;
             long captureMask = 1L << captureSquare;
             if (whiteMove) {
-                if (capturedBits >= 1 && capturedBits <= 6) {
-                    blackByType[capturedBits] &= ~captureMask;
-                }
+                blackState.clearBit(capturedBits, captureMask);
             } else {
-                if (capturedBits >= 1 && capturedBits <= 6) {
-                    whiteByType[capturedBits] &= ~captureMask;
-                }
+                whiteState.clearBit(capturedBits, captureMask);
             }
             occ &= ~captureMask;
         }
 
         if (whiteMove) {
-            whiteByType[pieceBits] &= ~fromMask;
+            whiteState.clearBit(pieceBits, fromMask);
         } else {
-            blackByType[pieceBits] &= ~fromMask;
+            blackState.clearBit(pieceBits, fromMask);
         }
         occ &= ~fromMask;
 
         int placedBits = promotionBits != 0 ? promotionBits : pieceBits;
         if (whiteMove) {
-            whiteByType[placedBits] |= toMask;
+            whiteState.addBit(placedBits, toMask);
         } else {
-            blackByType[placedBits] |= toMask;
+            blackState.addBit(placedBits, toMask);
         }
         occ |= toMask;
 
@@ -1599,11 +1707,11 @@ public class BitBoard {
             long rookFromMask = 1L << rookFrom;
             long rookToMask = 1L << rookTo;
             if (whiteMove) {
-                whiteByType[4] &= ~rookFromMask;
-                whiteByType[4] |= rookToMask;
+                whiteState.clearBit(4, rookFromMask);
+                whiteState.addBit(4, rookToMask);
             } else {
-                blackByType[4] &= ~rookFromMask;
-                blackByType[4] |= rookToMask;
+                blackState.clearBit(4, rookFromMask);
+                blackState.addBit(4, rookToMask);
             }
             occ &= ~rookFromMask;
             occ |= rookToMask;
@@ -1614,7 +1722,7 @@ public class BitBoard {
             kingSquare = to;
         }
 
-        return !isSquareUnderAttack(kingSquare, whiteMove, occ, whiteByType, blackByType);
+        return !isSquareUnderAttack(kingSquare, whiteMove, occ, whiteState, blackState);
     }
 
 

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -8,11 +8,11 @@ import julius.game.chessengine.helper.KnightHelper;
 import julius.game.chessengine.helper.RookHelper;
 import julius.game.chessengine.helper.ZobristTable;
 import julius.game.chessengine.utils.Color;
-import julius.game.chessengine.board.MoveHelper;
 
 import julius.game.chessengine.utils.Score;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 
 import java.util.ArrayDeque;
@@ -52,7 +52,9 @@ public class BitBoard {
     private long blackPieces = 0L;
     private long allPieces = 0L;
     private long zKey = 0L;
+    @Setter
     private int halfmoveClock = 0;
+    @Setter
     private int fullmoveNumber = 1;
     /**
      * Bitboards caching the squares attacked by each side.
@@ -71,56 +73,25 @@ public class BitBoard {
 
     private static final int MAX_PSEUDO_LEGAL_MOVES = 218;
 
-    public static final class PinState {
-        private final boolean whiteSide;
-        private final int kingSquare;
-        private final long diagonalPinned;
-        private final long straightPinned;
-
-        public PinState(boolean whiteSide, int kingSquare, long diagonalPinned, long straightPinned) {
-            this.whiteSide = whiteSide;
-            this.kingSquare = kingSquare;
-            this.diagonalPinned = diagonalPinned;
-            this.straightPinned = straightPinned;
-        }
-
-        public boolean isWhiteSide() {
-            return whiteSide;
-        }
-
-        public int getKingSquare() {
-            return kingSquare;
-        }
-
-        public long getDiagonalPinned() {
-            return diagonalPinned;
-        }
-
-        public long getStraightPinned() {
-            return straightPinned;
-        }
+    public record PinState(boolean whiteSide, int kingSquare, long diagonalPinned, long straightPinned) {
 
         public long getAllPinned() {
             return diagonalPinned | straightPinned;
         }
     }
 
-    private static final class PinRayInfo {
-        private final long rayMask;
-        private final int pinnerSquare;
+    private record PinRayInfo(long rayMask, int pinnerSquare) { }
 
-        private PinRayInfo(long rayMask, int pinnerSquare) {
-            this.rayMask = rayMask;
-            this.pinnerSquare = pinnerSquare;
-        }
+    public static final class MoveGenResult {
+        public final IntArrayList moves;
+        public final PinState pinState;
 
-        public long getRayMask() {
-            return rayMask;
+        public MoveGenResult(IntArrayList moves, PinState pinState) {
+            this.moves = moves;
+            this.pinState = pinState;
         }
-
-        public int getPinnerSquare() {
-            return pinnerSquare;
-        }
+        public IntArrayList moves() { return moves; }
+        public PinState pinState() { return pinState; }
     }
 
     private static final class PieceBitboards {
@@ -132,10 +103,6 @@ public class BitBoard {
         long king;
 
         PieceBitboards() {
-        }
-
-        PieceBitboards(long pawns, long knights, long bishops, long rooks, long queens, long king) {
-            load(pawns, knights, bishops, rooks, queens, king);
         }
 
         void load(long pawns, long knights, long bishops, long rooks, long queens, long king) {
@@ -291,8 +258,6 @@ public class BitBoard {
         this.blackKingHasCastled = blackKingHasCastled;
         this.halfmoveClock = halfmoveClock;
         this.fullmoveNumber = fullmoveNumber;
-        this.halfmoveHistory.clear();
-        this.fullmoveHistory.clear();
         initPieceBoardFromBitboards();
         recomputeWhiteAttackMap();
         recomputeBlackAttackMap();
@@ -359,23 +324,12 @@ public class BitBoard {
         }
     }
 
-    public BitBoard snapshotWithoutHistory() {
-        return new BitBoard(this, false);
-    }
     public void setLastMoveDoubleStepPawnIndex(int index) {
         int oldEp = getEnPassantTargetIndex();
         this.lastMoveDoubleStepPawnIndex = index;
         int newEp = getEnPassantTargetIndex();
         if (oldEp != -1) xorEp(oldEp);
         if (newEp != -1) xorEp(newEp);
-    }
-
-    public void setHalfmoveClock(int halfmoveClock) {
-        this.halfmoveClock = halfmoveClock;
-    }
-
-    public void setFullmoveNumber(int fullmoveNumber) {
-        this.fullmoveNumber = fullmoveNumber;
     }
 
     public void flipSideToMove() {
@@ -467,19 +421,19 @@ public class BitBoard {
         if ((pinState.getAllPinned() & fromMask) == 0) {
             return true;
         }
-        if ((pinState.getStraightPinned() & fromMask) != 0) {
-            return areAlignedStraight(pinState.getKingSquare(), to)
-                    && isOnSameRay(pinState.getKingSquare(), from, to, false);
+        if ((pinState.straightPinned() & fromMask) != 0) {
+            return areAlignedStraight(pinState.kingSquare(), to)
+                    && isOnSameRay(pinState.kingSquare(), from, to, false);
         }
-        if ((pinState.getDiagonalPinned() & fromMask) != 0) {
-            return areAlignedDiagonal(pinState.getKingSquare(), to)
-                    && isOnSameRay(pinState.getKingSquare(), from, to, true);
+        if ((pinState.diagonalPinned() & fromMask) != 0) {
+            return areAlignedDiagonal(pinState.kingSquare(), to)
+                    && isOnSameRay(pinState.kingSquare(), from, to, true);
         }
         return true;
     }
 
     private PinRayInfo resolvePinRayInfo(PinState pinState, int pinnedSquare) {
-        int kingSquare = pinState.getKingSquare();
+        int kingSquare = pinState.kingSquare();
         int kingRank = kingSquare >>> 3;
         int kingFile = kingSquare & 7;
         int pieceRank = pinnedSquare >>> 3;
@@ -613,27 +567,33 @@ public class BitBoard {
         blackAttackDirty = true;
     }
 
-    /** Bishop-ray attacks from 'sq' with an explicit occupancy. */
+    /**
+     * Bishop-ray attacks from 'sq' with an explicit occupancy.
+     */
     private long bishopAttacksFromWithOcc(int sq, long occ) {
         long mask = bishopHelper.bishopMasks[sq];
         long occMasked = occ & mask;
         return bishopHelper.calculateMovesUsingBishopMagic(sq, occMasked);
     }
 
-    /** Rook-ray attacks from 'sq' with an explicit occupancy. */
+    /**
+     * Rook-ray attacks from 'sq' with an explicit occupancy.
+     */
     private long rookAttacksFromWithOcc(int sq, long occ) {
         long mask = rookHelper.rookMasks[sq];
         long occMasked = occ & mask;
         return rookHelper.calculateMovesUsingRookMagic(sq, occMasked);
     }
 
-    /** Bitboard of pawns (for the given side) that attack 'sq'. */
+    /**
+     * Bitboard of pawns (for the given side) that attack 'sq'.
+     */
     private long pawnAttackersToSquare(int sq, boolean whiteSide, long whitePawnsBB, long blackPawnsBB) {
         int file = sq & 7;
         long res = 0L;
         if (whiteSide) {
-            if (file != 7 && sq >= 7)  res |= (1L << (sq - 7));  // from ... -> to = +7
-            if (file != 0 && sq >= 9)  res |= (1L << (sq - 9));  // from ... -> to = +9
+            if (file != 7 && sq >= 7) res |= (1L << (sq - 7));  // from ... -> to = +7
+            if (file != 0 && sq >= 9) res |= (1L << (sq - 9));  // from ... -> to = +9
             return res & whitePawnsBB;
         } else {
             if (file != 0 && sq <= 56) res |= (1L << (sq + 7));  // from ... -> to = -7
@@ -654,7 +614,7 @@ public class BitBoard {
         if (!isCapture && promoBits == 0) return 0;
 
         int from = MoveHelper.deriveFromIndex(move);
-        int to   = MoveHelper.deriveToIndex(move);
+        int to = MoveHelper.deriveToIndex(move);
         boolean whiteMove = MoveHelper.isWhitesMove(move);
         int moverBits = MoveHelper.derivePieceTypeBits(move);
         boolean isEp = MoveHelper.isEnPassantMove(move);
@@ -712,24 +672,23 @@ public class BitBoard {
 
         while (true) {
             // Build attackers for the side to move now
-            long pawns   = sideWhite ? whiteState.pawns : blackState.pawns;
             long knights = sideWhite ? whiteState.knights : blackState.knights;
             long bishops = sideWhite ? whiteState.bishops : blackState.bishops;
-            long rooks   = sideWhite ? whiteState.rooks : blackState.rooks;
-            long queens  = sideWhite ? whiteState.queens : blackState.queens;
-            long king    = sideWhite ? whiteState.king : blackState.king;
+            long rooks = sideWhite ? whiteState.rooks : blackState.rooks;
+            long queens = sideWhite ? whiteState.queens : blackState.queens;
+            long king = sideWhite ? whiteState.king : blackState.king;
 
-            long attPawns   = pawnAttackersToSquare(to, sideWhite, whiteState.pawns, blackState.pawns);
+            long attPawns = pawnAttackersToSquare(to, sideWhite, whiteState.pawns, blackState.pawns);
             long attKnights = KnightHelper.knightMoveTable[to] & knights;
             long bRay = bishopAttacksFromWithOcc(to, occ);
             long rRay = rookAttacksFromWithOcc(to, occ);
             long attBishops = bRay & bishops;
-            long attRooks   = rRay & rooks;
-            long attQueens  = (bRay | rRay) & queens;
-            long attKing    = KING_ATTACKS[to] & king;
+            long attRooks = rRay & rooks;
+            long attQueens = (bRay | rRay) & queens;
+            long attKing = KING_ATTACKS[to] & king;
 
-            long fromBB = 0L;
-            int  attBits = 0;
+            long fromBB;
+            int attBits = 0;
             int attFrom = -1;
             long attMask = 0L;
 
@@ -870,7 +829,7 @@ public class BitBoard {
 
         long occCopy = (occ & ~fromMask) | toMask;
 
-        boolean safe = !isSquareAttackedInSee(target, !kingIsWhite, whiteState, blackState, occCopy);
+        boolean safe = isSquareAttackedNotInSee(target, !kingIsWhite, whiteState, blackState, occCopy);
 
         if (kingIsWhite) {
             whiteState.king = originalWhite;
@@ -894,7 +853,7 @@ public class BitBoard {
         while (attackers != 0) {
             int from = Long.numberOfTrailingZeros(attackers);
             if (attBits == 6 || isNonKingCaptureLegal(sideWhite, from, target, attBits, whiteState, blackState, occ,
-                                                     toPieceWhite, toPieceBits)) {
+                    toPieceWhite, toPieceBits)) {
                 return from;
             }
             attackers &= attackers - 1;
@@ -949,7 +908,7 @@ public class BitBoard {
             return false;
         }
         int kingSquare = Long.numberOfTrailingZeros(kingBB);
-        boolean safe = !isSquareAttackedInSee(kingSquare, !attackerWhite, whiteState, blackState, occCopy);
+        boolean safe = isSquareAttackedNotInSee(kingSquare, !attackerWhite, whiteState, blackState, occCopy);
 
         if (attackerWhite) {
             whiteState.set(attackerBits, originalAttacker);
@@ -967,9 +926,9 @@ public class BitBoard {
         return safe;
     }
 
-    private boolean isSquareAttackedInSee(int square, boolean attackerWhite,
-                                          PieceBitboards whiteState, PieceBitboards blackState, long occ) {
-        return isSquareUnderAttack(square, !attackerWhite, occ, whiteState, blackState);
+    private boolean isSquareAttackedNotInSee(int square, boolean attackerWhite,
+                                             PieceBitboards whiteState, PieceBitboards blackState, long occ) {
+        return isSquareSafe(square, !attackerWhite, occ, whiteState, blackState);
     }
 
 
@@ -1052,6 +1011,7 @@ public class BitBoard {
         }
     }
 
+
     /**
      * Generates all pseudo-legal moves for the specified side.
      *
@@ -1064,14 +1024,12 @@ public class BitBoard {
      * @return an {@link IntArrayList} containing pseudo-legal moves encoded with
      * {@link MoveHelper#createMoveInt(int, int, PieceType, boolean, boolean, boolean, boolean, PieceType, PieceType, boolean, boolean, int)}
      */
-    public IntArrayList generateAllPossibleMoves(boolean whitesTurn) {
+
+    // New method (rename of existing generateAllPossibleMoves) that exposes pins:
+    public MoveGenResult generateAllPossibleMovesWithPins(boolean whitesTurn) {
         IntArrayList moves = new IntArrayList(MAX_PSEUDO_LEGAL_MOVES);
 
-        // Do NOT recompute white/black attack maps here.
-        // They are recomputed lazily inside isSquareUnderAttack() only when needed
-        // (e.g., castling checks, isInCheck). This saves a full-board attack rebuild
-        // on most plies where castling isn’t even considered.
-
+        // NOTE: single computation here
         PinState pinState = computePinState(whitesTurn);
 
         generatePawnMoves(whitesTurn, moves, pinState);
@@ -1081,9 +1039,13 @@ public class BitBoard {
         generateQueenMoves(whitesTurn, moves, pinState);
         generateKingMoves(whitesTurn, moves, pinState);
 
-        return moves;
+        return new MoveGenResult(moves, pinState);
     }
 
+
+    public IntArrayList generateAllPossibleMoves(boolean whitesTurn) {
+        return generateAllPossibleMovesWithPins(whitesTurn).moves;
+    }
 
     /**
      * Generates a bitboard of all squares attacked by the given side.
@@ -1401,10 +1363,10 @@ public class BitBoard {
             long attacks = bishopHelper.calculateMovesUsingBishopMagic(bishopSquare, occupancy) & ~ownPieces;
 
             PinRayInfo pinRayInfo = null;
-            if (pinState != null && pinState.isWhiteSide() == isWhite
+            if (pinState != null && pinState.whiteSide() == isWhite
                     && (pinState.getAllPinned() & (1L << bishopSquare)) != 0) {
                 pinRayInfo = resolvePinRayInfo(pinState, bishopSquare);
-                long allowedMask = pinRayInfo.getRayMask() & ~(1L << pinState.getKingSquare());
+                long allowedMask = pinRayInfo.rayMask() & ~(1L << pinState.kingSquare());
                 attacks &= allowedMask;
             }
 
@@ -1416,7 +1378,7 @@ public class BitBoard {
                 boolean isCapture = (opponentPieces & (1L << targetSquare)) != 0;
                 PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetSquare) : null;
                 if (capturedType != PieceType.KING) {
-                    if (pinRayInfo != null && isCapture && pinRayInfo.getPinnerSquare() != targetSquare) {
+                    if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
                         continue;
                     }
                     moves.add(createMoveInt(bishopSquare, targetSquare, PieceType.BISHOP, isWhite, isCapture, false, false, null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
@@ -1439,10 +1401,10 @@ public class BitBoard {
             long attacks = rookHelper.calculateMovesUsingRookMagic(rookSquare, occupancy) & ~ownPieces;
 
             PinRayInfo pinRayInfo = null;
-            if (pinState != null && pinState.isWhiteSide() == whitesTurn
+            if (pinState != null && pinState.whiteSide() == whitesTurn
                     && (pinState.getAllPinned() & (1L << rookSquare)) != 0) {
                 pinRayInfo = resolvePinRayInfo(pinState, rookSquare);
-                long allowedMask = pinRayInfo.getRayMask() & ~(1L << pinState.getKingSquare());
+                long allowedMask = pinRayInfo.rayMask() & ~(1L << pinState.kingSquare());
                 attacks &= allowedMask;
             }
 
@@ -1453,7 +1415,7 @@ public class BitBoard {
                 boolean isCapture = (opponentPieces & (1L << targetSquare)) != 0;
                 PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetSquare) : null;
                 if (capturedType != PieceType.KING) {
-                    if (pinRayInfo != null && isCapture && pinRayInfo.getPinnerSquare() != targetSquare) {
+                    if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
                         continue;
                     }
                     moves.add(createMoveInt(rookSquare, targetSquare, PieceType.ROOK, whitesTurn, isCapture, false, false, null, capturedType, false, isFirstRookMove, lastMoveDoubleStepPawnIndex));
@@ -1479,10 +1441,10 @@ public class BitBoard {
             ) & ~ownPieces;
 
             PinRayInfo pinRayInfo = null;
-            if (pinState != null && pinState.isWhiteSide() == whitesTurn
+            if (pinState != null && pinState.whiteSide() == whitesTurn
                     && (pinState.getAllPinned() & (1L << queenSquare)) != 0) {
                 pinRayInfo = resolvePinRayInfo(pinState, queenSquare);
-                long allowedMask = pinRayInfo.getRayMask() & ~(1L << pinState.getKingSquare());
+                long allowedMask = pinRayInfo.rayMask() & ~(1L << pinState.kingSquare());
                 attacks &= allowedMask;
             }
 
@@ -1492,7 +1454,7 @@ public class BitBoard {
                 boolean isCapture = (opponentPieces & (1L << targetSquare)) != 0;
                 PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetSquare) : null;
                 if (capturedType != PieceType.KING) {
-                    if (pinRayInfo != null && isCapture && pinRayInfo.getPinnerSquare() != targetSquare) {
+                    if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
                         continue;
                     }
                     moves.add(createMoveInt(queenSquare, targetSquare, PieceType.QUEEN, whitesTurn, isCapture, false, false, null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
@@ -1529,7 +1491,7 @@ public class BitBoard {
 
     private void addCastlingMoves(boolean whitesTurn, int kingPositionIndex, IntArrayList moves, PinState pinState) {
         // Avoid an extra bit scan: we already know the king's square.
-        if (canKingCastle(whitesTurn, kingPositionIndex, pinState)) {
+        if (canKingCastle(whitesTurn, kingPositionIndex)) {
             if (canCastleKingside(whitesTurn, kingPositionIndex, pinState)) {
                 moves.add(createMoveInt(kingPositionIndex, kingPositionIndex + 2, PieceType.KING,
                         whitesTurn, false, true, false, null, null, true, true, lastMoveDoubleStepPawnIndex));
@@ -1541,7 +1503,7 @@ public class BitBoard {
         }
     }
 
-    private boolean canKingCastle(boolean whitesTurn, int kingIndex, PinState pinState) {
+    private boolean canKingCastle(boolean whitesTurn, int kingIndex) {
         // King must not have moved and must not be in check now.
         // isSquareUnderAttack() will lazily recompute opponent attack map if dirty.
         return hasKingNotMoved(whitesTurn) && !isSquareUnderAttack(kingIndex, whitesTurn);
@@ -1563,7 +1525,7 @@ public class BitBoard {
             return false;
         }
 
-        if (pinState != null && pinState.isWhiteSide() == colorWhite
+        if (pinState != null && pinState.whiteSide() == colorWhite
                 && (pinState.getAllPinned() & (1L << rookIndex)) != 0) {
             return false;
         }
@@ -1587,7 +1549,7 @@ public class BitBoard {
         if (hasRookMoved(rookIndex)) {
             return false;
         }
-        if (pinState != null && pinState.isWhiteSide() == colorWhite
+        if (pinState != null && pinState.whiteSide() == colorWhite
                 && (pinState.getAllPinned() & (1L << rookIndex)) != 0) {
             return false;
         }
@@ -1599,16 +1561,31 @@ public class BitBoard {
         return pieceAtPosition == PieceType.ROOK;
     }
 
-    // Replace your current isSquareUnderAttack with this version
+    // Fast path: no loads, uses live fields directly.
     private boolean isSquareUnderAttack(int index, boolean colorWhite) {
-        attackScratchWhite.load(whitePawns, whiteKnights, whiteBishops, whiteRooks, whiteQueens, whiteKing);
-        attackScratchBlack.load(blackPawns, blackKnights, blackBishops, blackRooks, blackQueens, blackKing);
-        return isSquareUnderAttack(index, colorWhite, allPieces, attackScratchWhite, attackScratchBlack);
+        if (colorWhite) {
+            if (pawnAttackersToSquare(index, false, whitePawns, blackPawns) != 0) return true;
+            if ((KnightHelper.knightMoveTable[index] & blackKnights) != 0) return true;
+            if ((KING_ATTACKS[index] & blackKing) != 0) return true;
+            long b = bishopAttacksFromWithOcc(index, allPieces);
+            if ((b & (blackBishops | blackQueens)) != 0) return true;
+            long r = rookAttacksFromWithOcc(index, allPieces);
+            return (r & (blackRooks | blackQueens)) != 0;
+        } else {
+            if (pawnAttackersToSquare(index, true, whitePawns, blackPawns) != 0) return true;
+            if ((KnightHelper.knightMoveTable[index] & whiteKnights) != 0) return true;
+            if ((KING_ATTACKS[index] & whiteKing) != 0) return true;
+            long b = bishopAttacksFromWithOcc(index, allPieces);
+            if ((b & (whiteBishops | whiteQueens)) != 0) return true;
+            long r = rookAttacksFromWithOcc(index, allPieces);
+            return (r & (whiteRooks | whiteQueens)) != 0;
+        }
     }
 
-    private boolean isSquareUnderAttack(int index, boolean colorWhite, long occ,
-                                        PieceBitboards whiteState, PieceBitboards blackState) {
-        return isSquareUnderAttack(index, colorWhite, occ,
+
+    private boolean isSquareSafe(int index, boolean colorWhite, long occ,
+                                 PieceBitboards whiteState, PieceBitboards blackState) {
+        return !isSquareUnderAttack(index, colorWhite, occ,
                 whiteState.pawns, whiteState.knights, whiteState.bishops, whiteState.rooks, whiteState.queens, whiteState.king,
                 blackState.pawns, blackState.knights, blackState.bishops, blackState.rooks, blackState.queens, blackState.king);
     }
@@ -1639,7 +1616,7 @@ public class BitBoard {
 
     public boolean isMoveLegalFast(int move, PinState pinState) {
         boolean whiteMove = MoveHelper.isWhitesMove(move);
-        if (pinState == null || pinState.isWhiteSide() != whiteMove) {
+        if (pinState == null || pinState.whiteSide() != whiteMove) {
             pinState = computePinState(whiteMove);
         }
 
@@ -1655,14 +1632,14 @@ public class BitBoard {
         long toMask = 1L << to;
 
         if (pieceBits != 6 && (pinState.getAllPinned() & fromMask) != 0) {
-            if ((pinState.getStraightPinned() & fromMask) != 0) {
-                if (!areAlignedStraight(pinState.getKingSquare(), to)
-                        || !isOnSameRay(pinState.getKingSquare(), from, to, false)) {
+            if ((pinState.straightPinned() & fromMask) != 0) {
+                if (!areAlignedStraight(pinState.kingSquare(), to)
+                        || !isOnSameRay(pinState.kingSquare(), from, to, false)) {
                     return false;
                 }
-            } else if ((pinState.getDiagonalPinned() & fromMask) != 0) {
-                if (!areAlignedDiagonal(pinState.getKingSquare(), to)
-                        || !isOnSameRay(pinState.getKingSquare(), from, to, true)) {
+            } else if ((pinState.diagonalPinned() & fromMask) != 0) {
+                if (!areAlignedDiagonal(pinState.kingSquare(), to)
+                        || !isOnSameRay(pinState.kingSquare(), from, to, true)) {
                     return false;
                 }
             }
@@ -1717,12 +1694,12 @@ public class BitBoard {
             occ |= rookToMask;
         }
 
-        int kingSquare = pinState.getKingSquare();
+        int kingSquare = pinState.kingSquare();
         if (pieceBits == 6) {
             kingSquare = to;
         }
 
-        return !isSquareUnderAttack(kingSquare, whiteMove, occ, whiteState, blackState);
+        return isSquareSafe(kingSquare, whiteMove, occ, whiteState, blackState);
     }
 
 
@@ -1832,7 +1809,7 @@ public class BitBoard {
         }
 
         // ---- 3) Move the piece (fast)
-        
+
         // remove from 'from'
         switch (pieceBits) {
             case 1 -> {
@@ -2416,15 +2393,6 @@ public class BitBoard {
         return rank * 8 + file;
     }
 
-
-    private PieceType getPieceTypeAtSquare(int square) {
-
-        return getPieceTypeAtIndex(square);
-    }
-
-    private Color getPieceColorAtSquare(int square) {
-        return getPieceColorAtIndex(square);
-    }
 
     private int getPieceIndex(PieceType pieceType, Color pieceColor) {
         int index = pieceType.ordinal() * 2; // There are two colors for each piece type

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -94,12 +94,6 @@ public class Engine {
         }
     }
 
-    public int getEnPassantTargetIndex() {
-        synchronized (boardLock) {
-            return bitBoard.getEnPassantTargetIndex();
-        }
-    }
-
     public void performMove(int move) {
         synchronized (boardLock) {
             boolean isOpeningMove = false;
@@ -202,10 +196,12 @@ public class Engine {
         synchronized (boardLock) {
             final long boardStateHash = getBoardStateHash();
 
-            IntArrayList pseudoMoves = bitBoard.getAllCurrentPossibleMoves();
-            IntArrayList legalMoves = new IntArrayList(pseudoMoves.size());
-            BitBoard.PinState pinState = bitBoard.computePinState(bitBoard.isWhitesTurn());
+            // Get pseudo moves + the already-computed PinState in one shot
+            BitBoard.MoveGenResult gen = bitBoard.generateAllPossibleMovesWithPins(bitBoard.whitesTurn);
+            IntArrayList pseudoMoves = gen.moves();
+            BitBoard.PinState pinState = gen.pinState();
 
+            IntArrayList legalMoves = new IntArrayList(pseudoMoves.size());
             for (int i = 0; i < pseudoMoves.size(); i++) {
                 int move = pseudoMoves.getInt(i);
                 if (bitBoard.isMoveLegalFast(move, pinState)) {
@@ -224,16 +220,17 @@ public class Engine {
                     bitBoard.undoMove(move);
                 }
                 if (!moveListsEqual(legalMoves, legacy)) {
-                    throw new IllegalStateException("Mismatch between fast and legacy legal move filtering: fast="
-                            + legalMoves + ", legacy=" + legacy);
+                    throw new IllegalStateException(
+                            "Mismatch between fast and legacy legal move filtering: fast=" + legalMoves + ", legacy=" + legacy
+                    );
                 }
             }
 
             cacheLegalMoves(boardStateHash, legalMoves);
-
             return legalMoves;
         }
     }
+
 
     private void markLegalMovesStale() {
         legalMovesNeedUpdate = true;

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -1,15 +1,16 @@
 package julius.game.chessengine.board;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.engine.Engine;
-import julius.game.chessengine.utils.Color;
 import julius.game.chessengine.figures.PieceType;
+import julius.game.chessengine.utils.Color;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Test;
 
 import static julius.game.chessengine.board.MoveHelper.convertStringToIndex;
 import static org.junit.jupiter.api.Assertions.*;
+
+//-XX:StartFlightRecording=name=uci,settings=profile,filename=Perft_refactor.jfr
 
 @Log4j2
 public class BitBoardTest {


### PR DESCRIPTION
## Summary
- introduce a reusable `PieceBitboards` snapshot to eliminate per-call array allocations
- update move legality, SEE helpers, and attack detection to operate on the new structure
- reuse scratch instances for SEE and attack queries to avoid cloning

## Testing
- ./mvnw test *(fails: network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d7dbdce6bc832a9f7ed06055d79fa1