### PR TITLE
Optimize numeric tuning parameter resolution

### DIFF
--- a/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
@@ -1,10 +1,12 @@
 package julius.game.chessengine.tuning;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Central registry for numeric tuning parameters. Supports thread-local overrides so that
@@ -13,36 +15,76 @@ import java.util.Objects;
 public final class NumericTuningParameters {
 
     private static final Map<String, Double> DEFAULTS = new LinkedHashMap<>();
-    private static final ThreadLocal<Map<String, Double>> THREAD_PARAMETERS = new ThreadLocal<>();
+    private static final Map<String, Integer> INDEX_BY_KEY = new ConcurrentHashMap<>();
+    private static final ThreadLocal<double[]> THREAD_PARAMETERS = new ThreadLocal<>();
     private static volatile Map<String, Double> GLOBAL_PARAMETERS = Map.of();
     private static volatile Map<String, Double> DEFAULT_CACHE = Map.of();
+    private static volatile double[] GLOBAL_CACHE = new double[0];
+
+    private static volatile double[] DEFAULT_VALUES = new double[32];
+    private static volatile int PARAMETER_COUNT;
 
     private NumericTuningParameters() {
     }
 
-    static synchronized void registerDefault(String key, double defaultValue) {
-        if (!DEFAULTS.containsKey(key)) {
-            DEFAULTS.put(key, defaultValue);
-            DEFAULT_CACHE = Collections.unmodifiableMap(new LinkedHashMap<>(DEFAULTS));
+    static synchronized int registerDefault(String key, double defaultValue) {
+        String normalized = normalizeKey(key);
+        Integer existing = INDEX_BY_KEY.get(normalized);
+        if (existing != null) {
+            return existing;
         }
+
+        int index = PARAMETER_COUNT;
+        int newCount = index + 1;
+        INDEX_BY_KEY.put(normalized, index);
+        ensureCapacity(newCount);
+        DEFAULTS.put(normalized, defaultValue);
+        DEFAULT_VALUES[index] = defaultValue;
+        DEFAULT_CACHE = Collections.unmodifiableMap(new LinkedHashMap<>(DEFAULTS));
+
+        double[] updatedGlobal = copyAndExtend(GLOBAL_CACHE, newCount);
+        Double override = GLOBAL_PARAMETERS.get(normalized);
+        updatedGlobal[index] = (override != null) ? override : Double.NaN;
+        GLOBAL_CACHE = updatedGlobal;
+        PARAMETER_COUNT = newCount;
+        return index;
     }
 
     static double resolve(String key, double defaultValue) {
         Objects.requireNonNull(key, "key");
         String normalized = normalizeKey(key);
-        Map<String, Double> local = THREAD_PARAMETERS.get();
-        if (local != null) {
-            Double value = local.get(normalized);
-            if (value != null) {
+        Integer index = INDEX_BY_KEY.get(normalized);
+        if (index == null) {
+            Double fallback = DEFAULT_CACHE.get(normalized);
+            return fallback != null ? fallback : defaultValue;
+        }
+        return resolve(index, defaultValue);
+    }
+
+    static double resolve(int index, double defaultValue) {
+        double[] local = THREAD_PARAMETERS.get();
+        if (local != null && index < local.length) {
+            double value = local[index];
+            if (!Double.isNaN(value)) {
                 return value;
             }
         }
-        Double global = GLOBAL_PARAMETERS.get(normalized);
-        if (global != null) {
-            return global;
+
+        double[] global = GLOBAL_CACHE;
+        if (index < global.length) {
+            double value = global[index];
+            if (!Double.isNaN(value)) {
+                return value;
+            }
         }
-        Double fallback = DEFAULT_CACHE.get(normalized);
-        return fallback != null ? fallback : defaultValue;
+
+        int count = PARAMETER_COUNT;
+        if (index < count) {
+            double[] defaults = DEFAULT_VALUES;
+            double value = defaults[index];
+            return !Double.isNaN(value) ? value : defaultValue;
+        }
+        return defaultValue;
     }
 
     static Map<String, Double> defaults() {
@@ -51,8 +93,9 @@ public final class NumericTuningParameters {
 
     public static AutoCloseable use(Map<String, Double> parameters) {
         Map<String, Double> normalized = normalize(parameters);
-        Map<String, Double> previous = THREAD_PARAMETERS.get();
-        THREAD_PARAMETERS.set(normalized);
+        double[] overrides = buildOverrideArray(normalized);
+        double[] previous = THREAD_PARAMETERS.get();
+        THREAD_PARAMETERS.set(overrides);
         return () -> {
             if (previous == null) {
                 THREAD_PARAMETERS.remove();
@@ -64,6 +107,7 @@ public final class NumericTuningParameters {
 
     public static void setGlobal(Map<String, Double> parameters) {
         GLOBAL_PARAMETERS = normalize(parameters);
+        GLOBAL_CACHE = buildOverrideArray(GLOBAL_PARAMETERS);
     }
 
     private static Map<String, Double> normalize(Map<String, Double> parameters) {
@@ -78,6 +122,38 @@ public final class NumericTuningParameters {
             normalized.put(normalizeKey(key), value);
         });
         return Collections.unmodifiableMap(normalized);
+    }
+
+    private static double[] buildOverrideArray(Map<String, Double> parameters) {
+        int size = PARAMETER_COUNT;
+        double[] overrides = new double[size];
+        Arrays.fill(overrides, Double.NaN);
+        parameters.forEach((key, value) -> {
+            Integer index = INDEX_BY_KEY.get(key);
+            if (index != null && index < overrides.length) {
+                overrides[index] = value;
+            }
+        });
+        return overrides;
+    }
+
+    private static double[] copyAndExtend(double[] source, int length) {
+        if (source.length == length) {
+            return Arrays.copyOf(source, length);
+        }
+        double[] copy = Arrays.copyOf(source, length);
+        if (length > source.length) {
+            Arrays.fill(copy, source.length, length, Double.NaN);
+        }
+        return copy;
+    }
+
+    private static void ensureCapacity(int capacity) {
+        if (DEFAULT_VALUES.length >= capacity) {
+            return;
+        }
+        int newCapacity = Math.max(DEFAULT_VALUES.length << 1, capacity);
+        DEFAULT_VALUES = Arrays.copyOf(DEFAULT_VALUES, newCapacity);
     }
 
     static String normalizeKey(String key) {

--- a/src/main/java/julius/game/chessengine/tuning/TunableParameter.java
+++ b/src/main/java/julius/game/chessengine/tuning/TunableParameter.java
@@ -11,6 +11,7 @@ public final class TunableParameter {
     private final double defaultValue;
     private final Double minValue;
     private final Double maxValue;
+    private final int index;
 
     private TunableParameter(String key, double defaultValue, Double minValue, Double maxValue) {
         if (key == null || key.isBlank()) {
@@ -20,7 +21,7 @@ public final class TunableParameter {
         this.defaultValue = defaultValue;
         this.minValue = minValue;
         this.maxValue = maxValue;
-        NumericTuningParameters.registerDefault(this.key, defaultValue);
+        this.index = NumericTuningParameters.registerDefault(this.key, defaultValue);
     }
 
     public static TunableParameter of(String key, double defaultValue) {
@@ -35,7 +36,7 @@ public final class TunableParameter {
     }
 
     public double get() {
-        double value = NumericTuningParameters.resolve(key, defaultValue);
+        double value = NumericTuningParameters.resolve(index, defaultValue);
         if (!Double.isFinite(value)) {
             value = defaultValue;
         }


### PR DESCRIPTION
## Summary
- replace string-based parameter lookups with index-based resolution backed by double-array caches
- keep defaults/global metadata while updating thread-local overrides to use fast array lookups
- update `TunableParameter` to cache the parameter index and call the new integer-based resolver

## Testing
- ./mvnw -q -DskipTests compile *(fails: Maven wrapper download hit a network connectivity error)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3cc67794832ab55263833ec5cb52