### PR TITLE
Track castling rights in move encoding

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -1030,7 +1030,7 @@ public class BitBoard {
      *
      * @param whitesTurn {@code true} if white is to move, otherwise {@code false}
      * @return an {@link IntArrayList} containing pseudo-legal moves encoded with
-     * {@link MoveHelper#createMoveInt(int, int, PieceType, boolean, boolean, boolean, boolean, PieceType, PieceType, boolean, boolean, int)}
+     * {@link MoveHelper#createMoveInt(int, int, PieceType, boolean, boolean, boolean, boolean, PieceType, PieceType, int, int)}
      */
 
     // New method (rename of existing generateAllPossibleMoves) that exposes pins:
@@ -1148,6 +1148,31 @@ public class BitBoard {
         blackAttackDirty = false;
     }
 
+    private int encodeMove(int fromIndex, int toIndex, PieceType pieceType, boolean isWhite,
+                           boolean isCapture, boolean isCastlingMove, boolean isEnPassantMove,
+                           PieceType promotionPieceType, PieceType capturedPieceType) {
+        return createMoveInt(fromIndex, toIndex, pieceType, isWhite, isCapture, isCastlingMove,
+                isEnPassantMove, promotionPieceType, capturedPieceType,
+                getCastlingRightsMask(), lastMoveDoubleStepPawnIndex);
+    }
+
+    private int getCastlingRightsMask() {
+        int mask = 0;
+        if (!whiteKingMoved && !whiteRookH1Moved) {
+            mask |= 0b0001;
+        }
+        if (!whiteKingMoved && !whiteRookA1Moved) {
+            mask |= 0b0010;
+        }
+        if (!blackKingMoved && !blackRookH8Moved) {
+            mask |= 0b0100;
+        }
+        if (!blackKingMoved && !blackRookA8Moved) {
+            mask |= 0b1000;
+        }
+        return mask;
+    }
+
     private void generatePawnMoves(boolean whitesTurn, IntArrayList moves, PinState pinState) {
         long pawns = whitesTurn ? whitePawns : blackPawns;
         long opponentPieces = whitesTurn ? blackPieces : whitePieces;
@@ -1165,8 +1190,8 @@ public class BitBoard {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 8 : toIndex + 8;
             if (isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false,
-                        null, null, false, false, lastMoveDoubleStepPawnIndex));
+                moves.add(encodeMove(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false,
+                        null, null));
             }
             temp &= temp - 1;
         }
@@ -1199,8 +1224,8 @@ public class BitBoard {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 16 : toIndex + 16;
             if (isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false,
-                        null, null, false, false, lastMoveDoubleStepPawnIndex));
+                moves.add(encodeMove(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false,
+                        null, null));
             }
             temp &= temp - 1;
         }
@@ -1230,8 +1255,8 @@ public class BitBoard {
             int fromIndex = whitesTurn ? toIndex - 7 : toIndex + 7;
             PieceType capturedType = getPieceTypeAtIndex(toIndex);
             if (capturedType != PieceType.KING && isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
-                        null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                moves.add(encodeMove(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
+                        null, capturedType));
             }
             temp &= temp - 1;
         }
@@ -1243,8 +1268,8 @@ public class BitBoard {
             int fromIndex = whitesTurn ? toIndex - 9 : toIndex + 9;
             PieceType capturedType = getPieceTypeAtIndex(toIndex);
             if (capturedType != PieceType.KING && isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
-                        null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                moves.add(encodeMove(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
+                        null, capturedType));
             }
             temp &= temp - 1;
         }
@@ -1318,12 +1343,12 @@ public class BitBoard {
 
     private void addEnPassantMove(IntArrayList moves, int fromIndex, int toIndex, boolean whitesTurn) {
         moves.add(
-                createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, true, null, PieceType.PAWN, false, false, lastMoveDoubleStepPawnIndex));
+                encodeMove(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, true, null, PieceType.PAWN));
     }
 
     private void addPromotionMoves(IntArrayList moves, int fromIndex, int toIndex, boolean whitesTurn, boolean isCapture, PieceType capturedType) {
         for (PieceType promotionPiece : PROMOTION_PIECES) {
-            moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, isCapture, false, false, promotionPiece, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+            moves.add(encodeMove(fromIndex, toIndex, PieceType.PAWN, whitesTurn, isCapture, false, false, promotionPiece, capturedType));
         }
     }
 
@@ -1347,7 +1372,7 @@ public class BitBoard {
 
                 PieceType capturedPieceType = isCapture ? getPieceTypeAtIndex(targetIndex) : null;
                 if (capturedPieceType != PieceType.KING) {
-                    moves.add(createMoveInt(knightIndex, targetIndex, PieceType.KNIGHT, whitesTurn, isCapture, false, false, null, capturedPieceType, false, false, lastMoveDoubleStepPawnIndex));
+                    moves.add(encodeMove(knightIndex, targetIndex, PieceType.KNIGHT, whitesTurn, isCapture, false, false, null, capturedPieceType));
                 }
 
                 potentialMoves &= potentialMoves - 1; // Clear the lowest set bit
@@ -1389,7 +1414,7 @@ public class BitBoard {
                     if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
                         continue;
                     }
-                    moves.add(createMoveInt(bishopSquare, targetSquare, PieceType.BISHOP, isWhite, isCapture, false, false, null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                    moves.add(encodeMove(bishopSquare, targetSquare, PieceType.BISHOP, isWhite, isCapture, false, false, null, capturedType));
                 }
             }
         }
@@ -1419,14 +1444,13 @@ public class BitBoard {
             while (attacks != 0) {
                 int targetSquare = Long.numberOfTrailingZeros(attacks);
                 attacks &= attacks - 1; // Remove the least significant bit representing an attack
-                boolean isFirstRookMove = !hasRookMoved(rookSquare);
                 boolean isCapture = (opponentPieces & (1L << targetSquare)) != 0;
                 PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetSquare) : null;
                 if (capturedType != PieceType.KING) {
                     if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
                         continue;
                     }
-                    moves.add(createMoveInt(rookSquare, targetSquare, PieceType.ROOK, whitesTurn, isCapture, false, false, null, capturedType, false, isFirstRookMove, lastMoveDoubleStepPawnIndex));
+                    moves.add(encodeMove(rookSquare, targetSquare, PieceType.ROOK, whitesTurn, isCapture, false, false, null, capturedType));
                 }
             }
         }
@@ -1465,7 +1489,7 @@ public class BitBoard {
                     if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
                         continue;
                     }
-                    moves.add(createMoveInt(queenSquare, targetSquare, PieceType.QUEEN, whitesTurn, isCapture, false, false, null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                    moves.add(encodeMove(queenSquare, targetSquare, PieceType.QUEEN, whitesTurn, isCapture, false, false, null, capturedType));
                 }
             }
         }
@@ -1478,8 +1502,6 @@ public class BitBoard {
         }
         int kingPositionIndex = Long.numberOfTrailingZeros(kingBitboard);
         long kingAttacks = KING_ATTACKS[kingPositionIndex];
-        boolean isFirstKingMove = hasKingNotMoved(whitesTurn);
-
         long ownPieces = whitesTurn ? whitePieces : blackPieces;
         long opponentPieces = whitesTurn ? blackPieces : whitePieces;
         long legalMoves = kingAttacks & ~ownPieces;
@@ -1496,10 +1518,9 @@ public class BitBoard {
             boolean isCapture = (captureMoves & (1L << targetIndex)) != 0;
             PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetIndex) : null;
             if (capturedType != PieceType.KING) {
-                moves.add(createMoveInt(
+                moves.add(encodeMove(
                         kingPositionIndex, targetIndex, PieceType.KING, whitesTurn,
-                        isCapture, false, false, null, capturedType, isFirstKingMove, false,
-                        lastMoveDoubleStepPawnIndex
+                        isCapture, false, false, null, capturedType
                 ));
             }
         }
@@ -1512,12 +1533,12 @@ public class BitBoard {
         // Avoid an extra bit scan: we already know the king's square.
         if (canKingCastle(whitesTurn, kingPositionIndex)) {
             if (canCastleKingside(whitesTurn, kingPositionIndex, pinState)) {
-                moves.add(createMoveInt(kingPositionIndex, kingPositionIndex + 2, PieceType.KING,
-                        whitesTurn, false, true, false, null, null, true, true, lastMoveDoubleStepPawnIndex));
+                moves.add(encodeMove(kingPositionIndex, kingPositionIndex + 2, PieceType.KING,
+                        whitesTurn, false, true, false, null, null));
             }
             if (canCastleQueenside(whitesTurn, kingPositionIndex, pinState)) {
-                moves.add(createMoveInt(kingPositionIndex, kingPositionIndex - 2, PieceType.KING,
-                        whitesTurn, false, true, false, null, null, true, true, lastMoveDoubleStepPawnIndex));
+                moves.add(encodeMove(kingPositionIndex, kingPositionIndex - 2, PieceType.KING,
+                        whitesTurn, false, true, false, null, null));
             }
         }
     }
@@ -1774,6 +1795,7 @@ public class BitBoard {
                     } else {
                         whiteRooks &= ~capMask;
                     }
+                    markRookCaptured(capIndex);
                 }
                 case QUEEN -> {
                     if (isWhite) {
@@ -1996,6 +2018,33 @@ public class BitBoard {
         }
     }
 
+    private void markRookCaptured(int rookIndex) {
+        if (rookIndex == 0) {
+            whiteRookA1Moved = true;
+        } else if (rookIndex == 7) {
+            whiteRookH1Moved = true;
+        } else if (rookIndex == 56) {
+            blackRookA8Moved = true;
+        } else if (rookIndex == 63) {
+            blackRookH8Moved = true;
+        }
+    }
+
+    private void restoreCastlingFlags(int rights) {
+        boolean whiteKingside = (rights & 0b0001) != 0;
+        boolean whiteQueenside = (rights & 0b0010) != 0;
+        boolean blackKingside = (rights & 0b0100) != 0;
+        boolean blackQueenside = (rights & 0b1000) != 0;
+
+        whiteKingMoved = !(whiteKingside || whiteQueenside);
+        whiteRookH1Moved = !whiteKingside;
+        whiteRookA1Moved = !whiteQueenside;
+
+        blackKingMoved = !(blackKingside || blackQueenside);
+        blackRookH8Moved = !blackKingside;
+        blackRookA8Moved = !blackQueenside;
+    }
+
     public boolean hasRookMoved(int rookIndex) {
         return switch (rookIndex) {
             case 0 ->  // 'a1'
@@ -2111,9 +2160,7 @@ public class BitBoard {
         boolean isCastlingMove = MoveHelper.isCastlingMove(move);
         int promotionPieceTypeBits = MoveHelper.derivePromotionPieceTypeBits(move);
         int capturedPieceTypeBits = MoveHelper.deriveCapturedPieceTypeBits(move);
-        boolean isKingFirstMove = MoveHelper.isKingFirstMove(move);
-        boolean isRookFirstMove = MoveHelper.isRookFirstMove(move);
-        int doubleStepPawnIndex = MoveHelper.deriveLastMoveDoubleStepPawnIndex(move);
+        int castlingRights = MoveHelper.deriveCastlingRights(move);
 
         int oldEp = getEnPassantTargetIndex();
         boolean oldWK = !whiteKingMoved && !whiteRookH1Moved;
@@ -2163,7 +2210,7 @@ public class BitBoard {
         undoCastling(fromIndex, toIndex, isCastlingMove, isWhite);
 
         // 7) restore state flags + ep index
-        undoGameState(fromIndex, toIndex, pieceTypeBits, isKingFirstMove, isRookFirstMove, isWhite, doubleStepPawnIndex);
+        undoGameState(move, castlingRights);
 
         int newEp = (lastMoveDoubleStepPawnIndex != 0) ? ((isWhite ? 5 : 2) * 8 + (lastMoveDoubleStepPawnIndex & 7)) : -1;
         if (oldEp != -1) xorEp(oldEp);
@@ -2198,43 +2245,9 @@ public class BitBoard {
         flipSideToMove();
     }
 
-    private void undoGameState(int fromIndex, int toIndex, int pieceTypeBits, boolean isKingFirstMove, boolean isRookFirstMove, boolean isWhite, int doubleStepPawnIndex) {
-
-        lastMoveDoubleStepPawnIndex = doubleStepPawnIndex;
-
-        if (pieceTypeBits == 6 && isKingFirstMove) {
-            if (isWhite) {
-                whiteKingMoved = false;
-                if (isRookFirstMove) {
-                    if (toIndex == 6) { // 'g1'
-                        whiteRookH1Moved = false;
-                    } else if (toIndex == 2) { // 'c1'
-                        whiteRookA1Moved = false;
-                    }
-                }
-            } else {
-                blackKingMoved = false;
-                if (isRookFirstMove) {
-                    if (toIndex == 62) { // 'g8'
-                        blackRookH8Moved = false;
-                    } else if (toIndex == 58) { // 'c8'
-                        blackRookA8Moved = false;
-                    }
-                }
-            }
-        }
-
-        if (pieceTypeBits == 4 && isRookFirstMove) {
-            if (fromIndex == 0) { // 'a1'
-                whiteRookA1Moved = false;
-            } else if (fromIndex == 7) { // 'h1'
-                whiteRookH1Moved = false;
-            } else if (fromIndex == 56) { // 'a8'
-                blackRookA8Moved = false;
-            } else if (fromIndex == 63) { // 'h8'
-                blackRookH8Moved = false;
-            }
-        }
+    private void undoGameState(int move, int castlingRights) {
+        lastMoveDoubleStepPawnIndex = MoveHelper.deriveLastMoveDoubleStepPawnIndex(move);
+        restoreCastlingFlags(castlingRights);
     }
 
     private void undoCastling(int fromIndex, int toIndex, boolean isCastling, boolean isWhite) {

--- a/src/main/java/julius/game/chessengine/board/Move.java
+++ b/src/main/java/julius/game/chessengine/board/Move.java
@@ -1,6 +1,7 @@
 package julius.game.chessengine.board;
 
 import julius.game.chessengine.figures.PieceType;
+import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.utils.Color;
 import lombok.Getter;
 
@@ -181,8 +182,8 @@ public class Move {
             capturedPieceType = null; // No capture
         }
 
-        boolean isKingFirstMove = (moveInt & (1 << 24)) != 0; // Extract the king's first move bit
-        boolean isRookFirstMove = (moveInt & (1 << 25)) != 0; // Extract the rook's first move bit
+        boolean isKingFirstMove = MoveHelper.isKingFirstMove(moveInt);
+        boolean isRookFirstMove = MoveHelper.isRookFirstMove(moveInt);
 
         return new Move(from, to, pieceType, isWhite, isCapture, isCastlingMove, isEnPassantMove, promotionPieceType, capturedPieceType, isKingFirstMove, isRookFirstMove);
     }

--- a/src/main/java/julius/game/chessengine/board/MoveHelper.java
+++ b/src/main/java/julius/game/chessengine/board/MoveHelper.java
@@ -49,18 +49,63 @@ public class MoveHelper {
     }
 
     public static boolean isKingFirstMove(int move) {
-        return (move & (1 << 24)) != 0;
+        if (derivePieceTypeBits(move) != pieceTypeToInt(PieceType.KING)) {
+            return false;
+        }
+        int castlingRights = deriveCastlingRights(move);
+        boolean whiteMove = isWhitesMove(move);
+        if (whiteMove) {
+            return (castlingRights & 0b0011) != 0;
+        }
+        return (castlingRights & 0b1100) != 0;
     }
 
     public static boolean isRookFirstMove(int move) {
-        return (move & (1 << 25)) != 0;
+        if (isCastlingMove(move)) {
+            return true;
+        }
+        if (derivePieceTypeBits(move) != pieceTypeToInt(PieceType.ROOK)) {
+            return false;
+        }
+
+        int fromIndex = deriveFromIndex(move);
+        int castlingRights = deriveCastlingRights(move);
+        boolean whiteMove = isWhitesMove(move);
+
+        if (whiteMove) {
+            if (fromIndex == 0) {
+                return (castlingRights & 0b0010) != 0;
+            }
+            if (fromIndex == 7) {
+                return (castlingRights & 0b0001) != 0;
+            }
+        } else {
+            if (fromIndex == 56) {
+                return (castlingRights & 0b1000) != 0;
+            }
+            if (fromIndex == 63) {
+                return (castlingRights & 0b0100) != 0;
+            }
+        }
+        return false;
+    }
+
+    public static int deriveCastlingRights(int move) {
+        return (move >> 24) & 0x0F;
     }
 
     public static int deriveLastMoveDoubleStepPawnIndex(int move) {
-        return (move >> 26) & 0x3F; // Extract the 6 bits starting from the 26th bit
+        boolean hasDoubleStep = (move & (1 << 31)) != 0;
+        if (!hasDoubleStep) {
+            return 0;
+        }
+        int file = (move >> 28) & 0x7;
+        boolean doubleStepByWhite = !isWhitesMove(move);
+        int base = doubleStepByWhite ? 24 : 32;
+        return base + file;
     }
 
-    public static int createMoveInt(int fromIndex, int toIndex, PieceType pieceType, boolean isWhite, boolean isCapture, boolean isCastlingMove, boolean isEnPassantMove, PieceType promotionPieceType, PieceType capturedPieceType, boolean isKingFirstMove, boolean isRookFirstMove, int lastMoveDoubleStepPawnIndex) {
+    public static int createMoveInt(int fromIndex, int toIndex, PieceType pieceType, boolean isWhite, boolean isCapture, boolean isCastlingMove, boolean isEnPassantMove, PieceType promotionPieceType, PieceType capturedPieceType, int castlingRights, int lastMoveDoubleStepPawnIndex) {
         int moveInt = 0;
         moveInt |= fromIndex; // 6 bits for 'from' position
         moveInt |= toIndex << 6; // 6 bits for 'to' position, shifted by 6 bits
@@ -87,15 +132,12 @@ public class MoveHelper {
             moveInt &= ~(0x07 << 21); // Ensure captured piece bits are set to 000 if no piece is captured
         }
 
-        if (isKingFirstMove) {
-            moveInt |= 1 << 24; // 1 bit for king's first move, shifted by 24 bits
-        }
+        moveInt |= (castlingRights & 0x0F) << 24;
 
-        if (isRookFirstMove) {
-            moveInt |= 1 << 25; // 1 bit for rook's first move, shifted by 25 bits
+        if (lastMoveDoubleStepPawnIndex != 0) {
+            moveInt |= (lastMoveDoubleStepPawnIndex & 0x7) << 28;
+            moveInt |= 1 << 31;
         }
-
-        moveInt |= lastMoveDoubleStepPawnIndex << 26; // Shifted by 26 bits
 
         return moveInt;
     }

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -85,7 +85,7 @@ public class BitBoardTest {
         int e2 = convertStringToIndex("e2");
         int e4 = convertStringToIndex("e4");
         int move = MoveHelper.createMoveInt(e2, e4, PieceType.PAWN, true,
-                false, false, false, null, null, false, false,
+                false, false, false, null, null, computeCastlingRights(board),
                 board.getLastMoveDoubleStepPawnIndex());
         board.performMove(move);
 
@@ -96,24 +96,70 @@ public class BitBoardTest {
         int a7 = convertStringToIndex("a7");
         int a6 = convertStringToIndex("a6");
         move = MoveHelper.createMoveInt(a7, a6, PieceType.PAWN, false,
-                false, false, false, null, null, false, false,
+                false, false, false, null, null, computeCastlingRights(board),
                 board.getLastMoveDoubleStepPawnIndex());
         board.performMove(move);
 
         int e5 = convertStringToIndex("e5");
         move = MoveHelper.createMoveInt(e4, e5, PieceType.PAWN, true,
-                false, false, false, null, null, false, false,
+                false, false, false, null, null, computeCastlingRights(board),
                 board.getLastMoveDoubleStepPawnIndex());
         board.performMove(move);
 
         int d7 = convertStringToIndex("d7");
         int d5 = convertStringToIndex("d5");
         move = MoveHelper.createMoveInt(d7, d5, PieceType.PAWN, false,
-                false, false, false, null, null, false, false,
+                false, false, false, null, null, computeCastlingRights(board),
                 board.getLastMoveDoubleStepPawnIndex());
         board.performMove(move);
 
         assertEquals(d5, board.getLastMoveDoubleStepPawnIndex());
+    }
+
+    @Test
+    void capturingHomeRookDisablesCastling() {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/r7/R3K2R b KQ - 0 1");
+
+        int a2 = convertStringToIndex("a2");
+        int a1 = convertStringToIndex("a1");
+        int rightsBefore = computeCastlingRights(board);
+        int move = MoveHelper.createMoveInt(a2, a1, PieceType.ROOK, false,
+                true, false, false, null, PieceType.ROOK, rightsBefore,
+                board.getLastMoveDoubleStepPawnIndex());
+
+        assertEquals(rightsBefore, MoveHelper.deriveCastlingRights(move));
+
+        board.performMove(move);
+
+        assertTrue(board.isWhiteRookA1Moved());
+        assertFalse(board.isWhiteRookH1Moved());
+        assertFalse(board.isWhiteKingMoved());
+    }
+
+    @Test
+    void undoRedoRookCaptureRestoresHashAndRights() {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/r7/R3K2R b KQ - 0 1");
+        int a2 = convertStringToIndex("a2");
+        int a1 = convertStringToIndex("a1");
+        int move = MoveHelper.createMoveInt(a2, a1, PieceType.ROOK, false,
+                true, false, false, null, PieceType.ROOK, computeCastlingRights(board),
+                board.getLastMoveDoubleStepPawnIndex());
+
+        long initialHash = board.getBoardStateHash();
+
+        board.performMove(move);
+        long captureHash = board.getBoardStateHash();
+
+        board.undoMove(move);
+
+        assertEquals(initialHash, board.getBoardStateHash());
+        assertFalse(board.isWhiteRookA1Moved());
+        assertFalse(board.isWhiteKingMoved());
+
+        board.performMove(move);
+
+        assertEquals(captureHash, board.getBoardStateHash());
+        assertTrue(board.isWhiteRookA1Moved());
     }
 
     @Test
@@ -141,7 +187,8 @@ public class BitBoardTest {
         PieceType captured = engine.getBitBoard().getPieceTypeAtIndex(to);
 
         int move = MoveHelper.createMoveInt(from, to, PieceType.QUEEN, true,
-                true, false, false, null, captured, false, false,
+                true, false, false, null, captured,
+                computeCastlingRights(engine.getBitBoard()),
                 engine.getBitBoard().getLastMoveDoubleStepPawnIndex());
 
         int see = engine.see(move);
@@ -234,6 +281,23 @@ public class BitBoardTest {
             }
         }
         return false;
+    }
+
+    private int computeCastlingRights(BitBoard board) {
+        int rights = 0;
+        if (!board.isWhiteKingMoved() && !board.isWhiteRookH1Moved()) {
+            rights |= 0b0001;
+        }
+        if (!board.isWhiteKingMoved() && !board.isWhiteRookA1Moved()) {
+            rights |= 0b0010;
+        }
+        if (!board.isBlackKingMoved() && !board.isBlackRookH8Moved()) {
+            rights |= 0b0100;
+        }
+        if (!board.isBlackKingMoved() && !board.isBlackRookA8Moved()) {
+            rights |= 0b1000;
+        }
+        return rights;
     }
 
     @Test

--- a/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
@@ -197,7 +197,8 @@ public class ScoreEvaluationTest {
         int from = MoveHelper.convertStringToIndex("d4");
         int to = MoveHelper.convertStringToIndex("d5");
         int move = MoveHelper.createMoveInt(from, to, PieceType.PAWN, true, true,
-                false, false, null, PieceType.PAWN, false, false, board.getLastMoveDoubleStepPawnIndex());
+                false, false, null, PieceType.PAWN, computeCastlingRights(board),
+                board.getLastMoveDoubleStepPawnIndex());
 
         board.performMove(move);
         score.applyMove(board, move, null);
@@ -216,6 +217,23 @@ public class ScoreEvaluationTest {
         EvaluationPipeline pipeline = new EvaluationPipeline(java.util.List.of(module));
         pipeline.initialize(EvaluationContext.from(board, null));
         return pipeline.getBlendedScore();
+    }
+
+    private static int computeCastlingRights(BitBoard board) {
+        int rights = 0;
+        if (!board.isWhiteKingMoved() && !board.isWhiteRookH1Moved()) {
+            rights |= 0b0001;
+        }
+        if (!board.isWhiteKingMoved() && !board.isWhiteRookA1Moved()) {
+            rights |= 0b0010;
+        }
+        if (!board.isBlackKingMoved() && !board.isBlackRookH8Moved()) {
+            rights |= 0b0100;
+        }
+        if (!board.isBlackKingMoved() && !board.isBlackRookA8Moved()) {
+            rights |= 0b1000;
+        }
+        return rights;
     }
 
     private static KingSafetyView kingSafetyView(BitBoard board) {


### PR DESCRIPTION
## Summary
- capture the current castling rights in every encoded move and restore them during undo
- update the bitboard move execution to mark captured corner rooks, reuse the stored rights, and refresh Zobrist castling keys
- adjust move helpers and tests to the new encoding and add coverage for rook captures and undo/redo of those moves

## Testing
- `./mvnw test` *(fails: network unreachable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68d909fb8488832ab0bb9eb68a29d475