### PR TITLE
Optimize numeric tuning parameter lookups

### DIFF
--- a/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
@@ -1,10 +1,12 @@
 package julius.game.chessengine.tuning;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Central registry for numeric tuning parameters. Supports thread-local overrides so that
@@ -13,36 +15,57 @@ import java.util.Objects;
 public final class NumericTuningParameters {
 
     private static final Map<String, Double> DEFAULTS = new LinkedHashMap<>();
-    private static final ThreadLocal<Map<String, Double>> THREAD_PARAMETERS = new ThreadLocal<>();
-    private static volatile Map<String, Double> GLOBAL_PARAMETERS = Map.of();
+    private static final Map<String, Integer> KEY_TO_ID = new ConcurrentHashMap<>();
+    private static final ThreadLocal<double[]> THREAD_PARAMETERS = new ThreadLocal<>();
+    private static volatile double[] DEFAULT_VALUES = new double[0];
+    private static volatile double[] GLOBAL_VALUES = new double[0];
     private static volatile Map<String, Double> DEFAULT_CACHE = Map.of();
 
     private NumericTuningParameters() {
     }
 
-    static synchronized void registerDefault(String key, double defaultValue) {
-        if (!DEFAULTS.containsKey(key)) {
+    static synchronized int registerDefault(String key, double defaultValue) {
+        Integer existingId = KEY_TO_ID.get(key);
+        if (existingId != null) {
             DEFAULTS.put(key, defaultValue);
             DEFAULT_CACHE = Collections.unmodifiableMap(new LinkedHashMap<>(DEFAULTS));
+            if (existingId < DEFAULT_VALUES.length) {
+                DEFAULT_VALUES[existingId] = defaultValue;
+            }
+            return existingId;
         }
+        int id = KEY_TO_ID.size();
+        KEY_TO_ID.put(key, id);
+        DEFAULTS.put(key, defaultValue);
+        DEFAULT_CACHE = Collections.unmodifiableMap(new LinkedHashMap<>(DEFAULTS));
+        DEFAULT_VALUES = Arrays.copyOf(DEFAULT_VALUES, id + 1);
+        DEFAULT_VALUES[id] = defaultValue;
+        GLOBAL_VALUES = growWithNaN(GLOBAL_VALUES, id + 1);
+        return id;
     }
 
     static double resolve(String key, double defaultValue) {
         Objects.requireNonNull(key, "key");
         String normalized = normalizeKey(key);
-        Map<String, Double> local = THREAD_PARAMETERS.get();
-        if (local != null) {
-            Double value = local.get(normalized);
-            if (value != null) {
-                return value;
-            }
+        Integer id = KEY_TO_ID.get(normalized);
+        if (id == null) {
+            Double fallback = DEFAULT_CACHE.get(normalized);
+            return fallback != null ? fallback : defaultValue;
         }
-        Double global = GLOBAL_PARAMETERS.get(normalized);
-        if (global != null) {
-            return global;
+        return resolve(id, defaultValue);
+    }
+
+    static double resolve(int id, double defaultValue) {
+        double value = valueAt(THREAD_PARAMETERS.get(), id);
+        if (!Double.isNaN(value)) {
+            return value;
         }
-        Double fallback = DEFAULT_CACHE.get(normalized);
-        return fallback != null ? fallback : defaultValue;
+        value = valueAt(GLOBAL_VALUES, id);
+        if (!Double.isNaN(value)) {
+            return value;
+        }
+        value = valueAt(DEFAULT_VALUES, id);
+        return Double.isNaN(value) ? defaultValue : value;
     }
 
     static Map<String, Double> defaults() {
@@ -51,8 +74,13 @@ public final class NumericTuningParameters {
 
     public static AutoCloseable use(Map<String, Double> parameters) {
         Map<String, Double> normalized = normalize(parameters);
-        Map<String, Double> previous = THREAD_PARAMETERS.get();
-        THREAD_PARAMETERS.set(normalized);
+        double[] overrides = toValues(normalized);
+        double[] previous = THREAD_PARAMETERS.get();
+        if (overrides.length == 0) {
+            THREAD_PARAMETERS.remove();
+        } else {
+            THREAD_PARAMETERS.set(overrides);
+        }
         return () -> {
             if (previous == null) {
                 THREAD_PARAMETERS.remove();
@@ -63,7 +91,8 @@ public final class NumericTuningParameters {
     }
 
     public static void setGlobal(Map<String, Double> parameters) {
-        GLOBAL_PARAMETERS = normalize(parameters);
+        Map<String, Double> normalized = normalize(parameters);
+        GLOBAL_VALUES = toValues(normalized);
     }
 
     private static Map<String, Double> normalize(Map<String, Double> parameters) {
@@ -109,5 +138,42 @@ public final class NumericTuningParameters {
         }
         String trimmed = (start == 0 && end == length) ? key : key.substring(start, end);
         return needsLowerCase ? trimmed.toLowerCase(Locale.ROOT) : trimmed;
+    }
+
+    private static double[] toValues(Map<String, Double> normalized) {
+        if (normalized.isEmpty()) {
+            return new double[0];
+        }
+        double[] values = new double[DEFAULT_VALUES.length];
+        Arrays.fill(values, Double.NaN);
+        boolean hasOverride = false;
+        for (Map.Entry<String, Double> entry : normalized.entrySet()) {
+            Integer id = KEY_TO_ID.get(entry.getKey());
+            if (id == null || id >= values.length) {
+                continue;
+            }
+            Double override = entry.getValue();
+            if (override != null && !override.isNaN()) {
+                values[id] = override;
+                hasOverride = true;
+            }
+        }
+        return hasOverride ? values : new double[0];
+    }
+
+    private static double[] growWithNaN(double[] source, int newSize) {
+        if (source.length >= newSize) {
+            return source;
+        }
+        double[] resized = Arrays.copyOf(source, newSize);
+        Arrays.fill(resized, source.length, newSize, Double.NaN);
+        return resized;
+    }
+
+    private static double valueAt(double[] values, int id) {
+        if (values == null || id >= values.length) {
+            return Double.NaN;
+        }
+        return values[id];
     }
 }

--- a/src/main/java/julius/game/chessengine/tuning/TunableParameter.java
+++ b/src/main/java/julius/game/chessengine/tuning/TunableParameter.java
@@ -11,6 +11,7 @@ public final class TunableParameter {
     private final double defaultValue;
     private final Double minValue;
     private final Double maxValue;
+    private final int id;
 
     private TunableParameter(String key, double defaultValue, Double minValue, Double maxValue) {
         if (key == null || key.isBlank()) {
@@ -20,7 +21,7 @@ public final class TunableParameter {
         this.defaultValue = defaultValue;
         this.minValue = minValue;
         this.maxValue = maxValue;
-        NumericTuningParameters.registerDefault(this.key, defaultValue);
+        this.id = NumericTuningParameters.registerDefault(this.key, defaultValue);
     }
 
     public static TunableParameter of(String key, double defaultValue) {
@@ -35,7 +36,7 @@ public final class TunableParameter {
     }
 
     public double get() {
-        double value = NumericTuningParameters.resolve(key, defaultValue);
+        double value = NumericTuningParameters.resolve(id, defaultValue);
         if (!Double.isFinite(value)) {
             value = defaultValue;
         }


### PR DESCRIPTION
## Summary
- replace runtime string lookups with cached integer ids and array-backed storage in `NumericTuningParameters`
- cache per-thread and global overrides in primitive arrays while preserving normalized default maps
- update `TunableParameter` to store the resolved parameter id for direct access

## Testing
- `./mvnw -q -DskipTests compile` *(fails: Maven wrapper cannot download due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3cc67794832ab55263833ec5cb52