### PR TITLE
Fix Zobrist key side-to-move encoding

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -215,7 +215,8 @@ public class BitBoard {
 
     private void recomputeZobristKey() {
         zKey = 0;
-        if (whitesTurn) {
+        // The Zobrist side-to-move bit is set only when it is Black's turn.
+        if (!whitesTurn) {
             xorSide();
         }
         for (int sq = 0; sq < 64; sq++) {

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -2,6 +2,7 @@ package julius.game.chessengine.board;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.helper.ZobristTable;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.utils.Color;
 import lombok.extern.log4j.Log4j2;
@@ -50,6 +51,31 @@ public class BitBoardTest {
         b.logBoard();
 
         assertEquals(a.getBoardStateHash(), b.getBoardStateHash());
+    }
+
+    @Test
+    void zobristSideToMoveMatchesBlackTurnBit() {
+        BitBoard whiteToMove = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/8/4K3 w - - 0 1");
+        BitBoard blackToMove = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/8/4K3 b - - 0 1");
+
+        long whiteHash = whiteToMove.getBoardStateHash();
+        long blackHash = blackToMove.getBoardStateHash();
+
+        assertNotEquals(whiteHash, blackHash, "Side to move should change the Zobrist hash");
+        assertEquals(whiteHash ^ ZobristTable.getBlackTurnHash(), blackHash,
+                "Black side-to-move hash should equal the white hash XORed with the black-turn key");
+    }
+
+    @Test
+    void flippingSideUpdatesZobristKey() {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/8/4K3 w - - 0 1");
+        long whiteHash = board.getBoardStateHash();
+
+        board.flipSideToMove();
+
+        assertFalse(board.isWhitesTurn());
+        assertEquals(whiteHash ^ ZobristTable.getBlackTurnHash(), board.getBoardStateHash(),
+                "Flipping side should xor the black-turn key");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- ensure the Zobrist recomputation only toggles the side-to-move bit when Black is to move
- add regression tests covering side-to-move hashing and flip-to-move behaviour

## Testing
- mvn test *(fails: Fatal error compiling: error: release version 25 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68d907f25024832aa2cea85bc3491c55