### PR TITLE
Persist castling rights across captures and undo

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -1543,51 +1543,46 @@ public class BitBoard {
     }
 
     private boolean canCastleKingside(boolean colorWhite, int kingPositionIndex, PinState pinState) {
-        // Ensure the squares between the king and the rook are unoccupied and not under attack
-        int[] kingsideSquares = {kingPositionIndex + 1, kingPositionIndex + 2};
+        // Ensure the squares the KING crosses/lands on are empty and not attacked
+        int[] kingsideSquares = {kingPositionIndex + 1, kingPositionIndex + 2}; // f-file, g-file
         for (int square : kingsideSquares) {
             if (isOccupied(square) || isSquareUnderAttack(square, colorWhite)) {
                 return false;
             }
         }
 
+        // The rook must exist on the corner and must not have moved
         int rookIndex = colorWhite ? 7 : 63;
-
-        // Check if the rook has moved
         if (hasRookMoved(rookIndex)) {
             return false;
         }
 
-        if (pinState != null && pinState.whiteSide() == colorWhite
-                && (pinState.getAllPinned() & (1L << rookIndex)) != 0) {
-            return false;
-        }
-
-        // Check if the rook still exists
-
+        // Rook presence only (rook being attacked or "pinned" is irrelevant for castling rules)
         return isRookAtIndex(rookIndex);
     }
 
     private boolean canCastleQueenside(boolean colorWhite, int kingPositionIndex, PinState pinState) {
-        // Ensure the squares between the king and the rook are unoccupied and not under attack
-        int[] queensideSquares = {kingPositionIndex - 1, kingPositionIndex - 2, kingPositionIndex - 3};
+        // Ensure the squares the KING crosses/lands on are empty and not attacked.
+        // On queenside, the king goes e->d->c. Square b is only for rook travel and may be attacked.
+        int[] queensideSquares = {kingPositionIndex - 1, kingPositionIndex - 2, kingPositionIndex - 3}; // d, c, b
         for (int square : queensideSquares) {
-            if (isOccupied(square) || (square != kingPositionIndex - 3 && isSquareUnderAttack(square, colorWhite))) {
+            // The king path is d and c; b must be empty for rook travel but need not be safe for the king.
+            boolean isKingPath = (square != kingPositionIndex - 3); // exclude 'b' from attack check
+            if (isOccupied(square) || (isKingPath && isSquareUnderAttack(square, colorWhite))) {
                 return false;
             }
         }
 
+        // The rook must exist on the corner and must not have moved
         int rookIndex = colorWhite ? 0 : 56;
-
         if (hasRookMoved(rookIndex)) {
             return false;
         }
-        if (pinState != null && pinState.whiteSide() == colorWhite
-                && (pinState.getAllPinned() & (1L << rookIndex)) != 0) {
-            return false;
-        }
+
+        // Rook presence only (rook being attacked or "pinned" is irrelevant for castling rules)
         return isRookAtIndex(rookIndex);
     }
+
 
     private boolean isRookAtIndex(int index) {
         PieceType pieceAtPosition = getPieceTypeAtIndex(index);
@@ -2393,9 +2388,11 @@ public class BitBoard {
                 whiteRookH1Moved == bitBoard.whiteRookH1Moved &&
                 blackRookA8Moved == bitBoard.blackRookA8Moved &&
                 blackRookH8Moved == bitBoard.blackRookH8Moved &&
+                lastMoveDoubleStepPawnIndex == bitBoard.lastMoveDoubleStepPawnIndex &&   // ← added
                 halfmoveClock == bitBoard.halfmoveClock &&
                 fullmoveNumber == bitBoard.fullmoveNumber;
     }
+
 
     @Override
     public int hashCode() {

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -175,6 +175,8 @@ public class BitBoard {
     private final Deque<Integer> halfmoveHistory = new ArrayDeque<>();
     @Getter(AccessLevel.NONE)
     private final Deque<Integer> fullmoveHistory = new ArrayDeque<>();
+    @Getter(AccessLevel.NONE)
+    private final Deque<Integer> doubleStepHistory = new ArrayDeque<>();
 
     // This variable needs to be set whenever a move is made
     @Getter
@@ -329,6 +331,7 @@ public class BitBoard {
         if (includeHistory) {
             this.halfmoveHistory.addAll(other.halfmoveHistory);
             this.fullmoveHistory.addAll(other.fullmoveHistory);
+            this.doubleStepHistory.addAll(other.doubleStepHistory);
         }
     }
 
@@ -546,6 +549,7 @@ public class BitBoard {
         allPieces = whitePieces | blackPieces;
 
         lastMoveDoubleStepPawnIndex = 0;
+        doubleStepHistory.clear();
         halfmoveClock = 0;
         fullmoveNumber = 1;
         halfmoveHistory.clear();
@@ -1166,7 +1170,7 @@ public class BitBoard {
             int fromIndex = whitesTurn ? toIndex - 8 : toIndex + 8;
             if (isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
                 moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false,
-                        null, null, false, false, lastMoveDoubleStepPawnIndex));
+                        null, null, false, false, packCastlingState()));
             }
             temp &= temp - 1;
         }
@@ -1200,7 +1204,7 @@ public class BitBoard {
             int fromIndex = whitesTurn ? toIndex - 16 : toIndex + 16;
             if (isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
                 moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false,
-                        null, null, false, false, lastMoveDoubleStepPawnIndex));
+                        null, null, false, false, packCastlingState()));
             }
             temp &= temp - 1;
         }
@@ -1231,7 +1235,7 @@ public class BitBoard {
             PieceType capturedType = getPieceTypeAtIndex(toIndex);
             if (capturedType != PieceType.KING && isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
                 moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
-                        null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                        null, capturedType, false, false, packCastlingState()));
             }
             temp &= temp - 1;
         }
@@ -1244,7 +1248,7 @@ public class BitBoard {
             PieceType capturedType = getPieceTypeAtIndex(toIndex);
             if (capturedType != PieceType.KING && isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
                 moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
-                        null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                        null, capturedType, false, false, packCastlingState()));
             }
             temp &= temp - 1;
         }
@@ -1318,12 +1322,12 @@ public class BitBoard {
 
     private void addEnPassantMove(IntArrayList moves, int fromIndex, int toIndex, boolean whitesTurn) {
         moves.add(
-                createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, true, null, PieceType.PAWN, false, false, lastMoveDoubleStepPawnIndex));
+                createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, true, null, PieceType.PAWN, false, false, packCastlingState()));
     }
 
     private void addPromotionMoves(IntArrayList moves, int fromIndex, int toIndex, boolean whitesTurn, boolean isCapture, PieceType capturedType) {
         for (PieceType promotionPiece : PROMOTION_PIECES) {
-            moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, isCapture, false, false, promotionPiece, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+            moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, isCapture, false, false, promotionPiece, capturedType, false, false, packCastlingState()));
         }
     }
 
@@ -1347,7 +1351,7 @@ public class BitBoard {
 
                 PieceType capturedPieceType = isCapture ? getPieceTypeAtIndex(targetIndex) : null;
                 if (capturedPieceType != PieceType.KING) {
-                    moves.add(createMoveInt(knightIndex, targetIndex, PieceType.KNIGHT, whitesTurn, isCapture, false, false, null, capturedPieceType, false, false, lastMoveDoubleStepPawnIndex));
+                    moves.add(createMoveInt(knightIndex, targetIndex, PieceType.KNIGHT, whitesTurn, isCapture, false, false, null, capturedPieceType, false, false, packCastlingState()));
                 }
 
                 potentialMoves &= potentialMoves - 1; // Clear the lowest set bit
@@ -1389,7 +1393,7 @@ public class BitBoard {
                     if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
                         continue;
                     }
-                    moves.add(createMoveInt(bishopSquare, targetSquare, PieceType.BISHOP, isWhite, isCapture, false, false, null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                    moves.add(createMoveInt(bishopSquare, targetSquare, PieceType.BISHOP, isWhite, isCapture, false, false, null, capturedType, false, false, packCastlingState()));
                 }
             }
         }
@@ -1426,7 +1430,7 @@ public class BitBoard {
                     if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
                         continue;
                     }
-                    moves.add(createMoveInt(rookSquare, targetSquare, PieceType.ROOK, whitesTurn, isCapture, false, false, null, capturedType, false, isFirstRookMove, lastMoveDoubleStepPawnIndex));
+                    moves.add(createMoveInt(rookSquare, targetSquare, PieceType.ROOK, whitesTurn, isCapture, false, false, null, capturedType, false, isFirstRookMove, packCastlingState()));
                 }
             }
         }
@@ -1465,7 +1469,7 @@ public class BitBoard {
                     if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
                         continue;
                     }
-                    moves.add(createMoveInt(queenSquare, targetSquare, PieceType.QUEEN, whitesTurn, isCapture, false, false, null, capturedType, false, false, lastMoveDoubleStepPawnIndex));
+                    moves.add(createMoveInt(queenSquare, targetSquare, PieceType.QUEEN, whitesTurn, isCapture, false, false, null, capturedType, false, false, packCastlingState()));
                 }
             }
         }
@@ -1499,7 +1503,7 @@ public class BitBoard {
                 moves.add(createMoveInt(
                         kingPositionIndex, targetIndex, PieceType.KING, whitesTurn,
                         isCapture, false, false, null, capturedType, isFirstKingMove, false,
-                        lastMoveDoubleStepPawnIndex
+                        packCastlingState()
                 ));
             }
         }
@@ -1513,11 +1517,11 @@ public class BitBoard {
         if (canKingCastle(whitesTurn, kingPositionIndex)) {
             if (canCastleKingside(whitesTurn, kingPositionIndex, pinState)) {
                 moves.add(createMoveInt(kingPositionIndex, kingPositionIndex + 2, PieceType.KING,
-                        whitesTurn, false, true, false, null, null, true, true, lastMoveDoubleStepPawnIndex));
+                        whitesTurn, false, true, false, null, null, true, true, packCastlingState()));
             }
             if (canCastleQueenside(whitesTurn, kingPositionIndex, pinState)) {
                 moves.add(createMoveInt(kingPositionIndex, kingPositionIndex - 2, PieceType.KING,
-                        whitesTurn, false, true, false, null, null, true, true, lastMoveDoubleStepPawnIndex));
+                        whitesTurn, false, true, false, null, null, true, true, packCastlingState()));
             }
         }
     }
@@ -1711,6 +1715,7 @@ public class BitBoard {
     public void performMove(int move) {
         halfmoveHistory.push(halfmoveClock);
         fullmoveHistory.push(fullmoveNumber);
+        doubleStepHistory.push(lastMoveDoubleStepPawnIndex);
 
         int fromIndex = MoveHelper.deriveFromIndex(move);
         int toIndex = MoveHelper.deriveToIndex(move);
@@ -1784,6 +1789,9 @@ public class BitBoard {
                 }
                 case KING -> throw new IllegalStateException("Cannot capture the king");
                 default -> throw new IllegalArgumentException("Unknown captured piece type: " + capType);
+            }
+            if (capType == PieceType.ROOK) {
+                markRookCaptured(capIndex);
             }
             pieceBoard[capIndex] = null;
         }
@@ -1996,6 +2004,28 @@ public class BitBoard {
         }
     }
 
+    private void markRookCaptured(int rookIndex) {
+        switch (rookIndex) {
+            case 0 -> whiteRookA1Moved = true;
+            case 7 -> whiteRookH1Moved = true;
+            case 56 -> blackRookA8Moved = true;
+            case 63 -> blackRookH8Moved = true;
+            default -> {
+            }
+        }
+    }
+
+    private int packCastlingState() {
+        int state = 0;
+        if (whiteKingMoved) state |= 0x01;
+        if (whiteRookA1Moved) state |= 0x02;
+        if (whiteRookH1Moved) state |= 0x04;
+        if (blackKingMoved) state |= 0x08;
+        if (blackRookA8Moved) state |= 0x10;
+        if (blackRookH8Moved) state |= 0x20;
+        return state;
+    }
+
     public boolean hasRookMoved(int rookIndex) {
         return switch (rookIndex) {
             case 0 ->  // 'a1'
@@ -2111,9 +2141,7 @@ public class BitBoard {
         boolean isCastlingMove = MoveHelper.isCastlingMove(move);
         int promotionPieceTypeBits = MoveHelper.derivePromotionPieceTypeBits(move);
         int capturedPieceTypeBits = MoveHelper.deriveCapturedPieceTypeBits(move);
-        boolean isKingFirstMove = MoveHelper.isKingFirstMove(move);
-        boolean isRookFirstMove = MoveHelper.isRookFirstMove(move);
-        int doubleStepPawnIndex = MoveHelper.deriveLastMoveDoubleStepPawnIndex(move);
+        int castlingStateBits = MoveHelper.deriveCastlingState(move);
 
         int oldEp = getEnPassantTargetIndex();
         boolean oldWK = !whiteKingMoved && !whiteRookH1Moved;
@@ -2163,7 +2191,7 @@ public class BitBoard {
         undoCastling(fromIndex, toIndex, isCastlingMove, isWhite);
 
         // 7) restore state flags + ep index
-        undoGameState(fromIndex, toIndex, pieceTypeBits, isKingFirstMove, isRookFirstMove, isWhite, doubleStepPawnIndex);
+        undoGameState(fromIndex, toIndex, pieceTypeBits, isWhite, castlingStateBits);
 
         int newEp = (lastMoveDoubleStepPawnIndex != 0) ? ((isWhite ? 5 : 2) * 8 + (lastMoveDoubleStepPawnIndex & 7)) : -1;
         if (oldEp != -1) xorEp(oldEp);
@@ -2198,43 +2226,27 @@ public class BitBoard {
         flipSideToMove();
     }
 
-    private void undoGameState(int fromIndex, int toIndex, int pieceTypeBits, boolean isKingFirstMove, boolean isRookFirstMove, boolean isWhite, int doubleStepPawnIndex) {
+    private void undoGameState(int fromIndex, int toIndex, int pieceTypeBits, boolean isWhite, int castlingStateBits) {
 
-        lastMoveDoubleStepPawnIndex = doubleStepPawnIndex;
-
-        if (pieceTypeBits == 6 && isKingFirstMove) {
-            if (isWhite) {
-                whiteKingMoved = false;
-                if (isRookFirstMove) {
-                    if (toIndex == 6) { // 'g1'
-                        whiteRookH1Moved = false;
-                    } else if (toIndex == 2) { // 'c1'
-                        whiteRookA1Moved = false;
-                    }
-                }
-            } else {
-                blackKingMoved = false;
-                if (isRookFirstMove) {
-                    if (toIndex == 62) { // 'g8'
-                        blackRookH8Moved = false;
-                    } else if (toIndex == 58) { // 'c8'
-                        blackRookA8Moved = false;
-                    }
-                }
-            }
+        if (!doubleStepHistory.isEmpty()) {
+            lastMoveDoubleStepPawnIndex = doubleStepHistory.pop();
+        } else {
+            lastMoveDoubleStepPawnIndex = 0;
         }
 
-        if (pieceTypeBits == 4 && isRookFirstMove) {
-            if (fromIndex == 0) { // 'a1'
-                whiteRookA1Moved = false;
-            } else if (fromIndex == 7) { // 'h1'
-                whiteRookH1Moved = false;
-            } else if (fromIndex == 56) { // 'a8'
-                blackRookA8Moved = false;
-            } else if (fromIndex == 63) { // 'h8'
-                blackRookH8Moved = false;
-            }
-        }
+        boolean whiteKingMovedPrev = (castlingStateBits & 0x01) != 0;
+        boolean whiteRookA1MovedPrev = (castlingStateBits & 0x02) != 0;
+        boolean whiteRookH1MovedPrev = (castlingStateBits & 0x04) != 0;
+        boolean blackKingMovedPrev = (castlingStateBits & 0x08) != 0;
+        boolean blackRookA8MovedPrev = (castlingStateBits & 0x10) != 0;
+        boolean blackRookH8MovedPrev = (castlingStateBits & 0x20) != 0;
+
+        whiteKingMoved = whiteKingMovedPrev;
+        whiteRookA1Moved = whiteRookA1MovedPrev;
+        whiteRookH1Moved = whiteRookH1MovedPrev;
+        blackKingMoved = blackKingMovedPrev;
+        blackRookA8Moved = blackRookA8MovedPrev;
+        blackRookH8Moved = blackRookH8MovedPrev;
     }
 
     private void undoCastling(int fromIndex, int toIndex, boolean isCastling, boolean isWhite) {

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -2,13 +2,8 @@ package julius.game.chessengine.board;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import julius.game.chessengine.figures.PieceType;
-import julius.game.chessengine.helper.BishopHelper;
-import julius.game.chessengine.helper.BitboardHelper;
-import julius.game.chessengine.helper.KnightHelper;
-import julius.game.chessengine.helper.RookHelper;
-import julius.game.chessengine.helper.ZobristTable;
+import julius.game.chessengine.helper.*;
 import julius.game.chessengine.utils.Color;
-
 import julius.game.chessengine.utils.Score;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,7 +13,6 @@ import lombok.extern.log4j.Log4j2;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-import java.util.Objects;
 
 import static julius.game.chessengine.board.MoveHelper.createMoveInt;
 import static julius.game.chessengine.helper.BitHelper.*;

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -1153,15 +1153,15 @@ public class BitBoard {
     }
 
     private void generatePawnMoves(boolean whitesTurn, IntArrayList moves, PinState pinState) {
-        long pawns = whitesTurn ? whitePawns : blackPawns;
-        long opponentPieces = whitesTurn ? blackPieces : whitePieces;
-        long emptySquares = ~allPieces;
+        final long pawns = whitesTurn ? whitePawns : blackPawns;
+        final long opponentPieces = whitesTurn ? blackPieces : whitePieces;
+        final long emptySquares = ~allPieces;
+        final long promotionRank = whitesTurn ? RankMasks[7] : RankMasks[0];
+        final int cs = packCastlingState(); // cache once
 
         // ------------------ Single Pushes ------------------
         long singlePushes = whitesTurn ? (pawns << 8) & emptySquares
                 : (pawns >>> 8) & emptySquares;
-
-        long promotionRank = whitesTurn ? RankMasks[7] : RankMasks[0];
 
         // Non-promotion single pushes
         long temp = singlePushes & ~promotionRank;
@@ -1169,8 +1169,8 @@ public class BitBoard {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 8 : toIndex + 8;
             if (isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false,
-                        null, null, false, false, packCastlingState()));
+                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn,
+                        false, false, false, null, null, false, false, cs));
             }
             temp &= temp - 1;
         }
@@ -1181,7 +1181,7 @@ public class BitBoard {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 8 : toIndex + 8;
             if (isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, false, null);
+                addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, false, null, cs);
             }
             temp &= temp - 1;
         }
@@ -1203,8 +1203,8 @@ public class BitBoard {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 16 : toIndex + 16;
             if (isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, false, false, false,
-                        null, null, false, false, packCastlingState()));
+                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn,
+                        false, false, false, null, null, false, false, cs));
             }
             temp &= temp - 1;
         }
@@ -1232,10 +1232,10 @@ public class BitBoard {
         while (temp != 0) {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 7 : toIndex + 7;
-            PieceType capturedType = getPieceTypeAtIndex(toIndex);
+            PieceType capturedType = pieceBoard[toIndex]; // O(1)
             if (capturedType != PieceType.KING && isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
-                        null, capturedType, false, false, packCastlingState()));
+                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn,
+                        true, false, false, null, capturedType, false, false, cs));
             }
             temp &= temp - 1;
         }
@@ -1245,10 +1245,10 @@ public class BitBoard {
         while (temp != 0) {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 9 : toIndex + 9;
-            PieceType capturedType = getPieceTypeAtIndex(toIndex);
+            PieceType capturedType = pieceBoard[toIndex]; // O(1)
             if (capturedType != PieceType.KING && isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, false,
-                        null, capturedType, false, false, packCastlingState()));
+                moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn,
+                        true, false, false, null, capturedType, false, false, cs));
             }
             temp &= temp - 1;
         }
@@ -1258,9 +1258,9 @@ public class BitBoard {
         while (temp != 0) {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 7 : toIndex + 7;
-            PieceType capturedType = getPieceTypeAtIndex(toIndex);
+            PieceType capturedType = pieceBoard[toIndex]; // O(1)
             if (capturedType != PieceType.KING && isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, true, capturedType);
+                addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, true, capturedType, cs);
             }
             temp &= temp - 1;
         }
@@ -1269,50 +1269,60 @@ public class BitBoard {
         while (temp != 0) {
             int toIndex = Long.numberOfTrailingZeros(temp);
             int fromIndex = whitesTurn ? toIndex - 9 : toIndex + 9;
-            PieceType capturedType = getPieceTypeAtIndex(toIndex);
+            PieceType capturedType = pieceBoard[toIndex]; // O(1)
             if (capturedType != PieceType.KING && isMoveAllowedByPin(pinState, fromIndex, toIndex)) {
-                addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, true, capturedType);
+                addPromotionMoves(moves, fromIndex, toIndex, whitesTurn, true, capturedType, cs);
             }
             temp &= temp - 1;
         }
 
-        // ------------------ En Passant ------------------
-        if (lastMoveDoubleStepPawnIndex != 0) {
-            generateEnPassantMoves(moves, pawns, whitesTurn, pinState);
-        }
-
+        // En passant last (rare) — unchanged logic but reuse cs
+        addEnPassantIfAny(whitesTurn, moves, pinState, cs);
     }
 
-    private void generateEnPassantMoves(IntArrayList moves, long pawns, boolean whitesTurn, PinState pinState) {
-        int enPassantRank = whitesTurn ? 5 : 2;
-        int fileIndexOfDoubleSteppedPawn = lastMoveDoubleStepPawnIndex % 8;
-        int enPassantTargetIndex = (enPassantRank * 8) + fileIndexOfDoubleSteppedPawn;
-        long enPassantTargetSquare = 1L << enPassantTargetIndex;
-        long potentialEnPassantAttackers = pawns & RankMasks[whitesTurn ? 4 : 3];
+    private void addPromotionMoves(IntArrayList moves, int fromIndex, int toIndex,
+                                   boolean whitesTurn, boolean isCapture,
+                                   PieceType capturedType, int cs) {
+        for (PieceType promotionPiece : PROMOTION_PIECES) {
+            moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn,
+                    isCapture, false, false, promotionPiece, capturedType, false, false, cs));
+        }
+    }
 
+    private void addEnPassantIfAny(boolean whitesTurn, IntArrayList moves, PinState pinState, int cs) {
+        int enPassantTargetIndex = getEnPassantTargetIndex();
+        if (enPassantTargetIndex == -1) return;
+
+        long enPassantTargetSquare = 1L << enPassantTargetIndex;
+        long potentialAttackers = whitesTurn ? whitePawns : blackPawns;
+
+        int fileIndexOfDoubleSteppedPawn = lastMoveDoubleStepPawnIndex & 7;
+        // left attackers
         if (fileIndexOfDoubleSteppedPawn > 0) {
-            long leftAttackers = potentialEnPassantAttackers & FileMasks[fileIndexOfDoubleSteppedPawn - 1];
+            long leftAttackers = potentialAttackers & FileMasks[fileIndexOfDoubleSteppedPawn - 1];
             while (leftAttackers != 0) {
                 int from = Long.numberOfTrailingZeros(leftAttackers);
                 boolean hits = whitesTurn
                         ? (((1L << from) << 9) & enPassantTargetSquare) != 0
                         : (((1L << from) >> 7) & enPassantTargetSquare) != 0;
                 if (hits && isMoveAllowedByPin(pinState, from, enPassantTargetIndex)) {
-                    addEnPassantMove(moves, from, enPassantTargetIndex, whitesTurn);
+                    moves.add(createMoveInt(from, enPassantTargetIndex, PieceType.PAWN, whitesTurn,
+                            true, false, true, null, PieceType.PAWN, false, false, cs));
                 }
                 leftAttackers &= leftAttackers - 1;
             }
         }
-
+        // right attackers
         if (fileIndexOfDoubleSteppedPawn < 7) {
-            long rightAttackers = potentialEnPassantAttackers & FileMasks[fileIndexOfDoubleSteppedPawn + 1];
+            long rightAttackers = potentialAttackers & FileMasks[fileIndexOfDoubleSteppedPawn + 1];
             while (rightAttackers != 0) {
                 int from = Long.numberOfTrailingZeros(rightAttackers);
                 boolean hits = whitesTurn
                         ? (((1L << from) << 7) & enPassantTargetSquare) != 0
                         : (((1L << from) >> 9) & enPassantTargetSquare) != 0;
                 if (hits && isMoveAllowedByPin(pinState, from, enPassantTargetIndex)) {
-                    addEnPassantMove(moves, from, enPassantTargetIndex, whitesTurn);
+                    moves.add(createMoveInt(from, enPassantTargetIndex, PieceType.PAWN, whitesTurn,
+                            true, false, true, null, PieceType.PAWN, false, false, cs));
                 }
                 rightAttackers &= rightAttackers - 1;
             }
@@ -1320,80 +1330,70 @@ public class BitBoard {
     }
 
 
-    private void addEnPassantMove(IntArrayList moves, int fromIndex, int toIndex, boolean whitesTurn) {
-        moves.add(
-                createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, true, false, true, null, PieceType.PAWN, false, false, packCastlingState()));
-    }
-
-    private void addPromotionMoves(IntArrayList moves, int fromIndex, int toIndex, boolean whitesTurn, boolean isCapture, PieceType capturedType) {
-        for (PieceType promotionPiece : PROMOTION_PIECES) {
-            moves.add(createMoveInt(fromIndex, toIndex, PieceType.PAWN, whitesTurn, isCapture, false, false, promotionPiece, capturedType, false, false, packCastlingState()));
-        }
-    }
-
-
     private void generateKnightMoves(boolean whitesTurn, IntArrayList moves, PinState pinState) {
         long knights = whitesTurn ? whiteKnights : blackKnights;
-        long opponentPieces = whitesTurn ? blackPieces : whitePieces;
-        long ownPieces = whitesTurn ? whitePieces : blackPieces;
+        final long opponentPieces = whitesTurn ? blackPieces : whitePieces;
+        final long ownPieces = whitesTurn ? whitePieces : blackPieces;
+        final int cs = packCastlingState(); // cache once
 
         while (knights != 0) {
-            int knightIndex = Long.numberOfTrailingZeros(knights);
-            long potentialMoves = knightMoveTable[knightIndex] & ~ownPieces; // Pre-filter moves that land on own pieces
+            int from = Long.numberOfTrailingZeros(knights);
+            knights &= knights - 1;
 
-            while (potentialMoves != 0) {
-                int targetIndex = Long.numberOfTrailingZeros(potentialMoves);
-                if (!isMoveAllowedByPin(pinState, knightIndex, targetIndex)) {
-                    potentialMoves &= potentialMoves - 1;
-                    continue;
+            long potential = knightMoveTable[from] & ~ownPieces; // mask own
+            // If not pinned, we can avoid calling the pin checker for each target
+            final boolean mustRespectPin =
+                    pinState != null && pinState.whiteSide() == whitesTurn &&
+                            ((pinState.getAllPinned() & (1L << from)) != 0);
+
+            while (potential != 0) {
+                int to = Long.numberOfTrailingZeros(potential);
+                potential &= potential - 1;
+
+                if (mustRespectPin && !isMoveAllowedByPin(pinState, from, to)) continue;
+
+                boolean isCapture = (opponentPieces & (1L << to)) != 0;
+                PieceType captured = isCapture ? pieceBoard[to] : null; // O(1)
+                if (captured != PieceType.KING) {
+                    moves.add(createMoveInt(from, to, PieceType.KNIGHT, whitesTurn,
+                            isCapture, false, false, null, captured, false, false, cs));
                 }
-                boolean isCapture = (opponentPieces & (1L << targetIndex)) != 0;
-
-                PieceType capturedPieceType = isCapture ? getPieceTypeAtIndex(targetIndex) : null;
-                if (capturedPieceType != PieceType.KING) {
-                    moves.add(createMoveInt(knightIndex, targetIndex, PieceType.KNIGHT, whitesTurn, isCapture, false, false, null, capturedPieceType, false, false, packCastlingState()));
-                }
-
-                potentialMoves &= potentialMoves - 1; // Clear the lowest set bit
             }
-
-            knights &= knights - 1; // Clear the lowest set bit
         }
     }
-
 
     private void generateBishopMoves(boolean isWhite, IntArrayList moves, PinState pinState) {
         long bishops = isWhite ? whiteBishops : blackBishops;
-        long ownPieces = isWhite ? whitePieces : blackPieces;
-        long opponentPieces = isWhite ? blackPieces : whitePieces;
+        final long ownPieces = isWhite ? whitePieces : blackPieces;
+        final long oppPieces = isWhite ? blackPieces : whitePieces;
+        final int cs = packCastlingState(); // cache once
 
         while (bishops != 0) {
-            int bishopSquare = Long.numberOfTrailingZeros(bishops);
-            bishops &= bishops - 1; // Remove the least significant bit representing a bishop
+            int from = Long.numberOfTrailingZeros(bishops);
+            bishops &= bishops - 1;
 
-            long occupancy = allPieces & bishopHelper.bishopMasks[bishopSquare];
-            long attacks = bishopHelper.calculateMovesUsingBishopMagic(bishopSquare, occupancy) & ~ownPieces;
+            long occ = allPieces & bishopHelper.bishopMasks[from];
+            long attacks = bishopHelper.calculateMovesUsingBishopMagic(from, occ) & ~ownPieces;
 
-            PinRayInfo pinRayInfo = null;
-            if (pinState != null && pinState.whiteSide() == isWhite
-                    && (pinState.getAllPinned() & (1L << bishopSquare)) != 0) {
-                pinRayInfo = resolvePinRayInfo(pinState, bishopSquare);
-                long allowedMask = pinRayInfo.rayMask() & ~(1L << pinState.kingSquare());
+            boolean pinned = pinState != null && pinState.whiteSide() == isWhite
+                    && ((pinState.getAllPinned() & (1L << from)) != 0);
+            PinRayInfo pri = null;
+            if (pinned) {
+                pri = resolvePinRayInfo(pinState, from);
+                long allowedMask = pri.rayMask() & ~(1L << pinState.kingSquare());
                 attacks &= allowedMask;
             }
 
             while (attacks != 0) {
-                int targetSquare = Long.numberOfTrailingZeros(attacks);
-                attacks &= attacks - 1; // Remove the least significant bit representing an attack
+                int to = Long.numberOfTrailingZeros(attacks);
+                attacks &= attacks - 1;
 
-
-                boolean isCapture = (opponentPieces & (1L << targetSquare)) != 0;
-                PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetSquare) : null;
-                if (capturedType != PieceType.KING) {
-                    if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
-                        continue;
-                    }
-                    moves.add(createMoveInt(bishopSquare, targetSquare, PieceType.BISHOP, isWhite, isCapture, false, false, null, capturedType, false, false, packCastlingState()));
+                boolean isCapture = (oppPieces & (1L << to)) != 0;
+                PieceType captured = isCapture ? pieceBoard[to] : null; // O(1)
+                if (captured != PieceType.KING) {
+                    if (pinned && isCapture && pri.pinnerSquare() != to) continue;
+                    moves.add(createMoveInt(from, to, PieceType.BISHOP, isWhite,
+                            isCapture, false, false, null, captured, false, false, cs));
                 }
             }
         }
@@ -1401,36 +1401,38 @@ public class BitBoard {
 
     private void generateRookMoves(boolean whitesTurn, IntArrayList moves, PinState pinState) {
         long rooks = whitesTurn ? whiteRooks : blackRooks;
-        long ownPieces = whitesTurn ? whitePieces : blackPieces;
-        long opponentPieces = whitesTurn ? blackPieces : whitePieces;
+        final long ownPieces = whitesTurn ? whitePieces : blackPieces;
+        final long oppPieces = whitesTurn ? blackPieces : whitePieces;
+        final int cs = packCastlingState(); // cache once
 
         while (rooks != 0) {
-            int rookSquare = Long.numberOfTrailingZeros(rooks);
-            rooks &= rooks - 1; // Remove the least significant bit representing a rook
+            int from = Long.numberOfTrailingZeros(rooks);
+            rooks &= rooks - 1;
 
-            // Use RookHelper to calculate rook moves using magic bitboards
-            long occupancy = allPieces & rookHelper.rookMasks[rookSquare];
-            long attacks = rookHelper.calculateMovesUsingRookMagic(rookSquare, occupancy) & ~ownPieces;
+            long occ = allPieces & rookHelper.rookMasks[from];
+            long attacks = rookHelper.calculateMovesUsingRookMagic(from, occ) & ~ownPieces;
 
-            PinRayInfo pinRayInfo = null;
-            if (pinState != null && pinState.whiteSide() == whitesTurn
-                    && (pinState.getAllPinned() & (1L << rookSquare)) != 0) {
-                pinRayInfo = resolvePinRayInfo(pinState, rookSquare);
-                long allowedMask = pinRayInfo.rayMask() & ~(1L << pinState.kingSquare());
+            boolean pinned = pinState != null && pinState.whiteSide() == whitesTurn
+                    && ((pinState.getAllPinned() & (1L << from)) != 0);
+            PinRayInfo pri = null;
+            if (pinned) {
+                pri = resolvePinRayInfo(pinState, from);
+                long allowedMask = pri.rayMask() & ~(1L << pinState.kingSquare());
                 attacks &= allowedMask;
             }
 
+            final boolean isFirstRookMove = !hasRookMoved(from);
+
             while (attacks != 0) {
-                int targetSquare = Long.numberOfTrailingZeros(attacks);
-                attacks &= attacks - 1; // Remove the least significant bit representing an attack
-                boolean isFirstRookMove = !hasRookMoved(rookSquare);
-                boolean isCapture = (opponentPieces & (1L << targetSquare)) != 0;
-                PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetSquare) : null;
-                if (capturedType != PieceType.KING) {
-                    if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
-                        continue;
-                    }
-                    moves.add(createMoveInt(rookSquare, targetSquare, PieceType.ROOK, whitesTurn, isCapture, false, false, null, capturedType, false, isFirstRookMove, packCastlingState()));
+                int to = Long.numberOfTrailingZeros(attacks);
+                attacks &= attacks - 1;
+
+                boolean isCapture = (oppPieces & (1L << to)) != 0;
+                PieceType captured = isCapture ? pieceBoard[to] : null; // O(1)
+                if (captured != PieceType.KING) {
+                    if (pinned && isCapture && pri.pinnerSquare() != to) continue;
+                    moves.add(createMoveInt(from, to, PieceType.ROOK, whitesTurn,
+                            isCapture, false, false, null, captured, false, isFirstRookMove, cs));
                 }
             }
         }
@@ -1438,38 +1440,38 @@ public class BitBoard {
 
     private void generateQueenMoves(boolean whitesTurn, IntArrayList moves, PinState pinState) {
         long queens = whitesTurn ? whiteQueens : blackQueens;
-        long ownPieces = whitesTurn ? whitePieces : blackPieces;
-        long opponentPieces = whitesTurn ? blackPieces : whitePieces;
+        final long ownPieces = whitesTurn ? whitePieces : blackPieces;
+        final long oppPieces = whitesTurn ? blackPieces : whitePieces;
+        final int cs = packCastlingState(); // cache once
 
         while (queens != 0) {
-            int queenSquare = Long.numberOfTrailingZeros(queens);
+            int from = Long.numberOfTrailingZeros(queens);
             queens &= queens - 1;
-            long occupancyBishop = allPieces & bishopHelper.bishopMasks[queenSquare];
-            long occupancyRook = allPieces & rookHelper.rookMasks[queenSquare];
 
-            long attacks = (
-                    bishopHelper.calculateMovesUsingBishopMagic(queenSquare, occupancyBishop) |
-                            rookHelper.calculateMovesUsingRookMagic(queenSquare, occupancyRook)
-            ) & ~ownPieces;
+            long occB = allPieces & bishopHelper.bishopMasks[from];
+            long occR = allPieces & rookHelper.rookMasks[from];
+            long attacks = (bishopHelper.calculateMovesUsingBishopMagic(from, occB)
+                    | rookHelper.calculateMovesUsingRookMagic(from, occR)) & ~ownPieces;
 
-            PinRayInfo pinRayInfo = null;
-            if (pinState != null && pinState.whiteSide() == whitesTurn
-                    && (pinState.getAllPinned() & (1L << queenSquare)) != 0) {
-                pinRayInfo = resolvePinRayInfo(pinState, queenSquare);
-                long allowedMask = pinRayInfo.rayMask() & ~(1L << pinState.kingSquare());
+            boolean pinned = pinState != null && pinState.whiteSide() == whitesTurn
+                    && ((pinState.getAllPinned() & (1L << from)) != 0);
+            PinRayInfo pri = null;
+            if (pinned) {
+                pri = resolvePinRayInfo(pinState, from);
+                long allowedMask = pri.rayMask() & ~(1L << pinState.kingSquare());
                 attacks &= allowedMask;
             }
 
             while (attacks != 0) {
-                int targetSquare = Long.numberOfTrailingZeros(attacks);
-                attacks &= attacks - 1; // Remove the least significant bit representing an attack
-                boolean isCapture = (opponentPieces & (1L << targetSquare)) != 0;
-                PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetSquare) : null;
-                if (capturedType != PieceType.KING) {
-                    if (pinRayInfo != null && isCapture && pinRayInfo.pinnerSquare() != targetSquare) {
-                        continue;
-                    }
-                    moves.add(createMoveInt(queenSquare, targetSquare, PieceType.QUEEN, whitesTurn, isCapture, false, false, null, capturedType, false, false, packCastlingState()));
+                int to = Long.numberOfTrailingZeros(attacks);
+                attacks &= attacks - 1;
+
+                boolean isCapture = (oppPieces & (1L << to)) != 0;
+                PieceType captured = isCapture ? pieceBoard[to] : null; // O(1)
+                if (captured != PieceType.KING) {
+                    if (pinned && isCapture && pri.pinnerSquare() != to) continue;
+                    moves.add(createMoveInt(from, to, PieceType.QUEEN, whitesTurn,
+                            isCapture, false, false, null, captured, false, false, cs));
                 }
             }
         }
@@ -1477,40 +1479,48 @@ public class BitBoard {
 
     private void generateKingMoves(boolean whitesTurn, IntArrayList moves, PinState pinState) {
         long kingBitboard = whitesTurn ? whiteKing : blackKing;
-        if (kingBitboard == 0L) {
-            return; // No king present for the given color; cannot generate moves
-        }
-        int kingPositionIndex = Long.numberOfTrailingZeros(kingBitboard);
-        long kingAttacks = KING_ATTACKS[kingPositionIndex];
-        boolean isFirstKingMove = hasKingNotMoved(whitesTurn);
+        if (kingBitboard == 0L) return;
 
-        long ownPieces = whitesTurn ? whitePieces : blackPieces;
-        long opponentPieces = whitesTurn ? blackPieces : whitePieces;
-        long legalMoves = kingAttacks & ~ownPieces;
-        long captureMoves = kingAttacks & opponentPieces;
+        final int from = Long.numberOfTrailingZeros(kingBitboard);
+        final long kingAttacks = KING_ATTACKS[from];
+        final boolean isFirstKingMove = hasKingNotMoved(whitesTurn);
+        final long ownPieces = whitesTurn ? whitePieces : blackPieces;
+        final long oppPieces = whitesTurn ? blackPieces : whitePieces;
+        final long legal = kingAttacks & ~ownPieces;
+        final long captureMask = kingAttacks & oppPieces;
+        final int cs = packCastlingState(); // cache once
 
-        for (long possibleMoves = legalMoves; possibleMoves != 0; possibleMoves &= possibleMoves - 1) {
-            int targetIndex = Long.numberOfTrailingZeros(possibleMoves);
+        long possible = legal;
+        while (possible != 0) {
+            int to = Long.numberOfTrailingZeros(possible);
+            possible &= possible - 1;
 
-            // Skip squares attacked by opponent (cheap, cached)
-            if (isSquareUnderAttack(targetIndex, whitesTurn)) {
-                continue;
-            }
+            // cheap, cached
+            if (isSquareUnderAttack(to, whitesTurn)) continue;
 
-            boolean isCapture = (captureMoves & (1L << targetIndex)) != 0;
-            PieceType capturedType = isCapture ? getPieceTypeAtIndex(targetIndex) : null;
-            if (capturedType != PieceType.KING) {
-                moves.add(createMoveInt(
-                        kingPositionIndex, targetIndex, PieceType.KING, whitesTurn,
-                        isCapture, false, false, null, capturedType, isFirstKingMove, false,
-                        packCastlingState()
-                ));
+            boolean isCapture = (captureMask & (1L << to)) != 0;
+            PieceType captured = isCapture ? pieceBoard[to] : null; // O(1)
+            if (captured != PieceType.KING) {
+                moves.add(createMoveInt(from, to, PieceType.KING, whitesTurn,
+                        isCapture, false, false, null, captured, isFirstKingMove, false, cs));
             }
         }
 
-
-        addCastlingMoves(whitesTurn, kingPositionIndex, moves, pinState);
+        addCastlingMoves(whitesTurn, from, moves, pinState, cs);
     }
+
+    private void addCastlingMoves(boolean whitesTurn, int kingPos, IntArrayList moves, PinState pinState, int cs) {
+        if (!canKingCastle(whitesTurn, kingPos)) return;
+        if (canCastleKingside(whitesTurn, kingPos, pinState)) {
+            moves.add(createMoveInt(kingPos, kingPos + 2, PieceType.KING,
+                    whitesTurn, false, true, false, null, null, true, true, cs));
+        }
+        if (canCastleQueenside(whitesTurn, kingPos, pinState)) {
+            moves.add(createMoveInt(kingPos, kingPos - 2, PieceType.KING,
+                    whitesTurn, false, true, false, null, null, true, true, cs));
+        }
+    }
+
 
     private void addCastlingMoves(boolean whitesTurn, int kingPositionIndex, IntArrayList moves, PinState pinState) {
         // Avoid an extra bit scan: we already know the king's square.

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -71,6 +71,9 @@ public class BitBoard {
     private final PieceBitboards seeWhiteScratch = new PieceBitboards();
     private final PieceBitboards seeBlackScratch = new PieceBitboards();
 
+    // Reuse gain stack in SEE (allocation-free)
+    private final int[] seeGain = new int[32];
+
     private static final int MAX_PSEUDO_LEGAL_MOVES = 218;
 
     public record PinState(boolean whiteSide, int kingSquare, long diagonalPinned, long straightPinned) {
@@ -666,7 +669,7 @@ public class BitBoard {
         occ |= toMask;
 
         // Gain stack (swap-off)
-        int[] gain = new int[32];
+        int[] gain = seeGain;
         int d = 0;
 
         int capVal = isCapture ? Score.getPieceValue(isEp ? 1 : capturedBits) : 0;

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -2396,12 +2396,19 @@ public class BitBoard {
 
     @Override
     public int hashCode() {
-        return Objects.hash(whitePawns, blackPawns, whiteKnights, blackKnights, whiteBishops, blackBishops,
-                whiteRooks, blackRooks, whiteQueens, blackQueens, whiteKing, blackKing,
-                whitePieces, blackPieces, allPieces, whiteKingMoved, blackKingMoved,
-                whiteRookA1Moved, whiteRookH1Moved, blackRookA8Moved, blackRookH8Moved,
-                lastMoveDoubleStepPawnIndex, halfmoveClock, fullmoveNumber);
+        // Mix zKey to 32 bits and salt with clocks for better distribution
+        long x = zKey;
+        x ^= (x >>> 33);
+        x *= 0xff51afd7ed558ccdL;
+        x ^= (x >>> 33);
+        x *= 0xc4ceb9fe1a85ec53L;
+        x ^= (x >>> 33);
+        int h = Long.hashCode(x);
+        h = 31 * h + halfmoveClock;
+        h = 31 * h + fullmoveNumber;
+        return h;
     }
+
 
     /**
      * Returns the en-passant *target* square index [0..63], or -1 if none.

--- a/src/main/java/julius/game/chessengine/board/FEN.java
+++ b/src/main/java/julius/game/chessengine/board/FEN.java
@@ -183,8 +183,8 @@ public class FEN {
         // You'll need to parse the other FEN parts like castling availability, en passant, etc.
 
         // Set castling and en passant flags...
-        boolean whiteKingMoved = !parts[2].contains("K");
-        boolean blackKingMoved = !parts[2].contains("k");
+        boolean whiteKingMoved = !(parts[2].contains("K") || parts[2].contains("Q"));
+        boolean blackKingMoved = !(parts[2].contains("k") || parts[2].contains("q"));
         boolean whiteRookA1Moved = !parts[2].contains("Q");
         boolean whiteRookH1Moved = !parts[2].contains("K");
         boolean blackRookA8Moved = !parts[2].contains("q");

--- a/src/main/java/julius/game/chessengine/board/Move.java
+++ b/src/main/java/julius/game/chessengine/board/Move.java
@@ -181,8 +181,34 @@ public class Move {
             capturedPieceType = null; // No capture
         }
 
-        boolean isKingFirstMove = (moveInt & (1 << 24)) != 0; // Extract the king's first move bit
-        boolean isRookFirstMove = (moveInt & (1 << 25)) != 0; // Extract the rook's first move bit
+        int castlingStateBits = MoveHelper.deriveCastlingState(moveInt);
+        boolean whiteKingMoved = (castlingStateBits & 0x01) != 0;
+        boolean whiteRookA1Moved = (castlingStateBits & 0x02) != 0;
+        boolean whiteRookH1Moved = (castlingStateBits & 0x04) != 0;
+        boolean blackKingMoved = (castlingStateBits & 0x08) != 0;
+        boolean blackRookA8Moved = (castlingStateBits & 0x10) != 0;
+        boolean blackRookH8Moved = (castlingStateBits & 0x20) != 0;
+
+        boolean isKingFirstMove = pieceType == PieceType.KING &&
+                (isWhite ? !whiteKingMoved : !blackKingMoved);
+
+        boolean isRookFirstMove = false;
+        if (pieceType == PieceType.ROOK) {
+            int fromIndex = moveInt & 0x3F;
+            if (isWhite) {
+                if (fromIndex == 0) {
+                    isRookFirstMove = !whiteRookA1Moved;
+                } else if (fromIndex == 7) {
+                    isRookFirstMove = !whiteRookH1Moved;
+                }
+            } else {
+                if (fromIndex == 56) {
+                    isRookFirstMove = !blackRookA8Moved;
+                } else if (fromIndex == 63) {
+                    isRookFirstMove = !blackRookH8Moved;
+                }
+            }
+        }
 
         return new Move(from, to, pieceType, isWhite, isCapture, isCastlingMove, isEnPassantMove, promotionPieceType, capturedPieceType, isKingFirstMove, isRookFirstMove);
     }

--- a/src/main/java/julius/game/chessengine/board/Move.java
+++ b/src/main/java/julius/game/chessengine/board/Move.java
@@ -153,29 +153,29 @@ public class Move {
     }
 
     public static Move convertIntToMove(int moveInt) {
-        int fromIndex = moveInt & 0x3F; // Extract the first 6 bits
+        int fromIndex = MoveHelper.deriveFromIndex(moveInt);
         Position from = bitIndexToPosition(fromIndex);
 
-        int toIndex = (moveInt >> 6) & 0x3F; // Extract the next 6 bits
+        int toIndex = MoveHelper.deriveToIndex(moveInt);
         Position to = bitIndexToPosition(toIndex);
 
-        int pieceTypeBits = (moveInt >> 12) & 0x07; // Extract the next 3 bits
+        int pieceTypeBits = MoveHelper.derivePieceTypeBits(moveInt);
         PieceType pieceType = intToPieceType(pieceTypeBits);
 
-        boolean isWhite = (moveInt & (1 << 15)) != 0; // Extract the color bit
+        boolean isWhite = MoveHelper.isWhitesMove(moveInt);
 
-        int specialProperty = (moveInt >> 16) & 0x03; // Extract the next 2 bits
+        int specialProperty = MoveHelper.deriveSpecialProperty(moveInt);
         boolean isCapture = (specialProperty & 0x01) != 0;
         boolean isEnPassantMove = specialProperty == 3;
         boolean isCastlingMove = specialProperty == 2;
 
-        int promotionPieceTypeBits = (moveInt >> 18) & 0x07; // Extract the next 3 bits
+        int promotionPieceTypeBits = MoveHelper.derivePromotionPieceTypeBits(moveInt);
         PieceType promotionPieceType = intToPieceType(promotionPieceTypeBits);
         if (promotionPieceTypeBits == 0) {
             promotionPieceType = null; // No promotion
         }
 
-        int capturedPieceTypeBits = (moveInt >> 21) & 0x07; // Extract the next 3 bits
+        int capturedPieceTypeBits = MoveHelper.deriveCapturedPieceTypeBits(moveInt);
         PieceType capturedPieceType = intToPieceType(capturedPieceTypeBits);
         if (capturedPieceTypeBits == 0) {
             capturedPieceType = null; // No capture
@@ -194,7 +194,6 @@ public class Move {
 
         boolean isRookFirstMove = false;
         if (pieceType == PieceType.ROOK) {
-            int fromIndex = moveInt & 0x3F;
             if (isWhite) {
                 if (fromIndex == 0) {
                     isRookFirstMove = !whiteRookA1Moved;

--- a/src/main/java/julius/game/chessengine/board/MoveHelper.java
+++ b/src/main/java/julius/game/chessengine/board/MoveHelper.java
@@ -60,7 +60,8 @@ public class MoveHelper {
             moveInt |= 1 << 15; // 1 bit for color, shifted by 15 bits
         }
 
-        int specialProperty = (isCapture ? 1 : 0) | (isCastlingMove ? 2 : 0) | (isEnPassantMove ? 3 : 0);
+        int specialProperty = isEnPassantMove ? 3 : (isCastlingMove ? 2 : (isCapture ? 1 : 0));
+
         moveInt |= specialProperty << 16; // Shifted by 16 bits
 
         if (promotionPieceType != null) {

--- a/src/main/java/julius/game/chessengine/board/MoveHelper.java
+++ b/src/main/java/julius/game/chessengine/board/MoveHelper.java
@@ -48,19 +48,7 @@ public class MoveHelper {
         return ((move >>> 16) & 0x3) == 0x2;
     }
 
-    public static boolean isKingFirstMove(int move) {
-        return (move & (1 << 24)) != 0;
-    }
-
-    public static boolean isRookFirstMove(int move) {
-        return (move & (1 << 25)) != 0;
-    }
-
-    public static int deriveLastMoveDoubleStepPawnIndex(int move) {
-        return (move >> 26) & 0x3F; // Extract the 6 bits starting from the 26th bit
-    }
-
-    public static int createMoveInt(int fromIndex, int toIndex, PieceType pieceType, boolean isWhite, boolean isCapture, boolean isCastlingMove, boolean isEnPassantMove, PieceType promotionPieceType, PieceType capturedPieceType, boolean isKingFirstMove, boolean isRookFirstMove, int lastMoveDoubleStepPawnIndex) {
+    public static int createMoveInt(int fromIndex, int toIndex, PieceType pieceType, boolean isWhite, boolean isCapture, boolean isCastlingMove, boolean isEnPassantMove, PieceType promotionPieceType, PieceType capturedPieceType, boolean isKingFirstMove, boolean isRookFirstMove, int castlingStateBits) {
         int moveInt = 0;
         moveInt |= fromIndex; // 6 bits for 'from' position
         moveInt |= toIndex << 6; // 6 bits for 'to' position, shifted by 6 bits
@@ -87,17 +75,31 @@ public class MoveHelper {
             moveInt &= ~(0x07 << 21); // Ensure captured piece bits are set to 000 if no piece is captured
         }
 
-        if (isKingFirstMove) {
-            moveInt |= 1 << 24; // 1 bit for king's first move, shifted by 24 bits
-        }
-
-        if (isRookFirstMove) {
-            moveInt |= 1 << 25; // 1 bit for rook's first move, shifted by 25 bits
-        }
-
-        moveInt |= lastMoveDoubleStepPawnIndex << 26; // Shifted by 26 bits
+        // Store six bits describing king/rook movement state prior to the move.
+        moveInt |= (castlingStateBits & 0x3F) << 24;
 
         return moveInt;
+    }
+
+    public static int deriveCastlingState(int move) {
+        return (move >> 24) & 0x3F;
+    }
+
+    public static int deriveCastlingRights(int move) {
+        int state = deriveCastlingState(move);
+        boolean whiteKingMoved = (state & 0x01) != 0;
+        boolean whiteRookA1Moved = (state & 0x02) != 0;
+        boolean whiteRookH1Moved = (state & 0x04) != 0;
+        boolean blackKingMoved = (state & 0x08) != 0;
+        boolean blackRookA8Moved = (state & 0x10) != 0;
+        boolean blackRookH8Moved = (state & 0x20) != 0;
+
+        int rights = 0;
+        if (!whiteKingMoved && !whiteRookH1Moved) rights |= 0x1;
+        if (!whiteKingMoved && !whiteRookA1Moved) rights |= 0x2;
+        if (!blackKingMoved && !blackRookH8Moved) rights |= 0x4;
+        if (!blackKingMoved && !blackRookA8Moved) rights |= 0x8;
+        return rights;
     }
 
     public static int convertStringToIndex(String positionStr) {

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -35,12 +35,13 @@ public class Engine {
     @Getter
     private MoveStack line = new MoveStack();
     private MoveStack redoLine = new MoveStack();
+    @Getter
     private BitBoard bitBoard = new BitBoard();
     @Getter
     private GameState gameState = new GameState(bitBoard);
 
-    private LongConsumer onPositionChanged = h -> {};
-
+    private volatile LongConsumer onPositionChanged = _ -> {
+    };
 
     public Engine() {
         startNewGame();
@@ -62,21 +63,21 @@ public class Engine {
     }
 
     public void setOnPositionChanged(LongConsumer cb) {
-        this.onPositionChanged = (cb != null ? cb : h -> {});
+        this.onPositionChanged = (cb != null ? cb : h -> {
+        });
     }
+
     private void notifyPositionChanged() {
         onPositionChanged.accept(getBoardStateHash());
     }
 
-    /** Expose BitBoard's SEE to callers (AI). */
+    /**
+     * Expose BitBoard's SEE to callers (AI).
+     */
     public int see(int move) {
         synchronized (boardLock) {
             return bitBoard.see(move);
         }
-    }
-
-    public BitBoard getBitBoard() {
-        return bitBoard;
     }
 
     public IntArrayList getAllLegalMoves() {
@@ -86,7 +87,7 @@ public class Engine {
                 if (gameState.isGameOver()) {
                     IntArrayList empty = new IntArrayList(0);
                     cacheLegalMoves(boardHash, empty);
-                    return new IntArrayList(0);
+                    return empty;
                 }
                 return generateLegalMoves();
             }
@@ -246,7 +247,7 @@ public class Engine {
                     );
                 }
             }
-
+            legalMoves.trim();
             cacheLegalMoves(boardStateHash, legalMoves);
             return legalMoves;
         }
@@ -277,16 +278,10 @@ public class Engine {
     }
 
     private boolean moveListsEqual(IntArrayList a, IntArrayList b) {
-        if (a.size() != b.size()) {
-            return false;
-        }
-        for (int i = 0; i < a.size(); i++) {
-            if (a.getInt(i) != b.getInt(i)) {
-                return false;
-            }
-        }
-        return true;
+        return a.size() == b.size()
+                && java.util.Arrays.equals(a.elements(), 0, a.size(), b.elements(), 0, b.size());
     }
+
 
     // Each of these methods would need to be implemented to handle the specific move generation for each piece type.
     public List<Move> getMovesFromIndex(int fromIndex) {
@@ -342,31 +337,25 @@ public class Engine {
 
             if (move == -1) {
                 log.warn("Move not legal!");
-            } else {
-                performMove(move);
+                return gameState;
             }
-
+            performMove(move);
             return gameState;
         }
     }
 
     private int getMove(int fromIndex, int toIndex, int promotionPiece) {
         IntArrayList legalMoves = getAllLegalMoves();
-
-        int move = -1;
-
         for (int i = 0; i < legalMoves.size(); i++) {
             int m = legalMoves.getInt(i);
-            int from = MoveHelper.deriveFromIndex(m); // Extract the first 6 bits
-            int to = MoveHelper.deriveToIndex(m);     // Extract the next 6 bits
-            int promotionPieceTypeBits = MoveHelper.derivePromotionPieceTypeBits(m);
-
-            if (from == fromIndex && to == toIndex && (promotionPieceTypeBits == 0 || promotionPieceTypeBits == promotionPiece)) {
-                move = m;
-            }
+            if (MoveHelper.deriveFromIndex(m) != fromIndex) continue;
+            if (MoveHelper.deriveToIndex(m) != toIndex) continue;
+            int promo = MoveHelper.derivePromotionPieceTypeBits(m);
+            if (promo == 0 || promo == promotionPiece) return m; // exact or non-promo
         }
-        return move;
+        return -1;
     }
+
 
     public List<Position> getPossibleMovesForPosition(int fromIndex) {
         return getMovesFromIndex(fromIndex).stream()

--- a/src/test/java/julius/game/chessengine/board/BitBoardEqualityTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardEqualityTest.java
@@ -1,0 +1,52 @@
+package julius.game.chessengine.board;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BitBoardEqualityTest {
+
+    @Test
+    void boardsWithDifferentEnPassantAreNotEqual() {
+        BitBoard a = new BitBoard();
+        BitBoard b = new BitBoard();
+
+        // Same position initially -> equal & same hash
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+
+        // Diverge ONLY by en-passant target availability
+        // Pick a plausible target square index; API will compute EP keying internally.
+        // Here we simulate "some double-step landing square" ≠ 0 so EP target becomes valid.
+        b.setLastMoveDoubleStepPawnIndex(24); // arbitrary file/rank; just non-zero
+
+        // Now they must differ
+        assertNotEquals(a, b, "Boards should differ when only en-passant availability differs.");
+        assertNotEquals(a.hashCode(), b.hashCode(), "Hash codes must differ when EP state differs.");
+    }
+
+    @Test
+    void boardsWithSameEnPassantAreEqual() {
+        BitBoard a = new BitBoard();
+        BitBoard b = new BitBoard();
+
+        // Set the same EP state on both
+        a.setLastMoveDoubleStepPawnIndex(24);
+        b.setLastMoveDoubleStepPawnIndex(24);
+
+        assertEquals(a, b, "Boards with identical EP state should be equal.");
+        assertEquals(a.hashCode(), b.hashCode(), "Hash codes should match for identical EP state.");
+    }
+
+    @Test
+    void enPassantZeroVsZeroRemainsEqual() {
+        BitBoard a = new BitBoard();
+        BitBoard b = new BitBoard();
+
+        a.setLastMoveDoubleStepPawnIndex(0);
+        b.setLastMoveDoubleStepPawnIndex(0);
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+}

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -514,7 +514,75 @@ public class BitBoardTest {
 
     }
 
-/*    @Test
+    @Test
+    public void rookCaptureClearsWhiteQueensideRightAndUndoRestores() {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/r7/R3K3 b Q - 0 1");
+        long originalHash = board.getBoardStateHash();
+
+        IntArrayList moves = board.generateAllPossibleMoves(board.isWhitesTurn());
+        int from = convertStringToIndex("a2");
+        int to = convertStringToIndex("a1");
+
+        int captureMove = -1;
+        for (int i = 0; i < moves.size(); i++) {
+            int move = moves.getInt(i);
+            if (MoveHelper.deriveFromIndex(move) == from && MoveHelper.deriveToIndex(move) == to) {
+                captureMove = move;
+                break;
+            }
+        }
+        assertNotEquals(-1, captureMove);
+
+        int castlingRights = MoveHelper.deriveCastlingRights(captureMove);
+        assertTrue((castlingRights & 0x2) != 0);
+
+        board.performMove(captureMove);
+        assertTrue(board.isWhiteRookA1Moved());
+
+        board.undoMove(captureMove);
+        assertFalse(board.isWhiteRookA1Moved());
+        assertEquals(originalHash, board.getBoardStateHash());
+
+        board.performMove(captureMove);
+        board.undoMove(captureMove);
+        assertEquals(originalHash, board.getBoardStateHash());
+    }
+
+    @Test
+    public void rookCaptureClearsBlackKingsideRightAndUndoRestores() {
+        BitBoard board = FEN.translateFENtoBitBoard("r3k2r/8/8/8/8/8/7R/4K3 w k - 0 1");
+        long originalHash = board.getBoardStateHash();
+
+        IntArrayList moves = board.generateAllPossibleMoves(board.isWhitesTurn());
+        int from = convertStringToIndex("h2");
+        int to = convertStringToIndex("h8");
+
+        int captureMove = -1;
+        for (int i = 0; i < moves.size(); i++) {
+            int move = moves.getInt(i);
+            if (MoveHelper.deriveFromIndex(move) == from && MoveHelper.deriveToIndex(move) == to) {
+                captureMove = move;
+                break;
+            }
+        }
+        assertNotEquals(-1, captureMove);
+
+        int castlingRights = MoveHelper.deriveCastlingRights(captureMove);
+        assertTrue((castlingRights & 0x4) != 0);
+
+        board.performMove(captureMove);
+        assertTrue(board.isBlackRookH8Moved());
+
+        board.undoMove(captureMove);
+        assertFalse(board.isBlackRookH8Moved());
+        assertEquals(originalHash, board.getBoardStateHash());
+
+        board.performMove(captureMove);
+        board.undoMove(captureMove);
+        assertEquals(originalHash, board.getBoardStateHash());
+    }
+
+    /*    @Test
     public void checkRookFirstMove() {
         Engine engine = new Engine(); // The chess engine
 

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -8,7 +8,7 @@ import julius.game.chessengine.utils.Color;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Test;
 
-import static julius.game.chessengine.board.MoveHelper.convertStringToIndex;
+import static julius.game.chessengine.board.MoveHelper.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 //-XX:StartFlightRecording=name=uci,settings=profile,filename=Perft_refactor.jfr
@@ -114,6 +114,50 @@ public class BitBoardTest {
         board.performMove(move);
 
         assertEquals(d5, board.getLastMoveDoubleStepPawnIndex());
+    }
+
+    @Test
+    public void blackCanCastleKingsideEvenIfRookIsAttacked() {
+        // Position: Black to move, castling rights 'k', rook h8 is attacked by a white rook on h1.
+        // King path (e8->f8->g8) is empty and not attacked.
+        BitBoard board = FEN.translateFENtoBitBoard("4k2r/8/8/8/8/8/8/7R b k - 0 1");
+
+        IntArrayList moves = board.generateAllPossibleMoves(board.isWhitesTurn());
+        int e8 = convertStringToIndex("e8");
+        int g8 = convertStringToIndex("g8");
+
+        boolean foundCastle = false;
+        for (int i = 0; i < moves.size(); i++) {
+            int m = moves.getInt(i);
+            if (deriveFromIndex(m) == e8 && deriveToIndex(m) == g8 && isCastlingMove(m)) {
+                foundCastle = true;
+                break;
+            }
+        }
+
+        assertTrue(foundCastle, "Black should be able to castle O-O even if the rook is attacked.");
+    }
+
+    @Test
+    public void whiteCanCastleQueensideEvenIfRookIsAttacked() {
+        // Position: White to move, castling rights 'Q', rook a1 is attacked by a black rook on a8.
+        // King path (e1->d1->c1) is empty and not attacked.
+        BitBoard board = FEN.translateFENtoBitBoard("r3k3/8/8/8/8/8/8/R3K3 w Q - 0 1");
+
+        IntArrayList moves = board.generateAllPossibleMoves(board.isWhitesTurn());
+        int e1 = convertStringToIndex("e1");
+        int c1 = convertStringToIndex("c1");
+
+        boolean foundCastle = false;
+        for (int i = 0; i < moves.size(); i++) {
+            int m = moves.getInt(i);
+            if (deriveFromIndex(m) == e1 && deriveToIndex(m) == c1 && isCastlingMove(m)) {
+                foundCastle = true;
+                break;
+            }
+        }
+
+        assertTrue(foundCastle, "White should be able to castle O-O-O even if the rook is attacked.");
     }
 
     @Test
@@ -229,7 +273,7 @@ public class BitBoardTest {
     private boolean moveExists(IntArrayList moves, int from, int to) {
         for (int i = 0; i < moves.size(); i++) {
             int move = moves.getInt(i);
-            if (MoveHelper.deriveFromIndex(move) == from && MoveHelper.deriveToIndex(move) == to) {
+            if (deriveFromIndex(move) == from && deriveToIndex(move) == to) {
                 return true;
             }
         }
@@ -526,7 +570,7 @@ public class BitBoardTest {
         int captureMove = -1;
         for (int i = 0; i < moves.size(); i++) {
             int move = moves.getInt(i);
-            if (MoveHelper.deriveFromIndex(move) == from && MoveHelper.deriveToIndex(move) == to) {
+            if (deriveFromIndex(move) == from && deriveToIndex(move) == to) {
                 captureMove = move;
                 break;
             }
@@ -560,7 +604,7 @@ public class BitBoardTest {
         int captureMove = -1;
         for (int i = 0; i < moves.size(); i++) {
             int move = moves.getInt(i);
-            if (MoveHelper.deriveFromIndex(move) == from && MoveHelper.deriveToIndex(move) == to) {
+            if (deriveFromIndex(move) == from && deriveToIndex(move) == to) {
                 captureMove = move;
                 break;
             }


### PR DESCRIPTION
## Summary
- store king and rook movement state in encoded moves so castling rights can be restored during undo
- track rook captures on home squares and rebuild state from saved flags, updating Zobrist hashing appropriately
- add regression tests that cover rook capture castling-right loss and undo/redo behavior

## Testing
- ./mvnw -q test *(fails: network is unreachable when downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d909fb8488832ab0bb9eb68a29d475