### PR TITLE
Add configurable tuning and genetic optimisation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,22 @@ example via `file://`). Keep the Spring Boot application running in the
 background: the page automatically connects to `ws://localhost:8080/ws/uci` when
 it is not served by the app itself.
 
+## Engine tuning and self-play
+
+The engine can now load search and evaluation parameters from an external YAML
+file. Point the Spring Boot application at your configuration with
+
+```bash
+java -Dchessengine.tuning.file=/path/to/tunings.yaml -jar target/chess-engine-<version>-uci.jar
+```
+
+Each entry under the top-level `population` key defines an engine variant. The
+sample file in `src/main/resources/tuning/sample-tunings.yaml` demonstrates the
+structure and shows how to tweak search depth, hash size, and module weights.
+
+For automated exploration you can use the `GeneticOptimizer` together with the
+`MatchRunner`. The optimiser stages round-robin matches between configurations
+with identical thread counts, keeps the strongest performers, and mutates them
+into the next generation. This workflow makes it possible to evolve evaluation
+parameters while keeping the UCI engine executable unchanged.
+

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
             <artifactId>fastutil</artifactId>
             <version>8.5.16</version>
         </dependency>
+
+        <!-- YAML support for external tuning configuration -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -7,6 +7,7 @@ import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.tuning.AiTuning;
 import julius.game.chessengine.utils.Score;
 import lombok.Getter;
 import lombok.Setter;
@@ -32,6 +33,9 @@ public class AI {
 
     @Getter
     private final Engine mainEngine;
+
+    @Getter
+    private final AiTuning tuning;
 
     /**
      * Number of threads used for searching. Defaults to single-threaded search but
@@ -240,7 +244,7 @@ public class AI {
     @Setter
     private long timeLimit; // milliseconds
 
-    private final boolean useNullMovePruning = Boolean.parseBoolean(
+    private boolean useNullMovePruning = Boolean.parseBoolean(
             System.getProperty("chessengine.nullMove", "true")
     );
 
@@ -250,24 +254,40 @@ public class AI {
     private long nullMoveCount = 0;
 
     public AI(Engine mainEngine) {
+        this(mainEngine, AiTuning.defaults());
+    }
+
+    public AI(Engine mainEngine, AiTuning tuning) {
+        this.mainEngine = Objects.requireNonNull(mainEngine, "mainEngine");
+        this.tuning = tuning != null ? tuning : AiTuning.defaults();
+        this.searchThreads = this.tuning.searchThreads();
+        this.lazySmpThreads = Math.max(1, this.tuning.lazySmpThreads());
+        this.hashSizeMb = this.tuning.hashSizeMb();
+        this.maxDepth = this.tuning.maxDepth();
+        this.timeLimit = this.tuning.timeLimitMillis();
+        this.useNullMovePruning = this.tuning.nullMovePruning();
+
         log.info("### SearchThreads = " + searchThreads + ", LazySmpThreads = " + lazySmpThreads);
-        this.mainEngine = mainEngine;
-        this.timeLimit = 50;
 
         this.globalHeuristics = new Heuristics(maxDepth);
         this.threadHeuristics = ThreadLocal.withInitial(() -> new Heuristics(maxDepth));
 
         rebuildTranspositionTables();
 
-        this.searchPool = searchThreads > 1
-                ? Executors.newFixedThreadPool(searchThreads, r -> {
+        this.searchPool = createSearchPool();
+
+        this.mainEngine.setOnPositionChanged(h -> updateBoardStateHash());
+    }
+
+    private ExecutorService createSearchPool() {
+        if (searchThreads <= 1) {
+            return null;
+        }
+        return Executors.newFixedThreadPool(searchThreads, r -> {
             Thread t = new Thread(r, "AI-Search-" + System.identityHashCode(r));
             t.setDaemon(true);
             return t;
-        })
-                : null;
-
-        this.mainEngine.setOnPositionChanged(h -> updateBoardStateHash());
+        });
     }
 
     private long acquireWriteLock() {
@@ -664,6 +684,63 @@ public class AI {
             return getBestMoveParallel(sim, task, depth, task.getDeadline(), alpha, beta, rng);
         }
         return getBestMove(sim, task.isWhiteToMove(), depth, task.getDeadline(), alpha, beta, rng);
+    }
+
+    public synchronized MoveAndScore searchBestMoveBlocking(long timeLimitMillis) {
+        long previousTimeLimit = this.timeLimit;
+        if (timeLimitMillis > 0) {
+            this.timeLimit = timeLimitMillis;
+        }
+        try {
+            Engine simulatorEngine = mainEngine.createSimulation();
+            long boardStateHash = simulatorEngine.getBoardStateHash();
+            long deadline = System.nanoTime() + this.timeLimit * 1_000_000L;
+
+            SearchTask task = new SearchTask(
+                    searchIdGenerator.incrementAndGet(),
+                    boardStateHash,
+                    simulatorEngine.whitesTurn(),
+                    deadline,
+                    1,
+                    simulatorEngine.createSimulation()
+            );
+
+            activeSearch.set(task);
+            currentBoardState = boardStateHash;
+            beforeCalculationBoardState = boardStateHash;
+            currentBestMove = -1;
+            bestMoveForHash = -1;
+            previousBestMove = -1;
+            previousBestMoveHash = -1;
+            searchResultReady = false;
+            this.calculatedLine = Collections.synchronizedList(new ArrayList<>());
+
+            SplittableRandom rng = (lazySmpThreads > 1)
+                    ? new SplittableRandom(boardStateHash ^ System.nanoTime())
+                    : null;
+
+            threadSearchTask.set(task);
+            try {
+                iterativeDeepening(task, simulatorEngine, rng);
+            } finally {
+                threadSearchTask.remove();
+            }
+
+            task.workerDone();
+            completeSearchTask(task, simulatorEngine);
+            task.requestStop();
+
+            if (searchResultReady && currentBestMove != -1 && bestMoveForHash == boardStateHash) {
+                return new MoveAndScore(currentBestMove, task.getBest().score);
+            }
+            return null;
+        } catch (RuntimeException ex) {
+            log.error("Synchronous search failed", ex);
+            return null;
+        } finally {
+            activeSearch.set(null);
+            this.timeLimit = previousTimeLimit;
+        }
     }
 
 

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -837,6 +837,26 @@ public class AI {
         }, 0, 50, TimeUnit.MILLISECONDS);
     }
 
+    public void shutdown() {
+        stopCalculation();
+
+        if (scheduler != null && !scheduler.isShutdown()) {
+            scheduler.shutdownNow();
+        }
+
+        if (searchPool != null) {
+            searchPool.shutdown();
+            try {
+                if (!searchPool.awaitTermination(5, TimeUnit.SECONDS)) {
+                    searchPool.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                searchPool.shutdownNow();
+            }
+        }
+    }
+
     public void performMove() {
         if (currentBestMove == -1) return;
 

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
@@ -19,16 +19,19 @@ public final class EvaluationPipeline {
 
     private static final class ModuleState {
         private final EvaluationModule module;
+        private final EvaluationWeights.ModuleWeight weight;
         private int midgameCache;
         private int endgameCache;
 
-        private ModuleState(EvaluationModule module) {
+        private ModuleState(EvaluationModule module, EvaluationWeights.ModuleWeight weight) {
             this.module = module;
+            this.weight = weight;
             this.module.markDirty();
         }
     }
 
     private final List<ModuleState> modules;
+    private final EvaluationWeights weights;
     private EvaluationContext context;
     private boolean initialized;
     private boolean aggregateDirty = true;
@@ -36,12 +39,18 @@ public final class EvaluationPipeline {
     private int endgameTotal;
 
     public EvaluationPipeline(List<? extends EvaluationModule> modules) {
+        this(modules, EvaluationWeights.identity());
+    }
+
+    public EvaluationPipeline(List<? extends EvaluationModule> modules, EvaluationWeights weights) {
         if (modules == null || modules.isEmpty()) {
             throw new IllegalArgumentException("At least one evaluation module is required");
         }
+        this.weights = (weights != null ? weights : EvaluationWeights.identity());
         List<ModuleState> moduleStates = new ArrayList<>(modules.size());
         for (EvaluationModule module : modules) {
-            moduleStates.add(new ModuleState(module));
+            EvaluationWeights.ModuleWeight weight = this.weights.weightFor(module.getClass());
+            moduleStates.add(new ModuleState(module, weight));
         }
         this.modules = Collections.unmodifiableList(moduleStates);
     }
@@ -121,22 +130,22 @@ public final class EvaluationPipeline {
         if (!aggregateDirty) {
             return;
         }
-        int midgame = 0;
-        int endgame = 0;
+        double midgame = 0.0;
+        double endgame = 0.0;
         for (ModuleState state : modules) {
             if (state.module.isDirty()) {
                 state.module.evaluate(context);
             }
             state.midgameCache = state.module.getMidgameScore();
             state.endgameCache = state.module.getEndgameScore();
-            midgame += state.midgameCache;
-            endgame += state.endgameCache;
+            midgame += state.midgameCache * state.weight.midgame();
+            endgame += state.endgameCache * state.weight.endgame();
         }
         int checkAdjustment = computeCheckAdjustment();
         midgame += checkAdjustment;
         endgame += checkAdjustment;
-        midgameTotal = midgame;
-        endgameTotal = endgame;
+        midgameTotal = (int) Math.round(midgame);
+        endgameTotal = (int) Math.round(endgame);
         aggregateDirty = false;
     }
 

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationWeights.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationWeights.java
@@ -1,0 +1,88 @@
+package julius.game.chessengine.evaluation;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable container for scaling factors applied to each evaluation module. The weights are
+ * represented as simple double multipliers for the midgame and endgame contributions produced by
+ * a module. When no explicit weight is configured a neutral weight of {@code 1.0} is used.
+ */
+public final class EvaluationWeights {
+
+    private static final ModuleWeight NEUTRAL = new ModuleWeight(1.0, 1.0);
+
+    private final Map<String, ModuleWeight> weights;
+
+    private EvaluationWeights(Map<String, ModuleWeight> weights) {
+        this.weights = weights;
+    }
+
+    /**
+     * Returns an {@link EvaluationWeights} instance that does not alter module contributions.
+     */
+    public static EvaluationWeights identity() {
+        return new EvaluationWeights(Collections.emptyMap());
+    }
+
+    /**
+     * Creates an {@link EvaluationWeights} instance using the provided mapping. The map keys are
+     * compared case-insensitively against the simple class name of an evaluation module.
+     */
+    public static EvaluationWeights of(Map<String, ModuleWeight> rawWeights) {
+        if (rawWeights == null || rawWeights.isEmpty()) {
+            return identity();
+        }
+        Map<String, ModuleWeight> normalized = new LinkedHashMap<>();
+        rawWeights.forEach((key, weight) -> {
+            if (key == null || key.isBlank() || weight == null) {
+                return;
+            }
+            normalized.put(normalizeKey(key), weight);
+        });
+        if (normalized.isEmpty()) {
+            return identity();
+        }
+        return new EvaluationWeights(Collections.unmodifiableMap(normalized));
+    }
+
+    private static String normalizeKey(String key) {
+        return key.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Resolves the weight to use for the provided module. When the module has not been configured
+     * explicitly this method returns the neutral weight ({@code 1.0} for both phases).
+     */
+    public ModuleWeight weightFor(Class<? extends EvaluationModule> moduleClass) {
+        Objects.requireNonNull(moduleClass, "moduleClass");
+        if (weights.isEmpty()) {
+            return NEUTRAL;
+        }
+        ModuleWeight configured = weights.get(normalizeKey(moduleClass.getSimpleName()));
+        return configured != null ? configured : NEUTRAL;
+    }
+
+    /**
+     * Provides the underlying mapping for serialization or inspection purposes. The returned map
+     * is immutable.
+     */
+    public Map<String, ModuleWeight> asMap() {
+        return weights;
+    }
+
+    /**
+     * Simple value object describing the scaling factors for the midgame and endgame contribution
+     * of a module.
+     */
+    public record ModuleWeight(double midgame, double endgame) {
+        public ModuleWeight {
+            if (!Double.isFinite(midgame) || !Double.isFinite(endgame)) {
+                throw new IllegalArgumentException("Module weights must be finite values");
+            }
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/AiTuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/AiTuning.java
@@ -1,0 +1,164 @@
+package julius.game.chessengine.tuning;
+
+import java.util.Objects;
+import java.util.Random;
+
+/**
+ * Immutable representation of the configurable parameters used by the search component. The
+ * mutation helpers are intentionally conservative to keep generated offspring close to their
+ * parents unless a large mutation strength is requested.
+ */
+public final class AiTuning {
+
+    private final int searchThreads;
+    private final int lazySmpThreads;
+    private final int hashSizeMb;
+    private final int maxDepth;
+    private final long timeLimitMillis;
+    private final boolean nullMovePruning;
+
+    private AiTuning(Builder builder) {
+        this.searchThreads = builder.searchThreads;
+        this.lazySmpThreads = builder.lazySmpThreads;
+        this.hashSizeMb = builder.hashSizeMb;
+        this.maxDepth = builder.maxDepth;
+        this.timeLimitMillis = builder.timeLimitMillis;
+        this.nullMovePruning = builder.nullMovePruning;
+    }
+
+    public static AiTuning defaults() {
+        return builder().build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    public int searchThreads() {
+        return searchThreads;
+    }
+
+    public int lazySmpThreads() {
+        return lazySmpThreads;
+    }
+
+    public int hashSizeMb() {
+        return hashSizeMb;
+    }
+
+    public int maxDepth() {
+        return maxDepth;
+    }
+
+    public long timeLimitMillis() {
+        return timeLimitMillis;
+    }
+
+    public boolean nullMovePruning() {
+        return nullMovePruning;
+    }
+
+    public AiTuning mutate(Random random, double strength) {
+        Objects.requireNonNull(random, "random");
+        if (strength <= 0.0) {
+            return this;
+        }
+        Builder mutated = toBuilder();
+        mutated.hashSizeMb = mutateInt(hashSizeMb, 1, 4096, random, strength);
+        mutated.maxDepth = mutateInt(maxDepth, 4, 96, random, strength);
+        mutated.timeLimitMillis = mutateLong(timeLimitMillis, 5L, 10_000L, random, strength);
+        mutated.nullMovePruning = random.nextDouble() < strength ? !nullMovePruning : nullMovePruning;
+        return mutated.build();
+    }
+
+    private static int mutateInt(int value, int min, int max, Random random, double strength) {
+        double factor = gaussianFactor(random, strength);
+        int mutated = (int) Math.round(value * factor);
+        if (mutated < min) {
+            mutated = min;
+        } else if (mutated > max) {
+            mutated = max;
+        }
+        return mutated;
+    }
+
+    private static long mutateLong(long value, long min, long max, Random random, double strength) {
+        double factor = gaussianFactor(random, strength);
+        long mutated = Math.round(value * factor);
+        if (mutated < min) {
+            mutated = min;
+        } else if (mutated > max) {
+            mutated = max;
+        }
+        return mutated;
+    }
+
+    private static double gaussianFactor(Random random, double strength) {
+        double variance = Math.max(0.05, strength);
+        double offset = random.nextGaussian() * variance;
+        double factor = 1.0 + offset;
+        if (factor < 0.25) {
+            factor = 0.25;
+        }
+        return factor;
+    }
+
+    public static final class Builder {
+        private int searchThreads = Integer.getInteger("chessengine.searchThreads", 1);
+        private int lazySmpThreads = Math.max(1, Integer.getInteger("chessengine.lazySmpThreads", 1));
+        private int hashSizeMb = 16;
+        private int maxDepth = 32;
+        private long timeLimitMillis = 50L;
+        private boolean nullMovePruning = Boolean.parseBoolean(System.getProperty("chessengine.nullMove", "true"));
+
+        private Builder() {
+        }
+
+        private Builder(AiTuning source) {
+            this.searchThreads = source.searchThreads;
+            this.lazySmpThreads = source.lazySmpThreads;
+            this.hashSizeMb = source.hashSizeMb;
+            this.maxDepth = source.maxDepth;
+            this.timeLimitMillis = source.timeLimitMillis;
+            this.nullMovePruning = source.nullMovePruning;
+        }
+
+        public Builder searchThreads(int searchThreads) {
+            this.searchThreads = Math.max(1, searchThreads);
+            return this;
+        }
+
+        public Builder lazySmpThreads(int lazySmpThreads) {
+            this.lazySmpThreads = Math.max(1, lazySmpThreads);
+            return this;
+        }
+
+        public Builder hashSizeMb(int hashSizeMb) {
+            this.hashSizeMb = Math.max(1, hashSizeMb);
+            return this;
+        }
+
+        public Builder maxDepth(int maxDepth) {
+            this.maxDepth = Math.max(4, maxDepth);
+            return this;
+        }
+
+        public Builder timeLimitMillis(long timeLimitMillis) {
+            this.timeLimitMillis = Math.max(5L, timeLimitMillis);
+            return this;
+        }
+
+        public Builder nullMovePruning(boolean nullMovePruning) {
+            this.nullMovePruning = nullMovePruning;
+            return this;
+        }
+
+        public AiTuning build() {
+            return new AiTuning(this);
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/EngineTuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuning.java
@@ -1,0 +1,147 @@
+package julius.game.chessengine.tuning;
+
+import julius.game.chessengine.evaluation.EvaluationWeights;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+
+/**
+ * Aggregates the tunable aspects of the engine. Instances are immutable and can be safely shared
+ * across threads.
+ */
+public final class EngineTuning {
+
+    private final String name;
+    private final AiTuning ai;
+    private final EvaluationTuning evaluation;
+    private final Map<String, Double> numericParameters;
+
+    private EngineTuning(Builder builder) {
+        this.name = builder.name;
+        this.ai = builder.ai;
+        this.evaluation = builder.evaluation;
+        this.numericParameters = builder.numericParameters;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public AiTuning ai() {
+        return ai;
+    }
+
+    public EvaluationTuning evaluation() {
+        return evaluation;
+    }
+
+    public Map<String, Double> numericParameters() {
+        return numericParameters;
+    }
+
+    public EvaluationWeights evaluationWeights() {
+        return evaluation.toWeights();
+    }
+
+    public EngineTuning mutate(Random random, double strength) {
+        Objects.requireNonNull(random, "random");
+        if (strength <= 0.0) {
+            return this;
+        }
+        AiTuning mutatedAi = ai.mutate(random, strength);
+        EvaluationTuning mutatedEval = evaluation.mutate(random, strength);
+        Map<String, Double> mutatedNumeric = mutateNumericParameters(random, strength);
+        return EngineTuning.builder()
+                .name(name + "_mut")
+                .ai(mutatedAi)
+                .evaluation(mutatedEval)
+                .numericParameters(mutatedNumeric)
+                .build();
+    }
+
+    private Map<String, Double> mutateNumericParameters(Random random, double strength) {
+        if (numericParameters.isEmpty()) {
+            return numericParameters;
+        }
+        Map<String, Double> mutated = new LinkedHashMap<>();
+        numericParameters.forEach((key, value) -> {
+            if (value == null) {
+                return;
+            }
+            double variance = Math.max(0.05, strength);
+            double factor = 1.0 + random.nextGaussian() * variance;
+            double newValue = value * factor;
+            mutated.put(key, newValue);
+        });
+        return Collections.unmodifiableMap(mutated);
+    }
+
+    public EngineTuning rename(String newName) {
+        return toBuilder().name(newName).build();
+    }
+
+    public static final class Builder {
+        private String name = "baseline";
+        private AiTuning ai = AiTuning.defaults();
+        private EvaluationTuning evaluation = EvaluationTuning.identity();
+        private Map<String, Double> numericParameters = Collections.emptyMap();
+
+        private Builder() {
+        }
+
+        private Builder(EngineTuning source) {
+            this.name = source.name;
+            this.ai = source.ai;
+            this.evaluation = source.evaluation;
+            this.numericParameters = source.numericParameters;
+        }
+
+        public Builder name(String name) {
+            if (name != null && !name.isBlank()) {
+                this.name = name;
+            }
+            return this;
+        }
+
+        public Builder ai(AiTuning ai) {
+            this.ai = Objects.requireNonNull(ai, "ai");
+            return this;
+        }
+
+        public Builder evaluation(EvaluationTuning evaluation) {
+            this.evaluation = Objects.requireNonNull(evaluation, "evaluation");
+            return this;
+        }
+
+        public Builder numericParameters(Map<String, Double> parameters) {
+            if (parameters == null || parameters.isEmpty()) {
+                this.numericParameters = Collections.emptyMap();
+            } else {
+                Map<String, Double> normalized = new LinkedHashMap<>();
+                parameters.forEach((k, v) -> {
+                    if (k != null && !k.isBlank() && v != null) {
+                        normalized.put(k.toLowerCase(Locale.ROOT), v);
+                    }
+                });
+                this.numericParameters = Collections.unmodifiableMap(normalized);
+            }
+            return this;
+        }
+
+        public EngineTuning build() {
+            return new EngineTuning(this);
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/EngineTuningLoader.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuningLoader.java
@@ -1,0 +1,166 @@
+package julius.game.chessengine.tuning;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Helper capable of loading {@link EngineTuning} definitions from a YAML document. The expected
+ * structure is:
+ *
+ * <pre>{@code
+ * population:
+ *   - name: baseline
+ *     ai:
+ *       maxDepth: 32
+ *       timeLimitMillis: 50
+ *     evaluation:
+ *       modules:
+ *         MaterialModule:
+ *           midgame: 1.0
+ *           endgame: 1.0
+ * }</pre>
+ */
+public final class EngineTuningLoader {
+
+    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private EngineTuningLoader() {
+    }
+
+    public static EngineTuningSet load(Path path) throws IOException {
+        Objects.requireNonNull(path, "path");
+        try (InputStream in = Files.newInputStream(path)) {
+            return load(in);
+        }
+    }
+
+    public static EngineTuningSet load(InputStream inputStream) throws IOException {
+        Objects.requireNonNull(inputStream, "inputStream");
+        EngineTuningDocument document = YAML_MAPPER.readValue(inputStream, EngineTuningDocument.class);
+        if (document == null || document.population == null || document.population.isEmpty()) {
+            return EngineTuningSet.empty();
+        }
+        List<EngineTuning> tunings = document.population.stream()
+                .map(EngineTuningLoader::toEngineTuning)
+                .collect(Collectors.toUnmodifiableList());
+        return new EngineTuningSet(tunings);
+    }
+
+    public static EngineTuningSet loadFromString(String yaml) throws JsonProcessingException {
+        EngineTuningDocument document = YAML_MAPPER.readValue(yaml, EngineTuningDocument.class);
+        if (document == null || document.population == null || document.population.isEmpty()) {
+            return EngineTuningSet.empty();
+        }
+        List<EngineTuning> tunings = document.population.stream()
+                .map(EngineTuningLoader::toEngineTuning)
+                .collect(Collectors.toUnmodifiableList());
+        return new EngineTuningSet(tunings);
+    }
+
+    private static EngineTuning toEngineTuning(EngineTuningConfig config) {
+        if (config == null) {
+            return EngineTuning.builder().build();
+        }
+        EngineTuning.Builder builder = EngineTuning.builder();
+        if (config.name != null && !config.name.isBlank()) {
+            builder.name(config.name);
+        }
+        builder.ai(toAiTuning(config.ai));
+        builder.evaluation(toEvaluation(config.evaluation));
+        builder.numericParameters(normalizeNumeric(config.numericParameters));
+        return builder.build();
+    }
+
+    private static AiTuning toAiTuning(AiConfig config) {
+        if (config == null) {
+            return AiTuning.defaults();
+        }
+        AiTuning.Builder builder = AiTuning.builder();
+        if (config.searchThreads != null) {
+            builder.searchThreads(config.searchThreads);
+        }
+        if (config.lazySmpThreads != null) {
+            builder.lazySmpThreads(config.lazySmpThreads);
+        }
+        if (config.hashSizeMb != null) {
+            builder.hashSizeMb(config.hashSizeMb);
+        }
+        if (config.maxDepth != null) {
+            builder.maxDepth(config.maxDepth);
+        }
+        if (config.timeLimitMillis != null) {
+            builder.timeLimitMillis(config.timeLimitMillis);
+        }
+        if (config.nullMovePruning != null) {
+            builder.nullMovePruning(config.nullMovePruning);
+        }
+        return builder.build();
+    }
+
+    private static EvaluationTuning toEvaluation(EvaluationConfig config) {
+        if (config == null || config.modules == null || config.modules.isEmpty()) {
+            return EvaluationTuning.identity();
+        }
+        Map<String, EvaluationTuning.ModuleConfig> modules = config.modules.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey().toLowerCase(Locale.ROOT),
+                        entry -> new EvaluationTuning.ModuleConfig(entry.getValue().midgame, entry.getValue().endgame)
+                ));
+        return EvaluationTuning.of(modules);
+    }
+
+    private static Map<String, Double> normalizeNumeric(Map<String, Double> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return values.entrySet().stream()
+                .filter(e -> e.getKey() != null && !e.getKey().isBlank() && e.getValue() != null)
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey().toLowerCase(Locale.ROOT),
+                        Map.Entry::getValue
+                ));
+    }
+
+    private static final class EngineTuningDocument {
+        public List<EngineTuningConfig> population;
+    }
+
+    private static final class EngineTuningConfig {
+        public String name;
+        public AiConfig ai;
+        public EvaluationConfig evaluation;
+        public Map<String, Double> numericParameters;
+    }
+
+    private static final class AiConfig {
+        public Integer searchThreads;
+        public Integer lazySmpThreads;
+        public Integer hashSizeMb;
+        public Integer maxDepth;
+        public Long timeLimitMillis;
+        public Boolean nullMovePruning;
+    }
+
+    private static final class EvaluationConfig {
+        public Map<String, ModuleConfig> modules;
+    }
+
+    private static final class ModuleConfig {
+        public double midgame = 1.0;
+        public double endgame = 1.0;
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/EngineTuningSet.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuningSet.java
@@ -1,0 +1,33 @@
+package julius.game.chessengine.tuning;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable wrapper around a population of {@link EngineTuning} instances. The list is guaranteed
+ * to be unmodifiable.
+ */
+public final class EngineTuningSet {
+
+    private static final EngineTuningSet EMPTY = new EngineTuningSet(Collections.emptyList());
+
+    private final List<EngineTuning> population;
+
+    public EngineTuningSet(List<EngineTuning> population) {
+        this.population = population == null
+                ? Collections.emptyList()
+                : List.copyOf(population);
+    }
+
+    public static EngineTuningSet empty() {
+        return EMPTY;
+    }
+
+    public List<EngineTuning> population() {
+        return population;
+    }
+
+    public boolean isEmpty() {
+        return population.isEmpty();
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/EvaluationTuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/EvaluationTuning.java
@@ -1,0 +1,130 @@
+package julius.game.chessengine.tuning;
+
+import julius.game.chessengine.evaluation.EvaluationModule;
+import julius.game.chessengine.evaluation.EvaluationWeights;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+/**
+ * Configuration holder for module weights used by the evaluation pipeline. The configuration is
+ * expressed as a mapping from module simple names to {@link ModuleConfig} instances.
+ */
+public final class EvaluationTuning {
+
+    private final Map<String, ModuleConfig> modules;
+
+    private EvaluationTuning(Map<String, ModuleConfig> modules) {
+        this.modules = modules;
+    }
+
+    public static EvaluationTuning identity() {
+        return new EvaluationTuning(Collections.emptyMap());
+    }
+
+    public static EvaluationTuning of(Map<String, ModuleConfig> modules) {
+        if (modules == null || modules.isEmpty()) {
+            return identity();
+        }
+        Map<String, ModuleConfig> normalized = new LinkedHashMap<>();
+        modules.forEach((name, cfg) -> {
+            if (name == null || name.isBlank() || cfg == null) {
+                return;
+            }
+            normalized.put(normalize(name), cfg);
+        });
+        if (normalized.isEmpty()) {
+            return identity();
+        }
+        return new EvaluationTuning(Collections.unmodifiableMap(normalized));
+    }
+
+    public Map<String, ModuleConfig> modules() {
+        return modules;
+    }
+
+    public EvaluationWeights toWeights() {
+        if (modules.isEmpty()) {
+            return EvaluationWeights.identity();
+        }
+        Map<String, EvaluationWeights.ModuleWeight> weights = modules.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> new EvaluationWeights.ModuleWeight(entry.getValue().midgame(), entry.getValue().endgame())
+                ));
+        return EvaluationWeights.of(weights);
+    }
+
+    public EvaluationTuning mutate(Random random, double strength) {
+        Objects.requireNonNull(random, "random");
+        if (strength <= 0.0 || modules.isEmpty()) {
+            return this;
+        }
+        Map<String, ModuleConfig> mutated = new LinkedHashMap<>();
+        modules.forEach((name, cfg) -> {
+            double mid = mutateWeight(cfg.midgame(), random, strength);
+            double end = mutateWeight(cfg.endgame(), random, strength);
+            mutated.put(name, new ModuleConfig(mid, end));
+        });
+        return EvaluationTuning.of(mutated);
+    }
+
+    private static double mutateWeight(double value, Random random, double strength) {
+        double variance = Math.max(0.05, strength);
+        double factor = 1.0 + random.nextGaussian() * variance;
+        double mutated = value * factor;
+        if (!Double.isFinite(mutated) || mutated < -100.0) {
+            mutated = -100.0;
+        } else if (mutated > 100.0) {
+            mutated = 100.0;
+        }
+        return mutated;
+    }
+
+    private static String normalize(String name) {
+        return name.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Convenience accessor for retrieving a configured module weight.
+     */
+    public EvaluationWeights.ModuleWeight resolveWeight(Class<? extends EvaluationModule> module) {
+        if (module == null) {
+            return new EvaluationWeights.ModuleWeight(1.0, 1.0);
+        }
+        ModuleConfig cfg = modules.getOrDefault(normalize(module.getSimpleName()), ModuleConfig.IDENTITY);
+        return new EvaluationWeights.ModuleWeight(cfg.midgame(), cfg.endgame());
+    }
+
+    public static final class ModuleConfig {
+        private static final ModuleConfig IDENTITY = new ModuleConfig(1.0, 1.0);
+
+        private final double midgame;
+        private final double endgame;
+
+        public ModuleConfig() {
+            this(1.0, 1.0);
+        }
+
+        public ModuleConfig(double midgame, double endgame) {
+            if (!Double.isFinite(midgame) || !Double.isFinite(endgame)) {
+                throw new IllegalArgumentException("Module weights must be finite");
+            }
+            this.midgame = midgame;
+            this.endgame = endgame;
+        }
+
+        public double midgame() {
+            return midgame;
+        }
+
+        public double endgame() {
+            return endgame;
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/GeneticOptimizer.java
+++ b/src/main/java/julius/game/chessengine/tuning/GeneticOptimizer.java
@@ -1,0 +1,91 @@
+package julius.game.chessengine.tuning;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+
+/**
+ * Runs a simple genetic algorithm on top of the chess engine by repeatedly letting configurations
+ * play against each other and mutating the top performers into the next generation.
+ */
+public final class GeneticOptimizer {
+
+    private final MatchRunner matchRunner;
+    private final Random random;
+
+    public GeneticOptimizer() {
+        this(new MatchRunner(), new Random());
+    }
+
+    public GeneticOptimizer(MatchRunner matchRunner, Random random) {
+        this.matchRunner = Objects.requireNonNull(matchRunner, "matchRunner");
+        this.random = Objects.requireNonNull(random, "random");
+    }
+
+    public GeneticResult evolve(EngineTuningSet seedPopulation, GeneticOptions options) {
+        Objects.requireNonNull(seedPopulation, "seedPopulation");
+        Objects.requireNonNull(options, "options");
+        if (seedPopulation.isEmpty()) {
+            throw new IllegalArgumentException("Seed population must contain at least one tuning");
+        }
+
+        List<EngineTuning> population = new ArrayList<>(seedPopulation.population());
+        while (population.size() < options.populationSize()) {
+            EngineTuning parent = population.get(random.nextInt(population.size()));
+            population.add(parent.mutate(random, options.mutationStrength()).rename(parent.name() + "_seed"));
+        }
+
+        List<MatchRunner.MatchResult> allMatches = new ArrayList<>();
+
+        for (int generation = 0; generation < options.generations(); generation++) {
+            Map<EngineTuning, Double> scoreboard = new HashMap<>();
+
+            for (int i = 0; i < population.size(); i++) {
+                for (int j = i + 1; j < population.size(); j++) {
+                    EngineTuning a = population.get(i);
+                    EngineTuning b = population.get(j);
+                    for (int match = 0; match < options.matchesPerPair(); match++) {
+                        boolean swap = (match % 2) == 1;
+                        EngineTuning white = swap ? b : a;
+                        EngineTuning black = swap ? a : b;
+                        MatchRunner.MatchResult result = matchRunner.playMatch(
+                                white,
+                                black,
+                                new MatchRunner.MatchOptions(options.maxPlies(), options.moveTimeMillis())
+                        );
+                        allMatches.add(result);
+                        if (swap) {
+                            scoreboard.merge(a, result.blackScore(), Double::sum);
+                            scoreboard.merge(b, result.whiteScore(), Double::sum);
+                        } else {
+                            scoreboard.merge(a, result.whiteScore(), Double::sum);
+                            scoreboard.merge(b, result.blackScore(), Double::sum);
+                        }
+                    }
+                }
+            }
+
+            population = scoreboard.entrySet().stream()
+                    .sorted(Map.Entry.<EngineTuning, Double>comparingByValue(Comparator.reverseOrder()))
+                    .limit(Math.max(options.retainCount(), 2))
+                    .map(Map.Entry::getKey)
+                    .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+
+            while (population.size() < options.populationSize()) {
+                EngineTuning parent = population.get(random.nextInt(population.size()));
+                EngineTuning offspring = parent.mutate(random, options.mutationStrength())
+                        .rename(parent.name() + "_g" + generation + "_mut");
+                population.add(offspring);
+            }
+        }
+
+        return new GeneticResult(new EngineTuningSet(population), List.copyOf(allMatches));
+    }
+
+    public record GeneticResult(EngineTuningSet population, List<MatchRunner.MatchResult> matches) {
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/GeneticOptions.java
+++ b/src/main/java/julius/game/chessengine/tuning/GeneticOptions.java
@@ -1,0 +1,27 @@
+package julius.game.chessengine.tuning;
+
+/**
+ * Configuration options that control the genetic optimisation loop.
+ */
+public record GeneticOptions(int generations,
+                             int retainCount,
+                             int populationSize,
+                             int matchesPerPair,
+                             double mutationStrength,
+                             long moveTimeMillis,
+                             int maxPlies) {
+
+    public GeneticOptions {
+        if (generations < 1) generations = 1;
+        if (retainCount < 1) retainCount = 1;
+        if (populationSize < 2) populationSize = 2;
+        if (matchesPerPair < 1) matchesPerPair = 1;
+        if (mutationStrength < 0.0) mutationStrength = 0.0;
+        if (moveTimeMillis <= 0L) moveTimeMillis = 50L;
+        if (maxPlies <= 0) maxPlies = 512;
+    }
+
+    public static GeneticOptions defaults() {
+        return new GeneticOptions(5, 4, 8, 2, 0.15, 50L, 512);
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/MatchRunner.java
+++ b/src/main/java/julius/game/chessengine/tuning/MatchRunner.java
@@ -28,46 +28,51 @@ public final class MatchRunner {
         AI whiteAi = new AI(whiteEngine, whiteTuning.ai());
         AI blackAi = new AI(blackEngine, blackTuning.ai());
 
-        int maxPlies = options.maxPlies() > 0 ? options.maxPlies() : 512;
-        long moveTime = options.moveTimeMillis() > 0 ? options.moveTimeMillis() : whiteTuning.ai().timeLimitMillis();
+        try {
+            int maxPlies = options.maxPlies() > 0 ? options.maxPlies() : 512;
+            long moveTime = options.moveTimeMillis() > 0 ? options.moveTimeMillis() : whiteTuning.ai().timeLimitMillis();
 
-        int plies = 0;
-        while (!whiteEngine.getGameState().isGameOver() && plies < maxPlies) {
-            boolean whiteToMove = whiteEngine.whitesTurn();
-            AI mover = whiteToMove ? whiteAi : blackAi;
-            MoveAndScore ms = mover.searchBestMoveBlocking(moveTime);
-            if (ms == null || ms.move == -1) {
-                break;
+            int plies = 0;
+            while (!whiteEngine.getGameState().isGameOver() && plies < maxPlies) {
+                boolean whiteToMove = whiteEngine.whitesTurn();
+                AI mover = whiteToMove ? whiteAi : blackAi;
+                MoveAndScore ms = mover.searchBestMoveBlocking(moveTime);
+                if (ms == null || ms.getMove() == -1) {
+                    break;
+                }
+                int move = ms.getMove();
+                whiteEngine.performMove(move);
+                blackEngine.performMove(move);
+                plies++;
             }
-            int move = ms.move;
-            whiteEngine.performMove(move);
-            blackEngine.performMove(move);
-            plies++;
+
+            GameStateEnum finalState = whiteEngine.getGameState().getState();
+            double whiteScore;
+            double blackScore;
+            switch (finalState) {
+                case WHITE_WON -> {
+                    whiteScore = 1.0;
+                    blackScore = 0.0;
+                }
+                case BLACK_WON -> {
+                    whiteScore = 0.0;
+                    blackScore = 1.0;
+                }
+                case DRAW -> {
+                    whiteScore = 0.5;
+                    blackScore = 0.5;
+                }
+                default -> {
+                    whiteScore = 0.5;
+                    blackScore = 0.5;
+                }
+            }
+
+            return new MatchResult(whiteTuning, blackTuning, whiteScore, blackScore, finalState, plies);
+        } finally {
+            whiteAi.shutdown();
+            blackAi.shutdown();
         }
-
-        GameStateEnum finalState = whiteEngine.getGameState().getState();
-        double whiteScore;
-        double blackScore;
-        switch (finalState) {
-            case WHITE_WON -> {
-                whiteScore = 1.0;
-                blackScore = 0.0;
-            }
-            case BLACK_WON -> {
-                whiteScore = 0.0;
-                blackScore = 1.0;
-            }
-            case DRAW -> {
-                whiteScore = 0.5;
-                blackScore = 0.5;
-            }
-            default -> {
-                whiteScore = 0.5;
-                blackScore = 0.5;
-            }
-        }
-
-        return new MatchResult(whiteTuning, blackTuning, whiteScore, blackScore, finalState, plies);
     }
 
     private void ensureThreadParity(EngineTuning white, EngineTuning black) {

--- a/src/main/java/julius/game/chessengine/tuning/MatchRunner.java
+++ b/src/main/java/julius/game/chessengine/tuning/MatchRunner.java
@@ -1,0 +1,105 @@
+package julius.game.chessengine.tuning;
+
+import julius.game.chessengine.ai.AI;
+import julius.game.chessengine.ai.MoveAndScore;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.utils.Score;
+
+import java.util.Objects;
+
+/**
+ * Utility capable of staging self-play games between two {@link EngineTuning} configurations. The
+ * runner keeps the board state of both engines synchronised and returns a lightweight summary of
+ * the encounter.
+ */
+public final class MatchRunner {
+
+    public MatchResult playMatch(EngineTuning whiteTuning, EngineTuning blackTuning, MatchOptions options) {
+        Objects.requireNonNull(whiteTuning, "whiteTuning");
+        Objects.requireNonNull(blackTuning, "blackTuning");
+        Objects.requireNonNull(options, "options");
+
+        ensureThreadParity(whiteTuning, blackTuning);
+
+        Engine whiteEngine = createEngineForTuning(whiteTuning);
+        Engine blackEngine = createEngineForTuning(blackTuning);
+
+        AI whiteAi = new AI(whiteEngine, whiteTuning.ai());
+        AI blackAi = new AI(blackEngine, blackTuning.ai());
+
+        int maxPlies = options.maxPlies() > 0 ? options.maxPlies() : 512;
+        long moveTime = options.moveTimeMillis() > 0 ? options.moveTimeMillis() : whiteTuning.ai().timeLimitMillis();
+
+        int plies = 0;
+        while (!whiteEngine.getGameState().isGameOver() && plies < maxPlies) {
+            boolean whiteToMove = whiteEngine.whitesTurn();
+            AI mover = whiteToMove ? whiteAi : blackAi;
+            MoveAndScore ms = mover.searchBestMoveBlocking(moveTime);
+            if (ms == null || ms.move == -1) {
+                break;
+            }
+            int move = ms.move;
+            whiteEngine.performMove(move);
+            blackEngine.performMove(move);
+            plies++;
+        }
+
+        GameStateEnum finalState = whiteEngine.getGameState().getState();
+        double whiteScore;
+        double blackScore;
+        switch (finalState) {
+            case WHITE_WON -> {
+                whiteScore = 1.0;
+                blackScore = 0.0;
+            }
+            case BLACK_WON -> {
+                whiteScore = 0.0;
+                blackScore = 1.0;
+            }
+            case DRAW -> {
+                whiteScore = 0.5;
+                blackScore = 0.5;
+            }
+            default -> {
+                whiteScore = 0.5;
+                blackScore = 0.5;
+            }
+        }
+
+        return new MatchResult(whiteTuning, blackTuning, whiteScore, blackScore, finalState, plies);
+    }
+
+    private void ensureThreadParity(EngineTuning white, EngineTuning black) {
+        int whiteThreads = white.ai().searchThreads();
+        int blackThreads = black.ai().searchThreads();
+        if (whiteThreads != blackThreads) {
+            throw new IllegalArgumentException("All participants must use the same number of search threads");
+        }
+    }
+
+    private Engine createEngineForTuning(EngineTuning tuning) {
+        try (AutoCloseable ignored = Score.useEvaluationWeights(tuning.evaluationWeights())) {
+            return new Engine();
+        } catch (Exception e) {
+            if (e instanceof RuntimeException runtime) {
+                throw runtime;
+            }
+            throw new IllegalStateException("Failed to initialise engine for tuning " + tuning.name(), e);
+        }
+    }
+
+    public record MatchOptions(int maxPlies, long moveTimeMillis) {
+        public static MatchOptions defaults() {
+            return new MatchOptions(512, 50L);
+        }
+    }
+
+    public record MatchResult(EngineTuning whiteTuning,
+                              EngineTuning blackTuning,
+                              double whiteScore,
+                              double blackScore,
+                              GameStateEnum finalState,
+                              int plies) {
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/TuningManager.java
+++ b/src/main/java/julius/game/chessengine/tuning/TuningManager.java
@@ -1,0 +1,61 @@
+package julius.game.chessengine.tuning;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Spring-managed helper that keeps the currently active tuning population in memory and reloads
+ * it from disk when requested.
+ */
+@Component
+@Log4j2
+public class TuningManager {
+
+    private final Path tuningFile;
+    private volatile EngineTuningSet population = EngineTuningSet.empty();
+
+    public TuningManager(@Value("${chessengine.tuning.file:}") String tuningFilePath) {
+        if (tuningFilePath == null || tuningFilePath.isBlank()) {
+            this.tuningFile = null;
+            return;
+        }
+        this.tuningFile = Path.of(tuningFilePath);
+        if (Files.exists(this.tuningFile)) {
+            try {
+                this.population = EngineTuningLoader.load(this.tuningFile);
+                log.info("Loaded {} tuning configurations from {}", population.population().size(), this.tuningFile);
+            } catch (IOException e) {
+                log.warn("Failed to load tuning file {}", this.tuningFile, e);
+            }
+        } else {
+            log.info("Tuning file {} does not exist; starting with empty population", this.tuningFile);
+        }
+    }
+
+    public synchronized EngineTuningSet reload() {
+        if (tuningFile == null) {
+            population = EngineTuningSet.empty();
+            return population;
+        }
+        try {
+            population = EngineTuningLoader.load(tuningFile);
+            log.info("Reloaded {} tuning configurations from {}", population.population().size(), tuningFile);
+        } catch (IOException e) {
+            log.warn("Failed to reload tuning file {}", tuningFile, e);
+        }
+        return population;
+    }
+
+    public EngineTuningSet currentPopulation() {
+        return population;
+    }
+
+    public boolean hasPopulation() {
+        return !population.isEmpty();
+    }
+}

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -6,6 +6,7 @@ import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.evaluation.ActivityModule;
 import julius.game.chessengine.evaluation.EvaluationContext;
 import julius.game.chessengine.evaluation.EvaluationPipeline;
+import julius.game.chessengine.evaluation.EvaluationWeights;
 import julius.game.chessengine.evaluation.KingSafetyModule;
 import julius.game.chessengine.evaluation.MaterialModule;
 import julius.game.chessengine.evaluation.MoveContext;
@@ -24,6 +25,9 @@ import java.util.Objects;
  */
 public class Score {
 
+    private static final ThreadLocal<ScoreFactory> THREAD_FACTORY = new ThreadLocal<>();
+    private static volatile ScoreFactory GLOBAL_FACTORY = bitBoard -> new Score(bitBoard, EvaluationWeights.identity());
+
     public static final int CHECKMATE = 100000;
     public static final int CHECK = 50;
     public static final int DRAW = 0;
@@ -37,6 +41,7 @@ public class Score {
     private final ThreatModule threatModule = new ThreatModule();
 
     @JsonIgnore
+    private final EvaluationWeights weights;
     private final EvaluationPipeline evaluationPipeline;
     @JsonIgnore
     private EvaluationContext evaluationContext;
@@ -44,6 +49,11 @@ public class Score {
     private EvaluationContext spareEvaluationContext;
 
     public Score() {
+        this(null);
+    }
+
+    public Score(EvaluationWeights weights) {
+        this.weights = weights != null ? weights : EvaluationWeights.identity();
         materialModule.setPawnChangeListener(pawnStructureModule);
         this.evaluationPipeline = new EvaluationPipeline(List.of(
                 materialModule,
@@ -52,11 +62,16 @@ public class Score {
                 activityModule,
                 kingSafetyModule,
                 threatModule
-        ));
+        ), this.weights);
+    }
+
+    public Score(BitBoard bitBoard, EvaluationWeights weights) {
+        this(weights);
+        initializeFrom(bitBoard);
     }
 
     public Score(Score other) {
-        this();
+        this(other != null ? other.weights : null);
         if (other != null && other.evaluationContext != null) {
             this.evaluationContext = other.evaluationContext.copy();
             if (other.spareEvaluationContext != null) {
@@ -69,9 +84,8 @@ public class Score {
     }
 
     public static Score initializeScore(BitBoard bitBoard) {
-        Score score = new Score();
-        score.initializeFrom(bitBoard);
-        return score;
+        Objects.requireNonNull(bitBoard, "bitBoard");
+        return resolveFactory().create(bitBoard);
     }
 
     private void initializeFrom(BitBoard bitBoard) {
@@ -80,6 +94,37 @@ public class Score {
         this.evaluationContext = context;
         this.spareEvaluationContext = null;
         evaluationPipeline.initialize(context);
+    }
+
+    private static ScoreFactory resolveFactory() {
+        ScoreFactory local = THREAD_FACTORY.get();
+        return (local != null) ? local : GLOBAL_FACTORY;
+    }
+
+    public static AutoCloseable useFactory(ScoreFactory factory) {
+        Objects.requireNonNull(factory, "factory");
+        ScoreFactory previous = THREAD_FACTORY.get();
+        THREAD_FACTORY.set(factory);
+        return () -> {
+            if (previous == null) {
+                THREAD_FACTORY.remove();
+            } else {
+                THREAD_FACTORY.set(previous);
+            }
+        };
+    }
+
+    public static AutoCloseable useEvaluationWeights(EvaluationWeights weights) {
+        return useFactory(forEvaluationWeights(weights));
+    }
+
+    public static ScoreFactory forEvaluationWeights(EvaluationWeights weights) {
+        EvaluationWeights resolved = (weights != null ? weights : EvaluationWeights.identity());
+        return bitBoard -> new Score(bitBoard, resolved);
+    }
+
+    public static void setGlobalFactory(ScoreFactory factory) {
+        GLOBAL_FACTORY = Objects.requireNonNull(factory, "factory");
     }
 
     public void refresh(BitBoard bitBoard, GameStateEnum state) {

--- a/src/main/java/julius/game/chessengine/utils/ScoreFactory.java
+++ b/src/main/java/julius/game/chessengine/utils/ScoreFactory.java
@@ -1,0 +1,13 @@
+package julius.game.chessengine.utils;
+
+import julius.game.chessengine.board.BitBoard;
+
+/**
+ * Functional interface used to create {@link Score} instances for a given board state. The
+ * implementation is responsible for returning a fully initialised {@link Score} ready for use by
+ * the engine.
+ */
+@FunctionalInterface
+public interface ScoreFactory {
+    Score create(BitBoard bitBoard);
+}

--- a/src/main/resources/tuning/sample-tunings.yaml
+++ b/src/main/resources/tuning/sample-tunings.yaml
@@ -1,0 +1,33 @@
+population:
+  - name: baseline
+    ai:
+      searchThreads: 1
+      lazySmpThreads: 1
+      hashSizeMb: 32
+      maxDepth: 32
+      timeLimitMillis: 50
+      nullMovePruning: true
+    evaluation:
+      modules:
+        MaterialModule:
+          midgame: 1.0
+          endgame: 1.0
+        PawnStructureModule:
+          midgame: 1.0
+          endgame: 1.0
+  - name: aggressive
+    ai:
+      searchThreads: 1
+      lazySmpThreads: 1
+      hashSizeMb: 64
+      maxDepth: 36
+      timeLimitMillis: 75
+      nullMovePruning: true
+    evaluation:
+      modules:
+        MaterialModule:
+          midgame: 1.05
+          endgame: 1.0
+        ThreatModule:
+          midgame: 1.2
+          endgame: 1.1

--- a/src/test/java/julius/game/chessengine/evaluation/EvaluationPipelineTest.java
+++ b/src/test/java/julius/game/chessengine/evaluation/EvaluationPipelineTest.java
@@ -1,0 +1,80 @@
+package julius.game.chessengine.evaluation;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.engine.GameStateEnum;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EvaluationPipelineTest {
+
+    @Test
+    void appliesModuleWeightsDuringAggregation() {
+        EvaluationModule attack = new StaticModule(40, 10);
+        EvaluationModule safety = new StaticModule(-20, 30);
+        EvaluationWeights weights = EvaluationWeights.of(Map.of(
+                StaticModule.class.getSimpleName(), new EvaluationWeights.ModuleWeight(2.0, 0.5)
+        ));
+        EvaluationPipeline pipeline = new EvaluationPipeline(List.of(attack, safety), weights);
+
+        EvaluationContext context = EvaluationContext.from(new BitBoard(), GameStateEnum.PLAY);
+        pipeline.initialize(context);
+
+        assertThat(pipeline.getMidgameScore()).isEqualTo(40);
+        assertThat(pipeline.getEndgameScore()).isEqualTo(20);
+    }
+
+    private static final class StaticModule implements EvaluationModule {
+        private final int mid;
+        private final int end;
+        private boolean dirty = true;
+
+        private StaticModule(int mid, int end) {
+            this.mid = mid;
+            this.end = end;
+        }
+
+        @Override
+        public void initialize(EvaluationContext context) {
+            dirty = true;
+        }
+
+        @Override
+        public void evaluate(EvaluationContext context) {
+            dirty = false;
+        }
+
+        @Override
+        public void applyMove(MoveContext moveContext) {
+            dirty = true;
+        }
+
+        @Override
+        public void undoMove(MoveContext moveContext) {
+            dirty = true;
+        }
+
+        @Override
+        public int getMidgameScore() {
+            return mid;
+        }
+
+        @Override
+        public int getEndgameScore() {
+            return end;
+        }
+
+        @Override
+        public boolean isDirty() {
+            return dirty;
+        }
+
+        @Override
+        public void markDirty() {
+            dirty = true;
+        }
+    }
+}

--- a/src/test/java/julius/game/chessengine/tuning/EngineTuningLoaderTest.java
+++ b/src/test/java/julius/game/chessengine/tuning/EngineTuningLoaderTest.java
@@ -1,0 +1,37 @@
+package julius.game.chessengine.tuning;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EngineTuningLoaderTest {
+
+    @Test
+    void loadsPopulationFromYaml() throws Exception {
+        String yaml = """
+                population:
+                  - name: test
+                    ai:
+                      searchThreads: 1
+                      lazySmpThreads: 1
+                      hashSizeMb: 32
+                      maxDepth: 24
+                      timeLimitMillis: 60
+                      nullMovePruning: false
+                    evaluation:
+                      modules:
+                        MaterialModule:
+                          midgame: 1.1
+                          endgame: 0.9
+                """;
+
+        EngineTuningSet set = EngineTuningLoader.loadFromString(yaml);
+        assertThat(set.population()).hasSize(1);
+        EngineTuning tuning = set.population().getFirst();
+        assertThat(tuning.name()).isEqualTo("test");
+        assertThat(tuning.ai().maxDepth()).isEqualTo(24);
+        assertThat(tuning.ai().nullMovePruning()).isFalse();
+        assertThat(tuning.evaluation().modules())
+                .containsKey("materialmodule");
+    }
+}


### PR DESCRIPTION
## Summary
- add weighting support to Score and EvaluationPipeline so evaluation modules can be scaled from configuration
- introduce tuning data structures, YAML loader, Spring manager, and a genetic optimizer/match runner for automated self-play
- document the new workflow and provide a sample tuning file for external configuration

## Testing
- `./mvnw test` *(fails: network unreachable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68d9295a1478832aa38d9cb83473c10d