### PR TITLE
Prevent redundant search enqueue on autoplay start

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -457,7 +457,7 @@ public class AI {
         keepCalculating = true;
 
         if (calculationCoordinator != null && calculationCoordinator.isAlive()) {
-            enqueueCalculationRequest();
+            enqueueCalculationRequestIfNeeded();
             return;
         }
 
@@ -477,6 +477,16 @@ public class AI {
             calculationThreads[i] = worker;
         }
 
+        enqueueCalculationRequestIfNeeded();
+    }
+
+    private void enqueueCalculationRequestIfNeeded() {
+        if (searchResultReady && currentBestMove != -1) {
+            long currentHash = mainEngine.getBoardStateHash();
+            if (bestMoveForHash == currentHash) {
+                return;
+            }
+        }
         enqueueCalculationRequest();
     }
 


### PR DESCRIPTION
## Summary
- avoid enqueuing a new calculation request when a fresh search result already matches the current board state
- reuse the existing result when autoplay starts so that moves honour the side-to-move configuration

## Testing
- `./mvnw -Dtest=AITest_ConcurrencyAndStops test` *(fails: Maven wrapper cannot download dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbce543edc832a8509f867dbe50d0b