### PR TITLE
Load bundled engine tuning by default

### DIFF
--- a/src/main/java/julius/game/chessengine/tuning/EngineTuningBootstrap.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuningBootstrap.java
@@ -1,0 +1,133 @@
+package julius.game.chessengine.tuning;
+
+import julius.game.chessengine.utils.Score;
+import lombok.extern.log4j.Log4j2;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Bootstraps engine tuning defaults so the engine always starts with a sensible configuration,
+ * regardless of whether the Spring application context is present. The bundled YAML resource is
+ * loaded when no external tuning file is configured via the {@code chessengine.tuning.file}
+ * system property. The first entry in the population is applied as the active tuning.
+ */
+@Log4j2
+public final class EngineTuningBootstrap {
+
+    public static final String DEFAULT_TUNING_RESOURCE = "tuning/seed-tunings.yaml";
+    private static final String CLASSPATH_PREFIX = "classpath:";
+    private static final Object LOCK = new Object();
+
+    private static LoadedTuning cached;
+    private static boolean applied;
+
+    private EngineTuningBootstrap() {
+    }
+
+    /**
+     * Ensures the default tuning has been loaded and applied. Subsequent invocations are cheap and
+     * return immediately once the defaults are in place.
+     */
+    public static void ensureDefaultTuning() {
+        synchronized (LOCK) {
+            if (!applied) {
+                cached = loadPopulation();
+                apply(cached);
+                applied = true;
+            }
+        }
+    }
+
+    /**
+     * Reloads the configured tuning source. When no external file is configured this falls back to
+     * the bundled defaults. The loaded population is returned so callers (e.g. the {@link TuningManager})
+     * can inspect the available configurations.
+     */
+    public static LoadedTuning reloadDefaults() {
+        synchronized (LOCK) {
+            cached = loadPopulation();
+            apply(cached);
+            applied = true;
+            return cached;
+        }
+    }
+
+    static LoadedTuning loadBundledDefaults() {
+        return loadFromResource();
+    }
+
+    private static LoadedTuning loadPopulation() {
+        String configured = System.getProperty("chessengine.tuning.file");
+        if (configured != null && !configured.isBlank()) {
+            Path path = Path.of(configured);
+            if (Files.isRegularFile(path)) {
+                try {
+                    EngineTuningSet set = EngineTuningLoader.load(path);
+                    log.info("Loaded {} tuning configurations from {}", set.population().size(), path.toAbsolutePath());
+                    return new LoadedTuning(set, path.toAbsolutePath().toString());
+                } catch (IOException e) {
+                    log.warn("Failed to load tuning file {}; falling back to bundled defaults.", path.toAbsolutePath(), e);
+                }
+            } else {
+                log.warn("Configured tuning file {} does not exist; falling back to bundled defaults.", path.toAbsolutePath());
+            }
+        }
+        return loadFromResource();
+    }
+
+    private static LoadedTuning loadFromResource() {
+        String source = CLASSPATH_PREFIX + DEFAULT_TUNING_RESOURCE;
+        try (InputStream in = EngineTuningBootstrap.class.getClassLoader()
+                .getResourceAsStream(DEFAULT_TUNING_RESOURCE)) {
+            if (in == null) {
+                log.warn("Bundled tuning resource {} not found on the classpath.", source);
+                return new LoadedTuning(EngineTuningSet.empty(), source);
+            }
+            EngineTuningSet set = EngineTuningLoader.load(in);
+            log.info("Loaded {} tuning configurations from {}", set.population().size(), source);
+            return new LoadedTuning(set, source);
+        } catch (IOException e) {
+            log.warn("Failed to load bundled tuning resource {}", source, e);
+            return new LoadedTuning(EngineTuningSet.empty(), source);
+        }
+    }
+
+    private static void apply(LoadedTuning loaded) {
+        if (loaded.population().isEmpty()) {
+            NumericTuningParameters.setGlobal(Map.of());
+            Score.setGlobalFactory(Score.forEvaluationWeights(null));
+            log.info("No engine tuning configurations available after loading from {}; using built-in defaults.",
+                    loaded.sourceDescription());
+            return;
+        }
+        EngineTuning tuning = loaded.population().population().getFirst();
+        NumericTuningParameters.setGlobal(tuning.numericParameters());
+        Score.setGlobalFactory(Score.forEvaluationWeights(tuning.evaluationWeights()));
+        log.info("Applied engine tuning \"{}\" from {} ({} configurations available).",
+                tuning.name() != null && !tuning.name().isBlank() ? tuning.name() : "default",
+                loaded.sourceDescription(),
+                loaded.population().population().size());
+    }
+
+    static final class LoadedTuning {
+        private final EngineTuningSet population;
+        private final String sourceDescription;
+
+        LoadedTuning(EngineTuningSet population, String sourceDescription) {
+            this.population = population != null ? population : EngineTuningSet.empty();
+            this.sourceDescription = sourceDescription != null ? sourceDescription : "";
+        }
+
+        EngineTuningSet population() {
+            return population;
+        }
+
+        String sourceDescription() {
+            return sourceDescription;
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/TuningManager.java
+++ b/src/main/java/julius/game/chessengine/tuning/TuningManager.java
@@ -2,12 +2,9 @@ package julius.game.chessengine.tuning;
 
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -20,7 +17,7 @@ import java.nio.file.Path;
 public class TuningManager {
 
     private final Path tuningFile;
-    private static final String DEFAULT_TUNING_RESOURCE = "tuning/seed-tunings.yaml";
+    private static final String DEFAULT_TUNING_RESOURCE = EngineTuningBootstrap.DEFAULT_TUNING_RESOURCE;
 
     private volatile EngineTuningSet population = EngineTuningSet.empty();
 
@@ -66,18 +63,12 @@ public class TuningManager {
     }
 
     private void loadDefaultPopulation() {
-        Resource resource = new ClassPathResource(DEFAULT_TUNING_RESOURCE);
-        if (!resource.exists()) {
+        EngineTuningBootstrap.LoadedTuning loaded = EngineTuningBootstrap.reloadDefaults();
+        population = loaded.population();
+        if (population.isEmpty()) {
             log.warn("Default tuning resource {} not found on classpath", DEFAULT_TUNING_RESOURCE);
-            population = EngineTuningSet.empty();
             return;
         }
-        try (InputStream in = resource.getInputStream()) {
-            population = EngineTuningLoader.load(in);
-            log.info("Loaded {} tuning configurations from classpath resource {}", population.population().size(), DEFAULT_TUNING_RESOURCE);
-        } catch (IOException e) {
-            log.warn("Failed to load default tuning resource {}", DEFAULT_TUNING_RESOURCE, e);
-            population = EngineTuningSet.empty();
-        }
+        log.info("Loaded {} tuning configurations from {}", population.population().size(), loaded.sourceDescription());
     }
 }

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -13,6 +13,7 @@ import julius.game.chessengine.evaluation.MoveContext;
 import julius.game.chessengine.evaluation.PawnStructureModule;
 import julius.game.chessengine.evaluation.PieceSquareModule;
 import julius.game.chessengine.evaluation.ThreatModule;
+import julius.game.chessengine.tuning.EngineTuningBootstrap;
 import julius.game.chessengine.tuning.MoveOrderingParameters;
 import julius.game.chessengine.tuning.NumericTuningParameters;
 
@@ -30,6 +31,10 @@ public class Score {
 
     private static final ThreadLocal<ScoreFactory> THREAD_FACTORY = new ThreadLocal<>();
     private static volatile ScoreFactory GLOBAL_FACTORY = bitBoard -> new Score(bitBoard, EvaluationWeights.identity());
+
+    static {
+        EngineTuningBootstrap.ensureDefaultTuning();
+    }
 
     public static final int CHECKMATE = 100000;
     public static final int CHECK = 50;

--- a/src/test/java/julius/game/chessengine/tuning/EngineTuningBootstrapTest.java
+++ b/src/test/java/julius/game/chessengine/tuning/EngineTuningBootstrapTest.java
@@ -1,0 +1,36 @@
+package julius.game.chessengine.tuning;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EngineTuningBootstrapTest {
+
+    @BeforeEach
+    void clearOverrideProperty() {
+        System.clearProperty("chessengine.tuning.file");
+    }
+
+    @Test
+    void loadsBundledDefaultsWhenNoExternalFileIsConfigured() {
+        EngineTuningBootstrap.LoadedTuning loaded = EngineTuningBootstrap.loadBundledDefaults();
+
+        assertThat(loaded.population()).isNotNull();
+        assertThat(loaded.population().isEmpty()).isFalse();
+        assertThat(loaded.sourceDescription()).isEqualTo("classpath:" + EngineTuningBootstrap.DEFAULT_TUNING_RESOURCE);
+    }
+
+    @Test
+    void reloadAppliesNumericParametersFromBundledDefaults() {
+        // Start with a clearly distinct value so we can observe the reload effect.
+        NumericTuningParameters.setGlobal(Map.of("moveordering.killermovescore", 1.0));
+
+        EngineTuningBootstrap.reloadDefaults();
+
+        double killerScore = NumericTuningParameters.resolve("moveOrdering.killerMoveScore", 0.0);
+        assertThat(killerScore).isGreaterThan(10_000.0); // bundled defaults lift the baseline value
+    }
+}


### PR DESCRIPTION
## Summary
- add an EngineTuningBootstrap helper that applies the bundled tuning defaults when no external file is configured
- initialise Score with the bundled tuning and teach TuningManager to reuse the bootstrap fallback
- cover the new bootstrap with tests to prove the bundled defaults load and influence numeric parameters

## Testing
- `mvn -q -DskipTests package` *(fails: Fatal error compiling: error: release version 25 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68dac060dfe4832a938e916fe974bc80