### PR TITLE
Ignore AI settings in tuning YAML definitions

### DIFF
--- a/src/main/java/julius/game/chessengine/tuning/EngineTuningLoader.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuningLoader.java
@@ -24,6 +24,8 @@ import java.util.stream.Collectors;
  * <pre>{@code
  * population:
  *   - name: baseline
+ *     # The optional "ai" section is accepted for backwards compatibility but ignored,
+ *     # as engine-search parameters are no longer tuned via YAML definitions.
  *     ai:
  *       maxDepth: 32
  *       timeLimitMillis: 50
@@ -108,29 +110,10 @@ public final class EngineTuningLoader {
     }
 
     private static AiTuning toAiTuning(AiConfig config) {
-        if (config == null) {
-            return AiTuning.defaults();
-        }
-        AiTuning.Builder builder = AiTuning.builder();
-        if (config.searchThreads != null) {
-            builder.searchThreads(config.searchThreads);
-        }
-        if (config.lazySmpThreads != null) {
-            builder.lazySmpThreads(config.lazySmpThreads);
-        }
-        if (config.hashSizeMb != null) {
-            builder.hashSizeMb(config.hashSizeMb);
-        }
-        if (config.maxDepth != null) {
-            builder.maxDepth(config.maxDepth);
-        }
-        if (config.timeLimitMillis != null) {
-            builder.timeLimitMillis(config.timeLimitMillis);
-        }
-        if (config.nullMovePruning != null) {
-            builder.nullMovePruning(config.nullMovePruning);
-        }
-        return builder.build();
+        // Search configuration is intentionally kept outside of the genetic tuning pipeline to
+        // prevent accidental optimisation of engine runtime parameters. Any values present in the
+        // YAML document are therefore ignored in favour of the runtime defaults.
+        return AiTuning.defaults();
     }
 
     private static EvaluationTuning toEvaluation(EvaluationConfig config) {

--- a/src/main/java/julius/game/chessengine/tuning/EngineTuningWriter.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuningWriter.java
@@ -76,10 +76,6 @@ public final class EngineTuningWriter {
         if (tuning.name() != null && !tuning.name().isBlank()) {
             config.put("name", tuning.name());
         }
-        Map<String, Object> ai = toAiConfig(tuning.ai());
-        if (!ai.isEmpty()) {
-            config.put("ai", ai);
-        }
         Map<String, Object> evaluation = toEvaluationConfig(tuning.evaluation());
         if (!evaluation.isEmpty()) {
             config.put("evaluation", evaluation);
@@ -87,17 +83,6 @@ public final class EngineTuningWriter {
         if (!tuning.numericParameters().isEmpty()) {
             config.put("numericParameters", new LinkedHashMap<>(tuning.numericParameters()));
         }
-        return config;
-    }
-
-    private static Map<String, Object> toAiConfig(AiTuning tuning) {
-        Map<String, Object> config = new LinkedHashMap<>();
-        config.put("searchThreads", tuning.searchThreads());
-        config.put("lazySmpThreads", tuning.lazySmpThreads());
-        config.put("hashSizeMb", tuning.hashSizeMb());
-        config.put("maxDepth", tuning.maxDepth());
-        config.put("timeLimitMillis", tuning.timeLimitMillis());
-        config.put("nullMovePruning", tuning.nullMovePruning());
         return config;
     }
 

--- a/src/test/java/julius/game/chessengine/tuning/EngineTuningLoaderTest.java
+++ b/src/test/java/julius/game/chessengine/tuning/EngineTuningLoaderTest.java
@@ -29,8 +29,9 @@ class EngineTuningLoaderTest {
         assertThat(set.population()).hasSize(1);
         EngineTuning tuning = set.population().getFirst();
         assertThat(tuning.name()).isEqualTo("test");
-        assertThat(tuning.ai().maxDepth()).isEqualTo(24);
-        assertThat(tuning.ai().nullMovePruning()).isFalse();
+        AiTuning defaults = AiTuning.defaults();
+        assertThat(tuning.ai().maxDepth()).isEqualTo(defaults.maxDepth());
+        assertThat(tuning.ai().nullMovePruning()).isEqualTo(defaults.nullMovePruning());
         assertThat(tuning.evaluation().modules())
                 .containsKey("materialmodule");
     }


### PR DESCRIPTION
## Summary
- ignore AI search configuration values provided in tuning YAML definitions so runtime defaults remain fixed
- stop emitting AI sections when serialising tuning results to YAML files
- update the tuning loader test to assert the new behaviour and document the ignored section

## Testing
- ./mvnw -q -Dtest=EngineTuningLoaderTest test *(fails: Maven wrapper could not download dependencies because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d99bdf4610832aba72376e58865355