### PR TITLE
Add move ordering tuning parameters and optimizer logging

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -8,6 +8,7 @@ import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.tuning.AiTuning;
+import julius.game.chessengine.tuning.MoveOrderingParameters;
 import julius.game.chessengine.utils.Score;
 import lombok.Getter;
 import lombok.Setter;
@@ -130,6 +131,8 @@ public class AI {
      * structure between iterative-deepening iterations.
      */
     private final Heuristics globalHeuristics;
+
+    private final MoveOrderingParameters.Snapshot moveOrderingParameters;
 
     /**
      * Per-thread heuristic state used during move ordering. The tables are
@@ -269,6 +272,7 @@ public class AI {
 
         log.info("### SearchThreads = " + searchThreads + ", LazySmpThreads = " + lazySmpThreads);
 
+        this.moveOrderingParameters = MoveOrderingParameters.snapshot();
         this.globalHeuristics = new Heuristics(maxDepth);
         this.threadHeuristics = ThreadLocal.withInitial(() -> new Heuristics(maxDepth));
 
@@ -1985,10 +1989,13 @@ public class AI {
         final int CAT_TT = 7, CAT_PROMO = 6, CAT_CAP_GOOD = 5, CAT_CAP_EQUAL = 4,
                 CAT_KILLER0 = 3, CAT_KILLER1 = 2, CAT_QUIET = 1, CAT_CAP_BAD = 0;
 
-        // Lightweight bonuses (local so no class changes):
-        final int PROMOTION_ORDER_BONUS = 900;   // strong push for promotions
-        final int KILLER0_BONUS = 50;            // distinguish first vs second killer
-        final int KILLER1_BONUS = 30;
+        final int promotionBonus = moveOrderingParameters.promotionBonus();
+        final int killer0Bonus = moveOrderingParameters.killer0Bonus();
+        final int killer1Bonus = moveOrderingParameters.killer1Bonus();
+        final int killerMoveScore = moveOrderingParameters.killerMoveScore();
+        final int captureMvvMultiplier = moveOrderingParameters.captureMvvMultiplier();
+        final int captureSeeMultiplier = moveOrderingParameters.captureSeeMultiplier();
+        final int promotionSeeMultiplier = moveOrderingParameters.promotionSeeMultiplier();
 
         // Hash move (TT) handling — keep your "pin to front" approach
         TranspositionTableEntry ttEntry = transpositionTable.get(boardHash);
@@ -2002,7 +2009,7 @@ public class AI {
         final int prevFrom = (prevMove >= 0) ? (prevMove & 0x3F) : -1;
         final int prevTo = (prevMove >= 0) ? ((prevMove >>> 6) & 0x3F) : -1;
         final int cm = (prevFrom >= 0) ? counterMove[prevFrom][prevTo] : -1;
-        final int COUNTER_MOVE_BONUS = 400;
+        final int counterMoveBonus = moveOrderingParameters.counterMoveBonus();
 
         for (int i = 0; i < size; i++) {
             final int moveInt = moves.getInt(i);
@@ -2037,9 +2044,9 @@ public class AI {
                 int seeBonus = 0;
                 if (hasSee) {
                     int cappedSee = Math.max(-512, Math.min(512, seeValue));
-                    seeBonus = cappedSee * 16; // modest SEE influence within promotion bucket
+                    seeBonus = cappedSee * promotionSeeMultiplier;
                 }
-                score = base + PROMOTION_ORDER_BONUS + seeBonus;
+                score = base + promotionBonus + seeBonus;
             } else if (isCapture) {
                 // MVV-LVA for captures; classify as good/equal/bad without SEE
                 final int mvvLva = calculateMvvLvaScore(moveInt); // victim - attacker (can be negative)
@@ -2052,23 +2059,23 @@ public class AI {
                 }
                 // Scale captures so bigger victims / smaller attackers bubble up
                 int cappedSee = Math.max(-2048, Math.min(2048, seeValue));
-                score = (mvvLva * 16) + (cappedSee * 32);
+                score = (mvvLva * captureMvvMultiplier) + (cappedSee * captureSeeMultiplier);
                 if (score < 0) {
                     score = 0;
                 }
             } else if (moveInt == k0) {
                 category = CAT_KILLER0;
-                score = KILLER_MOVE_SCORE + KILLER0_BONUS;
+                score = killerMoveScore + killer0Bonus;
             } else if (moveInt == k1) {
                 category = CAT_KILLER1;
-                score = KILLER_MOVE_SCORE + KILLER1_BONUS;
+                score = killerMoveScore + killer1Bonus;
             } else {
                 // Quiet with history
                 final int from = moveInt & 0x3F;
                 final int to = (moveInt >>> 6) & 0x3F;
                 category = CAT_QUIET;
                 score = historyTable[from][to]; // butterfly history
-                if (moveInt == cm) score += COUNTER_MOVE_BONUS;
+                if (moveInt == cm) score += counterMoveBonus;
             }
 
             // Persist (kept for compatibility with your buffers)

--- a/src/main/java/julius/game/chessengine/tuning/EngineTuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuning.java
@@ -17,6 +17,10 @@ import java.util.Random;
  */
 public final class EngineTuning {
 
+    static {
+        MoveOrderingParameters.defaults();
+    }
+
     private final String name;
     private final AiTuning ai;
     private final EvaluationTuning evaluation;

--- a/src/main/java/julius/game/chessengine/tuning/GeneticOptimizer.java
+++ b/src/main/java/julius/game/chessengine/tuning/GeneticOptimizer.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
@@ -13,10 +14,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
+import lombok.extern.log4j.Log4j2;
+
 /**
  * Runs a simple genetic algorithm on top of the chess engine by repeatedly letting configurations
  * play against each other and mutating the top performers into the next generation.
  */
+@Log4j2
 public final class GeneticOptimizer {
 
     private final MatchRunner matchRunner;
@@ -39,9 +43,24 @@ public final class GeneticOptimizer {
         }
 
         List<EngineTuning> population = new ArrayList<>(seedPopulation.population());
+        log.info("Starting genetic evolution with {} seed configurations (target population {}, generations {}, retain {}, mutation strength {}, matches per pair {}, match threads {}).",
+                seedPopulation.population().size(),
+                options.populationSize(),
+                options.generations(),
+                options.retainCount(),
+                String.format(Locale.ROOT, "%.3f", options.mutationStrength()),
+                options.matchesPerPair(),
+                options.matchParallelism());
+        if (log.isDebugEnabled()) {
+            log.debug("Initial population: {}", population.stream().map(EngineTuning::name).toList());
+        }
         while (population.size() < options.populationSize()) {
             EngineTuning parent = population.get(random.nextInt(population.size()));
             population.add(parent.mutate(random, options.mutationStrength()).rename(parent.name() + "_seed"));
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Expanded initial population to {} entries: {}", population.size(),
+                    population.stream().map(EngineTuning::name).toList());
         }
 
         List<MatchRunner.MatchResult> allMatches = new ArrayList<>();
@@ -52,6 +71,7 @@ public final class GeneticOptimizer {
 
         try {
             for (int generation = 0; generation < options.generations(); generation++) {
+                int generationIndex = generation + 1;
                 Map<EngineTuning, Double> scoreboard = new HashMap<>();
                 List<ScheduledMatch> scheduledMatches = new ArrayList<>();
 
@@ -66,7 +86,11 @@ public final class GeneticOptimizer {
                     }
                 }
 
+                log.info("Generation {}: scheduled {} matches for {} configurations", generationIndex,
+                        scheduledMatches.size(), population.size());
+
                 List<CompletedMatch> completedMatches = runScheduledMatches(scheduledMatches, matchOptions, executor);
+                log.info("Generation {}: completed {} matches", generationIndex, completedMatches.size());
 
                 for (CompletedMatch completed : completedMatches) {
                     allMatches.add(completed.result());
@@ -80,19 +104,60 @@ public final class GeneticOptimizer {
                         scoreboard.merge(a, result.whiteScore(), Double::sum);
                         scoreboard.merge(b, result.blackScore(), Double::sum);
                     }
+                    if (log.isDebugEnabled()) {
+                        log.debug("Generation {} match: {} vs {} => {}-{} ({}, {} plies)",
+                                generationIndex,
+                                result.whiteTuning().name(),
+                                result.blackTuning().name(),
+                                String.format(Locale.ROOT, "%.2f", result.whiteScore()),
+                                String.format(Locale.ROOT, "%.2f", result.blackScore()),
+                                result.finalState(),
+                                result.plies());
+                    }
                 }
 
-                population = scoreboard.entrySet().stream()
+                if (scoreboard.isEmpty()) {
+                    for (EngineTuning tuning : population) {
+                        scoreboard.putIfAbsent(tuning, 0.0);
+                    }
+                }
+
+                List<Map.Entry<EngineTuning, Double>> leaderboard = scoreboard.entrySet().stream()
                         .sorted(Map.Entry.<EngineTuning, Double>comparingByValue(Comparator.reverseOrder()))
+                        .toList();
+
+                if (log.isInfoEnabled()) {
+                    log.info("Generation {} leaderboard:", generationIndex);
+                    leaderboard.stream()
+                            .limit(Math.min(5, leaderboard.size()))
+                            .forEach(entry -> log.info("  {} -> {}", entry.getKey().name(),
+                                    String.format(Locale.ROOT, "%.2f", entry.getValue())));
+                }
+
+                List<EngineTuning> retained = leaderboard.stream()
                         .limit(Math.max(options.retainCount(), 2))
                         .map(Map.Entry::getKey)
                         .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+
+                population = new ArrayList<>(retained);
+                int retainedCount = population.size();
 
                 while (population.size() < options.populationSize()) {
                     EngineTuning parent = population.get(random.nextInt(population.size()));
                     EngineTuning offspring = parent.mutate(random, options.mutationStrength())
                             .rename(parent.name() + "_g" + generation + "_mut");
                     population.add(offspring);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Generation {}: created offspring {} from parent {}", generationIndex,
+                                offspring.name(), parent.name());
+                    }
+                }
+
+                log.info("Generation {}: retained {} configurations and produced {} offspring (population size {}).",
+                        generationIndex, retainedCount, population.size() - retainedCount, population.size());
+                if (log.isDebugEnabled()) {
+                    log.debug("Generation {} population: {}", generationIndex,
+                            population.stream().map(EngineTuning::name).toList());
                 }
             }
         } finally {

--- a/src/main/java/julius/game/chessengine/tuning/MatchRunner.java
+++ b/src/main/java/julius/game/chessengine/tuning/MatchRunner.java
@@ -5,7 +5,9 @@ import julius.game.chessengine.ai.MoveAndScore;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.utils.Score;
+import lombok.extern.log4j.Log4j2;
 
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -13,6 +15,7 @@ import java.util.Objects;
  * runner keeps the board state of both engines synchronised and returns a lightweight summary of
  * the encounter.
  */
+@Log4j2
 public final class MatchRunner {
 
     public MatchResult playMatch(EngineTuning whiteTuning, EngineTuning blackTuning, MatchOptions options) {
@@ -25,14 +28,27 @@ public final class MatchRunner {
         Engine whiteEngine = createEngineForTuning(whiteTuning);
         Engine blackEngine = createEngineForTuning(blackTuning);
 
-        AI whiteAi = new AI(whiteEngine, whiteTuning.ai());
-        AI blackAi = new AI(blackEngine, blackTuning.ai());
+        AI whiteAi;
+        AI blackAi;
+        try (AutoCloseable numeric = Score.useNumericParameters(whiteTuning.numericParameters())) {
+            whiteAi = new AI(whiteEngine, whiteTuning.ai());
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to initialise white AI for " + whiteTuning.name(), e);
+        }
+        try (AutoCloseable numeric = Score.useNumericParameters(blackTuning.numericParameters())) {
+            blackAi = new AI(blackEngine, blackTuning.ai());
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to initialise black AI for " + blackTuning.name(), e);
+        }
 
         try {
             int maxPlies = options.maxPlies() > 0 ? options.maxPlies() : 512;
             long moveTime = options.moveTimeMillis() > 0 ? options.moveTimeMillis() : whiteTuning.ai().timeLimitMillis();
 
             int plies = 0;
+            log.info("Starting self-play match: white={} black={} moveTime={}ms maxPlies={}",
+                    whiteTuning.name(), blackTuning.name(), moveTime, maxPlies);
+
             while (!whiteEngine.getGameState().isGameOver() && plies < maxPlies) {
                 boolean whiteToMove = whiteEngine.whitesTurn();
                 AI mover = whiteToMove ? whiteAi : blackAi;
@@ -68,7 +84,15 @@ public final class MatchRunner {
                 }
             }
 
-            return new MatchResult(whiteTuning, blackTuning, whiteScore, blackScore, finalState, plies);
+            MatchResult result = new MatchResult(whiteTuning, blackTuning, whiteScore, blackScore, finalState, plies);
+            if (log.isInfoEnabled()) {
+                log.info("Match completed: white={} black={} score={} - {} result={} plies={}",
+                        whiteTuning.name(), blackTuning.name(),
+                        String.format(Locale.ROOT, "%.2f", whiteScore),
+                        String.format(Locale.ROOT, "%.2f", blackScore),
+                        finalState, plies);
+            }
+            return result;
         } finally {
             whiteAi.shutdown();
             blackAi.shutdown();

--- a/src/main/java/julius/game/chessengine/tuning/MoveOrderingParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/MoveOrderingParameters.java
@@ -1,0 +1,88 @@
+package julius.game.chessengine.tuning;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Registry for move-ordering heuristics used by the search. The parameters are exposed as
+ * {@link TunableParameter}s so the genetic tuner can mutate them alongside the evaluation
+ * weights. Consumers capture a {@link Snapshot} at construction time to obtain a stable view of
+ * the configuration for the duration of a search.
+ */
+public final class MoveOrderingParameters {
+
+    private static final TunableParameter KILLER_MOVE_SCORE =
+            TunableParameter.of("moveOrdering.killerMoveScore", 10_000);
+    private static final TunableParameter PROMOTION_BONUS =
+            TunableParameter.of("moveOrdering.promotionBonus", 900);
+    private static final TunableParameter KILLER0_BONUS =
+            TunableParameter.of("moveOrdering.killer0Bonus", 50);
+    private static final TunableParameter KILLER1_BONUS =
+            TunableParameter.of("moveOrdering.killer1Bonus", 30);
+    private static final TunableParameter COUNTER_MOVE_BONUS =
+            TunableParameter.of("moveOrdering.counterMoveBonus", 400);
+    private static final TunableParameter CAPTURE_MVV_MULTIPLIER =
+            TunableParameter.of("moveOrdering.captureMvvMultiplier", 16);
+    private static final TunableParameter CAPTURE_SEE_MULTIPLIER =
+            TunableParameter.of("moveOrdering.captureSeeMultiplier", 32);
+    private static final TunableParameter PROMOTION_SEE_MULTIPLIER =
+            TunableParameter.of("moveOrdering.promotionSeeMultiplier", 16);
+
+    private MoveOrderingParameters() {
+    }
+
+    public static Snapshot snapshot() {
+        return new Snapshot(
+                KILLER_MOVE_SCORE.getInt(),
+                PROMOTION_BONUS.getInt(),
+                KILLER0_BONUS.getInt(),
+                KILLER1_BONUS.getInt(),
+                COUNTER_MOVE_BONUS.getInt(),
+                CAPTURE_MVV_MULTIPLIER.getInt(),
+                CAPTURE_SEE_MULTIPLIER.getInt(),
+                PROMOTION_SEE_MULTIPLIER.getInt()
+        );
+    }
+
+    public static int killerMoveScore() {
+        return KILLER_MOVE_SCORE.getInt();
+    }
+
+    public static Map<String, Double> defaults() {
+        Map<String, Double> defaults = new LinkedHashMap<>();
+        defaults.put(KILLER_MOVE_SCORE.key(), KILLER_MOVE_SCORE.defaultValue());
+        defaults.put(PROMOTION_BONUS.key(), PROMOTION_BONUS.defaultValue());
+        defaults.put(KILLER0_BONUS.key(), KILLER0_BONUS.defaultValue());
+        defaults.put(KILLER1_BONUS.key(), KILLER1_BONUS.defaultValue());
+        defaults.put(COUNTER_MOVE_BONUS.key(), COUNTER_MOVE_BONUS.defaultValue());
+        defaults.put(CAPTURE_MVV_MULTIPLIER.key(), CAPTURE_MVV_MULTIPLIER.defaultValue());
+        defaults.put(CAPTURE_SEE_MULTIPLIER.key(), CAPTURE_SEE_MULTIPLIER.defaultValue());
+        defaults.put(PROMOTION_SEE_MULTIPLIER.key(), PROMOTION_SEE_MULTIPLIER.defaultValue());
+        return Collections.unmodifiableMap(defaults);
+    }
+
+    public record Snapshot(
+            int killerMoveScore,
+            int promotionBonus,
+            int killer0Bonus,
+            int killer1Bonus,
+            int counterMoveBonus,
+            int captureMvvMultiplier,
+            int captureSeeMultiplier,
+            int promotionSeeMultiplier
+    ) {
+        public Map<String, Integer> asMap() {
+            Map<String, Integer> values = new LinkedHashMap<>();
+            values.put("moveOrdering.killerMoveScore", killerMoveScore);
+            values.put("moveOrdering.promotionBonus", promotionBonus);
+            values.put("moveOrdering.killer0Bonus", killer0Bonus);
+            values.put("moveOrdering.killer1Bonus", killer1Bonus);
+            values.put("moveOrdering.counterMoveBonus", counterMoveBonus);
+            values.put("moveOrdering.captureMvvMultiplier", captureMvvMultiplier);
+            values.put("moveOrdering.captureSeeMultiplier", captureSeeMultiplier);
+            values.put("moveOrdering.promotionSeeMultiplier", promotionSeeMultiplier);
+            return Collections.unmodifiableMap(values);
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -13,6 +13,7 @@ import julius.game.chessengine.evaluation.MoveContext;
 import julius.game.chessengine.evaluation.PawnStructureModule;
 import julius.game.chessengine.evaluation.PieceSquareModule;
 import julius.game.chessengine.evaluation.ThreatModule;
+import julius.game.chessengine.tuning.MoveOrderingParameters;
 import julius.game.chessengine.tuning.NumericTuningParameters;
 
 import java.util.List;
@@ -33,7 +34,6 @@ public class Score {
     public static final int CHECKMATE = 100000;
     public static final int CHECK = 50;
     public static final int DRAW = 0;
-    public static final int KILLER_MOVE_SCORE = 10000;
 
     private final MaterialModule materialModule = new MaterialModule();
     private final PawnStructureModule pawnStructureModule = new PawnStructureModule();
@@ -122,6 +122,10 @@ public class Score {
 
     public static AutoCloseable useNumericParameters(Map<String, Double> parameters) {
         return NumericTuningParameters.use(parameters);
+    }
+
+    public static int killerMoveScore() {
+        return MoveOrderingParameters.killerMoveScore();
     }
 
     public static ScoreFactory forEvaluationWeights(EvaluationWeights weights) {


### PR DESCRIPTION
## Summary
- add a dedicated move ordering parameter registry so heuristic scores can be tuned
- consume the new snapshot in the AI move ordering path and register defaults with engine tunings
- enrich genetic optimisation logging and ensure match runners build AIs with the tuned numeric parameters

## Testing
- ./mvnw -q -DskipTests package *(fails: network unreachable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68da4cf412e0832a8b43ed41cb0242c9