### PR TITLE
Parallelize genetic tuner matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,8 @@ specified with `--output`), and optionally records every self-play result to the
 `--matches` CSV. Omit advanced flags to fall back to the defaults specified in
 `GeneticOptions.defaults()`.
 
+Use the optional `--match-threads` flag to run multiple self-play games at the
+same time when you have spare CPU cores. The tuner defaults to the number of
+available processors so you can fully utilise the machine without additional
+arguments.
+

--- a/src/main/java/julius/game/chessengine/tuning/GeneticOptimizer.java
+++ b/src/main/java/julius/game/chessengine/tuning/GeneticOptimizer.java
@@ -7,6 +7,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * Runs a simple genetic algorithm on top of the chess engine by repeatedly letting configurations
@@ -41,45 +46,58 @@ public final class GeneticOptimizer {
 
         List<MatchRunner.MatchResult> allMatches = new ArrayList<>();
 
-        for (int generation = 0; generation < options.generations(); generation++) {
-            Map<EngineTuning, Double> scoreboard = new HashMap<>();
+        MatchRunner.MatchOptions matchOptions = new MatchRunner.MatchOptions(options.maxPlies(), options.moveTimeMillis());
+        int parallelism = Math.max(1, options.matchParallelism());
+        ExecutorService executor = parallelism > 1 ? Executors.newFixedThreadPool(parallelism, matchThreadFactory()) : null;
 
-            for (int i = 0; i < population.size(); i++) {
-                for (int j = i + 1; j < population.size(); j++) {
-                    EngineTuning a = population.get(i);
-                    EngineTuning b = population.get(j);
-                    for (int match = 0; match < options.matchesPerPair(); match++) {
-                        boolean swap = (match % 2) == 1;
-                        EngineTuning white = swap ? b : a;
-                        EngineTuning black = swap ? a : b;
-                        MatchRunner.MatchResult result = matchRunner.playMatch(
-                                white,
-                                black,
-                                new MatchRunner.MatchOptions(options.maxPlies(), options.moveTimeMillis())
-                        );
-                        allMatches.add(result);
-                        if (swap) {
-                            scoreboard.merge(a, result.blackScore(), Double::sum);
-                            scoreboard.merge(b, result.whiteScore(), Double::sum);
-                        } else {
-                            scoreboard.merge(a, result.whiteScore(), Double::sum);
-                            scoreboard.merge(b, result.blackScore(), Double::sum);
+        try {
+            for (int generation = 0; generation < options.generations(); generation++) {
+                Map<EngineTuning, Double> scoreboard = new HashMap<>();
+                List<ScheduledMatch> scheduledMatches = new ArrayList<>();
+
+                for (int i = 0; i < population.size(); i++) {
+                    for (int j = i + 1; j < population.size(); j++) {
+                        EngineTuning a = population.get(i);
+                        EngineTuning b = population.get(j);
+                        for (int match = 0; match < options.matchesPerPair(); match++) {
+                            boolean swap = (match % 2) == 1;
+                            scheduledMatches.add(new ScheduledMatch(a, b, swap));
                         }
                     }
                 }
+
+                List<CompletedMatch> completedMatches = runScheduledMatches(scheduledMatches, matchOptions, executor);
+
+                for (CompletedMatch completed : completedMatches) {
+                    allMatches.add(completed.result());
+                    EngineTuning a = completed.assignment().first();
+                    EngineTuning b = completed.assignment().second();
+                    MatchRunner.MatchResult result = completed.result();
+                    if (completed.assignment().swapped()) {
+                        scoreboard.merge(a, result.blackScore(), Double::sum);
+                        scoreboard.merge(b, result.whiteScore(), Double::sum);
+                    } else {
+                        scoreboard.merge(a, result.whiteScore(), Double::sum);
+                        scoreboard.merge(b, result.blackScore(), Double::sum);
+                    }
+                }
+
+                population = scoreboard.entrySet().stream()
+                        .sorted(Map.Entry.<EngineTuning, Double>comparingByValue(Comparator.reverseOrder()))
+                        .limit(Math.max(options.retainCount(), 2))
+                        .map(Map.Entry::getKey)
+                        .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+
+                while (population.size() < options.populationSize()) {
+                    EngineTuning parent = population.get(random.nextInt(population.size()));
+                    EngineTuning offspring = parent.mutate(random, options.mutationStrength())
+                            .rename(parent.name() + "_g" + generation + "_mut");
+                    population.add(offspring);
+                }
             }
-
-            population = scoreboard.entrySet().stream()
-                    .sorted(Map.Entry.<EngineTuning, Double>comparingByValue(Comparator.reverseOrder()))
-                    .limit(Math.max(options.retainCount(), 2))
-                    .map(Map.Entry::getKey)
-                    .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
-
-            while (population.size() < options.populationSize()) {
-                EngineTuning parent = population.get(random.nextInt(population.size()));
-                EngineTuning offspring = parent.mutate(random, options.mutationStrength())
-                        .rename(parent.name() + "_g" + generation + "_mut");
-                population.add(offspring);
+        } finally {
+            if (executor != null) {
+                executor.shutdown();
             }
         }
 
@@ -87,5 +105,68 @@ public final class GeneticOptimizer {
     }
 
     public record GeneticResult(EngineTuningSet population, List<MatchRunner.MatchResult> matches) {
+    }
+
+    private List<CompletedMatch> runScheduledMatches(List<ScheduledMatch> scheduledMatches,
+                                                     MatchRunner.MatchOptions matchOptions,
+                                                     ExecutorService executor) {
+        if (scheduledMatches.isEmpty()) {
+            return List.of();
+        }
+
+        if (executor == null) {
+            List<CompletedMatch> results = new ArrayList<>(scheduledMatches.size());
+            for (ScheduledMatch scheduled : scheduledMatches) {
+                results.add(runSingleMatch(scheduled, matchOptions));
+            }
+            return results;
+        }
+
+        List<CompletableFuture<CompletedMatch>> futures = new ArrayList<>(scheduledMatches.size());
+        for (ScheduledMatch scheduled : scheduledMatches) {
+            futures.add(CompletableFuture.supplyAsync(() -> runSingleMatch(scheduled, matchOptions), executor));
+        }
+
+        List<CompletedMatch> results = new ArrayList<>(scheduledMatches.size());
+        for (CompletableFuture<CompletedMatch> future : futures) {
+            try {
+                results.add(future.join());
+            } catch (CompletionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException runtime) {
+                    throw runtime;
+                }
+                throw new IllegalStateException("Failed to complete self-play match", cause);
+            }
+        }
+        return results;
+    }
+
+    private CompletedMatch runSingleMatch(ScheduledMatch scheduledMatch, MatchRunner.MatchOptions matchOptions) {
+        EngineTuning a = scheduledMatch.first();
+        EngineTuning b = scheduledMatch.second();
+        EngineTuning white = scheduledMatch.swapped() ? b : a;
+        EngineTuning black = scheduledMatch.swapped() ? a : b;
+        MatchRunner.MatchResult result = matchRunner.playMatch(white, black, matchOptions);
+        return new CompletedMatch(scheduledMatch, result);
+    }
+
+    private ThreadFactory matchThreadFactory() {
+        return new ThreadFactory() {
+            private int counter;
+
+            @Override
+            public synchronized Thread newThread(Runnable r) {
+                Thread thread = new Thread(r, "genetic-match-" + (++counter));
+                thread.setDaemon(true);
+                return thread;
+            }
+        };
+    }
+
+    private record ScheduledMatch(EngineTuning first, EngineTuning second, boolean swapped) {
+    }
+
+    private record CompletedMatch(ScheduledMatch assignment, MatchRunner.MatchResult result) {
     }
 }

--- a/src/main/java/julius/game/chessengine/tuning/GeneticOptions.java
+++ b/src/main/java/julius/game/chessengine/tuning/GeneticOptions.java
@@ -9,7 +9,8 @@ public record GeneticOptions(int generations,
                              int matchesPerPair,
                              double mutationStrength,
                              long moveTimeMillis,
-                             int maxPlies) {
+                             int maxPlies,
+                             int matchParallelism) {
 
     public GeneticOptions {
         if (generations < 1) generations = 1;
@@ -19,9 +20,14 @@ public record GeneticOptions(int generations,
         if (mutationStrength < 0.0) mutationStrength = 0.0;
         if (moveTimeMillis <= 0L) moveTimeMillis = 50L;
         if (maxPlies <= 0) maxPlies = 512;
+        if (matchParallelism < 1) {
+            int availableProcessors = Runtime.getRuntime().availableProcessors();
+            matchParallelism = Math.max(1, availableProcessors);
+        }
     }
 
     public static GeneticOptions defaults() {
-        return new GeneticOptions(5, 4, 8, 2, 0.15, 50L, 512);
+        return new GeneticOptions(5, 4, 8, 2, 0.15, 50L, 512,
+                Math.max(1, Runtime.getRuntime().availableProcessors()));
     }
 }

--- a/src/main/java/julius/game/chessengine/tuning/GeneticTuningMain.java
+++ b/src/main/java/julius/game/chessengine/tuning/GeneticTuningMain.java
@@ -134,6 +134,7 @@ public final class GeneticTuningMain {
                 "  --mutation <value>     Mutation strength in the [0, 1] range (default 0.15).\n" +
                 "  --move-time <ms>       Move time in milliseconds for each search (default 50).\n" +
                 "  --max-plies <n>        Hard cap on plies per game (default 512).\n" +
+                "  --match-threads <n>    Concurrent self-play games during evaluation (default available processors).\n" +
                 "  -h, --help             Display this help message.\n");
     }
 
@@ -149,6 +150,7 @@ public final class GeneticTuningMain {
         private final double mutationStrength;
         private final long moveTimeMillis;
         private final int maxPlies;
+        private final int matchParallelism;
 
         private CliArguments(Path seedFile,
                              Path outputFile,
@@ -160,7 +162,8 @@ public final class GeneticTuningMain {
                              int matchesPerPair,
                              double mutationStrength,
                              long moveTimeMillis,
-                             int maxPlies) {
+                             int maxPlies,
+                             int matchParallelism) {
             this.seedFile = seedFile;
             this.outputFile = outputFile;
             this.matchLogFile = matchLogFile;
@@ -172,6 +175,7 @@ public final class GeneticTuningMain {
             this.mutationStrength = mutationStrength;
             this.moveTimeMillis = moveTimeMillis;
             this.maxPlies = maxPlies;
+            this.matchParallelism = matchParallelism;
         }
 
         private static CliArguments parse(String[] args) {
@@ -194,6 +198,7 @@ public final class GeneticTuningMain {
             double mutation = GeneticOptions.defaults().mutationStrength();
             long moveTime = GeneticOptions.defaults().moveTimeMillis();
             int maxPlies = GeneticOptions.defaults().maxPlies();
+            int matchParallelism = GeneticOptions.defaults().matchParallelism();
 
             for (int i = 0; i < args.length; i++) {
                 String arg = args[i];
@@ -228,12 +233,13 @@ public final class GeneticTuningMain {
                     case "mutation" -> mutation = Double.parseDouble(value);
                     case "move-time" -> moveTime = Long.parseLong(value);
                     case "max-plies" -> maxPlies = Integer.parseInt(value);
+                    case "match-threads" -> matchParallelism = Integer.parseInt(value);
                     default -> throw new IllegalArgumentException("Unknown option --" + name);
                 }
             }
 
             if (help) {
-                return new CliArguments(null, null, matches, true, generations, retain, population, matchesPerPair, mutation, moveTime, maxPlies);
+                return new CliArguments(null, null, matches, true, generations, retain, population, matchesPerPair, mutation, moveTime, maxPlies, matchParallelism);
             }
 
             if (seed == null) {
@@ -244,11 +250,11 @@ public final class GeneticTuningMain {
             }
 
             Path resolvedOutput = output != null ? output : defaultOutput(seed);
-            return new CliArguments(seed, resolvedOutput, matches, false, generations, retain, population, matchesPerPair, mutation, moveTime, maxPlies);
+            return new CliArguments(seed, resolvedOutput, matches, false, generations, retain, population, matchesPerPair, mutation, moveTime, maxPlies, matchParallelism);
         }
 
         private GeneticOptions toOptions() {
-            return new GeneticOptions(generations, retain, population, matchesPerPair, mutationStrength, moveTimeMillis, maxPlies);
+            return new GeneticOptions(generations, retain, population, matchesPerPair, mutationStrength, moveTimeMillis, maxPlies, matchParallelism);
         }
 
         private static Path defaultOutput(Path seedFile) {


### PR DESCRIPTION
## Summary
- add a configurable match-parallelism option to the genetic tuner settings
- execute self-play matches concurrently when multiple threads are available
- expose the new flag through the CLI and document it in the README

## Testing
- `./mvnw -q test` *(fails: Maven wrapper cannot download dependencies in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da4113f9d0832aafaff1b741b02d59