### PR TITLE
Refine null-move pruning heuristics in AI

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1425,8 +1425,17 @@ public class AI {
         BitBoard bitBoard = simulatorEngine.getBitBoard();
         boolean allowNullMove = useNullMovePruning
                 && !inCheck
-                && !simulatorEngine.isEndgame()
                 && prevMove != -1;
+
+        if (allowNullMove && simulatorEngine.isEndgame()) {
+            boolean hasPawns = bitBoard.hasAnyPawns();
+            int nonKingPieces = bitBoard.getNonKingPieceCount();
+            boolean cramped = mobility <= 6;
+
+            if (!hasPawns && nonKingPieces <= 2 && cramped) {
+                allowNullMove = false;
+            }
+        }
 
         if (allowNullMove) {
             double mateThreatScore = CHECKMATE - (plyFromRoot + 1);

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -2572,6 +2572,21 @@ public class BitBoard {
     }
 
 
+    public int getNonKingPieceCount() {
+        long nonKings = whitePawns | blackPawns
+                | whiteKnights | blackKnights
+                | whiteBishops | blackBishops
+                | whiteRooks | blackRooks
+                | whiteQueens | blackQueens;
+        return Long.bitCount(nonKings);
+    }
+
+
+    public boolean hasAnyPawns() {
+        return (whitePawns | blackPawns) != 0L;
+    }
+
+
     public int getPhase() {
         int phase = 0;
         phase += Long.bitCount(whiteQueens | blackQueens) * 4;


### PR DESCRIPTION
## Summary
- allow null-move pruning when safe even in simplified endgames by removing the blanket endgame restriction
- add BitBoard helpers to expose pawn presence and non-king piece counts for selective null-move gating

## Testing
- `./mvnw -q -Dtest=AITest_PruningAndReductions test` *(fails: Maven wrapper download blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd4d2b1e8832a9d3e79cb7deaab4a