### PR TITLE
Replace Jackson YAML usage with SnakeYAML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,6 @@
             <version>8.5.16</version>
         </dependency>
 
-        <!-- YAML support for external tuning configuration -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/julius/game/chessengine/tuning/EngineTuningLoader.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuningLoader.java
@@ -1,9 +1,10 @@
 package julius.game.chessengine.tuning;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.introspector.BeanAccess;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,8 +36,7 @@ import java.util.stream.Collectors;
  */
 public final class EngineTuningLoader {
 
-    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory())
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private static final Yaml YAML_MAPPER = createYamlMapper();
 
     private EngineTuningLoader() {
     }
@@ -50,7 +50,32 @@ public final class EngineTuningLoader {
 
     public static EngineTuningSet load(InputStream inputStream) throws IOException {
         Objects.requireNonNull(inputStream, "inputStream");
-        EngineTuningDocument document = YAML_MAPPER.readValue(inputStream, EngineTuningDocument.class);
+        EngineTuningDocument document = readDocument(() -> YAML_MAPPER.load(inputStream));
+        return toTuningSet(document);
+    }
+
+    public static EngineTuningSet loadFromString(String yaml) throws IOException {
+        Objects.requireNonNull(yaml, "yaml");
+        EngineTuningDocument document = readDocument(() -> YAML_MAPPER.load(yaml));
+        return toTuningSet(document);
+    }
+
+    private static EngineTuningDocument readDocument(YamlLoader loader) throws IOException {
+        try {
+            Object loaded = loader.load();
+            if (loaded == null) {
+                return null;
+            }
+            if (loaded instanceof EngineTuningDocument document) {
+                return document;
+            }
+            throw new IOException("Unexpected YAML structure for engine tuning definition");
+        } catch (YAMLException ex) {
+            throw new IOException("Failed to parse engine tuning definition", ex);
+        }
+    }
+
+    private static EngineTuningSet toTuningSet(EngineTuningDocument document) {
         if (document == null || document.population == null || document.population.isEmpty()) {
             return EngineTuningSet.empty();
         }
@@ -60,15 +85,12 @@ public final class EngineTuningLoader {
         return new EngineTuningSet(tunings);
     }
 
-    public static EngineTuningSet loadFromString(String yaml) throws JsonProcessingException {
-        EngineTuningDocument document = YAML_MAPPER.readValue(yaml, EngineTuningDocument.class);
-        if (document == null || document.population == null || document.population.isEmpty()) {
-            return EngineTuningSet.empty();
-        }
-        List<EngineTuning> tunings = document.population.stream()
-                .map(EngineTuningLoader::toEngineTuning)
-                .collect(Collectors.toUnmodifiableList());
-        return new EngineTuningSet(tunings);
+    private static Yaml createYamlMapper() {
+        LoaderOptions options = new LoaderOptions();
+        Constructor constructor = new Constructor(EngineTuningDocument.class, options);
+        constructor.getPropertyUtils().setBeanAccess(BeanAccess.FIELD);
+        constructor.getPropertyUtils().setSkipMissingProperties(true);
+        return new Yaml(constructor);
     }
 
     private static EngineTuning toEngineTuning(EngineTuningConfig config) {
@@ -162,5 +184,10 @@ public final class EngineTuningLoader {
     private static final class ModuleConfig {
         public double midgame = 1.0;
         public double endgame = 1.0;
+    }
+
+    @FunctionalInterface
+    private interface YamlLoader {
+        Object load();
     }
 }

--- a/src/main/java/julius/game/chessengine/tuning/EngineTuningWriter.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuningWriter.java
@@ -56,7 +56,7 @@ public final class EngineTuningWriter {
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         options.setPrettyFlow(true);
         options.setIndent(2);
-        options.setIndicatorIndent(2);
+        options.setIndicatorIndent(1);
         options.setSplitLines(false);
         return options;
     }

--- a/src/main/java/julius/game/chessengine/tuning/EngineTuningWriter.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuningWriter.java
@@ -1,13 +1,11 @@
 package julius.game.chessengine.tuning;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -16,15 +14,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * Serialises {@link EngineTuningSet} instances to a YAML structure that mirrors the format accepted
  * by {@link EngineTuningLoader}.
  */
 public final class EngineTuningWriter {
 
-    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory())
-            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
-            .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+    private static final Yaml YAML_MAPPER = new Yaml(createOptions());
 
     private EngineTuningWriter() {
     }
@@ -35,92 +33,89 @@ public final class EngineTuningWriter {
             throw new IllegalArgumentException("Population must contain at least one tuning");
         }
         Files.createDirectories(path.toAbsolutePath().getParent());
-        try (OutputStream out = Files.newOutputStream(path)) {
-            YAML_MAPPER.writerWithDefaultPrettyPrinter()
-                    .writeValue(out, toDocument(population));
+        try (Writer writer = Files.newBufferedWriter(path, UTF_8)) {
+            YAML_MAPPER.dump(toDocument(population), writer);
         }
     }
 
-    public static String toYaml(EngineTuningSet population) throws JsonProcessingException {
+    public static String toYaml(EngineTuningSet population) {
         if (population == null || population.isEmpty()) {
             throw new IllegalArgumentException("Population must contain at least one tuning");
         }
-        return YAML_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(toDocument(population));
+        try (StringWriter writer = new StringWriter()) {
+            YAML_MAPPER.dump(toDocument(population), writer);
+            return writer.toString();
+        } catch (IOException ex) {
+            // StringWriter does not throw IOException, but keep signature future-proof
+            throw new IllegalStateException("Failed to render tuning definition", ex);
+        }
     }
 
-    private static EngineTuningDocument toDocument(EngineTuningSet population) {
-        List<EngineTuningConfig> configs = new ArrayList<>();
+    private static DumperOptions createOptions() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        options.setIndent(2);
+        options.setIndicatorIndent(2);
+        options.setSplitLines(false);
+        return options;
+    }
+
+    private static Map<String, Object> toDocument(EngineTuningSet population) {
+        Map<String, Object> document = new LinkedHashMap<>();
+        List<Map<String, Object>> configs = new ArrayList<>();
         for (EngineTuning tuning : population.population()) {
             configs.add(toConfig(tuning));
         }
-        EngineTuningDocument document = new EngineTuningDocument();
-        document.population = configs;
+        document.put("population", configs);
         return document;
     }
 
-    private static EngineTuningConfig toConfig(EngineTuning tuning) {
-        EngineTuningConfig config = new EngineTuningConfig();
-        config.name = tuning.name();
-        config.ai = toAiConfig(tuning.ai());
-        config.evaluation = toEvaluationConfig(tuning.evaluation());
-        config.numericParameters = new LinkedHashMap<>(tuning.numericParameters());
+    private static Map<String, Object> toConfig(EngineTuning tuning) {
+        Map<String, Object> config = new LinkedHashMap<>();
+        if (tuning.name() != null && !tuning.name().isBlank()) {
+            config.put("name", tuning.name());
+        }
+        Map<String, Object> ai = toAiConfig(tuning.ai());
+        if (!ai.isEmpty()) {
+            config.put("ai", ai);
+        }
+        Map<String, Object> evaluation = toEvaluationConfig(tuning.evaluation());
+        if (!evaluation.isEmpty()) {
+            config.put("evaluation", evaluation);
+        }
+        if (!tuning.numericParameters().isEmpty()) {
+            config.put("numericParameters", new LinkedHashMap<>(tuning.numericParameters()));
+        }
         return config;
     }
 
-    private static AiConfig toAiConfig(AiTuning tuning) {
-        AiConfig config = new AiConfig();
-        config.searchThreads = tuning.searchThreads();
-        config.lazySmpThreads = tuning.lazySmpThreads();
-        config.hashSizeMb = tuning.hashSizeMb();
-        config.maxDepth = tuning.maxDepth();
-        config.timeLimitMillis = tuning.timeLimitMillis();
-        config.nullMovePruning = tuning.nullMovePruning();
+    private static Map<String, Object> toAiConfig(AiTuning tuning) {
+        Map<String, Object> config = new LinkedHashMap<>();
+        config.put("searchThreads", tuning.searchThreads());
+        config.put("lazySmpThreads", tuning.lazySmpThreads());
+        config.put("hashSizeMb", tuning.hashSizeMb());
+        config.put("maxDepth", tuning.maxDepth());
+        config.put("timeLimitMillis", tuning.timeLimitMillis());
+        config.put("nullMovePruning", tuning.nullMovePruning());
         return config;
     }
 
-    private static EvaluationConfig toEvaluationConfig(EvaluationTuning tuning) {
+    private static Map<String, Object> toEvaluationConfig(EvaluationTuning tuning) {
         Map<String, EvaluationTuning.ModuleConfig> modules = tuning.modules();
         if (modules.isEmpty()) {
-            return null;
+            return Map.of();
         }
-        EvaluationConfig config = new EvaluationConfig();
-        config.modules = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
+        Map<String, Object> serializedModules = new LinkedHashMap<>();
         modules.forEach((name, moduleConfig) -> {
-            ModuleConfig module = new ModuleConfig();
-            module.midgame = moduleConfig.midgame();
-            module.endgame = moduleConfig.endgame();
-            config.modules.put(name, module);
+            Map<String, Object> module = new LinkedHashMap<>();
+            module.put("midgame", moduleConfig.midgame());
+            module.put("endgame", moduleConfig.endgame());
+            serializedModules.put(name, module);
         });
+        config.put("modules", serializedModules);
         return config;
-    }
-
-    private static final class EngineTuningDocument {
-        public List<EngineTuningConfig> population;
-    }
-
-    private static final class EngineTuningConfig {
-        public String name;
-        public AiConfig ai;
-        public EvaluationConfig evaluation;
-        public Map<String, Double> numericParameters;
-    }
-
-    private static final class AiConfig {
-        public int searchThreads;
-        public int lazySmpThreads;
-        public int hashSizeMb;
-        public int maxDepth;
-        public long timeLimitMillis;
-        public boolean nullMovePruning;
-    }
-
-    private static final class EvaluationConfig {
-        public Map<String, ModuleConfig> modules;
-    }
-
-    private static final class ModuleConfig {
-        public double midgame;
-        public double endgame;
     }
 }
 

--- a/src/main/resources/bat/run-tuning.bat
+++ b/src/main/resources/bat/run-tuning.bat
@@ -38,7 +38,7 @@ REM ---------------------------------------------------------------------------
 java ^
   "-Dloader.main=julius.game.chessengine.tuning.GeneticTuningMain" ^
   -cp "%JARFILE%" ^
-  org.springframework.boot.loader.PropertiesLauncher ^
+  org.springframework.boot.loader.launch.PropertiesLauncher ^
   --seed "%SEED%" ^
   --generations 10 ^
   --population 12 ^


### PR DESCRIPTION
## Summary
- replace Jackson-based YAML parsing in the tuning loader with SnakeYAML to avoid the missing dependency during local builds
- rework the tuning writer to emit YAML via SnakeYAML and remove the unused Jackson dependency from the Maven build

## Testing
- `mvn -q test` *(fails: local toolchain Maven uses Java 21 and cannot target release 25)*

------
https://chatgpt.com/codex/tasks/task_e_68d9380ac7c4832a8e5c2f5d6f2da796