### PR TITLE
Add AI concurrency regression test

### DIFF
--- a/src/test/java/julius/game/chessengine/ai/AISimulationDesyncTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AISimulationDesyncTest.java
@@ -1,0 +1,154 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.tuning.AiTuning;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static julius.game.chessengine.board.BoardStateAssertions.assertBoardConsistent;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class AISimulationDesyncTest {
+
+    private record Scenario(String label, String fen) {
+    }
+
+    private static final List<Scenario> SCENARIOS = List.of(
+            new Scenario("Initial position", null),
+            new Scenario("Logged queen-capture position",
+                    "8/8/4q1k1/4p1p1/5p2/7P/4K3/8 b - - 2 43"),
+            new Scenario("Logged king-capture position",
+                    "8/8/3q4/4pk2/5pP1/8/4K3/8 b - - 0 44")
+    );
+
+    private static final Duration SEARCH_TIMEOUT = Duration.ofSeconds(2);
+    private static final int SEARCH_CYCLES = 3;
+
+    @Test
+    void lazySmpSearchesRemainSynchronizedWithBitBoards() throws InterruptedException {
+        for (Scenario scenario : SCENARIOS) {
+            Engine engine = new Engine();
+            if (scenario.fen() != null) {
+                engine.importBoardFromFen(scenario.fen());
+            }
+            assertBoardConsistent(engine.getBitBoard(), scenario.label() + " initial board");
+
+            AiTuning tuning = AiTuning.builder()
+                    .searchThreads(2)
+                    .lazySmpThreads(3)
+                    .hashSizeMb(4)
+                    .maxDepth(8)
+                    .timeLimitMillis(30)
+                    .build();
+
+            AI ai = new AI(engine, tuning);
+            CollectingAppender bitBoardAppender = CollectingAppender.attach(BitBoard.class);
+            CollectingAppender aiAppender = CollectingAppender.attach(AI.class);
+            try {
+                runSearchCycles(ai, engine, scenario.label());
+
+                assertFalse(bitBoardAppender.containsMessageFragment("Capture inconsistency detected"),
+                        scenario.label() + " produced capture inconsistency logs");
+                assertFalse(bitBoardAppender.containsMessageFragment("No captured piece present"),
+                        scenario.label() + " raised missing capture errors");
+                assertFalse(aiAppender.containsMessageFragment("Illegal board state during search"),
+                        scenario.label() + " encountered illegal board state during search");
+                assertFalse(aiAppender.containsMessageFragment("Failed to sync simulation"),
+                        scenario.label() + " failed to synchronise worker simulations");
+                assertFalse(aiAppender.containsMessageFragment("Search worker"),
+                        scenario.label() + " logged search worker errors");
+                assertFalse(aiAppender.containsMessageFragment("Failed to create initial simulation"),
+                        scenario.label() + " could not create worker simulations");
+            } finally {
+                ai.shutdown();
+                bitBoardAppender.close();
+                aiAppender.close();
+            }
+        }
+    }
+
+    private void runSearchCycles(AI ai, Engine engine, String label) throws InterruptedException {
+        for (int cycle = 1; cycle <= SEARCH_CYCLES; cycle++) {
+            ai.startAutoPlay(false, false);
+            waitForBestMove(ai, label + " cycle " + cycle);
+
+            assertBoardConsistent(engine.getBitBoard(), label + " cycle " + cycle + " main board");
+            Engine clone = engine.createSimulation();
+            assertBoardConsistent(clone.getBitBoard(), label + " cycle " + cycle + " clone board");
+
+            assertFalse(ai.getCalculatedLine().isEmpty(),
+                    label + " cycle " + cycle + " produced no principal variation");
+
+            ai.stopCalculation();
+            Thread.sleep(25L);
+        }
+    }
+
+    private void waitForBestMove(AI ai, String context) throws InterruptedException {
+        long deadline = System.nanoTime() + SEARCH_TIMEOUT.toNanos();
+        while (System.nanoTime() < deadline) {
+            Integer best = ai.getCurrentBestMoveInt();
+            if (best != null && best >= 0) {
+                return;
+            }
+            Thread.sleep(10L);
+        }
+        fail(context + " timed out waiting for best move");
+    }
+
+    private static final class CollectingAppender extends AbstractAppender {
+        private final CopyOnWriteArrayList<LogEvent> events = new CopyOnWriteArrayList<>();
+        private final Logger logger;
+
+        private CollectingAppender(Logger logger, String name) {
+            super(name, null, null, false, Property.EMPTY_ARRAY);
+            this.logger = logger;
+        }
+
+        static CollectingAppender attach(Class<?> target) {
+            LoggerContext context = LoggerContext.getContext(false);
+            Logger logger = context.getLogger(target.getName());
+            CollectingAppender appender = new CollectingAppender(logger, "test-" + target.getSimpleName());
+            appender.start();
+            logger.addAppender(appender);
+            return appender;
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            events.add(event.toImmutable());
+        }
+
+        boolean containsMessageFragment(String fragment) {
+            for (LogEvent event : events) {
+                String message = event.getMessage() != null
+                        ? event.getMessage().getFormattedMessage()
+                        : "";
+                if (message.contains(fragment)) {
+                    return true;
+                }
+                Throwable thrown = event.getThrown();
+                if (thrown != null && thrown.getMessage() != null && thrown.getMessage().contains(fragment)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        void close() {
+            logger.removeAppender(this);
+            stop();
+            events.clear();
+        }
+    }
+}

--- a/src/test/java/julius/game/chessengine/board/BitBoardDesynchronizationTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardDesynchronizationTest.java
@@ -1,0 +1,154 @@
+package julius.game.chessengine.board;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import julius.game.chessengine.figures.PieceType;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static julius.game.chessengine.board.BoardStateAssertions.assertBoardConsistent;
+import static julius.game.chessengine.board.MoveHelper.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BitBoardDesynchronizationTest {
+
+    private static final long DFS_VISIT_LIMIT = 1_000_000L;
+
+    private record Scenario(String label, String fen, int depth) {
+    }
+
+    private static final List<Scenario> SCENARIOS = List.of(
+            new Scenario("Initial position", null, 3),
+            new Scenario("Logged queen-capture position",
+                    "8/8/4q1k1/4p1p1/5p2/7P/4K3/8 b - - 2 43", 5),
+            new Scenario("Logged king-capture position",
+                    "8/8/3q4/4pk2/5pP1/8/4K3/8 b - - 0 44", 5)
+    );
+
+    @Test
+    void exhaustiveLegalMoveExplorationDetectsBoardStateDesync() {
+        for (Scenario scenario : SCENARIOS) {
+            BitBoard board = scenario.fen() == null
+                    ? new BitBoard()
+                    : FEN.translateFENtoBitBoard(scenario.fen());
+
+            String label = scenario.label();
+            long initialHash = board.getBoardStateHash();
+            assertBoardConsistent(board, label + " (initial state)");
+
+            long[] visited = new long[1];
+            explore(board, scenario.depth(), label, visited);
+
+            assertTrue(visited[0] > 0, label + " exploration should visit at least one position");
+            assertTrue(visited[0] <= DFS_VISIT_LIMIT,
+                    label + " exploration exceeded visit limit: " + visited[0]);
+
+            assertEquals(initialHash, board.getBoardStateHash(),
+                    label + " board hash should be restored after exhaustive exploration");
+            assertBoardConsistent(board, label + " (after exhaustive exploration)");
+        }
+    }
+
+    @Test
+    void randomPlayoutsMaintainBoardConsistency() {
+        long seedBase = 0xC0FFEE1234L;
+        for (int i = 0; i < SCENARIOS.size(); i++) {
+            Scenario scenario = SCENARIOS.get(i);
+            BitBoard board = scenario.fen() == null
+                    ? new BitBoard()
+                    : FEN.translateFENtoBitBoard(scenario.fen());
+
+            String label = scenario.label();
+            long seed = seedBase + i * 0x9E3779B97F4A7C15L;
+            runRandomPlayout(board, 256, seed, label);
+        }
+    }
+
+    private void explore(BitBoard board, int depth, String label, long[] visited) {
+        if (visited[0]++ > DFS_VISIT_LIMIT) {
+            fail(label + " exceeded exploration limit of " + DFS_VISIT_LIMIT + " positions");
+        }
+
+        assertBoardConsistent(board, label + " depth=" + depth + " (before branching)");
+
+        if (depth == 0) {
+            return;
+        }
+
+        BitBoard.MoveGenResult gen = board.generateAllPossibleMovesWithPins(board.isWhitesTurn());
+        IntArrayList pseudoMoves = gen.moves();
+        List<Integer> legalMoves = new ArrayList<>(pseudoMoves.size());
+        for (int idx = 0; idx < pseudoMoves.size(); idx++) {
+            int move = pseudoMoves.getInt(idx);
+            if (board.isMoveLegalFast(move, gen.pinState())) {
+                legalMoves.add(move);
+            }
+        }
+
+        if (legalMoves.isEmpty()) {
+            return;
+        }
+
+        for (int move : legalMoves) {
+            board.performMove(move);
+            assertBoardConsistent(board, label + " depth=" + depth + " after " + describeMove(move));
+            explore(board, depth - 1, label, visited);
+            board.undoMove(move);
+            assertBoardConsistent(board, label + " depth=" + depth + " after undo " + describeMove(move));
+        }
+    }
+
+    private void runRandomPlayout(BitBoard board, int maxPlies, long seed, String label) {
+        Random random = new Random(seed);
+        List<Integer> history = new ArrayList<>();
+        long initialHash = board.getBoardStateHash();
+        assertBoardConsistent(board, label + " (random playout start)");
+
+        for (int ply = 0; ply < maxPlies; ply++) {
+            BitBoard.MoveGenResult gen = board.generateAllPossibleMovesWithPins(board.isWhitesTurn());
+            IntArrayList pseudoMoves = gen.moves();
+            List<Integer> legalMoves = new ArrayList<>(pseudoMoves.size());
+            for (int idx = 0; idx < pseudoMoves.size(); idx++) {
+                int move = pseudoMoves.getInt(idx);
+                if (board.isMoveLegalFast(move, gen.pinState())) {
+                    legalMoves.add(move);
+                }
+            }
+
+            if (legalMoves.isEmpty()) {
+                break;
+            }
+
+            int move = legalMoves.get(random.nextInt(legalMoves.size()));
+            board.performMove(move);
+            history.add(move);
+            assertBoardConsistent(board, label + " random ply=" + history.size() + " after " + describeMove(move));
+        }
+
+        for (int i = history.size() - 1; i >= 0; i--) {
+            int move = history.get(i);
+            board.undoMove(move);
+            assertBoardConsistent(board, label + " undo ply=" + (history.size() - i) + " after " + describeMove(move));
+        }
+
+        assertEquals(initialHash, board.getBoardStateHash(),
+                label + " board hash should be restored after random playout undo");
+        assertBoardConsistent(board, label + " (after random playout)");
+    }
+
+    private static String describeMove(int move) {
+        PieceType mover = intToPieceType(derivePieceTypeBits(move));
+        String notation = mover + " " + convertIndexToString(deriveFromIndex(move))
+                + "-" + convertIndexToString(deriveToIndex(move));
+        if (isCapture(move)) {
+            notation += "x";
+        }
+        int promotionBits = derivePromotionPieceTypeBits(move);
+        if (promotionBits != 0) {
+            notation += "=" + intToPieceType(promotionBits);
+        }
+        return notation;
+    }
+}

--- a/src/test/java/julius/game/chessengine/board/BoardStateAssertions.java
+++ b/src/test/java/julius/game/chessengine/board/BoardStateAssertions.java
@@ -1,0 +1,74 @@
+package julius.game.chessengine.board;
+
+import julius.game.chessengine.figures.PieceType;
+import julius.game.chessengine.utils.Color;
+
+import static julius.game.chessengine.board.MoveHelper.convertIndexToString;
+import static org.junit.jupiter.api.Assertions.*;
+
+public final class BoardStateAssertions {
+
+    private BoardStateAssertions() {
+    }
+
+    public static void assertBoardConsistent(BitBoard board, String context) {
+        long whiteUnion = board.getWhitePawns()
+                | board.getWhiteKnights()
+                | board.getWhiteBishops()
+                | board.getWhiteRooks()
+                | board.getWhiteQueens()
+                | board.getWhiteKing();
+
+        long blackUnion = board.getBlackPawns()
+                | board.getBlackKnights()
+                | board.getBlackBishops()
+                | board.getBlackRooks()
+                | board.getBlackQueens()
+                | board.getBlackKing();
+
+        assertEquals(whiteUnion, board.getWhitePieces(), context + " - white aggregate mismatch");
+        assertEquals(blackUnion, board.getBlackPieces(), context + " - black aggregate mismatch");
+        assertEquals(0L, whiteUnion & blackUnion, context + " - overlapping white/black occupancy");
+        assertEquals(whiteUnion | blackUnion, board.getAllPieces(),
+                context + " - combined occupancy mismatch");
+
+        for (int square = 0; square < 64; square++) {
+            long mask = 1L << square;
+            PieceType piece = board.getPieceTypeAtIndex(square);
+            boolean whiteBit = (whiteUnion & mask) != 0;
+            boolean blackBit = (blackUnion & mask) != 0;
+            boolean aggregatedOccupancy = whiteBit || blackBit;
+            boolean boardOccupancy = board.isOccupied(square);
+
+            String squareLabel = context + " @" + convertIndexToString(square);
+
+            if (piece == null) {
+                assertFalse(aggregatedOccupancy, squareLabel + " - aggregate occupied but no piece recorded");
+                assertFalse(boardOccupancy, squareLabel + " - occupancy flag set without piece");
+                assertNull(board.getPieceColorAtIndex(square), squareLabel + " - color reported without piece");
+            } else {
+                assertTrue(aggregatedOccupancy, squareLabel + " - missing aggregate bit for piece " + piece);
+                assertTrue(boardOccupancy, squareLabel + " - occupancy flag missing for piece " + piece);
+                assertTrue(whiteBit ^ blackBit,
+                        squareLabel + " - piece " + piece + " associated with both colors");
+                Color color = whiteBit ? Color.WHITE : Color.BLACK;
+                assertEquals(color, board.getPieceColorAtIndex(square),
+                        squareLabel + " - piece color mismatch for " + piece);
+                long specific = getPieceBitboard(board, piece, color);
+                assertTrue((specific & mask) != 0,
+                        squareLabel + " - piece " + piece + " missing from specific bitboard");
+            }
+        }
+    }
+
+    private static long getPieceBitboard(BitBoard board, PieceType piece, Color color) {
+        return switch (piece) {
+            case PAWN -> color == Color.WHITE ? board.getWhitePawns() : board.getBlackPawns();
+            case KNIGHT -> color == Color.WHITE ? board.getWhiteKnights() : board.getBlackKnights();
+            case BISHOP -> color == Color.WHITE ? board.getWhiteBishops() : board.getBlackBishops();
+            case ROOK -> color == Color.WHITE ? board.getWhiteRooks() : board.getBlackRooks();
+            case QUEEN -> color == Color.WHITE ? board.getWhiteQueens() : board.getBlackQueens();
+            case KING -> color == Color.WHITE ? board.getWhiteKing() : board.getBlackKing();
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- extract reusable board state assertions into a shared helper for tests
- refactor BitBoardDesynchronizationTest to use the shared invariant checks
- add AISimulationDesyncTest that runs multi-threaded AI search cycles and fails on capture/desync log messages

## Testing
- ./mvnw test -q *(fails: Maven wrapper cannot download distribution because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68dacfb8b1d4832ab1fa906d43dedeb1