### PR TITLE
Fix minimizer TT bounds to use original alpha window

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1416,7 +1416,7 @@ public class AI {
         if (isWhite) {
             return maximizer(simulatorEngine, depth, alpha, beta, boardHash, alphaOriginal, betaOriginal, moves, deadline, prevMove, plyFromRoot, extStreak);
         } else {
-            return minimizer(simulatorEngine, depth, alpha, beta, boardHash, betaOriginal, moves, deadline, prevMove, plyFromRoot, extStreak);
+            return minimizer(simulatorEngine, depth, alpha, beta, boardHash, alphaOriginal, betaOriginal, moves, deadline, prevMove, plyFromRoot, extStreak);
         }
     }
 
@@ -1723,7 +1723,7 @@ public class AI {
 
 
     private double minimizer(Engine simulatorEngine, int depth, double alpha, double beta,
-                             long boardHash, double betaOriginal,
+                             long boardHash, double alphaOriginal, double betaOriginal,
                              IntArrayList moves, long deadline, int prevMove, int plyFromRoot,
                              int extStreak) {
 
@@ -1894,7 +1894,7 @@ public class AI {
 
         if (minEval >= betaOriginal && shouldUpdate) {
             transpositionTable.put(boardHash, new TranspositionTableEntry(minEval, depth, NodeType.LOWERBOUND, bestMoveAtThisNode), depth);
-        } else if (minEval <= alpha && shouldUpdate) {
+        } else if (minEval <= alphaOriginal && shouldUpdate) {
             transpositionTable.put(boardHash, new TranspositionTableEntry(minEval, depth, NodeType.UPPERBOUND, bestMoveAtThisNode), depth);
         } else if (shouldUpdate) {
             transpositionTable.put(boardHash, new TranspositionTableEntry(minEval, depth, NodeType.EXACT, bestMoveAtThisNode), depth);


### PR DESCRIPTION
## Summary
- pass the original alpha window into `minimizer` from `alphaBeta`
- use the original alpha value when deciding the transposition table node type

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daff37e7ec832a8489175cf29b3da0