### PR TITLE
Enable tuning of evaluation numeric parameters

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
@@ -7,6 +7,7 @@ import julius.game.chessengine.helper.BishopHelper;
 import julius.game.chessengine.helper.KingHelper;
 import julius.game.chessengine.helper.KnightHelper;
 import julius.game.chessengine.helper.RookHelper;
+import julius.game.chessengine.tuning.TunableParameter;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -28,10 +29,29 @@ public final class ActivityModule implements EvaluationModule {
     private static final int QUEEN = MoveHelper.pieceTypeToInt(PieceType.QUEEN);
     private static final int KING = MoveHelper.pieceTypeToInt(PieceType.KING);
 
-    private static final int[] MIDGAME_MOBILITY_WEIGHTS = new int[7];
-    private static final int[] ENDGAME_MOBILITY_WEIGHTS = new int[7];
-    private static final int[] MIDGAME_CENTER_WEIGHTS = new int[7];
-    private static final int[] ENDGAME_CENTER_WEIGHTS = new int[7];
+    private static final TunableParameter MIDGAME_KNIGHT_MOBILITY = TunableParameter.of("activity.midgameMobilityKnight", 2);
+    private static final TunableParameter MIDGAME_BISHOP_MOBILITY = TunableParameter.of("activity.midgameMobilityBishop", 4);
+    private static final TunableParameter MIDGAME_ROOK_MOBILITY = TunableParameter.of("activity.midgameMobilityRook", 2);
+    private static final TunableParameter MIDGAME_QUEEN_MOBILITY = TunableParameter.of("activity.midgameMobilityQueen", 1);
+    private static final TunableParameter MIDGAME_KING_MOBILITY = TunableParameter.of("activity.midgameMobilityKing", 0);
+
+    private static final TunableParameter ENDGAME_KNIGHT_MOBILITY = TunableParameter.of("activity.endgameMobilityKnight", 2);
+    private static final TunableParameter ENDGAME_BISHOP_MOBILITY = TunableParameter.of("activity.endgameMobilityBishop", 4);
+    private static final TunableParameter ENDGAME_ROOK_MOBILITY = TunableParameter.of("activity.endgameMobilityRook", 2);
+    private static final TunableParameter ENDGAME_QUEEN_MOBILITY = TunableParameter.of("activity.endgameMobilityQueen", 1);
+    private static final TunableParameter ENDGAME_KING_MOBILITY = TunableParameter.of("activity.endgameMobilityKing", 2);
+
+    private static final TunableParameter MIDGAME_KNIGHT_CENTER = TunableParameter.of("activity.midgameCenterKnight", 3);
+    private static final TunableParameter MIDGAME_BISHOP_CENTER = TunableParameter.of("activity.midgameCenterBishop", 3);
+    private static final TunableParameter MIDGAME_ROOK_CENTER = TunableParameter.of("activity.midgameCenterRook", 3);
+    private static final TunableParameter MIDGAME_QUEEN_CENTER = TunableParameter.of("activity.midgameCenterQueen", 3);
+    private static final TunableParameter MIDGAME_KING_CENTER = TunableParameter.of("activity.midgameCenterKing", 0);
+
+    private static final TunableParameter ENDGAME_KNIGHT_CENTER = TunableParameter.of("activity.endgameCenterKnight", 3);
+    private static final TunableParameter ENDGAME_BISHOP_CENTER = TunableParameter.of("activity.endgameCenterBishop", 3);
+    private static final TunableParameter ENDGAME_ROOK_CENTER = TunableParameter.of("activity.endgameCenterRook", 3);
+    private static final TunableParameter ENDGAME_QUEEN_CENTER = TunableParameter.of("activity.endgameCenterQueen", 3);
+    private static final TunableParameter ENDGAME_KING_CENTER = TunableParameter.of("activity.endgameCenterKing", 2);
 
     private static final long CENTRAL_SQUARES;
 
@@ -49,31 +69,12 @@ public final class ActivityModule implements EvaluationModule {
     private static final BishopHelper BISHOP_HELPER = BishopHelper.getInstance();
     private static final RookHelper ROOK_HELPER = RookHelper.getInstance();
 
+    private final int[] midgameMobilityWeights = new int[7];
+    private final int[] endgameMobilityWeights = new int[7];
+    private final int[] midgameCenterWeights = new int[7];
+    private final int[] endgameCenterWeights = new int[7];
+
     static {
-        MIDGAME_MOBILITY_WEIGHTS[KNIGHT] = 2;
-        MIDGAME_MOBILITY_WEIGHTS[BISHOP] = 4;
-        MIDGAME_MOBILITY_WEIGHTS[ROOK] = 2;
-        MIDGAME_MOBILITY_WEIGHTS[QUEEN] = 1;
-        MIDGAME_MOBILITY_WEIGHTS[KING] = 0;
-
-        ENDGAME_MOBILITY_WEIGHTS[KNIGHT] = 2;
-        ENDGAME_MOBILITY_WEIGHTS[BISHOP] = 4;
-        ENDGAME_MOBILITY_WEIGHTS[ROOK] = 2;
-        ENDGAME_MOBILITY_WEIGHTS[QUEEN] = 1;
-        ENDGAME_MOBILITY_WEIGHTS[KING] = 2;
-
-        MIDGAME_CENTER_WEIGHTS[KNIGHT] = 3;
-        MIDGAME_CENTER_WEIGHTS[BISHOP] = 3;
-        MIDGAME_CENTER_WEIGHTS[ROOK] = 3;
-        MIDGAME_CENTER_WEIGHTS[QUEEN] = 3;
-        MIDGAME_CENTER_WEIGHTS[KING] = 0;
-
-        ENDGAME_CENTER_WEIGHTS[KNIGHT] = 3;
-        ENDGAME_CENTER_WEIGHTS[BISHOP] = 3;
-        ENDGAME_CENTER_WEIGHTS[ROOK] = 3;
-        ENDGAME_CENTER_WEIGHTS[QUEEN] = 3;
-        ENDGAME_CENTER_WEIGHTS[KING] = 2;
-
         CENTRAL_SQUARES = (1L << squareIndex('d', 4))
                 | (1L << squareIndex('e', 4))
                 | (1L << squareIndex('d', 5))
@@ -131,6 +132,29 @@ public final class ActivityModule implements EvaluationModule {
         for (int i = 0; i < activities.length; i++) {
             activities[i] = new PieceActivity();
         }
+        midgameMobilityWeights[KNIGHT] = MIDGAME_KNIGHT_MOBILITY.getInt();
+        midgameMobilityWeights[BISHOP] = MIDGAME_BISHOP_MOBILITY.getInt();
+        midgameMobilityWeights[ROOK] = MIDGAME_ROOK_MOBILITY.getInt();
+        midgameMobilityWeights[QUEEN] = MIDGAME_QUEEN_MOBILITY.getInt();
+        midgameMobilityWeights[KING] = MIDGAME_KING_MOBILITY.getInt();
+
+        endgameMobilityWeights[KNIGHT] = ENDGAME_KNIGHT_MOBILITY.getInt();
+        endgameMobilityWeights[BISHOP] = ENDGAME_BISHOP_MOBILITY.getInt();
+        endgameMobilityWeights[ROOK] = ENDGAME_ROOK_MOBILITY.getInt();
+        endgameMobilityWeights[QUEEN] = ENDGAME_QUEEN_MOBILITY.getInt();
+        endgameMobilityWeights[KING] = ENDGAME_KING_MOBILITY.getInt();
+
+        midgameCenterWeights[KNIGHT] = MIDGAME_KNIGHT_CENTER.getInt();
+        midgameCenterWeights[BISHOP] = MIDGAME_BISHOP_CENTER.getInt();
+        midgameCenterWeights[ROOK] = MIDGAME_ROOK_CENTER.getInt();
+        midgameCenterWeights[QUEEN] = MIDGAME_QUEEN_CENTER.getInt();
+        midgameCenterWeights[KING] = MIDGAME_KING_CENTER.getInt();
+
+        endgameCenterWeights[KNIGHT] = ENDGAME_KNIGHT_CENTER.getInt();
+        endgameCenterWeights[BISHOP] = ENDGAME_BISHOP_CENTER.getInt();
+        endgameCenterWeights[ROOK] = ENDGAME_ROOK_CENTER.getInt();
+        endgameCenterWeights[QUEEN] = ENDGAME_QUEEN_CENTER.getInt();
+        endgameCenterWeights[KING] = ENDGAME_KING_CENTER.getInt();
     }
 
     @Override
@@ -559,10 +583,10 @@ public final class ActivityModule implements EvaluationModule {
         int mobility = Long.bitCount(legalTargets);
         int center = Long.bitCount(legalTargets & CENTRAL_SQUARES);
 
-        int midgameContribution = mobility * MIDGAME_MOBILITY_WEIGHTS[pieceType]
-                + center * MIDGAME_CENTER_WEIGHTS[pieceType];
-        int endgameContribution = mobility * ENDGAME_MOBILITY_WEIGHTS[pieceType]
-                + center * ENDGAME_CENTER_WEIGHTS[pieceType];
+        int midgameContribution = mobility * midgameMobilityWeights[pieceType]
+                + center * midgameCenterWeights[pieceType];
+        int endgameContribution = mobility * endgameMobilityWeights[pieceType]
+                + center * endgameCenterWeights[pieceType];
 
         midgameTotals[activity.color] += midgameContribution - activity.midgameScore;
         endgameTotals[activity.color] += endgameContribution - activity.endgameScore;

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationParameterRegistry.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationParameterRegistry.java
@@ -1,0 +1,37 @@
+package julius.game.chessengine.evaluation;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Ensures that evaluation modules register their tunable parameters before tuning defaults are
+ * requested. This avoids builder code observing an empty parameter set if the modules have not been
+ * loaded yet.
+ */
+public final class EvaluationParameterRegistry {
+
+    private static final AtomicBoolean INITIALIZED = new AtomicBoolean();
+
+    private EvaluationParameterRegistry() {
+    }
+
+    public static void initialize() {
+        if (!INITIALIZED.compareAndSet(false, true)) {
+            return;
+        }
+        initialize(MaterialModule.class);
+        initialize(PawnStructureModule.class);
+        initialize(PieceSquareModule.class);
+        initialize(ActivityModule.class);
+        initialize(KingSafetyModule.class);
+        initialize(ThreatModule.class);
+        initialize(EvaluationPipeline.class);
+    }
+
+    private static void initialize(Class<?> type) {
+        try {
+            Class.forName(type.getName(), true, type.getClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Unable to initialize evaluation parameters for " + type, e);
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
@@ -2,6 +2,7 @@ package julius.game.chessengine.evaluation;
 
 import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.utils.Score;
+import julius.game.chessengine.tuning.TunableParameter;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -15,7 +16,7 @@ import java.util.Objects;
  */
 public final class EvaluationPipeline {
 
-    private static final int BLEND_SCALE = 256;
+    private static final TunableParameter BLEND_SCALE_PARAM = TunableParameter.of("evaluation.blendScale", 256, 1, 1024);
 
     private static final class ModuleState {
         private final EvaluationModule module;
@@ -32,6 +33,7 @@ public final class EvaluationPipeline {
 
     private final List<ModuleState> modules;
     private final EvaluationWeights weights;
+    private final int blendScale;
     private EvaluationContext context;
     private boolean initialized;
     private boolean aggregateDirty = true;
@@ -47,6 +49,7 @@ public final class EvaluationPipeline {
             throw new IllegalArgumentException("At least one evaluation module is required");
         }
         this.weights = (weights != null ? weights : EvaluationWeights.identity());
+        this.blendScale = BLEND_SCALE_PARAM.getInt();
         List<ModuleState> moduleStates = new ArrayList<>(modules.size());
         for (EvaluationModule module : modules) {
             EvaluationWeights.ModuleWeight weight = this.weights.weightFor(module.getClass());
@@ -107,10 +110,10 @@ public final class EvaluationPipeline {
             return 0;
         }
         int phase = clamp(context.getPhase());
-        int midgameWeight = BLEND_SCALE - phase;
+        int midgameWeight = blendScale - phase;
         int endgameWeight = phase;
         long blended = (long) midgameTotal * midgameWeight + (long) endgameTotal * endgameWeight;
-        return (int) (blended / BLEND_SCALE);
+        return (int) (blended / blendScale);
     }
 
     public double getScoreDifference() {
@@ -162,12 +165,12 @@ public final class EvaluationPipeline {
         aggregateDirty = true;
     }
 
-    private static int clamp(int phase) {
+    private int clamp(int phase) {
         if (phase < 0) {
             return 0;
         }
-        if (phase > BLEND_SCALE) {
-            return BLEND_SCALE;
+        if (phase > blendScale) {
+            return blendScale;
         }
         return phase;
     }

--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -6,6 +6,7 @@ import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.BishopHelper;
 import julius.game.chessengine.helper.RookHelper;
+import julius.game.chessengine.tuning.TunableParameter;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -32,15 +33,27 @@ public final class KingSafetyModule implements EvaluationModule {
     private static final int QUEEN = MoveHelper.pieceTypeToInt(PieceType.QUEEN);
     private static final int KING = MoveHelper.pieceTypeToInt(PieceType.KING);
 
-    private static final int MISSING_PAWN_SHIELD_PENALTY = -15;
-    private static final int HALF_OPEN_FILE_PENALTY = -15;
-    private static final int OPEN_FILE_PENALTY = -25;
-    private static final int DEFENDER_BONUS = 5;
-    private static final int QUEEN_ATTACKED_PENALTY = -75;
-    private static final int BACKRANK_WEAKNESS_MIDGAME_PENALTY = -100;
-    private static final int BACKRANK_WEAKNESS_ENDGAME_PENALTY = -50;
+    private static final int DEFAULT_MISSING_PAWN_SHIELD_PENALTY = -15;
+    private static final int DEFAULT_HALF_OPEN_FILE_PENALTY = -15;
+    private static final int DEFAULT_OPEN_FILE_PENALTY = -25;
+    private static final int DEFAULT_DEFENDER_BONUS = 5;
+    private static final int DEFAULT_QUEEN_ATTACKED_PENALTY = -75;
+    private static final int DEFAULT_BACKRANK_WEAKNESS_MIDGAME_PENALTY = -100;
+    private static final int DEFAULT_BACKRANK_WEAKNESS_ENDGAME_PENALTY = -50;
 
-    private static final int[] ATTACK_WEIGHTS = new int[7];
+    private static final TunableParameter MISSING_PAWN_SHIELD_PENALTY = TunableParameter.of("kingSafety.missingPawnShieldPenalty", DEFAULT_MISSING_PAWN_SHIELD_PENALTY);
+    private static final TunableParameter HALF_OPEN_FILE_PENALTY = TunableParameter.of("kingSafety.halfOpenFilePenalty", DEFAULT_HALF_OPEN_FILE_PENALTY);
+    private static final TunableParameter OPEN_FILE_PENALTY = TunableParameter.of("kingSafety.openFilePenalty", DEFAULT_OPEN_FILE_PENALTY);
+    private static final TunableParameter DEFENDER_BONUS = TunableParameter.of("kingSafety.defenderBonus", DEFAULT_DEFENDER_BONUS);
+    private static final TunableParameter QUEEN_ATTACKED_PENALTY = TunableParameter.of("kingSafety.queenAttackedPenalty", DEFAULT_QUEEN_ATTACKED_PENALTY);
+    private static final TunableParameter BACKRANK_WEAKNESS_MIDGAME_PENALTY = TunableParameter.of("kingSafety.backrankWeaknessMidgamePenalty", DEFAULT_BACKRANK_WEAKNESS_MIDGAME_PENALTY);
+    private static final TunableParameter BACKRANK_WEAKNESS_ENDGAME_PENALTY = TunableParameter.of("kingSafety.backrankWeaknessEndgamePenalty", DEFAULT_BACKRANK_WEAKNESS_ENDGAME_PENALTY);
+
+    private static final TunableParameter PAWN_ATTACK_WEIGHT = TunableParameter.of("kingSafety.attackWeightPawn", 5);
+    private static final TunableParameter KNIGHT_ATTACK_WEIGHT = TunableParameter.of("kingSafety.attackWeightKnight", 10);
+    private static final TunableParameter BISHOP_ATTACK_WEIGHT = TunableParameter.of("kingSafety.attackWeightBishop", 10);
+    private static final TunableParameter ROOK_ATTACK_WEIGHT = TunableParameter.of("kingSafety.attackWeightRook", 15);
+    private static final TunableParameter QUEEN_ATTACK_WEIGHT = TunableParameter.of("kingSafety.attackWeightQueen", 20);
 
     private static final long NOT_A_FILE = ~FileMasks[0];
     private static final long NOT_H_FILE = ~FileMasks[7];
@@ -48,13 +61,14 @@ public final class KingSafetyModule implements EvaluationModule {
     private static final BishopHelper BISHOP_HELPER = BishopHelper.getInstance();
     private static final RookHelper ROOK_HELPER = RookHelper.getInstance();
 
-    static {
-        ATTACK_WEIGHTS[PAWN] = 5;
-        ATTACK_WEIGHTS[KNIGHT] = 10;
-        ATTACK_WEIGHTS[BISHOP] = 10;
-        ATTACK_WEIGHTS[ROOK] = 15;
-        ATTACK_WEIGHTS[QUEEN] = 20;
-    }
+    private final int missingPawnShieldPenalty;
+    private final int halfOpenFilePenalty;
+    private final int openFilePenalty;
+    private final int defenderBonus;
+    private final int queenAttackedPenalty;
+    private final int backrankWeaknessMidgamePenalty;
+    private final int backrankWeaknessEndgamePenalty;
+    private final int[] attackWeights = new int[7];
 
     private final SideState[] sideStates = {new SideState(), new SideState()};
     private KingSafetyView currentView = KingSafetyView.empty();
@@ -62,6 +76,21 @@ public final class KingSafetyModule implements EvaluationModule {
     private boolean dirty = true;
     private int midgameScoreCache;
     private int endgameScoreCache;
+
+    public KingSafetyModule() {
+        this.missingPawnShieldPenalty = MISSING_PAWN_SHIELD_PENALTY.getInt();
+        this.halfOpenFilePenalty = HALF_OPEN_FILE_PENALTY.getInt();
+        this.openFilePenalty = OPEN_FILE_PENALTY.getInt();
+        this.defenderBonus = DEFENDER_BONUS.getInt();
+        this.queenAttackedPenalty = QUEEN_ATTACKED_PENALTY.getInt();
+        this.backrankWeaknessMidgamePenalty = BACKRANK_WEAKNESS_MIDGAME_PENALTY.getInt();
+        this.backrankWeaknessEndgamePenalty = BACKRANK_WEAKNESS_ENDGAME_PENALTY.getInt();
+        attackWeights[PAWN] = PAWN_ATTACK_WEIGHT.getInt();
+        attackWeights[KNIGHT] = KNIGHT_ATTACK_WEIGHT.getInt();
+        attackWeights[BISHOP] = BISHOP_ATTACK_WEIGHT.getInt();
+        attackWeights[ROOK] = ROOK_ATTACK_WEIGHT.getInt();
+        attackWeights[QUEEN] = QUEEN_ATTACK_WEIGHT.getInt();
+    }
 
     @Override
     public void initialize(EvaluationContext context) {
@@ -263,7 +292,7 @@ public final class KingSafetyModule implements EvaluationModule {
 
         boolean friendlyPawnOnFile = (friendlyPawns & state.fileMask) != 0;
         if (!friendlyPawnOnFile) {
-            state.filePenalty = (enemyPawns & state.fileMask) != 0 ? HALF_OPEN_FILE_PENALTY : OPEN_FILE_PENALTY;
+            state.filePenalty = (enemyPawns & state.fileMask) != 0 ? halfOpenFilePenalty : openFilePenalty;
         }
 
         state.defenderCount = Long.bitCount(friendlyAttacks & state.kingZone);
@@ -284,9 +313,9 @@ public final class KingSafetyModule implements EvaluationModule {
         }
         state.totalAttackWeight = total;
 
-        int shieldPenalty = state.missingShield * MISSING_PAWN_SHIELD_PENALTY;
+        int shieldPenalty = state.missingShield * missingPawnShieldPenalty;
         int attackPenalty = -state.totalAttackWeight;
-        int defenderBonus = state.defenderCount * DEFENDER_BONUS;
+        int defenderBonus = state.defenderCount * this.defenderBonus;
         computeBackrankWeaknessPenalty(state, board, isWhite);
         int baseMidgame = shieldPenalty + state.filePenalty + attackPenalty + defenderBonus;
         state.midgameKingSafety = baseMidgame + state.backrankWeaknessMidgame;
@@ -299,8 +328,8 @@ public final class KingSafetyModule implements EvaluationModule {
         while (remaining != 0) {
             long q = remaining & -remaining;
             if ((enemyAttacks & q) != 0) {
-                queenMid += QUEEN_ATTACKED_PENALTY;
-                queenEnd += QUEEN_ATTACKED_PENALTY;
+                queenMid += queenAttackedPenalty;
+                queenEnd += queenAttackedPenalty;
             }
             remaining ^= q;
         }
@@ -336,8 +365,8 @@ public final class KingSafetyModule implements EvaluationModule {
             return;
         }
 
-        state.backrankWeaknessMidgame = BACKRANK_WEAKNESS_MIDGAME_PENALTY;
-        state.backrankWeaknessEndgame = BACKRANK_WEAKNESS_ENDGAME_PENALTY;
+        state.backrankWeaknessMidgame = backrankWeaknessMidgamePenalty;
+        state.backrankWeaknessEndgame = backrankWeaknessEndgamePenalty;
     }
 
     private static long computeEscapeSquares(long kingMask, boolean isWhite) {
@@ -443,7 +472,7 @@ public final class KingSafetyModule implements EvaluationModule {
             long pawn = remaining & -remaining;
             int index = Long.numberOfTrailingZeros(pawn);
             long attacks = PAWN_ATTACKS[color][index];
-            addAttacks(state, attacks, ATTACK_WEIGHTS[PAWN]);
+            addAttacks(state, attacks, attackWeights[PAWN]);
             remaining ^= pawn;
         }
     }
@@ -457,7 +486,7 @@ public final class KingSafetyModule implements EvaluationModule {
             long knight = remaining & -remaining;
             int index = Long.numberOfTrailingZeros(knight);
             long attacks = knightMoveTable[index];
-            addAttacks(state, attacks, ATTACK_WEIGHTS[KNIGHT]);
+            addAttacks(state, attacks, attackWeights[KNIGHT]);
             remaining ^= knight;
         }
     }
@@ -472,7 +501,7 @@ public final class KingSafetyModule implements EvaluationModule {
             int index = Long.numberOfTrailingZeros(bishop);
             long mask = BISHOP_HELPER.bishopMasks[index];
             long attacks = BISHOP_HELPER.calculateMovesUsingBishopMagic(index, occupancy & mask);
-            addAttacks(state, attacks, ATTACK_WEIGHTS[BISHOP]);
+            addAttacks(state, attacks, attackWeights[BISHOP]);
             remaining ^= bishop;
         }
     }
@@ -487,7 +516,7 @@ public final class KingSafetyModule implements EvaluationModule {
             int index = Long.numberOfTrailingZeros(rook);
             long mask = ROOK_HELPER.rookMasks[index];
             long attacks = ROOK_HELPER.calculateMovesUsingRookMagic(index, occupancy & mask);
-            addAttacks(state, attacks, ATTACK_WEIGHTS[ROOK]);
+            addAttacks(state, attacks, attackWeights[ROOK]);
             remaining ^= rook;
         }
     }
@@ -504,7 +533,7 @@ public final class KingSafetyModule implements EvaluationModule {
             long rookMask = ROOK_HELPER.rookMasks[index];
             long diagonal = BISHOP_HELPER.calculateMovesUsingBishopMagic(index, occupancy & bishopMask);
             long straight = ROOK_HELPER.calculateMovesUsingRookMagic(index, occupancy & rookMask);
-            addAttacks(state, diagonal | straight, ATTACK_WEIGHTS[QUEEN]);
+            addAttacks(state, diagonal | straight, attackWeights[QUEEN]);
             remaining ^= queen;
         }
     }

--- a/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
@@ -5,18 +5,26 @@ import java.util.Objects;
 
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.figures.PieceType;
+import julius.game.chessengine.tuning.TunableParameter;
 /**
  * Tracks per-side material using incremental updates so the evaluation pipeline can
  * access midgame and endgame material totals without rescanning the board.
  */
 public final class MaterialModule implements EvaluationModule {
 
-    public static final int PAWN_VALUE = 100;
-    public static final int KNIGHT_VALUE = 320;
-    public static final int BISHOP_VALUE = 330;
-    public static final int ROOK_VALUE = 500;
-    public static final int QUEEN_VALUE = 900;
-    public static final int BISHOP_PAIR_BONUS = 40;
+    public static final int DEFAULT_PAWN_VALUE = 100;
+    public static final int DEFAULT_KNIGHT_VALUE = 320;
+    public static final int DEFAULT_BISHOP_VALUE = 330;
+    public static final int DEFAULT_ROOK_VALUE = 500;
+    public static final int DEFAULT_QUEEN_VALUE = 900;
+    public static final int DEFAULT_BISHOP_PAIR_BONUS = 40;
+
+    private static final TunableParameter PAWN_VALUE = TunableParameter.of("material.pawnValue", DEFAULT_PAWN_VALUE);
+    private static final TunableParameter KNIGHT_VALUE = TunableParameter.of("material.knightValue", DEFAULT_KNIGHT_VALUE);
+    private static final TunableParameter BISHOP_VALUE = TunableParameter.of("material.bishopValue", DEFAULT_BISHOP_VALUE);
+    private static final TunableParameter ROOK_VALUE = TunableParameter.of("material.rookValue", DEFAULT_ROOK_VALUE);
+    private static final TunableParameter QUEEN_VALUE = TunableParameter.of("material.queenValue", DEFAULT_QUEEN_VALUE);
+    private static final TunableParameter BISHOP_PAIR_BONUS = TunableParameter.of("material.bishopPairBonus", DEFAULT_BISHOP_PAIR_BONUS);
 
     public interface PawnChangeListener {
         void onPawnAdded(boolean isWhite, int squareIndex);
@@ -33,31 +41,58 @@ public final class MaterialModule implements EvaluationModule {
     private static final int QUEEN = MoveHelper.pieceTypeToInt(PieceType.QUEEN);
     private static final int KING = MoveHelper.pieceTypeToInt(PieceType.KING);
 
-    private static final int[] MIDGAME_VALUES = new int[7];
-    private static final int[] ENDGAME_VALUES = new int[7];
-
-    static {
-        MIDGAME_VALUES[PAWN] = PAWN_VALUE;
-        MIDGAME_VALUES[KNIGHT] = KNIGHT_VALUE;
-        MIDGAME_VALUES[BISHOP] = BISHOP_VALUE;
-        MIDGAME_VALUES[ROOK] = ROOK_VALUE;
-        MIDGAME_VALUES[QUEEN] = QUEEN_VALUE;
-
-        ENDGAME_VALUES[PAWN] = PAWN_VALUE;
-        ENDGAME_VALUES[KNIGHT] = KNIGHT_VALUE;
-        ENDGAME_VALUES[BISHOP] = BISHOP_VALUE;
-        ENDGAME_VALUES[ROOK] = ROOK_VALUE;
-        ENDGAME_VALUES[QUEEN] = QUEEN_VALUE;
-    }
+    private final int[] midgameValues = new int[7];
+    private final int[] endgameValues = new int[7];
 
     private final int[] midgameMaterial = new int[2];
     private final int[] endgameMaterial = new int[2];
     private final int[] bishopCounts = new int[2];
+    private final int bishopPairBonus;
 
     private PawnChangeListener pawnChangeListener;
     private boolean dirty = true;
     private int midgameScoreCache;
     private int endgameScoreCache;
+
+    public MaterialModule() {
+        midgameValues[PAWN] = pawnValue();
+        midgameValues[KNIGHT] = knightValue();
+        midgameValues[BISHOP] = bishopValue();
+        midgameValues[ROOK] = rookValue();
+        midgameValues[QUEEN] = queenValue();
+
+        endgameValues[PAWN] = pawnValue();
+        endgameValues[KNIGHT] = knightValue();
+        endgameValues[BISHOP] = bishopValue();
+        endgameValues[ROOK] = rookValue();
+        endgameValues[QUEEN] = queenValue();
+
+        this.bishopPairBonus = bishopPairBonus();
+    }
+
+    public static int pawnValue() {
+        return PAWN_VALUE.getInt();
+    }
+
+    public static int knightValue() {
+        return KNIGHT_VALUE.getInt();
+    }
+
+    public static int bishopValue() {
+        return BISHOP_VALUE.getInt();
+    }
+
+    public static int rookValue() {
+        return ROOK_VALUE.getInt();
+    }
+
+    public static int queenValue() {
+        return QUEEN_VALUE.getInt();
+    }
+
+    public static int bishopPairBonus() {
+        return BISHOP_PAIR_BONUS.getInt();
+    }
 
     @Override
     public void initialize(EvaluationContext context) {
@@ -183,14 +218,14 @@ public final class MaterialModule implements EvaluationModule {
         if (count <= 0 || pieceType == 0 || pieceType == KING) {
             return;
         }
-        midgameMaterial[colorIndex] += count * MIDGAME_VALUES[pieceType];
-        endgameMaterial[colorIndex] += count * ENDGAME_VALUES[pieceType];
+        midgameMaterial[colorIndex] += count * midgameValues[pieceType];
+        endgameMaterial[colorIndex] += count * endgameValues[pieceType];
         if (pieceType == BISHOP) {
             int previous = bishopCounts[colorIndex];
             bishopCounts[colorIndex] = previous + count;
             if (previous < 2 && bishopCounts[colorIndex] >= 2) {
-                midgameMaterial[colorIndex] += BISHOP_PAIR_BONUS;
-                endgameMaterial[colorIndex] += BISHOP_PAIR_BONUS;
+                midgameMaterial[colorIndex] += bishopPairBonus;
+                endgameMaterial[colorIndex] += bishopPairBonus;
             }
         }
     }
@@ -199,14 +234,14 @@ public final class MaterialModule implements EvaluationModule {
         if (pieceType == 0 || pieceType == KING) {
             return;
         }
-        midgameMaterial[colorIndex] += MIDGAME_VALUES[pieceType];
-        endgameMaterial[colorIndex] += ENDGAME_VALUES[pieceType];
+        midgameMaterial[colorIndex] += midgameValues[pieceType];
+        endgameMaterial[colorIndex] += endgameValues[pieceType];
         if (pieceType == BISHOP) {
             int previous = bishopCounts[colorIndex];
             bishopCounts[colorIndex] = previous + 1;
             if (previous == 1) {
-                midgameMaterial[colorIndex] += BISHOP_PAIR_BONUS;
-                endgameMaterial[colorIndex] += BISHOP_PAIR_BONUS;
+                midgameMaterial[colorIndex] += bishopPairBonus;
+                endgameMaterial[colorIndex] += bishopPairBonus;
             }
         }
     }
@@ -215,14 +250,14 @@ public final class MaterialModule implements EvaluationModule {
         if (pieceType == 0 || pieceType == KING) {
             return;
         }
-        midgameMaterial[colorIndex] -= MIDGAME_VALUES[pieceType];
-        endgameMaterial[colorIndex] -= ENDGAME_VALUES[pieceType];
+        midgameMaterial[colorIndex] -= midgameValues[pieceType];
+        endgameMaterial[colorIndex] -= endgameValues[pieceType];
         if (pieceType == BISHOP) {
             int previous = bishopCounts[colorIndex];
             bishopCounts[colorIndex] = previous - 1;
             if (previous == 2) {
-                midgameMaterial[colorIndex] -= BISHOP_PAIR_BONUS;
-                endgameMaterial[colorIndex] -= BISHOP_PAIR_BONUS;
+                midgameMaterial[colorIndex] -= bishopPairBonus;
+                endgameMaterial[colorIndex] -= bishopPairBonus;
             }
         }
     }

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -5,6 +5,7 @@ import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.PawnHelper;
+import julius.game.chessengine.tuning.TunableParameter;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -23,25 +24,39 @@ import static julius.game.chessengine.helper.PawnMoveTables.PAWN_PUSHES;
  */
 public final class PawnStructureModule implements EvaluationModule, MaterialModule.PawnChangeListener {
 
-    public static final int CENTER_PAWN_BONUS = 15;
-    public static final int PASSED_PAWN_BONUS = 60;
-    public static final int CONNECTED_PAWN_BONUS = 8;
-    public static final int PAWN_ISLAND_PENALTY = -5;
-    public static final int DOUBLED_PAWN_PENALTY = -12;
-    public static final int ISOLATED_PAWN_PENALTY = -10;
-    public static final int ADVANCED_PAWN_BONUS = 8;
-    public static final int BLOCKED_PAWN_PENALTY = -10;
-    public static final int BACKWARD_PAWN_PENALTY = -12;
-    public static final int OWN_KING_BLOCKS_PASSED_PAWN_PENALTY = -150;
-    public static final int PASSED_PAWN_FREE_PATH_BONUS_PER_RANK = 12;
-    public static final int ROOK_HALF_OPEN_FILE_BONUS = 15;
-    public static final int ROOK_OPEN_FILE_BONUS = 25;
+    public static final int DEFAULT_CENTER_PAWN_BONUS = 15;
+    public static final int DEFAULT_PASSED_PAWN_BONUS = 60;
+    public static final int DEFAULT_CONNECTED_PAWN_BONUS = 8;
+    public static final int DEFAULT_PAWN_ISLAND_PENALTY = -5;
+    public static final int DEFAULT_DOUBLED_PAWN_PENALTY = -12;
+    public static final int DEFAULT_ISOLATED_PAWN_PENALTY = -10;
+    public static final int DEFAULT_ADVANCED_PAWN_BONUS = 8;
+    public static final int DEFAULT_BLOCKED_PAWN_PENALTY = -10;
+    public static final int DEFAULT_BACKWARD_PAWN_PENALTY = -12;
+    public static final int DEFAULT_OWN_KING_BLOCKS_PASSED_PAWN_PENALTY = -150;
+    public static final int DEFAULT_PASSED_PAWN_FREE_PATH_BONUS_PER_RANK = 12;
+    public static final int DEFAULT_ROOK_HALF_OPEN_FILE_BONUS = 15;
+    public static final int DEFAULT_ROOK_OPEN_FILE_BONUS = 25;
+
+    private static final TunableParameter CENTER_PAWN_BONUS = TunableParameter.of("pawnStructure.centerPawnBonus", DEFAULT_CENTER_PAWN_BONUS);
+    private static final TunableParameter PASSED_PAWN_BONUS = TunableParameter.of("pawnStructure.passedPawnBonus", DEFAULT_PASSED_PAWN_BONUS);
+    private static final TunableParameter CONNECTED_PAWN_BONUS = TunableParameter.of("pawnStructure.connectedPawnBonus", DEFAULT_CONNECTED_PAWN_BONUS);
+    private static final TunableParameter PAWN_ISLAND_PENALTY = TunableParameter.of("pawnStructure.islandPenalty", DEFAULT_PAWN_ISLAND_PENALTY);
+    private static final TunableParameter DOUBLED_PAWN_PENALTY = TunableParameter.of("pawnStructure.doubledPawnPenalty", DEFAULT_DOUBLED_PAWN_PENALTY);
+    private static final TunableParameter ISOLATED_PAWN_PENALTY = TunableParameter.of("pawnStructure.isolatedPawnPenalty", DEFAULT_ISOLATED_PAWN_PENALTY);
+    private static final TunableParameter ADVANCED_PAWN_BONUS = TunableParameter.of("pawnStructure.advancedPawnBonus", DEFAULT_ADVANCED_PAWN_BONUS);
+    private static final TunableParameter BLOCKED_PAWN_PENALTY = TunableParameter.of("pawnStructure.blockedPawnPenalty", DEFAULT_BLOCKED_PAWN_PENALTY);
+    private static final TunableParameter BACKWARD_PAWN_PENALTY = TunableParameter.of("pawnStructure.backwardPawnPenalty", DEFAULT_BACKWARD_PAWN_PENALTY);
+    private static final TunableParameter OWN_KING_BLOCKS_PASSED_PAWN_PENALTY = TunableParameter.of("pawnStructure.ownKingBlocksPassedPawnPenalty", DEFAULT_OWN_KING_BLOCKS_PASSED_PAWN_PENALTY);
+    private static final TunableParameter PASSED_PAWN_FREE_PATH_BONUS_PER_RANK = TunableParameter.of("pawnStructure.passedPawnFreePathBonusPerRank", DEFAULT_PASSED_PAWN_FREE_PATH_BONUS_PER_RANK);
+    private static final TunableParameter ROOK_HALF_OPEN_FILE_BONUS = TunableParameter.of("pawnStructure.rookHalfOpenFileBonus", DEFAULT_ROOK_HALF_OPEN_FILE_BONUS);
+    private static final TunableParameter ROOK_OPEN_FILE_BONUS = TunableParameter.of("pawnStructure.rookOpenFileBonus", DEFAULT_ROOK_OPEN_FILE_BONUS);
 
     private static final int WHITE = 0;
     private static final int BLACK = 1;
     private static final int PAWN = MoveHelper.pieceTypeToInt(PieceType.PAWN);
 
-    private static final ConcurrentMap<PawnStructureKey, CachedStructure> STRUCTURE_CACHE = new ConcurrentHashMap<>();
+    private final ConcurrentMap<PawnStructureKey, CachedStructure> structureCache = new ConcurrentHashMap<>();
 
     private final FileState[] fileStates = new FileState[8];
     private final boolean[] dirtyFiles = new boolean[8];
@@ -52,11 +67,90 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     private boolean dirty = true;
     private boolean metadataDirty = true;
 
+    private final int centerPawnBonus;
+    private final int passedPawnBonus;
+    private final int connectedPawnBonus;
+    private final int pawnIslandPenalty;
+    private final int doubledPawnPenalty;
+    private final int isolatedPawnPenalty;
+    private final int advancedPawnBonus;
+    private final int blockedPawnPenalty;
+    private final int backwardPawnPenalty;
+    private final int ownKingBlocksPassedPawnPenalty;
+    private final int passedPawnFreePathBonusPerRank;
+    private final int rookHalfOpenFileBonus;
+    private final int rookOpenFileBonus;
+
     public PawnStructureModule() {
+        this.centerPawnBonus = centerPawnBonus();
+        this.passedPawnBonus = passedPawnBonus();
+        this.connectedPawnBonus = connectedPawnBonus();
+        this.pawnIslandPenalty = pawnIslandPenalty();
+        this.doubledPawnPenalty = doubledPawnPenalty();
+        this.isolatedPawnPenalty = isolatedPawnPenalty();
+        this.advancedPawnBonus = advancedPawnBonus();
+        this.blockedPawnPenalty = blockedPawnPenalty();
+        this.backwardPawnPenalty = backwardPawnPenalty();
+        this.ownKingBlocksPassedPawnPenalty = ownKingBlocksPassedPawnPenalty();
+        this.passedPawnFreePathBonusPerRank = passedPawnFreePathBonusPerRank();
+        this.rookHalfOpenFileBonus = rookHalfOpenFileBonus();
+        this.rookOpenFileBonus = rookOpenFileBonus();
         for (int file = 0; file < fileStates.length; file++) {
             fileStates[file] = new FileState(file);
             dirtyFiles[file] = true;
         }
+    }
+
+    public static int centerPawnBonus() {
+        return CENTER_PAWN_BONUS.getInt();
+    }
+
+    public static int passedPawnBonus() {
+        return PASSED_PAWN_BONUS.getInt();
+    }
+
+    public static int connectedPawnBonus() {
+        return CONNECTED_PAWN_BONUS.getInt();
+    }
+
+    public static int pawnIslandPenalty() {
+        return PAWN_ISLAND_PENALTY.getInt();
+    }
+
+    public static int doubledPawnPenalty() {
+        return DOUBLED_PAWN_PENALTY.getInt();
+    }
+
+    public static int isolatedPawnPenalty() {
+        return ISOLATED_PAWN_PENALTY.getInt();
+    }
+
+    public static int advancedPawnBonus() {
+        return ADVANCED_PAWN_BONUS.getInt();
+    }
+
+    public static int blockedPawnPenalty() {
+        return BLOCKED_PAWN_PENALTY.getInt();
+    }
+
+    public static int backwardPawnPenalty() {
+        return BACKWARD_PAWN_PENALTY.getInt();
+    }
+
+    public static int ownKingBlocksPassedPawnPenalty() {
+        return OWN_KING_BLOCKS_PASSED_PAWN_PENALTY.getInt();
+    }
+
+    public static int passedPawnFreePathBonusPerRank() {
+        return PASSED_PAWN_FREE_PATH_BONUS_PER_RANK.getInt();
+    }
+
+    public static int rookHalfOpenFileBonus() {
+        return ROOK_HALF_OPEN_FILE_BONUS.getInt();
+    }
+
+    public static int rookOpenFileBonus() {
+        return ROOK_OPEN_FILE_BONUS.getInt();
     }
 
     @Override
@@ -117,14 +211,14 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         PhaseScore blackIslands = PhaseScore.constant(structure.blackPawnIslandPenalty);
 
         PhaseScore whiteRookHalfOpen = PhaseScore.constant(
-                countHalfOpenFilesWithRooks(board, whiteRooks, true) * ROOK_HALF_OPEN_FILE_BONUS);
+                countHalfOpenFilesWithRooks(board, whiteRooks, true) * rookHalfOpenFileBonus);
         PhaseScore blackRookHalfOpen = PhaseScore.constant(
-                countHalfOpenFilesWithRooks(board, blackRooks, false) * ROOK_HALF_OPEN_FILE_BONUS);
+                countHalfOpenFilesWithRooks(board, blackRooks, false) * rookHalfOpenFileBonus);
 
         PhaseScore whiteRookOpen = PhaseScore.constant(
-                countOpenFilesWithRooks(board, whiteRooks) * ROOK_OPEN_FILE_BONUS);
+                countOpenFilesWithRooks(board, whiteRooks) * rookOpenFileBonus);
         PhaseScore blackRookOpen = PhaseScore.constant(
-                countOpenFilesWithRooks(board, blackRooks) * ROOK_OPEN_FILE_BONUS);
+                countOpenFilesWithRooks(board, blackRooks) * rookOpenFileBonus);
 
         PhaseScore whitePassed = PhaseScore.constant(
                 calculatePassedPawnBonus(whitePawns, blackPawns, allPieces, whiteKing, true));
@@ -399,12 +493,19 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         return MoveHelper.isWhitesMove(move) ? toIndex - 8 : toIndex + 8;
     }
 
-    private static CachedStructure getStructure(long whitePawns, long blackPawns) {
+    private CachedStructure getStructure(long whitePawns, long blackPawns) {
         PawnStructureKey key = new PawnStructureKey(whitePawns, blackPawns);
-        return STRUCTURE_CACHE.computeIfAbsent(key, k -> new CachedStructure(whitePawns, blackPawns));
+        return structureCache.computeIfAbsent(key, k -> new CachedStructure(
+                whitePawns,
+                blackPawns,
+                centerPawnBonus,
+                doubledPawnPenalty,
+                isolatedPawnPenalty,
+                connectedPawnBonus,
+                pawnIslandPenalty));
     }
 
-    private static int calculatePawnAdvanceBonus(long pawns, long allPieces, long enemyAttacks, boolean isWhite, int phase) {
+    private int calculatePawnAdvanceBonus(long pawns, long allPieces, long enemyAttacks, boolean isWhite, int phase) {
         int bonus = 0;
         long advancedRanks = isWhite
                 ? (RankMasks[3] | RankMasks[4] | RankMasks[5] | RankMasks[6])
@@ -416,21 +517,21 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
             if ((forward & (allPieces | enemyAttacks)) == 0) {
                 int rank = square / 8 + 1;
                 int rankBonus = isWhite ? (rank - 3) : (6 - rank);
-                bonus += ADVANCED_PAWN_BONUS * rankBonus;
+                bonus += advancedPawnBonus * rankBonus;
             }
             advancedPawns &= advancedPawns - 1;
         }
         return scaleByPhase(bonus, phase);
     }
 
-    private static int calculateBlockedPawnPenalty(long pawns, long allPieces, boolean isWhite, int phase) {
+    private int calculateBlockedPawnPenalty(long pawns, long allPieces, boolean isWhite, int phase) {
         int penalty = 0;
         long remaining = pawns;
         while (remaining != 0) {
             int square = Long.numberOfTrailingZeros(remaining);
             long forward = PAWN_PUSHES[isWhite ? WHITE : BLACK][square];
             if ((forward & allPieces) != 0) {
-                penalty += BLOCKED_PAWN_PENALTY;
+                penalty += blockedPawnPenalty;
             }
             remaining &= remaining - 1;
         }
@@ -481,7 +582,7 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         return total;
     }
 
-    private static int calculatePassedPawnBonus(long pawns, long opponentPawns, long allPieces, long ownKing, boolean isWhite) {
+    private int calculatePassedPawnBonus(long pawns, long opponentPawns, long allPieces, long ownKing, boolean isWhite) {
         int bonus = 0;
         long remaining = pawns;
 
@@ -518,18 +619,18 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
                 continue;
             }
 
-            int base = PASSED_PAWN_BONUS * (isWhite ? (rank - 1) : (8 - rank));
+            int base = passedPawnBonus * (isWhite ? (rank - 1) : (8 - rank));
 
             long filePathAhead = fileMask & forwardRanksMask;
             long oneStep = isWhite ? (pawn << 8) : (pawn >>> 8);
 
             if ((oneStep & ownKing) != 0L) {
-                base += OWN_KING_BLOCKS_PASSED_PAWN_PENALTY;
+                base += ownKingBlocksPassedPawnPenalty;
             }
 
             if ((filePathAhead & allPieces) == 0L) {
                 int distToPromo = isWhite ? (8 - rank) : (rank - 1);
-                base += PASSED_PAWN_FREE_PATH_BONUS_PER_RANK * distToPromo;
+                base += passedPawnFreePathBonusPerRank * distToPromo;
             }
 
             bonus += base;
@@ -557,17 +658,23 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         private final int whitePawnIslandPenalty;
         private final int blackPawnIslandPenalty;
 
-        private CachedStructure(long whitePawns, long blackPawns) {
-            this.whiteCenterPawnBonus = PawnHelper.countCenterPawns(whitePawns) * CENTER_PAWN_BONUS;
-            this.blackCenterPawnBonus = PawnHelper.countCenterPawns(blackPawns) * CENTER_PAWN_BONUS;
-            this.whiteDoubledPawnPenalty = PawnHelper.countDoubledPawns(whitePawns) * DOUBLED_PAWN_PENALTY;
-            this.blackDoubledPawnPenalty = PawnHelper.countDoubledPawns(blackPawns) * DOUBLED_PAWN_PENALTY;
-            this.whiteIsolatedPawnPenalty = PawnHelper.countIsolatedPawns(whitePawns) * ISOLATED_PAWN_PENALTY;
-            this.blackIsolatedPawnPenalty = PawnHelper.countIsolatedPawns(blackPawns) * ISOLATED_PAWN_PENALTY;
-            this.whiteConnectedPawnBonus = PawnHelper.countConnectedPawns(whitePawns) * CONNECTED_PAWN_BONUS;
-            this.blackConnectedPawnBonus = PawnHelper.countConnectedPawns(blackPawns) * CONNECTED_PAWN_BONUS;
-            this.whitePawnIslandPenalty = Math.max(0, PawnHelper.countPawnIslands(whitePawns) - 1) * PAWN_ISLAND_PENALTY;
-            this.blackPawnIslandPenalty = Math.max(0, PawnHelper.countPawnIslands(blackPawns) - 1) * PAWN_ISLAND_PENALTY;
+        private CachedStructure(long whitePawns,
+                                long blackPawns,
+                                int centerBonus,
+                                int doubledPenalty,
+                                int isolatedPenalty,
+                                int connectedBonus,
+                                int islandPenalty) {
+            this.whiteCenterPawnBonus = PawnHelper.countCenterPawns(whitePawns) * centerBonus;
+            this.blackCenterPawnBonus = PawnHelper.countCenterPawns(blackPawns) * centerBonus;
+            this.whiteDoubledPawnPenalty = PawnHelper.countDoubledPawns(whitePawns) * doubledPenalty;
+            this.blackDoubledPawnPenalty = PawnHelper.countDoubledPawns(blackPawns) * doubledPenalty;
+            this.whiteIsolatedPawnPenalty = PawnHelper.countIsolatedPawns(whitePawns) * isolatedPenalty;
+            this.blackIsolatedPawnPenalty = PawnHelper.countIsolatedPawns(blackPawns) * isolatedPenalty;
+            this.whiteConnectedPawnBonus = PawnHelper.countConnectedPawns(whitePawns) * connectedBonus;
+            this.blackConnectedPawnBonus = PawnHelper.countConnectedPawns(blackPawns) * connectedBonus;
+            this.whitePawnIslandPenalty = Math.max(0, PawnHelper.countPawnIslands(whitePawns) - 1) * islandPenalty;
+            this.blackPawnIslandPenalty = Math.max(0, PawnHelper.countPawnIslands(blackPawns) - 1) * islandPenalty;
         }
     }
 

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -548,7 +548,7 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
                 int forwardIndex = Long.numberOfTrailingZeros(forward);
                 long enemyAttack = PAWN_ATTACKS[isWhite ? WHITE : BLACK][forwardIndex] & enemyPawns;
                 if (enemyAttack != 0) {
-                    penalty += BACKWARD_PAWN_PENALTY;
+                    penalty += BACKWARD_PAWN_PENALTY.getInt();
                 }
             }
             remaining &= remaining - 1;

--- a/src/main/java/julius/game/chessengine/evaluation/PieceSquareModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PieceSquareModule.java
@@ -6,12 +6,8 @@ import java.util.Objects;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
+import julius.game.chessengine.tuning.TunableParameter;
 
-import static julius.game.chessengine.evaluation.MaterialModule.BISHOP_VALUE;
-import static julius.game.chessengine.evaluation.MaterialModule.KNIGHT_VALUE;
-import static julius.game.chessengine.evaluation.MaterialModule.PAWN_VALUE;
-import static julius.game.chessengine.evaluation.MaterialModule.QUEEN_VALUE;
-import static julius.game.chessengine.evaluation.MaterialModule.ROOK_VALUE;
 import static julius.game.chessengine.helper.BishopHelper.BISHOP_ENDGAME_POSITIONAL_VALUES;
 import static julius.game.chessengine.helper.BishopHelper.BISHOP_MIDGAME_POSITIONAL_VALUES;
 import static julius.game.chessengine.helper.BitHelper.FileMasks;
@@ -47,15 +43,25 @@ public final class PieceSquareModule implements EvaluationModule {
     private static final int QUEEN = MoveHelper.pieceTypeToInt(PieceType.QUEEN);
     private static final int KING = MoveHelper.pieceTypeToInt(PieceType.KING);
 
-    private static final int DEVELOPMENT_PHASE_THRESHOLD = 64;
-    private static final int QUEEN_DEVELOPMENT_PHASE_THRESHOLD = 80;
-    private static final int UNDEVELOPED_MINOR_PENALTY = -20;
-    private static final int EARLY_QUEEN_DEVELOPMENT_PENALTY_PER_MINOR = -15;
-    private static final int MIN_UNDEVELOPED_MINORS_FOR_QUEEN_PENALTY = 2;
-    private static final int START_POSITION_PENALTY = -40;
-    private static final int BLEND_SCALE = 256;
-    private static final int CASTLING_BONUS = 20;
-    private static final int NOT_CASTLED_AND_ROOK_MOVE_PENALTY = -10;
+    private static final int DEFAULT_DEVELOPMENT_PHASE_THRESHOLD = 64;
+    private static final int DEFAULT_QUEEN_DEVELOPMENT_PHASE_THRESHOLD = 80;
+    private static final int DEFAULT_UNDEVELOPED_MINOR_PENALTY = -20;
+    private static final int DEFAULT_EARLY_QUEEN_DEVELOPMENT_PENALTY_PER_MINOR = -15;
+    private static final int DEFAULT_MIN_UNDEVELOPED_MINORS_FOR_QUEEN_PENALTY = 2;
+    private static final int DEFAULT_START_POSITION_PENALTY = -40;
+    private static final int DEFAULT_BLEND_SCALE = 256;
+    private static final int DEFAULT_CASTLING_BONUS = 20;
+    private static final int DEFAULT_NOT_CASTLED_AND_ROOK_MOVE_PENALTY = -10;
+
+    private static final TunableParameter DEVELOPMENT_PHASE_THRESHOLD = TunableParameter.of("pieceSquare.developmentPhaseThreshold", DEFAULT_DEVELOPMENT_PHASE_THRESHOLD, 0, 256);
+    private static final TunableParameter QUEEN_DEVELOPMENT_PHASE_THRESHOLD = TunableParameter.of("pieceSquare.queenDevelopmentPhaseThreshold", DEFAULT_QUEEN_DEVELOPMENT_PHASE_THRESHOLD, 0, 256);
+    private static final TunableParameter UNDEVELOPED_MINOR_PENALTY = TunableParameter.of("pieceSquare.undevelopedMinorPenalty", DEFAULT_UNDEVELOPED_MINOR_PENALTY);
+    private static final TunableParameter EARLY_QUEEN_DEVELOPMENT_PENALTY_PER_MINOR = TunableParameter.of("pieceSquare.earlyQueenDevelopmentPenaltyPerMinor", DEFAULT_EARLY_QUEEN_DEVELOPMENT_PENALTY_PER_MINOR);
+    private static final TunableParameter MIN_UNDEVELOPED_MINORS_FOR_QUEEN_PENALTY = TunableParameter.of("pieceSquare.minUndevelopedMinorsForQueenPenalty", DEFAULT_MIN_UNDEVELOPED_MINORS_FOR_QUEEN_PENALTY, 0, 8);
+    private static final TunableParameter START_POSITION_PENALTY = TunableParameter.of("pieceSquare.startPositionPenalty", DEFAULT_START_POSITION_PENALTY);
+    private static final TunableParameter BLEND_SCALE = TunableParameter.of("pieceSquare.blendScale", DEFAULT_BLEND_SCALE, 1, 1024);
+    private static final TunableParameter CASTLING_BONUS = TunableParameter.of("pieceSquare.castlingBonus", DEFAULT_CASTLING_BONUS);
+    private static final TunableParameter NOT_CASTLED_AND_ROOK_MOVE_PENALTY = TunableParameter.of("pieceSquare.notCastledRookMovePenalty", DEFAULT_NOT_CASTLED_AND_ROOK_MOVE_PENALTY);
 
     private static final long NOT_A_FILE = ~FileMasks[0];
     private static final long NOT_H_FILE = ~FileMasks[7];
@@ -130,6 +136,16 @@ public final class PieceSquareModule implements EvaluationModule {
     private final int[] queenCount = new int[2];
     private final boolean[] queenOnStart = new boolean[2];
 
+    private final int developmentPhaseThreshold;
+    private final int queenDevelopmentPhaseThreshold;
+    private final int undevelopedMinorPenalty;
+    private final int earlyQueenDevelopmentPenaltyPerMinor;
+    private final int minUndevelopedMinorsForQueenPenalty;
+    private final int startPositionPenalty;
+    private final int blendScale;
+    private final int castlingBonus;
+    private final int notCastledRookMovePenalty;
+
     private int midgameTotal;
     private int endgameTotal;
     private int developmentContribution;
@@ -141,7 +157,28 @@ public final class PieceSquareModule implements EvaluationModule {
     private boolean castlingDirty = true;
 
     public PieceSquareModule() {
+        this.developmentPhaseThreshold = DEVELOPMENT_PHASE_THRESHOLD.getInt();
+        this.queenDevelopmentPhaseThreshold = QUEEN_DEVELOPMENT_PHASE_THRESHOLD.getInt();
+        this.undevelopedMinorPenalty = UNDEVELOPED_MINOR_PENALTY.getInt();
+        this.earlyQueenDevelopmentPenaltyPerMinor = EARLY_QUEEN_DEVELOPMENT_PENALTY_PER_MINOR.getInt();
+        this.minUndevelopedMinorsForQueenPenalty = MIN_UNDEVELOPED_MINORS_FOR_QUEEN_PENALTY.getInt();
+        this.startPositionPenalty = START_POSITION_PENALTY.getInt();
+        this.blendScale = BLEND_SCALE.getInt();
+        this.castlingBonus = CASTLING_BONUS.getInt();
+        this.notCastledRookMovePenalty = NOT_CASTLED_AND_ROOK_MOVE_PENALTY.getInt();
         Arrays.fill(occupantColor, -1);
+    }
+
+    public static int castlingBonus() {
+        return CASTLING_BONUS.getInt();
+    }
+
+    public static int notCastledRookMovePenalty() {
+        return NOT_CASTLED_AND_ROOK_MOVE_PENALTY.getInt();
+    }
+
+    public static int blendScale() {
+        return BLEND_SCALE.getInt();
     }
 
     @Override
@@ -465,25 +502,25 @@ public final class PieceSquareModule implements EvaluationModule {
     }
 
     private void recalculateDevelopmentContribution() {
-        int whiteStart = (minorPiecesAtHome[WHITE] + rooksAtHome[WHITE] == 6) ? START_POSITION_PENALTY : 0;
-        int blackStart = (minorPiecesAtHome[BLACK] + rooksAtHome[BLACK] == 6) ? START_POSITION_PENALTY : 0;
+        int whiteStart = (minorPiecesAtHome[WHITE] + rooksAtHome[WHITE] == 6) ? startPositionPenalty : 0;
+        int blackStart = (minorPiecesAtHome[BLACK] + rooksAtHome[BLACK] == 6) ? startPositionPenalty : 0;
 
-        int whiteMinor = currentPhase >= DEVELOPMENT_PHASE_THRESHOLD
-                ? minorPiecesAtHome[WHITE] * UNDEVELOPED_MINOR_PENALTY : 0;
-        int blackMinor = currentPhase >= DEVELOPMENT_PHASE_THRESHOLD
-                ? minorPiecesAtHome[BLACK] * UNDEVELOPED_MINOR_PENALTY : 0;
+        int whiteMinor = currentPhase >= developmentPhaseThreshold
+                ? minorPiecesAtHome[WHITE] * undevelopedMinorPenalty : 0;
+        int blackMinor = currentPhase >= developmentPhaseThreshold
+                ? minorPiecesAtHome[BLACK] * undevelopedMinorPenalty : 0;
 
         int whiteQueen = 0;
-        if (currentPhase <= QUEEN_DEVELOPMENT_PHASE_THRESHOLD && queenCount[WHITE] > 0 && !queenOnStart[WHITE]) {
-            if (minorPiecesAtHome[WHITE] >= MIN_UNDEVELOPED_MINORS_FOR_QUEEN_PENALTY) {
-                whiteQueen = minorPiecesAtHome[WHITE] * EARLY_QUEEN_DEVELOPMENT_PENALTY_PER_MINOR;
+        if (currentPhase <= queenDevelopmentPhaseThreshold && queenCount[WHITE] > 0 && !queenOnStart[WHITE]) {
+            if (minorPiecesAtHome[WHITE] >= minUndevelopedMinorsForQueenPenalty) {
+                whiteQueen = minorPiecesAtHome[WHITE] * earlyQueenDevelopmentPenaltyPerMinor;
             }
         }
 
         int blackQueen = 0;
-        if (currentPhase <= QUEEN_DEVELOPMENT_PHASE_THRESHOLD && queenCount[BLACK] > 0 && !queenOnStart[BLACK]) {
-            if (minorPiecesAtHome[BLACK] >= MIN_UNDEVELOPED_MINORS_FOR_QUEEN_PENALTY) {
-                blackQueen = minorPiecesAtHome[BLACK] * EARLY_QUEEN_DEVELOPMENT_PENALTY_PER_MINOR;
+        if (currentPhase <= queenDevelopmentPhaseThreshold && queenCount[BLACK] > 0 && !queenOnStart[BLACK]) {
+            if (minorPiecesAtHome[BLACK] >= minUndevelopedMinorsForQueenPenalty) {
+                blackQueen = minorPiecesAtHome[BLACK] * earlyQueenDevelopmentPenaltyPerMinor;
             }
         }
 
@@ -555,8 +592,8 @@ public final class PieceSquareModule implements EvaluationModule {
         if (king == 0L) {
             return 0;
         }
-        int castlingBonus = CASTLING_BONUS * (BLEND_SCALE - phase) / BLEND_SCALE;
-        int rookMovePenalty = NOT_CASTLED_AND_ROOK_MOVE_PENALTY * (BLEND_SCALE - phase) / BLEND_SCALE;
+        int castlingBonusValue = castlingBonus * (blendScale - phase) / blendScale;
+        int rookMovePenalty = notCastledRookMovePenalty * (blendScale - phase) / blendScale;
         if (white) {
             if (materialBalance < 0) {
                 rookMovePenalty /= 2;
@@ -597,7 +634,7 @@ public final class PieceSquareModule implements EvaluationModule {
 
         int adjustment = 0;
         if (hasCastled) {
-            adjustment += castlingBonus;
+            adjustment += castlingBonusValue;
         } else if (applyPenalty) {
             if (rookAFileMoved) {
                 adjustment += rookMovePenalty;
@@ -613,16 +650,16 @@ public final class PieceSquareModule implements EvaluationModule {
     }
 
     private static int computeMaterialBalance(ImmutableBoardView board) {
-        int whiteMaterial = Long.bitCount(board.getWhitePawns()) * PAWN_VALUE
-                + Long.bitCount(board.getWhiteKnights()) * KNIGHT_VALUE
-                + Long.bitCount(board.getWhiteBishops()) * BISHOP_VALUE
-                + Long.bitCount(board.getWhiteRooks()) * ROOK_VALUE
-                + Long.bitCount(board.getWhiteQueens()) * QUEEN_VALUE;
-        int blackMaterial = Long.bitCount(board.getBlackPawns()) * PAWN_VALUE
-                + Long.bitCount(board.getBlackKnights()) * KNIGHT_VALUE
-                + Long.bitCount(board.getBlackBishops()) * BISHOP_VALUE
-                + Long.bitCount(board.getBlackRooks()) * ROOK_VALUE
-                + Long.bitCount(board.getBlackQueens()) * QUEEN_VALUE;
+        int whiteMaterial = Long.bitCount(board.getWhitePawns()) * MaterialModule.pawnValue()
+                + Long.bitCount(board.getWhiteKnights()) * MaterialModule.knightValue()
+                + Long.bitCount(board.getWhiteBishops()) * MaterialModule.bishopValue()
+                + Long.bitCount(board.getWhiteRooks()) * MaterialModule.rookValue()
+                + Long.bitCount(board.getWhiteQueens()) * MaterialModule.queenValue();
+        int blackMaterial = Long.bitCount(board.getBlackPawns()) * MaterialModule.pawnValue()
+                + Long.bitCount(board.getBlackKnights()) * MaterialModule.knightValue()
+                + Long.bitCount(board.getBlackBishops()) * MaterialModule.bishopValue()
+                + Long.bitCount(board.getBlackRooks()) * MaterialModule.rookValue()
+                + Long.bitCount(board.getBlackQueens()) * MaterialModule.queenValue();
         return whiteMaterial - blackMaterial;
     }
 

--- a/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
@@ -3,6 +3,7 @@ package julius.game.chessengine.evaluation;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
+import julius.game.chessengine.tuning.TunableParameter;
 
 import java.util.Objects;
 
@@ -25,20 +26,31 @@ public final class ThreatModule implements EvaluationModule {
     private static final int QUEEN = MoveHelper.pieceTypeToInt(PieceType.QUEEN);
     private static final int KING = MoveHelper.pieceTypeToInt(PieceType.KING);
 
-    private static final int[] HANGING_PENALTIES = new int[7];
-    private static final int[] PAWN_THREAT_PENALTIES = new int[7];
+    private static final TunableParameter HANGING_PAWN_PENALTY = TunableParameter.of("threat.hangingPawnPenalty", -12);
+    private static final TunableParameter HANGING_KNIGHT_PENALTY = TunableParameter.of("threat.hangingKnightPenalty", -30);
+    private static final TunableParameter HANGING_BISHOP_PENALTY = TunableParameter.of("threat.hangingBishopPenalty", -30);
+    private static final TunableParameter HANGING_ROOK_PENALTY = TunableParameter.of("threat.hangingRookPenalty", -45);
+    private static final TunableParameter HANGING_QUEEN_PENALTY = TunableParameter.of("threat.hangingQueenPenalty", -70);
 
-    static {
-        HANGING_PENALTIES[PAWN] = -12;
-        HANGING_PENALTIES[KNIGHT] = -30;
-        HANGING_PENALTIES[BISHOP] = -30;
-        HANGING_PENALTIES[ROOK] = -45;
-        HANGING_PENALTIES[QUEEN] = -70;
+    private static final TunableParameter PAWN_THREAT_KNIGHT_PENALTY = TunableParameter.of("threat.pawnThreatKnightPenalty", -10);
+    private static final TunableParameter PAWN_THREAT_BISHOP_PENALTY = TunableParameter.of("threat.pawnThreatBishopPenalty", -10);
+    private static final TunableParameter PAWN_THREAT_ROOK_PENALTY = TunableParameter.of("threat.pawnThreatRookPenalty", -18);
+    private static final TunableParameter PAWN_THREAT_QUEEN_PENALTY = TunableParameter.of("threat.pawnThreatQueenPenalty", -25);
 
-        PAWN_THREAT_PENALTIES[KNIGHT] = -10;
-        PAWN_THREAT_PENALTIES[BISHOP] = -10;
-        PAWN_THREAT_PENALTIES[ROOK] = -18;
-        PAWN_THREAT_PENALTIES[QUEEN] = -25;
+    private final int[] hangingPenalties = new int[7];
+    private final int[] pawnThreatPenalties = new int[7];
+
+    public ThreatModule() {
+        hangingPenalties[PAWN] = HANGING_PAWN_PENALTY.getInt();
+        hangingPenalties[KNIGHT] = HANGING_KNIGHT_PENALTY.getInt();
+        hangingPenalties[BISHOP] = HANGING_BISHOP_PENALTY.getInt();
+        hangingPenalties[ROOK] = HANGING_ROOK_PENALTY.getInt();
+        hangingPenalties[QUEEN] = HANGING_QUEEN_PENALTY.getInt();
+
+        pawnThreatPenalties[KNIGHT] = PAWN_THREAT_KNIGHT_PENALTY.getInt();
+        pawnThreatPenalties[BISHOP] = PAWN_THREAT_BISHOP_PENALTY.getInt();
+        pawnThreatPenalties[ROOK] = PAWN_THREAT_ROOK_PENALTY.getInt();
+        pawnThreatPenalties[QUEEN] = PAWN_THREAT_QUEEN_PENALTY.getInt();
     }
 
     private int midgameScoreCache;
@@ -136,9 +148,9 @@ public final class ThreatModule implements EvaluationModule {
                 continue;
             }
 
-            penalty += HANGING_PENALTIES[typeBits];
+            penalty += hangingPenalties[typeBits];
             if (typeBits > PAWN && (enemyPawnAttacks & mask) != 0) {
-                penalty += PAWN_THREAT_PENALTIES[typeBits];
+                penalty += pawnThreatPenalties[typeBits];
             }
             remaining ^= bit;
         }

--- a/src/main/java/julius/game/chessengine/tuning/AiTuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/AiTuning.java
@@ -64,47 +64,7 @@ public final class AiTuning {
 
     public AiTuning mutate(Random random, double strength) {
         Objects.requireNonNull(random, "random");
-        if (strength <= 0.0) {
-            return this;
-        }
-        Builder mutated = toBuilder();
-        mutated.hashSizeMb = mutateInt(hashSizeMb, 1, 4096, random, strength);
-        mutated.maxDepth = mutateInt(maxDepth, 4, 96, random, strength);
-        mutated.timeLimitMillis = mutateLong(timeLimitMillis, 5L, 10_000L, random, strength);
-        mutated.nullMovePruning = random.nextDouble() < strength ? !nullMovePruning : nullMovePruning;
-        return mutated.build();
-    }
-
-    private static int mutateInt(int value, int min, int max, Random random, double strength) {
-        double factor = gaussianFactor(random, strength);
-        int mutated = (int) Math.round(value * factor);
-        if (mutated < min) {
-            mutated = min;
-        } else if (mutated > max) {
-            mutated = max;
-        }
-        return mutated;
-    }
-
-    private static long mutateLong(long value, long min, long max, Random random, double strength) {
-        double factor = gaussianFactor(random, strength);
-        long mutated = Math.round(value * factor);
-        if (mutated < min) {
-            mutated = min;
-        } else if (mutated > max) {
-            mutated = max;
-        }
-        return mutated;
-    }
-
-    private static double gaussianFactor(Random random, double strength) {
-        double variance = Math.max(0.05, strength);
-        double offset = random.nextGaussian() * variance;
-        double factor = 1.0 + offset;
-        if (factor < 0.25) {
-            factor = 0.25;
-        }
-        return factor;
+        return this;
     }
 
     public static final class Builder {

--- a/src/main/java/julius/game/chessengine/tuning/EngineTuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuning.java
@@ -2,6 +2,8 @@ package julius.game.chessengine.tuning;
 
 import julius.game.chessengine.evaluation.EvaluationWeights;
 
+import julius.game.chessengine.evaluation.EvaluationParameterRegistry;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -96,9 +98,11 @@ public final class EngineTuning {
         private String name = "baseline";
         private AiTuning ai = AiTuning.defaults();
         private EvaluationTuning evaluation = EvaluationTuning.identity();
-        private Map<String, Double> numericParameters = Collections.emptyMap();
+        private Map<String, Double> numericParameters;
 
         private Builder() {
+            EvaluationParameterRegistry.initialize();
+            this.numericParameters = NumericTuningParameters.defaults();
         }
 
         private Builder(EngineTuning source) {
@@ -127,12 +131,13 @@ public final class EngineTuning {
 
         public Builder numericParameters(Map<String, Double> parameters) {
             if (parameters == null || parameters.isEmpty()) {
-                this.numericParameters = Collections.emptyMap();
+                this.numericParameters = NumericTuningParameters.defaults();
             } else {
                 Map<String, Double> normalized = new LinkedHashMap<>();
                 parameters.forEach((k, v) -> {
-                    if (k != null && !k.isBlank() && v != null) {
-                        normalized.put(k.toLowerCase(Locale.ROOT), v);
+                    if (k != null && !k.isBlank() && v != null && !v.isNaN()) {
+                        String key = NumericTuningParameters.normalizeKey(k);
+                        normalized.put(key, v);
                     }
                 });
                 this.numericParameters = Collections.unmodifiableMap(normalized);

--- a/src/main/java/julius/game/chessengine/tuning/MatchRunner.java
+++ b/src/main/java/julius/game/chessengine/tuning/MatchRunner.java
@@ -84,7 +84,8 @@ public final class MatchRunner {
     }
 
     private Engine createEngineForTuning(EngineTuning tuning) {
-        try (AutoCloseable ignored = Score.useEvaluationWeights(tuning.evaluationWeights())) {
+        try (AutoCloseable weights = Score.useEvaluationWeights(tuning.evaluationWeights());
+             AutoCloseable numeric = Score.useNumericParameters(tuning.numericParameters())) {
             return new Engine();
         } catch (Exception e) {
             if (e instanceof RuntimeException runtime) {

--- a/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
@@ -1,0 +1,92 @@
+package julius.game.chessengine.tuning;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Central registry for numeric tuning parameters. Supports thread-local overrides so that
+ * independent searches can evaluate different parameter sets concurrently.
+ */
+public final class NumericTuningParameters {
+
+    private static final Map<String, Double> DEFAULTS = new LinkedHashMap<>();
+    private static final ThreadLocal<Map<String, Double>> THREAD_PARAMETERS = new ThreadLocal<>();
+    private static volatile Map<String, Double> GLOBAL_PARAMETERS = Map.of();
+
+    private NumericTuningParameters() {
+    }
+
+    static synchronized void registerDefault(String key, double defaultValue) {
+        DEFAULTS.putIfAbsent(key, defaultValue);
+    }
+
+    static double resolve(String key, double defaultValue) {
+        Objects.requireNonNull(key, "key");
+        String normalized = normalizeKey(key);
+        Map<String, Double> local = THREAD_PARAMETERS.get();
+        if (local != null) {
+            Double value = local.get(normalized);
+            if (value != null) {
+                return value;
+            }
+        }
+        Double global = GLOBAL_PARAMETERS.get(normalized);
+        if (global != null) {
+            return global;
+        }
+        synchronized (DEFAULTS) {
+            return DEFAULTS.getOrDefault(normalized, defaultValue);
+        }
+    }
+
+    static Map<String, Double> defaults() {
+        synchronized (DEFAULTS) {
+            return Collections.unmodifiableMap(new LinkedHashMap<>(DEFAULTS));
+        }
+    }
+
+    public static AutoCloseable use(Map<String, Double> parameters) {
+        Map<String, Double> normalized = normalize(parameters);
+        Map<String, Double> previous = THREAD_PARAMETERS.get();
+        THREAD_PARAMETERS.set(normalized);
+        return () -> {
+            if (previous == null) {
+                THREAD_PARAMETERS.remove();
+            } else {
+                THREAD_PARAMETERS.set(previous);
+            }
+        };
+    }
+
+    public static void setGlobal(Map<String, Double> parameters) {
+        GLOBAL_PARAMETERS = normalize(parameters);
+    }
+
+    private static Map<String, Double> normalize(Map<String, Double> parameters) {
+        if (parameters == null || parameters.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Double> normalized = new LinkedHashMap<>();
+        parameters.forEach((key, value) -> {
+            if (key == null || key.isBlank() || value == null || value.isNaN()) {
+                return;
+            }
+            normalized.put(normalizeKey(key), value);
+        });
+        return Collections.unmodifiableMap(normalized);
+    }
+
+    static String normalizeKey(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("Key must not be null");
+        }
+        String normalized = key.trim().toLowerCase(Locale.ROOT);
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("Key must not be blank");
+        }
+        return normalized;
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/TunableParameter.java
+++ b/src/main/java/julius/game/chessengine/tuning/TunableParameter.java
@@ -1,0 +1,66 @@
+package julius.game.chessengine.tuning;
+
+/**
+ * Represents a single numeric evaluation parameter that can be tuned. Instances register their
+ * default value with {@link NumericTuningParameters} so that tuning seeds can start from the
+ * current handcrafted values.
+ */
+public final class TunableParameter {
+
+    private final String key;
+    private final double defaultValue;
+    private final Double minValue;
+    private final Double maxValue;
+
+    private TunableParameter(String key, double defaultValue, Double minValue, Double maxValue) {
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("Parameter key must not be blank");
+        }
+        this.key = NumericTuningParameters.normalizeKey(key);
+        this.defaultValue = defaultValue;
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+        NumericTuningParameters.registerDefault(this.key, defaultValue);
+    }
+
+    public static TunableParameter of(String key, double defaultValue) {
+        return new TunableParameter(key, defaultValue, null, null);
+    }
+
+    public static TunableParameter of(String key, double defaultValue, double minValue, double maxValue) {
+        if (minValue > maxValue) {
+            throw new IllegalArgumentException("Min value cannot exceed max value");
+        }
+        return new TunableParameter(key, defaultValue, minValue, maxValue);
+    }
+
+    public double get() {
+        double value = NumericTuningParameters.resolve(key, defaultValue);
+        if (!Double.isFinite(value)) {
+            value = defaultValue;
+        }
+        if (minValue != null && value < minValue) {
+            value = minValue;
+        }
+        if (maxValue != null && value > maxValue) {
+            value = maxValue;
+        }
+        return value;
+    }
+
+    public int getInt() {
+        return (int) Math.round(get());
+    }
+
+    public long getLong() {
+        return Math.round(get());
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public double defaultValue() {
+        return defaultValue;
+    }
+}

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -13,9 +13,11 @@ import julius.game.chessengine.evaluation.MoveContext;
 import julius.game.chessengine.evaluation.PawnStructureModule;
 import julius.game.chessengine.evaluation.PieceSquareModule;
 import julius.game.chessengine.evaluation.ThreatModule;
+import julius.game.chessengine.tuning.NumericTuningParameters;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Map;
 
 /**
  * Central entry point for the evaluation pipeline.  The legacy score bookkeeping previously
@@ -116,6 +118,10 @@ public class Score {
 
     public static AutoCloseable useEvaluationWeights(EvaluationWeights weights) {
         return useFactory(forEvaluationWeights(weights));
+    }
+
+    public static AutoCloseable useNumericParameters(Map<String, Double> parameters) {
+        return NumericTuningParameters.use(parameters);
     }
 
     public static ScoreFactory forEvaluationWeights(EvaluationWeights weights) {
@@ -228,11 +234,11 @@ public class Score {
 
     public static int getPieceValue(int pieceTypeBits) {
         return switch (pieceTypeBits) {
-            case 1 -> MaterialModule.PAWN_VALUE / 100;
-            case 2 -> MaterialModule.KNIGHT_VALUE / 100;
-            case 3 -> MaterialModule.BISHOP_VALUE / 100;
-            case 4 -> MaterialModule.ROOK_VALUE / 100;
-            case 5 -> MaterialModule.QUEEN_VALUE / 100;
+            case 1 -> MaterialModule.pawnValue() / 100;
+            case 2 -> MaterialModule.knightValue() / 100;
+            case 3 -> MaterialModule.bishopValue() / 100;
+            case 4 -> MaterialModule.rookValue() / 100;
+            case 5 -> MaterialModule.queenValue() / 100;
             case 6 -> 1000;
             default -> throw new IllegalStateException("Unexpected value: " + pieceTypeBits);
         };

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -1,33 +1,163 @@
 population:
-  - name: baseline
-    ai:
-      searchThreads: 1
-      lazySmpThreads: 1
-      hashSizeMb: 32
-      maxDepth: 32
-      timeLimitMillis: 50
-      nullMovePruning: true
+  -
+    name: aggressive
     evaluation:
       modules:
-        MaterialModule:
-          midgame: 1.0
-          endgame: 1.0
-        PawnStructureModule:
-          midgame: 1.0
-          endgame: 1.0
-  - name: aggressive
-    ai:
-      searchThreads: 1
-      lazySmpThreads: 1
-      hashSizeMb: 64
-      maxDepth: 36
-      timeLimitMillis: 75
-      nullMovePruning: true
-    evaluation:
-      modules:
-        MaterialModule:
+        materialmodule:
           midgame: 1.05
           endgame: 1.0
-        ThreatModule:
+        threatmodule:
           midgame: 1.2
           endgame: 1.1
+    numericParameters:
+      material.pawnvalue: 100.0
+      material.knightvalue: 320.0
+      material.bishopvalue: 330.0
+      material.rookvalue: 500.0
+      material.queenvalue: 900.0
+      material.bishoppairbonus: 40.0
+      pawnstructure.centerpawnbonus: 15.0
+      pawnstructure.passedpawnbonus: 60.0
+      pawnstructure.connectedpawnbonus: 8.0
+      pawnstructure.islandpenalty: -5.0
+      pawnstructure.doubledpawnpenalty: -12.0
+      pawnstructure.isolatedpawnpenalty: -10.0
+      pawnstructure.advancedpawnbonus: 8.0
+      pawnstructure.blockedpawnpenalty: -10.0
+      pawnstructure.backwardpawnpenalty: -12.0
+      pawnstructure.ownkingblockspassedpawnpenalty: -150.0
+      pawnstructure.passedpawnfreepathbonusperrank: 12.0
+      pawnstructure.rookhalfopenfilebonus: 15.0
+      pawnstructure.rookopenfilebonus: 25.0
+      piecesquare.developmentphasethreshold: 64.0
+      piecesquare.queendevelopmentphasethreshold: 80.0
+      piecesquare.undevelopedminorpenalty: -20.0
+      piecesquare.earlyqueendevelopmentpenaltyperminor: -15.0
+      piecesquare.minundevelopedminorsforqueenpenalty: 2.0
+      piecesquare.startpositionpenalty: -40.0
+      piecesquare.blendscale: 256.0
+      piecesquare.castlingbonus: 20.0
+      piecesquare.notcastledrookmovepenalty: -10.0
+      activity.midgamemobilityknight: 2.0
+      activity.midgamemobilitybishop: 4.0
+      activity.midgamemobilityrook: 2.0
+      activity.midgamemobilityqueen: 1.0
+      activity.midgamemobilityking: 0.0
+      activity.endgamemobilityknight: 2.0
+      activity.endgamemobilitybishop: 4.0
+      activity.endgamemobilityrook: 2.0
+      activity.endgamemobilityqueen: 1.0
+      activity.endgamemobilityking: 2.0
+      activity.midgamecenterknight: 3.0
+      activity.midgamecenterbishop: 3.0
+      activity.midgamecenterrook: 3.0
+      activity.midgamecenterqueen: 3.0
+      activity.midgamecenterking: 0.0
+      activity.endgamecenterknight: 3.0
+      activity.endgamecenterbishop: 3.0
+      activity.endgamecenterrook: 3.0
+      activity.endgamecenterqueen: 3.0
+      activity.endgamecenterking: 2.0
+      kingsafety.missingpawnshieldpenalty: -15.0
+      kingsafety.halfopenfilepenalty: -15.0
+      kingsafety.openfilepenalty: -25.0
+      kingsafety.defenderbonus: 5.0
+      kingsafety.queenattackedpenalty: -75.0
+      kingsafety.backrankweaknessmidgamepenalty: -100.0
+      kingsafety.backrankweaknessendgamepenalty: -50.0
+      kingsafety.attackweightpawn: 5.0
+      kingsafety.attackweightknight: 10.0
+      kingsafety.attackweightbishop: 10.0
+      kingsafety.attackweightrook: 15.0
+      kingsafety.attackweightqueen: 20.0
+      threat.hangingpawnpenalty: -12.0
+      threat.hangingknightpenalty: -30.0
+      threat.hangingbishoppenalty: -30.0
+      threat.hangingrookpenalty: -45.0
+      threat.hangingqueenpenalty: -70.0
+      threat.pawnthreatknightpenalty: -10.0
+      threat.pawnthreatbishoppenalty: -10.0
+      threat.pawnthreatrookpenalty: -18.0
+      threat.pawnthreatqueenpenalty: -25.0
+      evaluation.blendscale: 256.0
+  -
+    name: baseline
+    evaluation:
+      modules:
+        materialmodule:
+          midgame: 1.0
+          endgame: 1.0
+        pawnstructuremodule:
+          midgame: 1.0
+          endgame: 1.0
+    numericParameters:
+      material.pawnvalue: 100.0
+      material.knightvalue: 320.0
+      material.bishopvalue: 330.0
+      material.rookvalue: 500.0
+      material.queenvalue: 900.0
+      material.bishoppairbonus: 40.0
+      pawnstructure.centerpawnbonus: 15.0
+      pawnstructure.passedpawnbonus: 60.0
+      pawnstructure.connectedpawnbonus: 8.0
+      pawnstructure.islandpenalty: -5.0
+      pawnstructure.doubledpawnpenalty: -12.0
+      pawnstructure.isolatedpawnpenalty: -10.0
+      pawnstructure.advancedpawnbonus: 8.0
+      pawnstructure.blockedpawnpenalty: -10.0
+      pawnstructure.backwardpawnpenalty: -12.0
+      pawnstructure.ownkingblockspassedpawnpenalty: -150.0
+      pawnstructure.passedpawnfreepathbonusperrank: 12.0
+      pawnstructure.rookhalfopenfilebonus: 15.0
+      pawnstructure.rookopenfilebonus: 25.0
+      piecesquare.developmentphasethreshold: 64.0
+      piecesquare.queendevelopmentphasethreshold: 80.0
+      piecesquare.undevelopedminorpenalty: -20.0
+      piecesquare.earlyqueendevelopmentpenaltyperminor: -15.0
+      piecesquare.minundevelopedminorsforqueenpenalty: 2.0
+      piecesquare.startpositionpenalty: -40.0
+      piecesquare.blendscale: 256.0
+      piecesquare.castlingbonus: 20.0
+      piecesquare.notcastledrookmovepenalty: -10.0
+      activity.midgamemobilityknight: 2.0
+      activity.midgamemobilitybishop: 4.0
+      activity.midgamemobilityrook: 2.0
+      activity.midgamemobilityqueen: 1.0
+      activity.midgamemobilityking: 0.0
+      activity.endgamemobilityknight: 2.0
+      activity.endgamemobilitybishop: 4.0
+      activity.endgamemobilityrook: 2.0
+      activity.endgamemobilityqueen: 1.0
+      activity.endgamemobilityking: 2.0
+      activity.midgamecenterknight: 3.0
+      activity.midgamecenterbishop: 3.0
+      activity.midgamecenterrook: 3.0
+      activity.midgamecenterqueen: 3.0
+      activity.midgamecenterking: 0.0
+      activity.endgamecenterknight: 3.0
+      activity.endgamecenterbishop: 3.0
+      activity.endgamecenterrook: 3.0
+      activity.endgamecenterqueen: 3.0
+      activity.endgamecenterking: 2.0
+      kingsafety.missingpawnshieldpenalty: -15.0
+      kingsafety.halfopenfilepenalty: -15.0
+      kingsafety.openfilepenalty: -25.0
+      kingsafety.defenderbonus: 5.0
+      kingsafety.queenattackedpenalty: -75.0
+      kingsafety.backrankweaknessmidgamepenalty: -100.0
+      kingsafety.backrankweaknessendgamepenalty: -50.0
+      kingsafety.attackweightpawn: 5.0
+      kingsafety.attackweightknight: 10.0
+      kingsafety.attackweightbishop: 10.0
+      kingsafety.attackweightrook: 15.0
+      kingsafety.attackweightqueen: 20.0
+      threat.hangingpawnpenalty: -12.0
+      threat.hangingknightpenalty: -30.0
+      threat.hangingbishoppenalty: -30.0
+      threat.hangingrookpenalty: -45.0
+      threat.hangingqueenpenalty: -70.0
+      threat.pawnthreatknightpenalty: -10.0
+      threat.pawnthreatbishoppenalty: -10.0
+      threat.pawnthreatrookpenalty: -18.0
+      threat.pawnthreatqueenpenalty: -25.0
+      evaluation.blendscale: 256.0

--- a/src/test/java/julius/game/chessengine/evaluation/CastlingEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/evaluation/CastlingEvaluationTest.java
@@ -10,10 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CastlingEvaluationTest {
 
-    private static final int CASTLING_BONUS = 20;
-    private static final int NOT_CASTLED_AND_ROOK_MOVE_PENALTY = -10;
-    private static final int BLEND_SCALE = 256;
-
     @Test
     void castledKingReceivesBonusInTaperedScores() {
         BitBoard castled = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/8/5RK1 w - - 0 1");
@@ -23,7 +19,7 @@ class CastlingEvaluationTest {
         ScoreSnapshot uncastledScore = evaluatePieceSquares(uncastled);
 
         int phase = castled.getPhase();
-        int expectedBonus = CASTLING_BONUS * (BLEND_SCALE - phase) / BLEND_SCALE;
+        int expectedBonus = PieceSquareModule.castlingBonus() * (PieceSquareModule.blendScale() - phase) / PieceSquareModule.blendScale();
 
         assertEquals(expectedBonus, castledScore.midgame() - uncastledScore.midgame());
         assertEquals(expectedBonus, castledScore.endgame() - uncastledScore.endgame());
@@ -39,7 +35,8 @@ class CastlingEvaluationTest {
         ScoreSnapshot exposedScore = evaluatePieceSquares(exposed);
 
         int phase = safe.getPhase();
-        int rookPenalty = NOT_CASTLED_AND_ROOK_MOVE_PENALTY * (BLEND_SCALE - phase) / BLEND_SCALE;
+        int rookPenalty = PieceSquareModule.notCastledRookMovePenalty()
+                * (PieceSquareModule.blendScale() - phase) / PieceSquareModule.blendScale();
         int expectedPenalty = 4 * rookPenalty;
 
         assertEquals(expectedPenalty, exposedScore.midgame() - safeScore.midgame());

--- a/src/test/java/julius/game/chessengine/utils/BishopPairBonusTest.java
+++ b/src/test/java/julius/game/chessengine/utils/BishopPairBonusTest.java
@@ -17,7 +17,7 @@ public class BishopPairBonusTest {
         BitBoard single = FEN.translateFENtoBitBoard("4k3/8/8/8/8/8/8/4KB2 w - - 0 1");
 
         int diff = materialScore(pair) - materialScore(single);
-        assertEquals(MaterialModule.BISHOP_VALUE + MaterialModule.BISHOP_PAIR_BONUS, diff);
+        assertEquals(MaterialModule.bishopValue() + MaterialModule.bishopPairBonus(), diff);
     }
 
     @Test
@@ -26,7 +26,7 @@ public class BishopPairBonusTest {
         BitBoard single = FEN.translateFENtoBitBoard("4kb2/8/8/8/8/8/8/4K3 w - - 0 1");
 
         int diff = materialScore(single) - materialScore(pair);
-        assertEquals(MaterialModule.BISHOP_VALUE + MaterialModule.BISHOP_PAIR_BONUS, diff);
+        assertEquals(MaterialModule.bishopValue() + MaterialModule.bishopPairBonus(), diff);
     }
 
     private static int materialScore(BitBoard board) {

--- a/src/test/java/julius/game/chessengine/utils/PassedPawnScoreTest.java
+++ b/src/test/java/julius/game/chessengine/utils/PassedPawnScoreTest.java
@@ -14,7 +14,7 @@ public class PassedPawnScoreTest {
     void whitePassedPawnGetsBonus() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/4P3/8/8/8/4K3 w - - 0 1");
         PawnStructureView view = pawnStructure(board);
-        assertEquals(PawnStructureModule.PASSED_PAWN_BONUS * 4,
+        assertEquals(PawnStructureModule.passedPawnBonus() * 4,
                 view.whitePassed().blend(board.getPhase()));
         assertEquals(0, view.blackPassed().blend(board.getPhase()));
     }
@@ -23,7 +23,7 @@ public class PassedPawnScoreTest {
     void blackPassedPawnGetsBonus() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/3p4/8/8/4K3 w - - 0 1");
         PawnStructureView view = pawnStructure(board);
-        assertEquals(PawnStructureModule.PASSED_PAWN_BONUS * 4,
+        assertEquals(PawnStructureModule.passedPawnBonus() * 4,
                 view.blackPassed().blend(board.getPhase()));
         assertEquals(0, view.whitePassed().blend(board.getPhase()));
     }

--- a/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
@@ -85,7 +85,7 @@ public class ScoreEvaluationTest {
     void centerPawnsGrantBonusToWhite() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/8/4P3/8/8/4K3 w - - 0 1");
         PawnStructureView view = pawnStructure(board);
-        assertEquals(PawnStructureModule.CENTER_PAWN_BONUS, view.whiteCenter().blend(board.getPhase()));
+        assertEquals(PawnStructureModule.centerPawnBonus(), view.whiteCenter().blend(board.getPhase()));
         assertEquals(0, view.blackCenter().blend(board.getPhase()));
     }
 
@@ -93,7 +93,7 @@ public class ScoreEvaluationTest {
     void centerPawnsGrantBonusToBlack() {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/4p3/8/8/8/4K3 w - - 0 1");
         PawnStructureView view = pawnStructure(board);
-        assertEquals(PawnStructureModule.CENTER_PAWN_BONUS, view.blackCenter().blend(board.getPhase()));
+        assertEquals(PawnStructureModule.centerPawnBonus(), view.blackCenter().blend(board.getPhase()));
         assertEquals(0, view.whiteCenter().blend(board.getPhase()));
     }
 


### PR DESCRIPTION
## Summary
- add a numeric tuning registry with thread-local overrides and expose helper TunableParameter
- convert evaluation modules to consume tunable parameters instead of static constants and register defaults
- prevent AI tuning from mutating search configuration and propagate numeric parameters through Score and MatchRunner
- update evaluation-related tests to use the new accessors

## Testing
- ./mvnw -q test *(fails: network unavailable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68d995723dd8832aa33e9747c3dea93b