### PR TITLE
Ensure jackson YAML module is available for tuning builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
         <!-- Boot uses this to set the compiler release -->
         <java.version>25</java.version>
         <lombok.version>1.18.42</lombok.version>
+        <!-- Explicit version for dataformat-yaml so IDE builds pick it up reliably -->
+        <jackson-dataformat-yaml.version>2.18.2</jackson-dataformat-yaml.version>
     </properties>
 
     <dependencies>
@@ -86,6 +88,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson-dataformat-yaml.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
- define an explicit version property for `jackson-dataformat-yaml`
- wire the property into the dependency declaration so IDE builds resolve the YAML factory classes

## Testing
- not run (network access is required to download Maven artifacts in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d9380ac7c4832a8e5c2f5d6f2da796