### PR TITLE
Fix PropertiesLauncher package in tuning script

### DIFF
--- a/src/main/resources/bat/run-tuning.bat
+++ b/src/main/resources/bat/run-tuning.bat
@@ -38,7 +38,7 @@ REM ---------------------------------------------------------------------------
 java ^
   "-Dloader.main=julius.game.chessengine.tuning.GeneticTuningMain" ^
   -cp "%JARFILE%" ^
-  org.springframework.boot.loader.PropertiesLauncher ^
+  org.springframework.boot.loader.launch.PropertiesLauncher ^
   --seed "%SEED%" ^
   --generations 10 ^
   --population 12 ^


### PR DESCRIPTION
## Summary
- point the tuning batch script at the relocated Spring Boot PropertiesLauncher class so the JVM can find it when running the jar

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d981bd0840832ab42e356ae414e8ed