### PR TITLE
Store castling rights in move encoding and add rook capture tests

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.Objects;
 
-import static julius.game.chessengine.board.MoveHelper.createMoveInt;
 import static julius.game.chessengine.helper.BitHelper.*;
 import static julius.game.chessengine.helper.KingHelper.KING_ATTACKS;
 import static julius.game.chessengine.helper.KnightHelper.knightMoveTable;
@@ -175,6 +174,8 @@ public class BitBoard {
     private final Deque<Integer> halfmoveHistory = new ArrayDeque<>();
     @Getter(AccessLevel.NONE)
     private final Deque<Integer> fullmoveHistory = new ArrayDeque<>();
+    @Getter(AccessLevel.NONE)
+    private final Deque<Integer> doubleStepHistory = new ArrayDeque<>();
 
     // This variable needs to be set whenever a move is made
     @Getter
@@ -329,6 +330,7 @@ public class BitBoard {
         if (includeHistory) {
             this.halfmoveHistory.addAll(other.halfmoveHistory);
             this.fullmoveHistory.addAll(other.fullmoveHistory);
+            this.doubleStepHistory.addAll(other.doubleStepHistory);
         }
     }
 
@@ -1165,8 +1167,8 @@ public class BitBoard {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 8 : toIndex + 8;
             if (isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false,
-                        null, null, false, false, lastMoveDoubleStepPawnIndex));
+                moves.add(encodeMove(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false,
+                        null, null, false, false));
             }
             temp &= temp - 1;
         }
@@ -1199,8 +1201,8 @@ public class BitBoard {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 16 : toIndex + 16;
             if (isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false,
-                        null, null, false, false, lastMoveDoubleStepPawnIndex));
+                moves.add(encodeMove(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false,
+                        null, null, false, false));
             }
             temp &= temp - 1;
         }
@@ -1230,8 +1232,8 @@ public class BitBoard {
             int fromIndex = whitesTurn ? toIndex - 7 : toIndex + 7;
             PieceType capturedType = getPieceTypeAtIndex(toIndex);
             if (capturedType != PieceType.KING && isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
-                        null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                moves.add(encodeMove(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
+                        null, capturedType, false, false));
             }
             temp &= temp - 1;
         }
@@ -1243,8 +1245,8 @@ public class BitBoard {
             int fromIndex = whitesTurn ? toIndex - 9 : toIndex + 9;
             PieceType capturedType = getPieceTypeAtIndex(toIndex);
             if (capturedType != PieceType.KING && isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
-                        null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                moves.add(encodeMove(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
+                        null, capturedType, false, false));
             }
             temp &= temp - 1;
         }
@@ -1318,13 +1320,23 @@ public class BitBoard {
 
     private void addEnPassantMove(IntArrayList moves, int fromIndex, int toIndex, boolean whitesTurn) {
         moves.add(
-                createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, true, null, PieceType.PAWN, false, false, lastMoveDoubleStepPawnIndex));
+                encodeMove(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, true, null, PieceType.PAWN, false, false));
     }
 
     private void addPromotionMoves(IntArrayList moves, int fromIndex, int toIndex, boolean whitesTurn, boolean isCapture, PieceType capturedType) {
         for (PieceType promotionPiece : PROMOTION_PIECES) {
-            moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, isCapture, false, false, promotionPiece, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+            moves.add(encodeMove(fromIndex, toIndex, PieceType.PAWN, whitesTurn, isCapture, false, false, promotionPiece, capturedType, false, false));
         }
+    }
+
+
+    private int encodeMove(int fromIndex, int toIndex, PieceType pieceType, boolean isWhite,
+                           boolean isCapture, boolean isCastlingMove, boolean isEnPassantMove,
+                           PieceType promotionPieceType, PieceType capturedPieceType,
+                           boolean isKingFirstMove, boolean isRookFirstMove) {
+        return MoveHelper.createMoveInt(fromIndex, toIndex, pieceType, isWhite, isCapture, isCastlingMove,
+                isEnPassantMove, promotionPieceType, capturedPieceType, isKingFirstMove,
+                isRookFirstMove, getCastlingRightsMask());
     }
 
 
@@ -1347,7 +1359,7 @@ public class BitBoard {
 
                 PieceType capturedPieceType = isCapture ? getPieceTypeAtIndex(targetIndex) : null;
                 if (capturedPieceType != PieceType.KING) {
-                    moves.add(createMoveInt(knightIndex, targetIndex, PieceType.KNIGHT, whitesTurn, isCapture, false, false, null, capturedPieceType, false, false, lastMoveDoubleStepPawnIndex));
+                    moves.add(encodeMove(knightIndex, targetIndex, PieceType.KNIGHT, whitesTurn, isCapture, false, false, null, capturedPieceType, false, false));
                 }
 
                 potentialMoves &= potentialMoves - 1; // Clear the lowest set bit
@@ -1389,7 +1401,7 @@ public class BitBoard {
                     if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
                         continue;
                     }
-                    moves.add(createMoveInt(bishopSquare, targetSquare, PieceType.BISHOP, isWhite, isCapture, false, false, null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                    moves.add(encodeMove(bishopSquare, targetSquare, PieceType.BISHOP, isWhite, isCapture, false, false, null, capturedType, false, false));
                 }
             }
         }
@@ -1426,7 +1438,7 @@ public class BitBoard {
                     if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
                         continue;
                     }
-                    moves.add(createMoveInt(rookSquare, targetSquare, PieceType.ROOK, whitesTurn, isCapture, false, false, null, capturedType, false, isFirstRookMove, lastMoveDoubleStepPawnIndex));
+                    moves.add(encodeMove(rookSquare, targetSquare, PieceType.ROOK, whitesTurn, isCapture, false, false, null, capturedType, false, isFirstRookMove));
                 }
             }
         }
@@ -1465,7 +1477,7 @@ public class BitBoard {
                     if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
                         continue;
                     }
-                    moves.add(createMoveInt(queenSquare, targetSquare, PieceType.QUEEN, whitesTurn, isCapture, false, false, null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                    moves.add(encodeMove(queenSquare, targetSquare, PieceType.QUEEN, whitesTurn, isCapture, false, false, null, capturedType, false, false));
                 }
             }
         }
@@ -1496,7 +1508,7 @@ public class BitBoard {
             boolean isCapture = (captureMoves & (1L << targetIndex)) != 0;
             PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetIndex) : null;
             if (capturedType != PieceType.KING) {
-                moves.add(createMoveInt(
+                moves.add(encodeMove(
                         kingPositionIndex, targetIndex, PieceType.KING, whitesTurn,
                         isCapture, false, false, null, capturedType, isFirstKingMove, false,
                         lastMoveDoubleStepPawnIndex
@@ -1512,12 +1524,12 @@ public class BitBoard {
         // Avoid an extra bit scan: we already know the king's square.
         if (canKingCastle(whitesTurn, kingPositionIndex)) {
             if (canCastleKingside(whitesTurn, kingPositionIndex, pinState)) {
-                moves.add(createMoveInt(kingPositionIndex, kingPositionIndex + 2, PieceType.KING,
-                        whitesTurn, false, true, false, null, null, true, true, lastMoveDoubleStepPawnIndex));
+                moves.add(encodeMove(kingPositionIndex, kingPositionIndex + 2, PieceType.KING,
+                        whitesTurn, false, true, false, null, null, true, true));
             }
             if (canCastleQueenside(whitesTurn, kingPositionIndex, pinState)) {
-                moves.add(createMoveInt(kingPositionIndex, kingPositionIndex - 2, PieceType.KING,
-                        whitesTurn, false, true, false, null, null, true, true, lastMoveDoubleStepPawnIndex));
+                moves.add(encodeMove(kingPositionIndex, kingPositionIndex - 2, PieceType.KING,
+                        whitesTurn, false, true, false, null, null, true, true));
             }
         }
     }
@@ -1730,6 +1742,8 @@ public class BitBoard {
         boolean oldBK = !blackKingMoved && !blackRookH8Moved;
         boolean oldBQ = !blackKingMoved && !blackRookA8Moved;
 
+        doubleStepHistory.push(lastMoveDoubleStepPawnIndex);
+
         PieceType movingPiece = pieceTypeFromBits(pieceBits);
         Color moverColor = isWhite ? Color.WHITE : Color.BLACK;
         xorPiece(moverColor, movingPiece, fromIndex);
@@ -1774,6 +1788,7 @@ public class BitBoard {
                     } else {
                         whiteRooks &= ~capMask;
                     }
+                    markRookCaptured(capIndex);
                 }
                 case QUEEN -> {
                     if (isWhite) {
@@ -1996,6 +2011,10 @@ public class BitBoard {
         }
     }
 
+    private void markRookCaptured(int rookIndex) {
+        markRookAsMoved(rookIndex);
+    }
+
     public boolean hasRookMoved(int rookIndex) {
         return switch (rookIndex) {
             case 0 ->  // 'a1'
@@ -2113,7 +2132,7 @@ public class BitBoard {
         int capturedPieceTypeBits = MoveHelper.deriveCapturedPieceTypeBits(move);
         boolean isKingFirstMove = MoveHelper.isKingFirstMove(move);
         boolean isRookFirstMove = MoveHelper.isRookFirstMove(move);
-        int doubleStepPawnIndex = MoveHelper.deriveLastMoveDoubleStepPawnIndex(move);
+        int castlingRightsMask = MoveHelper.deriveCastlingRights(move);
 
         int oldEp = getEnPassantTargetIndex();
         boolean oldWK = !whiteKingMoved && !whiteRookH1Moved;
@@ -2163,7 +2182,7 @@ public class BitBoard {
         undoCastling(fromIndex, toIndex, isCastlingMove, isWhite);
 
         // 7) restore state flags + ep index
-        undoGameState(fromIndex, toIndex, pieceTypeBits, isKingFirstMove, isRookFirstMove, isWhite, doubleStepPawnIndex);
+        undoGameState(fromIndex, toIndex, pieceTypeBits, isKingFirstMove, isRookFirstMove, isWhite, castlingRightsMask);
 
         int newEp = (lastMoveDoubleStepPawnIndex != 0) ? ((isWhite ? 5 : 2) * 8 + (lastMoveDoubleStepPawnIndex & 7)) : -1;
         if (oldEp != -1) xorEp(oldEp);
@@ -2198,9 +2217,11 @@ public class BitBoard {
         flipSideToMove();
     }
 
-    private void undoGameState(int fromIndex, int toIndex, int pieceTypeBits, boolean isKingFirstMove, boolean isRookFirstMove, boolean isWhite, int doubleStepPawnIndex) {
+    private void undoGameState(int fromIndex, int toIndex, int pieceTypeBits, boolean isKingFirstMove, boolean isRookFirstMove, boolean isWhite, int castlingRightsMask) {
 
-        lastMoveDoubleStepPawnIndex = doubleStepPawnIndex;
+        lastMoveDoubleStepPawnIndex = doubleStepHistory.isEmpty() ? 0 : doubleStepHistory.pop();
+
+        restoreCastlingFlags(castlingRightsMask);
 
         if (pieceTypeBits == 6 && isKingFirstMove) {
             if (isWhite) {
@@ -2234,6 +2255,27 @@ public class BitBoard {
             } else if (fromIndex == 63) { // 'h8'
                 blackRookH8Moved = false;
             }
+        }
+    }
+
+    private void restoreCastlingFlags(int castlingRightsMask) {
+        if ((castlingRightsMask & 0x1) != 0) {
+            whiteRookH1Moved = false;
+        }
+        if ((castlingRightsMask & 0x2) != 0) {
+            whiteRookA1Moved = false;
+        }
+        if ((castlingRightsMask & 0x4) != 0) {
+            blackRookH8Moved = false;
+        }
+        if ((castlingRightsMask & 0x8) != 0) {
+            blackRookA8Moved = false;
+        }
+        if ((castlingRightsMask & 0x3) != 0) {
+            whiteKingMoved = false;
+        }
+        if ((castlingRightsMask & 0xC) != 0) {
+            blackKingMoved = false;
         }
     }
 
@@ -2395,6 +2437,23 @@ public class BitBoard {
         int file = lastMoveDoubleStepPawnIndex & 7;
         int rank = whitesTurn ? 5 : 2;
         return rank * 8 + file;
+    }
+
+    public int getCastlingRightsMask() {
+        int mask = 0;
+        if (!whiteKingMoved && !whiteRookH1Moved) {
+            mask |= 1;
+        }
+        if (!whiteKingMoved && !whiteRookA1Moved) {
+            mask |= 1 << 1;
+        }
+        if (!blackKingMoved && !blackRookH8Moved) {
+            mask |= 1 << 2;
+        }
+        if (!blackKingMoved && !blackRookA8Moved) {
+            mask |= 1 << 3;
+        }
+        return mask;
     }
 
 

--- a/src/main/java/julius/game/chessengine/board/Move.java
+++ b/src/main/java/julius/game/chessengine/board/Move.java
@@ -165,9 +165,8 @@ public class Move {
         boolean isWhite = (moveInt & (1 << 15)) != 0; // Extract the color bit
 
         int specialProperty = (moveInt >> 16) & 0x03; // Extract the next 2 bits
-        boolean isCapture = (specialProperty & 0x01) != 0;
-        boolean isEnPassantMove = specialProperty == 3;
         boolean isCastlingMove = specialProperty == 2;
+        boolean isEnPassantMove = specialProperty == 3;
 
         int promotionPieceTypeBits = (moveInt >> 18) & 0x07; // Extract the next 3 bits
         PieceType promotionPieceType = intToPieceType(promotionPieceTypeBits);
@@ -180,6 +179,8 @@ public class Move {
         if (capturedPieceTypeBits == 0) {
             capturedPieceType = null; // No capture
         }
+
+        boolean isCapture = capturedPieceType != null;
 
         boolean isKingFirstMove = (moveInt & (1 << 24)) != 0; // Extract the king's first move bit
         boolean isRookFirstMove = (moveInt & (1 << 25)) != 0; // Extract the rook's first move bit

--- a/src/main/java/julius/game/chessengine/board/MoveHelper.java
+++ b/src/main/java/julius/game/chessengine/board/MoveHelper.java
@@ -37,7 +37,7 @@ public class MoveHelper {
     }
 
     public static boolean isCapture(int move) {
-        return ((move >>> 16) & 0x1) != 0;
+        return deriveCapturedPieceTypeBits(move) != 0;
     }
 
     public static boolean isEnPassantMove(int move) {
@@ -56,11 +56,11 @@ public class MoveHelper {
         return (move & (1 << 25)) != 0;
     }
 
-    public static int deriveLastMoveDoubleStepPawnIndex(int move) {
-        return (move >> 26) & 0x3F; // Extract the 6 bits starting from the 26th bit
+    public static int deriveCastlingRights(int move) {
+        return (move >> 26) & 0x0F;
     }
 
-    public static int createMoveInt(int fromIndex, int toIndex, PieceType pieceType, boolean isWhite, boolean isCapture, boolean isCastlingMove, boolean isEnPassantMove, PieceType promotionPieceType, PieceType capturedPieceType, boolean isKingFirstMove, boolean isRookFirstMove, int lastMoveDoubleStepPawnIndex) {
+    public static int createMoveInt(int fromIndex, int toIndex, PieceType pieceType, boolean isWhite, boolean isCapture, boolean isCastlingMove, boolean isEnPassantMove, PieceType promotionPieceType, PieceType capturedPieceType, boolean isKingFirstMove, boolean isRookFirstMove, int castlingRightsMask) {
         int moveInt = 0;
         moveInt |= fromIndex; // 6 bits for 'from' position
         moveInt |= toIndex << 6; // 6 bits for 'to' position, shifted by 6 bits
@@ -72,7 +72,7 @@ public class MoveHelper {
             moveInt |= 1 << 15; // 1 bit for color, shifted by 15 bits
         }
 
-        int specialProperty = (isCapture ? 1 : 0) | (isCastlingMove ? 2 : 0) | (isEnPassantMove ? 3 : 0);
+        int specialProperty = isCastlingMove ? 2 : (isEnPassantMove ? 3 : 0);
         moveInt |= specialProperty << 16; // Shifted by 16 bits
 
         if (promotionPieceType != null) {
@@ -95,7 +95,7 @@ public class MoveHelper {
             moveInt |= 1 << 25; // 1 bit for rook's first move, shifted by 25 bits
         }
 
-        moveInt |= lastMoveDoubleStepPawnIndex << 26; // Shifted by 26 bits
+        moveInt |= (castlingRightsMask & 0x0F) << 26; // 4 bits for castling rights, shifted by 26 bits
 
         return moveInt;
     }

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -86,7 +86,7 @@ public class BitBoardTest {
         int e4 = convertStringToIndex("e4");
         int move = MoveHelper.createMoveInt(e2, e4, PieceType.PAWN, true,
                 false, false, false, null, null, false, false,
-                board.getLastMoveDoubleStepPawnIndex());
+                board.getCastlingRightsMask());
         board.performMove(move);
 
         // No black pawn can capture the pawn on e4, so en passant index should be 0
@@ -97,20 +97,20 @@ public class BitBoardTest {
         int a6 = convertStringToIndex("a6");
         move = MoveHelper.createMoveInt(a7, a6, PieceType.PAWN, false,
                 false, false, false, null, null, false, false,
-                board.getLastMoveDoubleStepPawnIndex());
+                board.getCastlingRightsMask());
         board.performMove(move);
 
         int e5 = convertStringToIndex("e5");
         move = MoveHelper.createMoveInt(e4, e5, PieceType.PAWN, true,
                 false, false, false, null, null, false, false,
-                board.getLastMoveDoubleStepPawnIndex());
+                board.getCastlingRightsMask());
         board.performMove(move);
 
         int d7 = convertStringToIndex("d7");
         int d5 = convertStringToIndex("d5");
         move = MoveHelper.createMoveInt(d7, d5, PieceType.PAWN, false,
                 false, false, false, null, null, false, false,
-                board.getLastMoveDoubleStepPawnIndex());
+                board.getCastlingRightsMask());
         board.performMove(move);
 
         assertEquals(d5, board.getLastMoveDoubleStepPawnIndex());
@@ -142,11 +142,69 @@ public class BitBoardTest {
 
         int move = MoveHelper.createMoveInt(from, to, PieceType.QUEEN, true,
                 true, false, false, null, captured, false, false,
-                engine.getBitBoard().getLastMoveDoubleStepPawnIndex());
+                engine.getBitBoard().getCastlingRightsMask());
 
         int see = engine.see(move);
 
         assertTrue(see < 0, "King recapture after checking capture should be evaluated");
+    }
+
+    @Test
+    void rookCaptureUpdatesCastlingRightsAndZobristHash() {
+        BitBoard board = FEN.translateFENtoBitBoard("r3k2r/8/8/8/8/8/4K3/R6R w KQkq - 0 1");
+        long originalHash = board.getBoardStateHash();
+        int initialRights = board.getCastlingRightsMask();
+
+        int from = convertStringToIndex("a1");
+        int to = convertStringToIndex("a8");
+        int move = MoveHelper.createMoveInt(from, to, PieceType.ROOK, true, true,
+                false, false, null, PieceType.ROOK, false, false, board.getCastlingRightsMask());
+
+        board.performMove(move);
+        long hashAfterCapture = board.getBoardStateHash();
+        int expectedRightsAfterCapture = initialRights & ~(1 << 1) & ~(1 << 3);
+
+        assertTrue(board.isBlackRookA8Moved(), "Black rook capture should mark A8 rook as moved");
+        assertTrue(board.isWhiteRookA1Moved(), "Moving rook should mark A1 rook as moved");
+        assertEquals(expectedRightsAfterCapture, board.getCastlingRightsMask(), "Castling rights should reflect captured rooks");
+
+        board.undoMove(move);
+
+        assertFalse(board.isBlackRookA8Moved());
+        assertFalse(board.isWhiteRookA1Moved());
+        assertEquals(initialRights, board.getCastlingRightsMask());
+        assertEquals(originalHash, board.getBoardStateHash(), "Undo should restore original hash");
+
+        board.performMove(move);
+        assertEquals(hashAfterCapture, board.getBoardStateHash(), "Redo should reproduce capture hash");
+        board.undoMove(move);
+        assertEquals(originalHash, board.getBoardStateHash());
+    }
+
+    @Test
+    void blackRookCaptureRestoresRightsOnUndo() {
+        BitBoard board = FEN.translateFENtoBitBoard("4k2r/8/8/8/8/8/4K3/7R b Kk - 0 1");
+        long initialHash = board.getBoardStateHash();
+        int initialRights = board.getCastlingRightsMask();
+
+        int from = convertStringToIndex("h8");
+        int to = convertStringToIndex("h1");
+        int move = MoveHelper.createMoveInt(from, to, PieceType.ROOK, false, true,
+                false, false, null, PieceType.ROOK, false, false, board.getCastlingRightsMask());
+
+        board.performMove(move);
+        int rightsAfterCapture = board.getCastlingRightsMask();
+
+        assertTrue(board.isWhiteRookH1Moved());
+        assertTrue(board.isBlackRookH8Moved());
+        assertEquals(0, rightsAfterCapture, "Both sides should lose relevant castling rights after capture");
+
+        board.undoMove(move);
+
+        assertFalse(board.isWhiteRookH1Moved());
+        assertFalse(board.isBlackRookH8Moved());
+        assertEquals(initialRights, board.getCastlingRightsMask());
+        assertEquals(initialHash, board.getBoardStateHash());
     }
 
     @Test

--- a/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
@@ -197,7 +197,7 @@ public class ScoreEvaluationTest {
         int from = MoveHelper.convertStringToIndex("d4");
         int to = MoveHelper.convertStringToIndex("d5");
         int move = MoveHelper.createMoveInt(from, to, PieceType.PAWN, true, true,
-                false, false, null, PieceType.PAWN, false, false, board.getLastMoveDoubleStepPawnIndex());
+                false, false, null, PieceType.PAWN, false, false, board.getCastlingRightsMask());
 
         board.performMove(move);
         score.applyMove(board, move, null);


### PR DESCRIPTION
## Summary
- record pre-move castling availability in encoded moves and restore the flags during undo
- update BitBoard to track rook captures, maintain en-passant history separately, and expose castling rights
- adjust move decoding helpers and add tests that cover rook captures plus undo/redo scenarios

## Testing
- `mvn -q test` *(fails: maven-compiler-plugin release version 25 not supported in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d909fb8488832ab0bb9eb68a29d475