### PR TITLE
Fix null-move pruning check for infinite windows

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1439,7 +1439,9 @@ public class AI {
 
         if (allowNullMove) {
             double mateThreatScore = CHECKMATE - (plyFromRoot + 1);
-            if ((isWhite && beta >= mateThreatScore) || (!isWhite && alpha <= -mateThreatScore)) {
+            boolean betaSignalsMateThreat = isWhite && Double.isFinite(beta) && beta >= mateThreatScore;
+            boolean alphaSignalsMateThreat = !isWhite && Double.isFinite(alpha) && alpha <= -mateThreatScore;
+            if (betaSignalsMateThreat || alphaSignalsMateThreat) {
                 allowNullMove = false;
             }
         }


### PR DESCRIPTION
## Summary
- ensure null-move pruning only disables for mate threats when search bounds are finite

## Testing
- mvn -Dtest=AITest_PruningAndReductions#nullMoveDisabledInCheck test *(fails: Maven compiler plugin requires JDK release 25 support in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd6467ab0832abdab9a94123f9203