### PR TITLE
Guard auto-play by configured sides

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -192,6 +192,9 @@ public class AI {
 
     private ScheduledExecutorService scheduler;
 
+    private volatile boolean autoPlayWhite;
+    private volatile boolean autoPlayBlack;
+
     private final BlockingQueue<CalculationRequest> calculationRequests = new LinkedBlockingQueue<>();
     private final BlockingQueue<SearchJob> searchJobs = new LinkedBlockingQueue<>();
 
@@ -814,10 +817,17 @@ public class AI {
         previousBestMove = -1;
         previousBestMoveHash = -1;
         searchResultReady = false;
+        setAutoPlaySides(false, false);
     }
 
 
+    protected void setAutoPlaySides(boolean aiIsWhite, boolean aiIsBlack) {
+        this.autoPlayWhite = aiIsWhite;
+        this.autoPlayBlack = aiIsBlack;
+    }
+
     public void startAutoPlay(boolean aiIsWhite, boolean aiIsBlack) {
+        setAutoPlaySides(aiIsWhite, aiIsBlack);
         if (scheduler != null && !scheduler.isShutdown()) {
             scheduler.shutdownNow(); // Ensure previous scheduler is stopped
         }
@@ -831,7 +841,9 @@ public class AI {
                 scheduler.shutdown();
                 return;
             }
-            if ((aiIsWhite && mainEngine.whitesTurn()) || (aiIsBlack && !mainEngine.whitesTurn())) {
+            boolean whitesTurn = mainEngine.whitesTurn();
+            boolean shouldMove = (autoPlayWhite && whitesTurn) || (autoPlayBlack && !whitesTurn);
+            if (shouldMove) {
                 if (searchResultReady && currentBestMove != -1 &&
                         bestMoveForHash == mainEngine.getBoardStateHash()) {
                     performMove();
@@ -875,7 +887,18 @@ public class AI {
             return;
         }
 
-        if (MoveHelper.isWhitesMove(currentBestMove) != mainEngine.whitesTurn()) {
+        boolean moveIsWhite = MoveHelper.isWhitesMove(currentBestMove);
+        if ((moveIsWhite && !autoPlayWhite) || (!moveIsWhite && !autoPlayBlack)) {
+            log.info("Best move {} disabled by auto-play configuration", Move.convertIntToMove(currentBestMove));
+            currentBestMove = -1;
+            bestMoveForHash = -1;
+            previousBestMove = -1;
+            previousBestMoveHash = -1;
+            searchResultReady = false;
+            return;
+        }
+
+        if (moveIsWhite != mainEngine.whitesTurn()) {
             log.info("Best move {} not for side to move", Move.convertIntToMove(currentBestMove));
             currentBestMove = -1;                           // (optional) also drop here
             bestMoveForHash = -1;

--- a/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
@@ -113,6 +113,7 @@ class AITest_ConcurrencyAndStops {
 
         @Override
         public void startAutoPlay(boolean aiIsWhite, boolean aiIsBlack) {
+            setAutoPlaySides(aiIsWhite, aiIsBlack);
             try {
                 TestUtils.writeField(this, "scheduler", scheduler);
                 Method start = AI.class.getDeclaredMethod("startCalculationThread");


### PR DESCRIPTION
## Summary
- track auto-play side preferences on the AI so auto-play only performs moves for the configured colours
- reset and honour the stored auto-play configuration when scheduling moves and when stopping the calculation threads
- extend the FakeAutoAI test double to initialise the new configuration hook

## Testing
- not run (Java 25 with preview features is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbcf8f0f80832ab8f5631eae62bed0