### PR TITLE
Add AI concurrency board state tests

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static julius.game.chessengine.board.MoveHelper.convertIndexToString;
 import static julius.game.chessengine.board.MoveHelper.createMoveInt;
@@ -27,6 +28,8 @@ import static julius.game.chessengine.helper.KnightHelper.knightMoveTable;
 public class BitBoard {
 
     private static final PieceType[] PROMOTION_PIECES = {PieceType.QUEEN, PieceType.ROOK, PieceType.BISHOP, PieceType.KNIGHT};
+
+    private static final AtomicLong CAPTURE_INCONSISTENCIES = new AtomicLong();
 
     BishopHelper bishopHelper = BishopHelper.getInstance();
     RookHelper rookHelper = RookHelper.getInstance();
@@ -171,11 +174,20 @@ public class BitBoard {
         }
     }
 
+    public static void resetCaptureInconsistencyCounter() {
+        CAPTURE_INCONSISTENCIES.set(0L);
+    }
+
+    public static long getCaptureInconsistencyCount() {
+        return CAPTURE_INCONSISTENCIES.get();
+    }
+
     private void logCaptureInconsistency(String context, PieceType moverType, int fromIndex, int targetIndex) {
         logCaptureInconsistency(context, moverType, fromIndex, targetIndex, null);
     }
 
     private void logCaptureInconsistency(String context, PieceType moverType, int fromIndex, int targetIndex, PieceType expectedCaptured) {
+        CAPTURE_INCONSISTENCIES.incrementAndGet();
         if (log.isErrorEnabled()) {
             log.error("{}", () -> buildCaptureInconsistencyReport(context, moverType, fromIndex, targetIndex, expectedCaptured));
         } else if (log.isWarnEnabled()) {

--- a/src/test/java/julius/game/chessengine/ai/AIMultiThreadConsistencyTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AIMultiThreadConsistencyTest.java
@@ -1,0 +1,114 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.tuning.AiTuning;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static julius.game.chessengine.board.BoardStateAssertions.assertBoardConsistent;
+import static julius.game.chessengine.board.BoardStateAssertions.describeMove;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AIMultiThreadConsistencyTest {
+
+    private record Scenario(String label, String fen, int plies) {
+    }
+
+    private static final List<Scenario> SCENARIOS = List.of(
+            new Scenario("Initial position", null, 6),
+            new Scenario("Logged queen-capture position",
+                    "8/8/4q1k1/4p1p1/5p2/7P/4K3/8 b - - 2 43", 8),
+            new Scenario("Logged king-capture position",
+                    "8/8/3q4/4pk2/5pP1/8/4K3/8 b - - 0 44", 8)
+    );
+
+    @Test
+    void multiThreadedSearchAndPlayMaintainsBoardConsistency() throws InterruptedException {
+        AiTuning tuning = AiTuning.builder()
+                .searchThreads(2)
+                .lazySmpThreads(4)
+                .maxDepth(6)
+                .timeLimitMillis(75)
+                .build();
+
+        Engine engine = new Engine();
+        AI ai = new AI(engine, tuning);
+
+        try {
+            for (Scenario scenario : SCENARIOS) {
+                runScenario(engine, ai, scenario);
+            }
+        } finally {
+            ai.stopCalculation();
+            ai.shutdown();
+        }
+    }
+
+    private void runScenario(Engine engine, AI ai, Scenario scenario) throws InterruptedException {
+        ai.stopCalculation();
+        BitBoard.resetCaptureInconsistencyCounter();
+
+        if (scenario.fen() == null) {
+            engine.startNewGame();
+        } else {
+            engine.importBoardFromFen(scenario.fen());
+        }
+
+        String label = scenario.label();
+        long baselineHash = engine.getBoardStateHash();
+        assertBoardConsistent(engine.getBitBoard(), label + " (start)");
+
+        ai.startAutoPlay(false, false);
+
+        List<Integer> playedMoves = new ArrayList<>(scenario.plies());
+        for (int ply = 0; ply < scenario.plies(); ply++) {
+            if (engine.getGameState().isGameOver()) {
+                break;
+            }
+            int move = waitForBestMove(ai, engine, label + " forward ply " + (ply + 1));
+            if (move == -1) {
+                break;
+            }
+            engine.performMove(move);
+            playedMoves.add(move);
+            assertBoardConsistent(engine.getBitBoard(), label + " after " + describeMove(move));
+        }
+
+        for (int i = playedMoves.size() - 1; i >= 0; i--) {
+            int move = playedMoves.get(i);
+            engine.undoLastMove();
+            assertBoardConsistent(engine.getBitBoard(), label + " after undo " + describeMove(move));
+        }
+
+        ai.stopCalculation();
+
+        assertEquals(baselineHash, engine.getBoardStateHash(),
+                label + " board hash should return to baseline after undo sequence");
+        assertEquals(0L, BitBoard.getCaptureInconsistencyCount(),
+                label + " triggered capture inconsistencies during multi-threaded search");
+        assertBoardConsistent(engine.getBitBoard(), label + " (restored)");
+    }
+
+    private int waitForBestMove(AI ai, Engine engine, String context) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            if (BitBoard.getCaptureInconsistencyCount() > 0) {
+                fail(context + " observed capture inconsistency in worker threads");
+            }
+            if (engine.getGameState().isGameOver()) {
+                return -1;
+            }
+            int move = ai.getCurrentBestMoveInt();
+            if (move != -1) {
+                return move;
+            }
+            Thread.sleep(10L);
+        }
+        fail(context + " timed out waiting for AI best move");
+        return -1;
+    }
+}

--- a/src/test/java/julius/game/chessengine/board/BitBoardDesynchronizationTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardDesynchronizationTest.java
@@ -1,0 +1,140 @@
+package julius.game.chessengine.board;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static julius.game.chessengine.board.BoardStateAssertions.assertBoardConsistent;
+import static julius.game.chessengine.board.BoardStateAssertions.describeMove;
+
+class BitBoardDesynchronizationTest {
+
+    private static final long DFS_VISIT_LIMIT = 1_000_000L;
+
+    private record Scenario(String label, String fen, int depth) {
+    }
+
+    private static final List<Scenario> SCENARIOS = List.of(
+            new Scenario("Initial position", null, 3),
+            new Scenario("Logged queen-capture position",
+                    "8/8/4q1k1/4p1p1/5p2/7P/4K3/8 b - - 2 43", 5),
+            new Scenario("Logged king-capture position",
+                    "8/8/3q4/4pk2/5pP1/8/4K3/8 b - - 0 44", 5)
+    );
+
+    @Test
+    void exhaustiveLegalMoveExplorationDetectsBoardStateDesync() {
+        for (Scenario scenario : SCENARIOS) {
+            BitBoard board = scenario.fen() == null
+                    ? new BitBoard()
+                    : FEN.translateFENtoBitBoard(scenario.fen());
+
+            String label = scenario.label();
+            long initialHash = board.getBoardStateHash();
+            assertBoardConsistent(board, label + " (initial state)");
+
+            long[] visited = new long[1];
+            explore(board, scenario.depth(), label, visited);
+
+            assertTrue(visited[0] > 0, label + " exploration should visit at least one position");
+            assertTrue(visited[0] <= DFS_VISIT_LIMIT,
+                    label + " exploration exceeded visit limit: " + visited[0]);
+
+            assertEquals(initialHash, board.getBoardStateHash(),
+                    label + " board hash should be restored after exhaustive exploration");
+            assertBoardConsistent(board, label + " (after exhaustive exploration)");
+        }
+    }
+
+    @Test
+    void randomPlayoutsMaintainBoardConsistency() {
+        long seedBase = 0xC0FFEE1234L;
+        for (int i = 0; i < SCENARIOS.size(); i++) {
+            Scenario scenario = SCENARIOS.get(i);
+            BitBoard board = scenario.fen() == null
+                    ? new BitBoard()
+                    : FEN.translateFENtoBitBoard(scenario.fen());
+
+            String label = scenario.label();
+            long seed = seedBase + i * 0x9E3779B97F4A7C15L;
+            runRandomPlayout(board, 256, seed, label);
+        }
+    }
+
+    private void explore(BitBoard board, int depth, String label, long[] visited) {
+        if (visited[0]++ > DFS_VISIT_LIMIT) {
+            fail(label + " exceeded exploration limit of " + DFS_VISIT_LIMIT + " positions");
+        }
+
+        assertBoardConsistent(board, label + " depth=" + depth + " (before branching)");
+
+        if (depth == 0) {
+            return;
+        }
+
+        BitBoard.MoveGenResult gen = board.generateAllPossibleMovesWithPins(board.isWhitesTurn());
+        IntArrayList pseudoMoves = gen.moves();
+        List<Integer> legalMoves = new ArrayList<>(pseudoMoves.size());
+        for (int idx = 0; idx < pseudoMoves.size(); idx++) {
+            int move = pseudoMoves.getInt(idx);
+            if (board.isMoveLegalFast(move, gen.pinState())) {
+                legalMoves.add(move);
+            }
+        }
+
+        if (legalMoves.isEmpty()) {
+            return;
+        }
+
+        for (int move : legalMoves) {
+            board.performMove(move);
+            assertBoardConsistent(board, label + " depth=" + depth + " after " + describeMove(move));
+            explore(board, depth - 1, label, visited);
+            board.undoMove(move);
+            assertBoardConsistent(board, label + " depth=" + depth + " after undo " + describeMove(move));
+        }
+    }
+
+    private void runRandomPlayout(BitBoard board, int maxPlies, long seed, String label) {
+        Random random = new Random(seed);
+        List<Integer> history = new ArrayList<>();
+        long initialHash = board.getBoardStateHash();
+        assertBoardConsistent(board, label + " (random playout start)");
+
+        for (int ply = 0; ply < maxPlies; ply++) {
+            BitBoard.MoveGenResult gen = board.generateAllPossibleMovesWithPins(board.isWhitesTurn());
+            IntArrayList pseudoMoves = gen.moves();
+            List<Integer> legalMoves = new ArrayList<>(pseudoMoves.size());
+            for (int idx = 0; idx < pseudoMoves.size(); idx++) {
+                int move = pseudoMoves.getInt(idx);
+                if (board.isMoveLegalFast(move, gen.pinState())) {
+                    legalMoves.add(move);
+                }
+            }
+
+            if (legalMoves.isEmpty()) {
+                break;
+            }
+
+            int move = legalMoves.get(random.nextInt(legalMoves.size()));
+            board.performMove(move);
+            history.add(move);
+            assertBoardConsistent(board, label + " random ply=" + history.size() + " after " + describeMove(move));
+        }
+
+        for (int i = history.size() - 1; i >= 0; i--) {
+            int move = history.get(i);
+            board.undoMove(move);
+            assertBoardConsistent(board, label + " undo ply=" + (history.size() - i) + " after " + describeMove(move));
+        }
+
+        assertEquals(initialHash, board.getBoardStateHash(),
+                label + " board hash should be restored after random playout undo");
+        assertBoardConsistent(board, label + " (after random playout)");
+    }
+
+}

--- a/src/test/java/julius/game/chessengine/board/BoardStateAssertions.java
+++ b/src/test/java/julius/game/chessengine/board/BoardStateAssertions.java
@@ -1,0 +1,88 @@
+package julius.game.chessengine.board;
+
+import julius.game.chessengine.figures.PieceType;
+import julius.game.chessengine.utils.Color;
+
+import static julius.game.chessengine.board.MoveHelper.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public final class BoardStateAssertions {
+
+    private BoardStateAssertions() {
+    }
+
+    public static void assertBoardConsistent(BitBoard board, String context) {
+        long whiteUnion = board.getWhitePawns()
+                | board.getWhiteKnights()
+                | board.getWhiteBishops()
+                | board.getWhiteRooks()
+                | board.getWhiteQueens()
+                | board.getWhiteKing();
+
+        long blackUnion = board.getBlackPawns()
+                | board.getBlackKnights()
+                | board.getBlackBishops()
+                | board.getBlackRooks()
+                | board.getBlackQueens()
+                | board.getBlackKing();
+
+        assertEquals(whiteUnion, board.getWhitePieces(), context + " - white aggregate mismatch");
+        assertEquals(blackUnion, board.getBlackPieces(), context + " - black aggregate mismatch");
+        assertEquals(0L, whiteUnion & blackUnion, context + " - overlapping white/black occupancy");
+        assertEquals(whiteUnion | blackUnion, board.getAllPieces(),
+                context + " - combined occupancy mismatch");
+
+        for (int square = 0; square < 64; square++) {
+            long mask = 1L << square;
+            PieceType piece = board.getPieceTypeAtIndex(square);
+            boolean whiteBit = (whiteUnion & mask) != 0;
+            boolean blackBit = (blackUnion & mask) != 0;
+            boolean aggregatedOccupancy = whiteBit || blackBit;
+            boolean boardOccupancy = board.isOccupied(square);
+
+            String squareLabel = context + " @" + convertIndexToString(square);
+
+            if (piece == null) {
+                assertFalse(aggregatedOccupancy, squareLabel + " - aggregate occupied but no piece recorded");
+                assertFalse(boardOccupancy, squareLabel + " - occupancy flag set without piece");
+                assertNull(board.getPieceColorAtIndex(square), squareLabel + " - color reported without piece");
+            } else {
+                assertTrue(aggregatedOccupancy, squareLabel + " - missing aggregate bit for piece " + piece);
+                assertTrue(boardOccupancy, squareLabel + " - occupancy flag missing for piece " + piece);
+                assertTrue(whiteBit ^ blackBit,
+                        squareLabel + " - piece " + piece + " associated with both colors");
+                Color color = whiteBit ? Color.WHITE : Color.BLACK;
+                assertEquals(color, board.getPieceColorAtIndex(square),
+                        squareLabel + " - piece color mismatch for " + piece);
+                long specific = getPieceBitboard(board, piece, color);
+                assertTrue((specific & mask) != 0,
+                        squareLabel + " - piece " + piece + " missing from specific bitboard");
+            }
+        }
+    }
+
+    public static String describeMove(int move) {
+        PieceType mover = intToPieceType(derivePieceTypeBits(move));
+        String notation = mover + " " + convertIndexToString(deriveFromIndex(move))
+                + "-" + convertIndexToString(deriveToIndex(move));
+        if (isCapture(move)) {
+            notation += "x";
+        }
+        int promotionBits = derivePromotionPieceTypeBits(move);
+        if (promotionBits != 0) {
+            notation += "=" + intToPieceType(promotionBits);
+        }
+        return notation;
+    }
+
+    private static long getPieceBitboard(BitBoard board, PieceType piece, Color color) {
+        return switch (piece) {
+            case PAWN -> color == Color.WHITE ? board.getWhitePawns() : board.getBlackPawns();
+            case KNIGHT -> color == Color.WHITE ? board.getWhiteKnights() : board.getBlackKnights();
+            case BISHOP -> color == Color.WHITE ? board.getWhiteBishops() : board.getBlackBishops();
+            case ROOK -> color == Color.WHITE ? board.getWhiteRooks() : board.getBlackRooks();
+            case QUEEN -> color == Color.WHITE ? board.getWhiteQueens() : board.getBlackQueens();
+            case KING -> color == Color.WHITE ? board.getWhiteKing() : board.getBlackKing();
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- expose BitBoard capture inconsistency counters so tests can detect desyncs triggered in worker threads
- extract reusable board state assertion helpers and refactor the BitBoard desync tests to use them
- add a multi-threaded AI regression test that drives Engine positions under concurrent search to surface board-state corruption

## Testing
- ./mvnw -q test *(fails: Maven wrapper cannot download distribution because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68dacfb8b1d4832ab1fa906d43dedeb1