### PR TITLE
Handle insufficient material without terminating move handling

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -165,6 +165,7 @@ public class Engine {
             if (gameState.isFiftyMoveRule() || gameState.isThreefoldRepetition()) {
                 cacheLegalMoves(getBoardStateHash(), new IntArrayList(0));
                 gameState.setState(GameStateEnum.DRAW);
+                gameState.setDrawByInsufficientMaterial(bitBoard.hasInsufficientMaterial());
             } else {
                 IntArrayList legalMoves = generateLegalMoves();
                 gameState.updateState(bitBoard, legalMoves, false);

--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -23,6 +23,8 @@ public class GameState {
 
     private Score score;
 
+    private boolean drawByInsufficientMaterial;
+
     @Getter
     private int halfmoveClock = 0;          // resets on pawn move or capture
     @Getter
@@ -33,6 +35,7 @@ public class GameState {
         this.repetition = createRepetitionMap();
         state = GameStateEnum.PLAY;
         score = Score.initializeScore(bitBoard);
+        this.drawByInsufficientMaterial = bitBoard.hasInsufficientMaterial();
         this.halfmoveClock = bitBoard.getHalfmoveClock();
         this.fullmoveNumber = bitBoard.getFullmoveNumber();
         recordHash(bitBoard.getBoardStateHash());
@@ -45,6 +48,7 @@ public class GameState {
         this.halfmoveClock = other.halfmoveClock;
         this.fullmoveNumber = other.fullmoveNumber;
         this.lastZobrist = other.lastZobrist;
+        this.drawByInsufficientMaterial = other.drawByInsufficientMaterial;
         this.hashHistory.addAll(other.hashHistory);
         this.halfmoveStack.addAll(other.halfmoveStack);
         this.fullmoveStack.addAll(other.fullmoveStack);
@@ -76,6 +80,8 @@ public class GameState {
     }
 
     public void updateState(BitBoard bitBoard, IntArrayList legalMoves, boolean isOpeningMove) {
+        drawByInsufficientMaterial = bitBoard.hasInsufficientMaterial();
+
         if (whiteInCheck(bitBoard)) {
             state = GameStateEnum.WHITE_IN_CHECK;
             if (whiteLost(legalMoves)) {
@@ -86,7 +92,7 @@ public class GameState {
             if (blackLost(legalMoves)) {
                 state = GameStateEnum.WHITE_WON;
             }
-        } else if (isDraw(bitBoard, legalMoves)) {
+        } else if (isStalemate(bitBoard, legalMoves)) {
             state = GameStateEnum.DRAW;
         } else if (isFiftyMoveRule() || isThreefoldRepetition()) {
             state = GameStateEnum.DRAW;
@@ -107,7 +113,7 @@ public class GameState {
      */
 
     public boolean isGameOver() {
-        return isInStateCheckMate() || isInStateDraw();
+        return isInStateCheckMate() || state.equals(GameStateEnum.DRAW);
     }
 
     public boolean isInStateCheck() {
@@ -120,7 +126,7 @@ public class GameState {
     }
 
     public boolean isInStateDraw() {
-        return state.equals(GameStateEnum.DRAW);
+        return state.equals(GameStateEnum.DRAW) || drawByInsufficientMaterial;
     }
 
     private boolean whiteInCheck(BitBoard bitBoard) {
@@ -140,11 +146,10 @@ public class GameState {
     }
 
 
-    private boolean isDraw(BitBoard bitBoard, IntArrayList legalMoves) {
-        boolean insufficientMaterial = bitBoard.hasInsufficientMaterial();
+    private boolean isStalemate(BitBoard bitBoard, IntArrayList legalMoves) {
         boolean noLegalMoves = legalMoves.isEmpty();
         boolean inCheck = bitBoard.isInCheck(bitBoard.isWhitesTurn());
-        return (noLegalMoves && !inCheck) || insufficientMaterial;
+        return noLegalMoves && !inCheck;
     }
 
     /**

--- a/src/test/java/julius/game/chessengine/engine/EngineFenImportTest.java
+++ b/src/test/java/julius/game/chessengine/engine/EngineFenImportTest.java
@@ -2,8 +2,9 @@ package julius.game.chessengine.engine;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 class EngineFenImportTest {
 
@@ -17,5 +18,29 @@ class EngineFenImportTest {
         assertTrue(gameState.isGameOver());
         assertEquals(GameStateEnum.DRAW, gameState.getState());
         assertEquals(0, engine.getAllLegalMoves().size());
+    }
+
+    @Test
+    void importingInsufficientMaterialRemainsPlayableButFlagsDraw() {
+        Engine engine = new Engine();
+
+        engine.importBoardFromFen("8/5k2/8/8/8/8/5K2/8 w - - 0 1");
+
+        GameState gameState = engine.getGameState();
+        assertFalse(gameState.isGameOver(), "Insufficient material should not stop move handling");
+        assertEquals(GameStateEnum.PLAY, gameState.getState(), "Engine should remain in PLAY state");
+        assertTrue(gameState.isDrawByInsufficientMaterial(), "Flag should mark draw for UI/evaluation");
+        assertTrue(gameState.isInStateDraw(), "Draw status should be visible to consumers");
+
+        IntArrayList moves = engine.getAllLegalMoves();
+        assertFalse(moves.isEmpty(), "Moves must still be generated under insufficient material");
+
+        int initialHistory = engine.getLine().size();
+        int move = moves.getInt(0);
+        engine.performMove(move);
+        assertEquals(initialHistory + 1, engine.getLine().size(), "performMove must push to history");
+
+        engine.undoLastMove();
+        assertEquals(initialHistory, engine.getLine().size(), "undoLastMove must restore history");
     }
 }


### PR DESCRIPTION
## Summary
- track draw-by-insufficient-material separately from terminal draw states so move handling continues
- update FEN import bookkeeping to preserve the draw flag without suppressing legal moves
- add a regression test ensuring insufficient material positions still generate and execute moves

## Testing
- `mvn -q test` *(fails: release version 25 not supported by available JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68daf0fff674832a9a8010db916dd8ff