### PR TITLE
Fix abort trigger on uninitialized board state

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -209,10 +209,12 @@ public class AI {
         }
     }
 
+    private static final long UNINITIALIZED_BOARD_STATE = Long.MIN_VALUE;
+
     private volatile boolean keepCalculating = true;
 
-    private volatile long currentBoardState = -1;
-    private volatile long beforeCalculationBoardState = -2;
+    private volatile long currentBoardState = UNINITIALIZED_BOARD_STATE;
+    private volatile long beforeCalculationBoardState = UNINITIALIZED_BOARD_STATE;
 
     private volatile int currentBestMove = -1;
     private volatile int previousBestMove = -1;
@@ -755,8 +757,8 @@ public class AI {
         previousBestMove = -1;
         previousBestMoveHash = -1;
         searchResultReady = false;
-        currentBoardState = -1;
-        beforeCalculationBoardState = -2;
+        currentBoardState = UNINITIALIZED_BOARD_STATE;
+        beforeCalculationBoardState = UNINITIALIZED_BOARD_STATE;
         calculatedLine = Collections.synchronizedList(new ArrayList<>());
         mainEngine.startNewGame();
         clearHistoryTable();
@@ -2283,7 +2285,9 @@ public class AI {
      * required cross-thread visibility.</p>
      */
     private boolean positionChanged() {
-        return currentBoardState != beforeCalculationBoardState;
+        return currentBoardState != UNINITIALIZED_BOARD_STATE
+                && beforeCalculationBoardState != UNINITIALIZED_BOARD_STATE
+                && currentBoardState != beforeCalculationBoardState;
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure the AI's board state sentinels are initialised consistently
- guard position change checks against uninitialised board state values so the search doesn't abort immediately

## Testing
- `mvn -q -Dtest=AITest_PruningAndReductions#nullMoveDisabledInCheck test` *(fails: release version 25 not supported with the available JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68dbddb88c4c832aa3b23de4dcd4c707