### PR TITLE
Enhance AI test diagnostics

### DIFF
--- a/src/test/java/julius/game/chessengine/ai/AITest.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest.java
@@ -1,9 +1,8 @@
 package julius.game.chessengine.ai;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.board.Move;
-import julius.game.chessengine.ai.NodeType;
+import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.tuning.AiTuning;
 import julius.game.chessengine.utils.MoveStack;
 import julius.game.chessengine.utils.Score;
@@ -11,17 +10,25 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import testsupport.TestLoggingExtension;
 
-import java.lang.reflect.Field;
+import julius.game.chessengine.ai.NodeType;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static testsupport.TestUtils.extractTableSize;
+import static testsupport.TestUtils.putDummyEntry;
+import static testsupport.TestUtils.readField;
+import static testsupport.TestUtils.readKillersLength;
+import static testsupport.TestUtils.writeField;
 
 @DisplayName("Comprehensive AI behavioural tests with verbose diagnostics")
+@ExtendWith(TestLoggingExtension.class)
 class AITest {
 
     private static final Logger log = LogManager.getLogger(AITest.class);
@@ -216,60 +223,6 @@ class AITest {
         log.info("Hash snapshot -> initial: {}, post-move: {}, after reset: {}", initialHash, mutatedHash, hashAfterReset);
         assertEquals(initialHash, hashAfterReset,
                 "Engine must restart to the initial position when reset is invoked");
-    }
-
-    // ---------------------------------------------------------------------
-    // Helper utilities with verbose logging
-    // ---------------------------------------------------------------------
-
-    private static long futureDeadline() {
-        return System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-    }
-
-    private static Object readField(Object target, String fieldName) throws Exception {
-        Field field = resolveField(target.getClass(), fieldName);
-        field.setAccessible(true);
-        return field.get(target);
-    }
-
-    private static void writeField(Object target, String fieldName, Object value) throws Exception {
-        Field field = resolveField(target.getClass(), fieldName);
-        field.setAccessible(true);
-        field.set(target, value);
-        log.debug("Field {} on {} updated to {}", fieldName, target.getClass().getSimpleName(), value);
-    }
-
-    private static Field resolveField(Class<?> type, String name) throws NoSuchFieldException {
-        Class<?> current = type;
-        while (current != null) {
-            try {
-                return current.getDeclaredField(name);
-            } catch (NoSuchFieldException ignored) {
-                current = current.getSuperclass();
-            }
-        }
-        throw new NoSuchFieldException(name);
-    }
-
-    private static int readKillersLength(Object heuristics) throws Exception {
-        Field killersField = heuristics.getClass().getDeclaredField("killers");
-        killersField.setAccessible(true);
-        int[][] killers = (int[][]) killersField.get(heuristics);
-        return killers.length;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void putDummyEntry(AI ai, String field, long key, Object value) throws Exception {
-        Object table = readField(ai, field);
-        assertNotNull(table, field + " should not be null");
-        Method put = table.getClass().getMethod("put", long.class, Object.class, int.class);
-        put.invoke(table, key, value, 1);
-    }
-
-    private static int extractTableSize(AI ai, String field) throws Exception {
-        Object table = readField(ai, field);
-        Method size = table.getClass().getMethod("size");
-        return (int) size.invoke(table);
     }
 
     private static int computeExpectedCapacity(int hashSizeMb, boolean mainTable)

--- a/src/test/java/testsupport/TestLoggingExtension.java
+++ b/src/test/java/testsupport/TestLoggingExtension.java
@@ -1,0 +1,73 @@
+package testsupport;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * JUnit 5 extension providing structured logging around test execution.
+ */
+public class TestLoggingExtension implements BeforeTestExecutionCallback, AfterTestExecutionCallback, TestWatcher {
+
+    private static final Logger log = LogManager.getLogger(TestLoggingExtension.class);
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(TestLoggingExtension.class);
+    private static final String START_TIME = "start-time";
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context) {
+        log.info(">>> START {}", describe(context));
+        context.getStore(NAMESPACE).put(context.getUniqueId() + START_TIME, System.nanoTime());
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext context) {
+        long start = Optional.ofNullable((Long) context.getStore(NAMESPACE)
+                        .remove(context.getUniqueId() + START_TIME, Long.class))
+                .orElse(System.nanoTime());
+        Duration duration = Duration.ofNanos(System.nanoTime() - start);
+        log.info("<<< END {} ({} ms)", describe(context), duration.toMillis());
+    }
+
+    @Override
+    public void testSuccessful(ExtensionContext context) {
+        log.info("✔ SUCCESS {}", describe(context));
+    }
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        log.error("✖ FAILURE {} -> {}", describe(context), cause.getMessage(), cause);
+        logThreadDump();
+    }
+
+    @Override
+    public void testAborted(ExtensionContext context, Throwable cause) {
+        log.warn("⚠ ABORTED {} -> {}", describe(context), cause == null ? "no reason" : cause.getMessage(), cause);
+    }
+
+    private static String describe(ExtensionContext context) {
+        return context.getRequiredTestClass().getSimpleName() + "." + context.getRequiredTestMethod().getName();
+    }
+
+    private void logThreadDump() {
+        StringBuilder dump = new StringBuilder();
+        dump.append(System.lineSeparator()).append("--- THREAD DUMP ---------------------------------------------------").append(System.lineSeparator());
+        for (Map.Entry<Thread, StackTraceElement[]> entry : Thread.getAllStackTraces().entrySet()) {
+            Thread thread = entry.getKey();
+            dump.append('[').append(thread.getState()).append("] ").append(thread.getName()).append(" (#")
+                    .append(thread.getId()).append(')').append(System.lineSeparator());
+            for (StackTraceElement element : entry.getValue()) {
+                dump.append("    at ").append(element).append(System.lineSeparator());
+            }
+            dump.append(System.lineSeparator());
+        }
+        dump.append("------------------------------------------------------------------");
+        log.error(dump.toString());
+    }
+}

--- a/src/test/java/testsupport/TestUtils.java
+++ b/src/test/java/testsupport/TestUtils.java
@@ -1,0 +1,66 @@
+package testsupport;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * Shared reflection helpers and domain-specific utilities to keep tests concise.
+ */
+public final class TestUtils {
+
+    private static final Logger log = LogManager.getLogger(TestUtils.class);
+
+    private TestUtils() {
+    }
+
+    public static Object readField(Object target, String fieldName) throws ReflectiveOperationException {
+        Field field = resolveField(target.getClass(), fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+
+    public static void writeField(Object target, String fieldName, Object value) throws ReflectiveOperationException {
+        Field field = resolveField(target.getClass(), fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+        log.debug("Field {} on {} updated to {}", fieldName, target.getClass().getSimpleName(), value);
+    }
+
+    public static int readKillersLength(Object heuristics) throws ReflectiveOperationException {
+        Field killersField = heuristics.getClass().getDeclaredField("killers");
+        killersField.setAccessible(true);
+        int[][] killers = (int[][]) killersField.get(heuristics);
+        return killers.length;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static void putDummyEntry(Object ai, String field, long key, Object value) throws ReflectiveOperationException {
+        Object table = readField(ai, field);
+        if (table == null) {
+            throw new IllegalStateException(field + " should not be null");
+        }
+        Method put = table.getClass().getMethod("put", long.class, Object.class, int.class);
+        put.invoke(table, key, value, 1);
+    }
+
+    public static int extractTableSize(Object ai, String field) throws ReflectiveOperationException {
+        Object table = readField(ai, field);
+        Method size = table.getClass().getMethod("size");
+        return (int) size.invoke(table);
+    }
+
+    private static Field resolveField(Class<?> type, String name) throws NoSuchFieldException {
+        Class<?> current = type;
+        while (current != null) {
+            try {
+                return current.getDeclaredField(name);
+            } catch (NoSuchFieldException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable TestLoggingExtension that reports lifecycle events, duration, and thread dumps on failure
- extract reflective helper utilities into testsupport.TestUtils for reuse across tests
- register the new extension and utilities inside AITest so future tests inherit the diagnostics

## Testing
- ./mvnw test *(fails: network is unreachable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc5a4df3c832a8cc2ce845ea6ad47