### PR TITLE
Fix default Score constructor

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -49,7 +49,7 @@ public class Score {
     private EvaluationContext spareEvaluationContext;
 
     public Score() {
-        this(null);
+        this(EvaluationWeights.identity());
     }
 
     public Score(EvaluationWeights weights) {


### PR DESCRIPTION
## Summary
- update the zero-argument `Score` constructor to explicitly use the identity evaluation weights
- avoid ambiguous constructor resolution errors reported by Maven when compiling

## Testing
- `./mvnw -q -DskipTests compile` *(fails: network is unreachable when downloading Maven wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d930266640832aa3da351b088f87aa