### PR TITLE
Add comprehensive AI behavioural test suites

### DIFF
--- a/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
@@ -1,0 +1,151 @@
+package julius.game.chessengine.ai;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.tuning.AiTuning;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import testsupport.FakeScheduler;
+import testsupport.TestLoggingExtension;
+import testsupport.TestUtils;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Log4j2
+@ExtendWith(TestLoggingExtension.class)
+class AITest_ConcurrencyAndStops {
+
+    @Test
+    @DisplayName("Stale best move is discarded without performing it")
+    void staleBestMoveIsDropped() throws Exception {
+        Engine engine = new Engine();
+        AI ai = new AI(engine, AiTuning.defaults());
+
+        IntArrayList moves = engine.getAllLegalMoves();
+        int candidate = moves.getInt(0);
+
+        long liveHash = engine.getBoardStateHash();
+        TestUtils.writeField(ai, "currentBestMove", candidate);
+        TestUtils.writeField(ai, "bestMoveForHash", liveHash ^ 0xFFL);
+        TestUtils.writeField(ai, "searchResultReady", true);
+
+        ai.performMove();
+
+        assertEquals(0, engine.getLine().size(), "Stale move must not be executed");
+        assertEquals(-1, TestUtils.readField(ai, "currentBestMove"));
+        assertEquals(-1L, TestUtils.readField(ai, "bestMoveForHash"));
+        assertEquals(Boolean.FALSE, TestUtils.readField(ai, "searchResultReady"));
+    }
+
+    @Test
+    @Timeout(5)
+    @DisplayName("stopCalculation interrupts workers and clears queues")
+    void stopCalculationResetsState() throws Exception {
+        Engine engine = new Engine();
+        AI ai = new AI(engine, AiTuning.defaults());
+
+        Method start = AI.class.getDeclaredMethod("startCalculationThread");
+        start.setAccessible(true);
+        start.invoke(ai);
+
+        // Wait briefly for threads to start
+        Thread.sleep(100);
+
+        ai.stopCalculation();
+
+        BlockingQueue<?> requests = (BlockingQueue<?>) TestUtils.readField(ai, "calculationRequests");
+        BlockingQueue<?> jobs = (BlockingQueue<?>) TestUtils.readField(ai, "searchJobs");
+
+        assertTrue(requests.isEmpty(), "Calculation request queue should be empty after stop");
+        assertTrue(jobs.isEmpty(), "Search job queue should be empty after stop");
+        assertEquals(-1, TestUtils.readField(ai, "currentBestMove"));
+        assertNull(TestUtils.readField(ai, "calculationThreads"));
+        assertNull(TestUtils.readField(ai, "calculationCoordinator"));
+    }
+
+    @Test
+    @DisplayName("Auto-play only executes moves for the configured side")
+    void autoplayRespectsSideToMove() throws Exception {
+        Engine engine = new Engine();
+        FakeAutoAI ai = new FakeAutoAI(engine, AiTuning.defaults());
+
+        IntArrayList moves = engine.getAllLegalMoves();
+        int candidate = moves.getInt(0);
+        long hash = engine.getBoardStateHash();
+
+        TestUtils.writeField(ai, "currentBestMove", candidate);
+        TestUtils.writeField(ai, "bestMoveForHash", hash);
+        TestUtils.writeField(ai, "searchResultReady", true);
+
+        ai.startAutoPlay(true, false);
+        ai.scheduler.tick();
+
+        assertEquals(1, engine.getLine().size(), "Auto-play should execute a move for matching side");
+        assertEquals(candidate, engine.getLine().peek());
+
+        // Reset candidate but mismatch side
+        engine.undoLastMove();
+        TestUtils.writeField(ai, "currentBestMove", candidate);
+        TestUtils.writeField(ai, "bestMoveForHash", engine.getBoardStateHash());
+        TestUtils.writeField(ai, "searchResultReady", true);
+
+        ai.scheduler.tick();
+        assertEquals(0, engine.getLine().size(),
+                "Auto-play must not execute when side to move does not match configuration");
+
+        BlockingQueue<?> requests = (BlockingQueue<?>) TestUtils.readField(ai, "calculationRequests");
+        assertFalse(requests.isEmpty(), "Auto-play should enqueue a new calculation request after executing a move");
+    }
+
+    private static class FakeAutoAI extends AI {
+        private final FakeScheduler scheduler = new FakeScheduler();
+
+        FakeAutoAI(Engine engine, AiTuning tuning) {
+            super(engine, tuning);
+        }
+
+        @Override
+        public void startAutoPlay(boolean aiIsWhite, boolean aiIsBlack) {
+            try {
+                TestUtils.writeField(this, "scheduler", scheduler);
+                Method start = AI.class.getDeclaredMethod("startCalculationThread");
+                start.setAccessible(true);
+                start.invoke(this);
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+
+            scheduler.scheduleAtFixedRate(() -> {
+                try {
+                    boolean keepCalculating = (boolean) TestUtils.readField(this, "keepCalculating");
+                    if (getMainEngine().getGameState().isGameOver() || !keepCalculating) {
+                        stopCalculation();
+                        scheduler.shutdown();
+                        return;
+                    }
+                    boolean whitesTurn = getMainEngine().whitesTurn();
+                    boolean shouldMove = (aiIsWhite && whitesTurn) || (aiIsBlack && !whitesTurn);
+                    if (!shouldMove) {
+                        return;
+                    }
+                    boolean ready = (boolean) TestUtils.readField(this, "searchResultReady");
+                    int current = (int) TestUtils.readField(this, "currentBestMove");
+                    long bestHash = (long) TestUtils.readField(this, "bestMoveForHash");
+                    if (ready && current != -1 && bestHash == getMainEngine().getBoardStateHash()) {
+                        performMove();
+                    }
+                } catch (ReflectiveOperationException e) {
+                    throw new IllegalStateException(e);
+                }
+            }, 0, 50, TimeUnit.MILLISECONDS);
+        }
+    }
+}
+

--- a/src/test/java/julius/game/chessengine/ai/AITest_IterativeDeepeningAndWindows.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_IterativeDeepeningAndWindows.java
@@ -1,0 +1,115 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.tuning.AiTuning;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import testsupport.DeterministicAiHelper;
+import testsupport.TestLoggingExtension;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.SplittableRandom;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Log4j2
+@ExtendWith(TestLoggingExtension.class)
+class AITest_IterativeDeepeningAndWindows {
+
+    @Test
+    @DisplayName("Aspiration windows narrow at depth >=3 and fall back to full window after retries")
+    void aspirationWindowFallsBackToFullWindow() throws Exception {
+        TrackingAI ai = new TrackingAI(new Engine(), AiTuning.defaults());
+        ai.setMaxDepth(4);
+        try (AutoCloseable threads = DeterministicAiHelper.withSingleThread(ai);
+             AutoCloseable time = DeterministicAiHelper.withShortTimeLimit(ai, 150)) {
+            MoveAndScore result = ai.searchBestMoveBlocking(200);
+            assertNotNull(result, "Search must yield a move even under forced retries");
+        }
+
+        List<TrackingAI.WindowInvocation> depthOne = ai.invocationsByDepth.getOrDefault(1, List.of());
+        List<TrackingAI.WindowInvocation> depthTwo = ai.invocationsByDepth.getOrDefault(2, List.of());
+        List<TrackingAI.WindowInvocation> depthThree = ai.invocationsByDepth.getOrDefault(3, List.of());
+
+        log.info("Depth1 invocations: {}", depthOne);
+        log.info("Depth2 invocations: {}", depthTwo);
+        log.info("Depth3 invocations: {}", depthThree);
+
+        assertFalse(depthOne.isEmpty(), "Depth 1 should execute at least once");
+        assertFalse(depthTwo.isEmpty(), "Depth 2 should execute at least once");
+        assertFalse(depthThree.isEmpty(), "Depth 3 should execute at least once");
+
+        assertTrue(depthOne.stream().allMatch(TrackingAI.WindowInvocation::isFullWindow),
+                "First depth must use the full alpha/beta window");
+        assertTrue(depthTwo.stream().allMatch(TrackingAI.WindowInvocation::isFullWindow),
+                "Second depth must use the full alpha/beta window");
+
+        assertTrue(depthThree.stream().anyMatch(TrackingAI.WindowInvocation::isAspirationWindow),
+                "Depth >=3 must start with an aspiration window");
+        assertTrue(depthThree.stream().anyMatch(TrackingAI.WindowInvocation::isFullWindow),
+                "Depth >=3 should fall back to the full window after retries");
+
+        assertTrue(ai.fullWindowFallbackObserved,
+                "Tracking AI should record at least one full-window retry after aspiration failures");
+    }
+
+    private static final class TrackingAI extends AI {
+        private final Map<Integer, List<WindowInvocation>> invocationsByDepth = new HashMap<>();
+        private int aspirationFailures;
+        private boolean fullWindowFallbackObserved;
+
+        private TrackingAI(Engine engine, AiTuning tuning) {
+            super(engine, tuning);
+        }
+
+        @Override
+        protected MoveAndScore searchRootMoves(Engine sim, SearchTask task, int depth, double alpha, double beta, SplittableRandom rng) {
+            WindowInvocation invocation = new WindowInvocation(depth, alpha, beta);
+            invocationsByDepth.computeIfAbsent(depth, d -> new ArrayList<>()).add(invocation);
+            log.info("Depth {} invocation -> alpha={}, beta={}", depth, alpha, beta);
+
+            if (depth >= 3 && invocation.isFullWindow()) {
+                fullWindowFallbackObserved = true;
+            }
+
+            if (depth >= 3 && invocation.isAspirationWindow() && aspirationFailures < 4) {
+                aspirationFailures++;
+                // Return a score below alpha to simulate fail-low and trigger another iteration.
+                return new MoveAndScore(0, alpha - 25.0);
+            }
+
+            double score;
+            if (Double.isInfinite(alpha) && Double.isInfinite(beta)) {
+                score = 0.0;
+            } else {
+                score = Math.min(beta - 1.0, alpha + 1.0);
+            }
+            return new MoveAndScore(0, score);
+        }
+
+        private record WindowInvocation(int depth, double alpha, double beta) {
+            boolean isFullWindow() {
+                return Double.isInfinite(alpha) && Double.isInfinite(beta);
+            }
+
+            boolean isAspirationWindow() {
+                return !isFullWindow();
+            }
+
+            @Override
+            public String toString() {
+                return "WindowInvocation{" +
+                        "depth=" + depth +
+                        ", alpha=" + alpha +
+                        ", beta=" + beta +
+                        '}';
+            }
+        }
+    }
+}
+

--- a/src/test/java/julius/game/chessengine/ai/AITest_PVReconstruction.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_PVReconstruction.java
@@ -1,0 +1,108 @@
+package julius.game.chessengine.ai;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.tuning.AiTuning;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import testsupport.InstrumentedTranspositionTable;
+import testsupport.TestLoggingExtension;
+import testsupport.TestUtils;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Log4j2
+@ExtendWith(TestLoggingExtension.class)
+class AITest_PVReconstruction {
+
+    @Test
+    @DisplayName("PV reconstruction stops at the first non-EXACT entry")
+    void pvStopsAtNonExactEntry() throws Exception {
+        Engine engine = new Engine();
+        AI ai = new AI(engine, AiTuning.defaults());
+
+        InstrumentedTranspositionTable<TranspositionTableEntry> tt = new InstrumentedTranspositionTable<>();
+        TestUtils.writeField(ai, "transpositionTable", tt);
+
+        IntArrayList rootMoves = engine.getAllLegalMoves();
+        assertTrue(rootMoves.size() >= 2, "Opening position must expose enough moves for PV test");
+        int rootMove = rootMoves.getInt(0);
+        Engine afterRoot = engine.createSimulation();
+        afterRoot.performMove(rootMove);
+
+        IntArrayList nextMoves = afterRoot.getAllLegalMoves();
+        assertFalse(nextMoves.isEmpty(), "Second ply must have at least one legal move");
+        int childMove = nextMoves.getInt(0);
+        Engine afterChild = afterRoot.createSimulation();
+        afterChild.performMove(childMove);
+
+        IntArrayList thirdMoves = afterChild.getAllLegalMoves();
+        int terminatingMove = thirdMoves.isEmpty() ? -1 : thirdMoves.getInt(0);
+
+        long rootHash = engine.getBoardStateHash();
+        long childHash = afterRoot.getBoardStateHash();
+        long thirdHash = afterChild.getBoardStateHash();
+
+        tt.put(rootHash, new TranspositionTableEntry(0.75, 4, NodeType.EXACT, rootMove), 4);
+        tt.put(childHash, new TranspositionTableEntry(0.60, 3, NodeType.EXACT, childMove), 3);
+        if (terminatingMove != -1) {
+            tt.put(thirdHash, new TranspositionTableEntry(0.25, 2, NodeType.LOWERBOUND, terminatingMove), 2);
+        }
+
+        Method fill = AI.class.getDeclaredMethod("fillCalculatedLine", Engine.class);
+        fill.setAccessible(true);
+        fill.invoke(ai, engine.createSimulation());
+
+        @SuppressWarnings("unchecked")
+        List<MoveAndScore> pv = (List<MoveAndScore>) TestUtils.readField(ai, "calculatedLine");
+        log.info("Reconstructed PV: {}", pv);
+
+        assertEquals(2, pv.size(), "PV should include root and first child but stop at non-EXACT entry");
+        assertEquals(rootMove, pv.get(0).move);
+        assertEquals(childMove, pv.get(1).move);
+    }
+
+    @Test
+    @DisplayName("Terminal roots skip PV reconstruction and avoid performing moves")
+    void terminalRootSkipsPv() throws Exception {
+        TrackingEngine engine = new TrackingEngine();
+        engine.getGameState().setState(GameStateEnum.DRAW);
+
+        AI ai = new AI(engine, AiTuning.defaults());
+        TestUtils.writeField(ai, "transpositionTable", new InstrumentedTranspositionTable<>());
+
+        Method fill = AI.class.getDeclaredMethod("fillCalculatedLine", Engine.class);
+        fill.setAccessible(true);
+        fill.invoke(ai, engine);
+
+        @SuppressWarnings("unchecked")
+        List<MoveAndScore> pv = (List<MoveAndScore>) TestUtils.readField(ai, "calculatedLine");
+        assertTrue(pv.isEmpty(), "Terminal nodes should yield an empty PV");
+        assertEquals(0, engine.performCount, "Terminal guard must avoid applying moves");
+    }
+
+    private static class TrackingEngine extends Engine {
+        private int performCount;
+
+        TrackingEngine() {
+            super();
+        }
+
+        TrackingEngine(Engine other) {
+            super(other);
+        }
+
+        @Override
+        public void performMove(int move) {
+            performCount++;
+            super.performMove(move);
+        }
+    }
+}
+

--- a/src/test/java/julius/game/chessengine/ai/AITest_PruningAndReductions.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_PruningAndReductions.java
@@ -1,0 +1,175 @@
+package julius.game.chessengine.ai;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.tuning.AiTuning;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import testsupport.DeterministicAiHelper;
+import testsupport.TestLoggingExtension;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Log4j2
+@ExtendWith(TestLoggingExtension.class)
+class AITest_PruningAndReductions {
+
+    @Test
+    @DisplayName("LMR reduction is bounded and monotonic across depth and move index")
+    void lmrReductionMonotonic() throws Exception {
+        AI ai = new AI(new Engine(), AiTuning.defaults());
+        Method lmr = AI.class.getDeclaredMethod("lmrReduction", int.class, int.class, int.class);
+        lmr.setAccessible(true);
+
+        int previousDepthReduction = 0;
+        for (int depth = 2; depth <= 6; depth++) {
+            int previousMoveReduction = 0;
+            for (int moveIndex = 0; moveIndex < 8; moveIndex++) {
+                int reduction = (int) lmr.invoke(ai, depth, moveIndex, 1500);
+                log.info("LMR(depth={}, moveIndex={}) -> {}", depth, moveIndex, reduction);
+                assertTrue(reduction >= 0, "Reduction must be non-negative");
+                assertTrue(reduction <= depth - 1, "Reduction must be < depth");
+                assertTrue(reduction >= previousMoveReduction,
+                        "Later moves should not decrease reduction compared to earlier ones");
+                previousMoveReduction = reduction;
+            }
+            assertTrue(previousMoveReduction >= previousDepthReduction,
+                    "Higher depths should not reduce the maximum reduction achieved at lower depths");
+            previousDepthReduction = previousMoveReduction;
+        }
+    }
+
+    @Test
+    @DisplayName("SEE pruning skips losing captures that fail to give check")
+    void seePruningDropsLosingCapture() throws Exception {
+        PrunableEngine engine = new PrunableEngine();
+        engine.importBoardFromFen("4k3/8/8/8/8/3p4/4P3/4K3 w - - 0 1");
+
+        AI ai = new AI(engine, AiTuning.defaults());
+        try (AutoCloseable threads = DeterministicAiHelper.withSingleThread(ai)) {
+            PrunableEngine simulation = (PrunableEngine) engine.createSimulation();
+            IntArrayList legal = simulation.getAllLegalMoves();
+            assertTrue(legal.size() > 0, "Test position should have legal moves");
+            simulation.markLosingCapture(legal);
+
+            ai.evaluateBoard(simulation, true,
+                    System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(200));
+
+            log.info("Performed moves recorded: {}", simulation.performedMoves);
+            assertEquals(0, simulation.losingCapturePerformed,
+                    "Losing capture without giving check should be pruned");
+        }
+    }
+
+    @Test
+    @DisplayName("Null-move pruning disabled when side to move is in check")
+    void nullMoveDisabledInCheck() throws Exception {
+        NullTrackingEngine inCheck = new NullTrackingEngine();
+        inCheck.importBoardFromFen("4k3/8/8/8/8/8/4R3/4K3 b - - 0 1");
+        inCheck.getGameState().setState(GameStateEnum.BLACK_IN_CHECK);
+
+        NullTrackingEngine safe = new NullTrackingEngine();
+        safe.importBoardFromFen("4k3/8/8/8/8/8/4R3/4K3 w - - 0 1");
+        safe.getGameState().setState(GameStateEnum.PLAY);
+
+        AI aiInCheck = new AI(inCheck, AiTuning.defaults());
+        AI aiSafe = new AI(safe, AiTuning.defaults());
+
+        Method alphaBeta = AI.class.getDeclaredMethod("alphaBeta", Engine.class, int.class, double.class, double.class,
+                boolean.class, long.class, int.class, int.class, int.class);
+        alphaBeta.setAccessible(true);
+
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1);
+        alphaBeta.invoke(aiInCheck, inCheck.createSimulation(), 3,
+                Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, false, deadline, 1, 0, 0);
+        alphaBeta.invoke(aiSafe, safe.createSimulation(), 3,
+                Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, true, deadline, 1, 0, 0);
+
+        log.info("Null-move counters -> inCheck={}, safe={}", inCheck.nullMoveCalls, safe.nullMoveCalls);
+        assertEquals(0, inCheck.nullMoveCalls,
+                "Engine in check must not attempt null-move pruning");
+        assertTrue(safe.nullMoveCalls > 0,
+                "Safe position should attempt at least one null move");
+    }
+
+    private static class PrunableEngine extends Engine {
+        private int losingCapture = -1;
+        private int losingCapturePerformed;
+        private final List<Integer> performedMoves = new ArrayList<>();
+
+        PrunableEngine() {
+            super();
+        }
+
+        PrunableEngine(Engine other) {
+            super(other);
+        }
+
+        @Override
+        public Engine createSimulation() {
+            return new PrunableEngine(this);
+        }
+
+        void markLosingCapture(IntArrayList legal) {
+            for (int i = 0; i < legal.size(); i++) {
+                int move = legal.getInt(i);
+                if (julius.game.chessengine.board.MoveHelper.isCapture(move)) {
+                    losingCapture = move;
+                    break;
+                }
+            }
+            if (losingCapture == -1) {
+                throw new IllegalStateException("No capture available to mark as losing");
+            }
+        }
+
+        @Override
+        public int see(int move) {
+            if (move == losingCapture) {
+                return -200;
+            }
+            return super.see(move);
+        }
+
+        @Override
+        public void performMove(int move) {
+            performedMoves.add(move);
+            if (move == losingCapture) {
+                losingCapturePerformed++;
+            }
+            super.performMove(move);
+        }
+    }
+
+    private static class NullTrackingEngine extends Engine {
+        private int nullMoveCalls;
+
+        NullTrackingEngine() {
+            super();
+        }
+
+        NullTrackingEngine(Engine other) {
+            super(other);
+        }
+
+        @Override
+        public Engine createSimulation() {
+            return new NullTrackingEngine(this);
+        }
+
+        @Override
+        public int doNullMoveForSearch() {
+            nullMoveCalls++;
+            return super.doNullMoveForSearch();
+        }
+    }
+}
+

--- a/src/test/java/julius/game/chessengine/ai/AITest_QuiescenceAndTerminalInvariants.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_QuiescenceAndTerminalInvariants.java
@@ -1,0 +1,113 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.tuning.AiTuning;
+import julius.game.chessengine.utils.Score;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import testsupport.DeterministicAiHelper;
+import testsupport.TestLoggingExtension;
+import testsupport.TestUtils;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Log4j2
+@ExtendWith(TestLoggingExtension.class)
+class AITest_QuiescenceAndTerminalInvariants {
+
+    @Test
+    @DisplayName("evaluateBoard applies draw bias based on score difference")
+    void evaluateBoardRespectsDrawBias() throws Exception {
+        try (AutoCloseable ignored = Score.useFactory(bitBoard -> new Score(bitBoard, null) {
+            @Override
+            public double getScoreDifference() {
+                return 150.0;
+            }
+        })) {
+            CountingEngine engine = new CountingEngine();
+            engine.getGameState().setState(GameStateEnum.DRAW);
+            engine.getGameState().setDrawByInsufficientMaterial(false);
+
+            AI ai = new AI(engine, AiTuning.defaults());
+            try (AutoCloseable threads = DeterministicAiHelper.withSingleThread(ai)) {
+                double whiteScore = ai.evaluateBoard(engine.createSimulation(), true,
+                        System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(200));
+                double blackScore = ai.evaluateBoard(engine.createSimulation(), false,
+                        System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(200));
+
+                log.info("Draw bias check -> whiteScore={}, blackScore={} ", whiteScore, blackScore);
+
+                assertEquals(Score.DRAW - 0.20, whiteScore, 1e-6,
+                        "White should see DRAW - bias when ahead in a terminal draw");
+                assertEquals(Score.DRAW + 0.20, blackScore, 1e-6,
+                        "Black should see DRAW + bias when behind in a terminal draw");
+            }
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    @DisplayName("Quiescence expands more evasions when side is in check")
+    void quiescenceExploresMoreMovesWhenInCheck() throws Exception {
+        CountingEngine inCheckRoot = new CountingEngine();
+        inCheckRoot.importBoardFromFen("4k3/8/8/8/8/8/4R3/4K3 b - - 0 1");
+
+        CountingEngine safeRoot = new CountingEngine();
+        safeRoot.importBoardFromFen("4k3/4p3/8/8/8/8/4R3/4K3 b - - 0 1");
+
+        AI ai = new AI(inCheckRoot, AiTuning.defaults());
+        try (AutoCloseable threads = DeterministicAiHelper.withSingleThread(ai);
+             AutoCloseable time = DeterministicAiHelper.withShortTimeLimit(ai, 150)) {
+            CountingEngine inCheckSim = (CountingEngine) inCheckRoot.createSimulation();
+            ai.evaluateBoard(inCheckSim, false,
+                    System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(200));
+
+            CountingEngine safeSim = (CountingEngine) safeRoot.createSimulation();
+            // swap main engine reference so SEE cache and TT remain valid for the safe position
+            TestUtils.writeField(ai, "mainEngine", safeRoot);
+            ai.evaluateBoard(safeSim, false,
+                    System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(200));
+
+            log.info("In-check quiescence performed {} moves, safe position performed {}", inCheckSim.getPerformCount(),
+                    safeSim.getPerformCount());
+
+            assertTrue(inCheckSim.getPerformCount() > safeSim.getPerformCount(),
+                    "In-check position should explore at least as many moves as the safe position");
+        }
+    }
+
+    private static class CountingEngine extends Engine {
+        private int performCount;
+
+        CountingEngine() {
+            super();
+        }
+
+        CountingEngine(Engine other) {
+            super(other);
+        }
+
+        @Override
+        public Engine createSimulation() {
+            return new CountingEngine(this);
+        }
+
+        @Override
+        public void performMove(int move) {
+            performCount++;
+            super.performMove(move);
+        }
+
+        int getPerformCount() {
+            return performCount;
+        }
+    }
+}
+

--- a/src/test/java/julius/game/chessengine/ai/AITest_TranspositionTableBehavior.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_TranspositionTableBehavior.java
@@ -1,0 +1,133 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.tuning.AiTuning;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import testsupport.DeterministicAiHelper;
+import testsupport.InstrumentedTranspositionTable;
+import testsupport.TestLoggingExtension;
+import testsupport.TestUtils;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Log4j2
+@ExtendWith(TestLoggingExtension.class)
+class AITest_TranspositionTableBehavior {
+
+    private static final double WINDOW_SECONDS = 0.25;
+
+    private AI newAi() {
+        Engine engine = new Engine();
+        AI ai = new AI(engine, AiTuning.defaults());
+        ai.setMaxDepth(4);
+        return ai;
+    }
+
+    @Test
+    @DisplayName("Iterative deepening interacts with the main and capture TT")
+    void transpositionTableCountersIncrementDuringSearch() throws Exception {
+        AI ai = newAi();
+        try (AutoCloseable ignore = DeterministicAiHelper.withSingleThread(ai);
+             AutoCloseable time = DeterministicAiHelper.withShortTimeLimit(ai, 150)) {
+
+            InstrumentedTranspositionTable<TranspositionTableEntry> main = new InstrumentedTranspositionTable<>();
+            InstrumentedTranspositionTable<CaptureTranspositionTableEntry> capture = new InstrumentedTranspositionTable<>();
+            TestUtils.writeField(ai, "transpositionTable", main);
+            TestUtils.writeField(ai, "captureTranspositionTable", capture);
+
+            log.info("Starting short deterministic search to observe TT interaction");
+            MoveAndScore result = ai.searchBestMoveBlocking(150);
+            log.info("Search result: move={}, score={}", result != null ? result.move : -1,
+                    result != null ? result.score : Double.NaN);
+
+            InstrumentedTranspositionTable.Snapshot mainSnapshot = main.snapshot();
+            InstrumentedTranspositionTable.Snapshot captureSnapshot = capture.snapshot();
+
+            log.info("Main TT snapshot: {}", mainSnapshot);
+            log.info("Capture TT snapshot: {}", captureSnapshot);
+
+            assertTrue(mainSnapshot.getCount() > 0, "Main table should be probed at least once");
+            assertTrue(mainSnapshot.putCount() > 0, "Main table should store at least one entry");
+            assertTrue(mainSnapshot.advanceAgeCount() >= 1, "advanceAge should run per iteration");
+
+            assertTrue(captureSnapshot.advanceAgeCount() >= 1, "Capture table ages with iterations");
+            assertTrue(captureSnapshot.putCount() >= 1, "Capture table should cache quiescence scores");
+        }
+    }
+
+    @ParameterizedTest(name = "Hash size {0} MB produces expected TT capacities")
+    @ValueSource(ints = {1, 8, 64, 4096})
+    void capacityMatchesProductionComputation(int hashSize) throws Exception {
+        AI ai = newAi();
+        ai.setHashSizeMb(hashSize);
+
+        int expectedMain = computeExpectedCapacity(hashSize, true);
+        int expectedCapture = computeExpectedCapacity(hashSize, false);
+
+        log.info("Hash {} MB -> expected main {} capture {}", hashSize, expectedMain, expectedCapture);
+        log.info("Observed capacities -> main {} capture {}", ai.getTranspositionTableCapacity(),
+                ai.getCaptureTranspositionTableCapacity());
+
+        assertEquals(expectedMain, ai.getTranspositionTableCapacity(),
+                "Main TT capacity mismatch for hash size " + hashSize);
+        assertEquals(expectedCapture, ai.getCaptureTranspositionTableCapacity(),
+                "Capture TT capacity mismatch for hash size " + hashSize);
+    }
+
+    @Test
+    @DisplayName("evaluateBoard reuses capture TT entries across calls")
+    void evaluateBoardUsesCaptureCache() throws Exception {
+        AI ai = newAi();
+
+        InstrumentedTranspositionTable<CaptureTranspositionTableEntry> capture = new InstrumentedTranspositionTable<>();
+        TestUtils.writeField(ai, "captureTranspositionTable", capture);
+
+        long deadline = System.nanoTime() + (long) (WINDOW_SECONDS * TimeUnit.SECONDS.toNanos(1));
+        boolean isWhite = ai.getMainEngine().whitesTurn();
+
+        log.info("First evaluation on empty cache");
+        double first = ai.evaluateBoard(ai.getMainEngine().createSimulation(), isWhite, deadline);
+        InstrumentedTranspositionTable.Snapshot afterFirst = capture.snapshot();
+        log.info("First score={} snapshot={}", first, afterFirst);
+
+        log.info("Second evaluation should hit the cache");
+        double second = ai.evaluateBoard(ai.getMainEngine().createSimulation(), isWhite, deadline);
+        InstrumentedTranspositionTable.Snapshot afterSecond = capture.snapshot();
+        log.info("Second score={} snapshot={}", second, afterSecond);
+
+        assertEquals(afterFirst.putCount(), afterSecond.putCount(),
+                "Second evaluation must not insert a new entry");
+        assertTrue(afterSecond.getCount() > afterFirst.getCount(),
+                "Second evaluation should perform at least one cache lookup");
+    }
+
+    @SneakyThrows
+    private static int computeExpectedCapacity(int hashSizeMb, boolean mainTable) {
+        long totalBytes = Math.max(1L, (long) hashSizeMb * 1024L * 1024L);
+        double totalWeight = 2.0 + 1.0;
+        long mainBudget = Math.max(1L, (long) (totalBytes * (2.0 / totalWeight)));
+        long captureBudget = Math.max(1L, totalBytes - mainBudget);
+        if (captureBudget <= 0) {
+            captureBudget = 1L;
+            mainBudget = Math.max(1L, totalBytes - captureBudget);
+        }
+        long budget = mainTable ? mainBudget : captureBudget;
+        int entrySize = mainTable ? 48 : 32;
+        int minEntries = mainTable ? (1 << 12) : (1 << 11);
+        int maxEntries = mainTable ? (1 << 26) : (1 << 25);
+
+        Method method = AI.class.getDeclaredMethod("computeTableCapacity", long.class, int.class, int.class, int.class);
+        method.setAccessible(true);
+        return (int) method.invoke(null, budget, entrySize, minEntries, maxEntries);
+    }
+}
+

--- a/src/test/java/julius/game/chessengine/ai/AITest_UtilitiesAndMath.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_UtilitiesAndMath.java
@@ -1,0 +1,69 @@
+package julius.game.chessengine.ai;
+
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import testsupport.TestLoggingExtension;
+
+import java.lang.reflect.Method;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Log4j2
+@ExtendWith(TestLoggingExtension.class)
+class AITest_UtilitiesAndMath {
+
+    @Test
+    @DisplayName("roundUpToPowerOfTwo handles edge cases and saturates")
+    void roundUpToPowerOfTwoEdgeCases() throws Exception {
+        Method method = AI.class.getDeclaredMethod("roundUpToPowerOfTwo", int.class);
+        method.setAccessible(true);
+
+        int[] inputs = {0, 1, 2, 3, 5, 1023, 1024, 1025, Integer.MAX_VALUE};
+        for (int value : inputs) {
+            int rounded = (int) method.invoke(null, value);
+            log.info("roundUpToPowerOfTwo({}) -> {}", value, rounded);
+            assertTrue(rounded >= 1, "Result must be at least one");
+            assertTrue(isPowerOfTwo(rounded), "Result must be a power of two");
+            if (value > (1 << 30)) {
+                assertEquals(1 << 30, rounded, "Values above 2^30 should saturate");
+            } else if (Integer.highestOneBit(value) == value && value > 0) {
+                assertEquals(value, rounded, "Exact powers must remain unchanged");
+            } else if (value > 1 && value <= (1 << 30)) {
+                assertTrue(rounded >= value, "Rounded value must not shrink");
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("computeTableCapacity clamps to range and returns power of two")
+    void computeTableCapacityProperties() throws Exception {
+        Method method = AI.class.getDeclaredMethod("computeTableCapacity", long.class, int.class, int.class, int.class);
+        method.setAccessible(true);
+
+        Random random = new Random(42);
+        int min = 1 << 12;
+        int max = 1 << 20;
+        for (int i = 0; i < 50; i++) {
+            long budget = 1 + Math.abs(random.nextLong()) % (1L << 34);
+            int entrySize = 16 + random.nextInt(32);
+            int capacity = (int) method.invoke(null, budget, entrySize, min, max);
+            log.info("Capacity computed from budget={} bytes entrySize={} -> {}", budget, entrySize, capacity);
+            assertTrue(capacity >= min && capacity <= max, "Capacity must be clamped within bounds");
+            assertTrue(isPowerOfTwo(capacity), "Capacity must be a power of two");
+        }
+
+        int belowMin = (int) method.invoke(null, 1L, 1024, min, max);
+        assertEquals(min, belowMin, "Tiny budgets should clamp to minimum");
+
+        int aboveMax = (int) method.invoke(null, Long.MAX_VALUE, 1, min, max);
+        assertEquals(max, aboveMax, "Huge budgets should clamp to maximum");
+    }
+
+    private static boolean isPowerOfTwo(int value) {
+        return value > 0 && (value & (value - 1)) == 0;
+    }
+}
+

--- a/src/test/java/testsupport/DeterministicAiHelper.java
+++ b/src/test/java/testsupport/DeterministicAiHelper.java
@@ -1,0 +1,56 @@
+package testsupport;
+
+import julius.game.chessengine.ai.AI;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Helper utilities to keep AI tests deterministic.
+ */
+public final class DeterministicAiHelper {
+
+    private static final Logger log = LogManager.getLogger(DeterministicAiHelper.class);
+
+    private DeterministicAiHelper() {
+    }
+
+    public static AutoCloseable withSingleThread(AI ai) {
+        int previousThreads = ai.getSearchThreads();
+        int previousLazy;
+        try {
+            previousLazy = (int) TestUtils.readField(ai, "lazySmpThreads");
+            TestUtils.writeField(ai, "lazySmpThreads", 1);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to force single threaded mode", e);
+        }
+        ai.setSearchThreads(1);
+        log.debug("Forced AI into single-threaded mode");
+        return () -> {
+            ai.setSearchThreads(previousThreads);
+            try {
+                TestUtils.writeField(ai, "lazySmpThreads", previousLazy);
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException("Unable to restore Lazy SMP threads", e);
+            }
+        };
+    }
+
+    public static AutoCloseable withShortTimeLimit(AI ai, long millis) {
+        long previous;
+        try {
+            previous = (long) TestUtils.readField(ai, "timeLimit");
+            TestUtils.writeField(ai, "timeLimit", millis);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to adjust AI time limit", e);
+        }
+        log.debug("Temporary time limit set to {} ms", millis);
+        return () -> {
+            try {
+                TestUtils.writeField(ai, "timeLimit", previous);
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException("Unable to restore AI time limit", e);
+            }
+        };
+    }
+}
+

--- a/src/test/java/testsupport/FakeScheduler.java
+++ b/src/test/java/testsupport/FakeScheduler.java
@@ -1,0 +1,175 @@
+package testsupport;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Simple {@link ScheduledExecutorService} that never spawns threads. Tests manually advance time by calling
+ * {@link #tick()} or {@link #tick(int)} which synchronously execute scheduled tasks.
+ */
+public final class FakeScheduler extends AbstractExecutorService implements ScheduledExecutorService {
+
+    private static final Logger log = LogManager.getLogger(FakeScheduler.class);
+
+    private final List<FakeScheduledFuture<?>> tasks = Collections.synchronizedList(new ArrayList<>());
+    private final AtomicBoolean shutdown = new AtomicBoolean();
+
+    @Override
+    public void shutdown() {
+        shutdown.set(true);
+        tasks.clear();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        shutdown();
+        return List.of();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return shutdown.get();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return isShutdown();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+        return isShutdown();
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        Objects.requireNonNull(command, "command");
+        if (isShutdown()) {
+            return;
+        }
+        command.run();
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        throw new UnsupportedOperationException("Single-shot scheduling not implemented for tests");
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        throw new UnsupportedOperationException("Single-shot scheduling not implemented for tests");
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        Objects.requireNonNull(command, "command");
+        if (isShutdown()) {
+            throw new IllegalStateException("Scheduler already shut down");
+        }
+        FakeScheduledFuture<?> future = new FakeScheduledFuture<>(command, period, unit);
+        tasks.add(future);
+        log.debug("Scheduled periodic task (delay={} {}, period={} {})", initialDelay, unit, period, unit);
+        if (initialDelay <= 0) {
+            future.runOnce();
+        }
+        return future;
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        throw new UnsupportedOperationException("Fixed-delay scheduling not implemented for tests");
+    }
+
+    public void tick() {
+        tick(1);
+    }
+
+    public void tick(int times) {
+        if (times <= 0) {
+            return;
+        }
+        List<FakeScheduledFuture<?>> snapshot;
+        synchronized (tasks) {
+            snapshot = new ArrayList<>(tasks);
+        }
+        for (int i = 0; i < times; i++) {
+            for (FakeScheduledFuture<?> task : snapshot) {
+                if (!task.isCancelled() && !isShutdown()) {
+                    task.runOnce();
+                }
+            }
+        }
+    }
+
+    private static final class FakeScheduledFuture<V> implements ScheduledFuture<V> {
+        private final Runnable command;
+        private final long periodNanos;
+        private final AtomicBoolean cancelled = new AtomicBoolean();
+
+        private FakeScheduledFuture(Runnable command, long period, TimeUnit unit) {
+            this.command = command;
+            this.periodNanos = unit.toNanos(period);
+        }
+
+        private void runOnce() {
+            if (cancelled.get()) {
+                return;
+            }
+            try {
+                command.run();
+            } catch (Throwable t) {
+                log.error("FakeScheduler task threw", t);
+            }
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return unit.convert(periodNanos, TimeUnit.NANOSECONDS);
+        }
+
+        @Override
+        public int compareTo(Delayed o) {
+            return 0;
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return cancelled.compareAndSet(false, true);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled.get();
+        }
+
+        @Override
+        public boolean isDone() {
+            return cancelled.get();
+        }
+
+        @Override
+        public V get() throws InterruptedException, ExecutionException {
+            return null;
+        }
+
+        @Override
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return null;
+        }
+    }
+}
+

--- a/src/test/java/testsupport/InstrumentedTranspositionTable.java
+++ b/src/test/java/testsupport/InstrumentedTranspositionTable.java
@@ -1,0 +1,71 @@
+package testsupport;
+
+import julius.game.chessengine.ai.TranspositionTable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Lightweight {@link TranspositionTable} implementation that records method invocation counts.
+ * Tests can inject this table to observe the interaction pattern without affecting production code.
+ */
+public final class InstrumentedTranspositionTable<V> implements TranspositionTable<V> {
+
+    private static final Logger log = LogManager.getLogger(InstrumentedTranspositionTable.class);
+
+    private final Map<Long, V> store = new ConcurrentHashMap<>();
+    private final AtomicInteger getCount = new AtomicInteger();
+    private final AtomicInteger putCount = new AtomicInteger();
+    private final AtomicInteger clearCount = new AtomicInteger();
+    private final AtomicInteger advanceAgeCount = new AtomicInteger();
+
+    @Override
+    public V get(long key) {
+        int count = getCount.incrementAndGet();
+        log.debug("Instrumented TT get #{} -> {}", count, key);
+        return store.get(key);
+    }
+
+    @Override
+    public void put(long key, V value, int depth) {
+        int count = putCount.incrementAndGet();
+        log.debug("Instrumented TT put #{} -> key {}, depth {}", count, key, depth);
+        store.put(key, value);
+    }
+
+    @Override
+    public void clear() {
+        int count = clearCount.incrementAndGet();
+        log.debug("Instrumented TT clear #{}", count);
+        store.clear();
+    }
+
+    @Override
+    public int size() {
+        return store.size();
+    }
+
+    @Override
+    public void advanceAge() {
+        int count = advanceAgeCount.incrementAndGet();
+        log.debug("Instrumented TT advanceAge #{}", count);
+    }
+
+    public Snapshot snapshot() {
+        return new Snapshot(getCount.get(), putCount.get(), clearCount.get(), advanceAgeCount.get(), store.size());
+    }
+
+    public void resetCounters() {
+        getCount.set(0);
+        putCount.set(0);
+        clearCount.set(0);
+        advanceAgeCount.set(0);
+    }
+
+    public record Snapshot(int getCount, int putCount, int clearCount, int advanceAgeCount, int size) {
+    }
+}
+


### PR DESCRIPTION
## Summary
- add dedicated AI behavioural suites covering TT usage, iterative deepening windows, quiescence invariants, pruning/null-move rules, PV reconstruction, and concurrency handling
- introduce reusable test utilities including an instrumented transposition table, fake scheduler, and deterministic AI helpers
- validate math helpers for table sizing and aspiration window fallbacks via reflection-driven assertions

## Testing
- mvn -q -DskipTests=false test *(fails: toolchain lacks Java 25 support in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc8a6e73c832aac9e8ff00de8dde8