### PR TITLE
Optimize numeric tuning parameter lookups

### DIFF
--- a/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
@@ -1,5 +1,6 @@
 package julius.game.chessengine.tuning;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -12,34 +13,72 @@ import java.util.Objects;
  */
 public final class NumericTuningParameters {
 
+    private static final double UNSET = Double.NaN;
+
     private static final Map<String, Double> DEFAULTS = new LinkedHashMap<>();
-    private static final ThreadLocal<Map<String, Double>> THREAD_PARAMETERS = new ThreadLocal<>();
+    private static final Map<String, Integer> KEY_INDICES = new LinkedHashMap<>();
+
+    private static volatile Map<String, Integer> KEY_INDEX_CACHE = Map.of();
     private static volatile Map<String, Double> GLOBAL_PARAMETERS = Map.of();
     private static volatile Map<String, Double> DEFAULT_CACHE = Map.of();
+    private static volatile double[] DEFAULT_VALUES = new double[0];
+    private static volatile OverrideValues GLOBAL_OVERRIDE = OverrideValues.EMPTY;
+
+    private static final ThreadLocal<OverrideValues> THREAD_OVERRIDES = new ThreadLocal<>();
 
     private NumericTuningParameters() {
     }
 
-    static synchronized void registerDefault(String key, double defaultValue) {
-        if (!DEFAULTS.containsKey(key)) {
-            DEFAULTS.put(key, defaultValue);
-            DEFAULT_CACHE = Collections.unmodifiableMap(new LinkedHashMap<>(DEFAULTS));
+    static synchronized int registerDefault(String key, double defaultValue) {
+        Integer existing = KEY_INDICES.get(key);
+        if (existing != null) {
+            return existing;
         }
+        int index = KEY_INDICES.size();
+        KEY_INDICES.put(key, index);
+        KEY_INDEX_CACHE = Collections.unmodifiableMap(new LinkedHashMap<>(KEY_INDICES));
+        DEFAULTS.put(key, defaultValue);
+        DEFAULT_CACHE = Collections.unmodifiableMap(new LinkedHashMap<>(DEFAULTS));
+        DEFAULT_VALUES = ensureCapacity(DEFAULT_VALUES, index + 1, UNSET);
+        DEFAULT_VALUES[index] = defaultValue;
+        GLOBAL_OVERRIDE = GLOBAL_OVERRIDE.expandTo(index + 1);
+        return index;
+    }
+
+    static double resolve(int index, double defaultValue) {
+        double override = valueAt(THREAD_OVERRIDES.get(), index);
+        if (!Double.isNaN(override)) {
+            return override;
+        }
+        override = valueAt(GLOBAL_OVERRIDE, index);
+        if (!Double.isNaN(override)) {
+            return override;
+        }
+        double[] defaults = DEFAULT_VALUES;
+        if (index < defaults.length) {
+            double value = defaults[index];
+            if (!Double.isNaN(value)) {
+                return value;
+            }
+        }
+        return defaultValue;
     }
 
     static double resolve(String key, double defaultValue) {
         Objects.requireNonNull(key, "key");
         String normalized = normalizeKey(key);
-        Map<String, Double> local = THREAD_PARAMETERS.get();
-        if (local != null) {
-            Double value = local.get(normalized);
-            if (value != null) {
-                return value;
-            }
+        Map<String, Integer> indices = KEY_INDEX_CACHE;
+        Double extra = lookupExtra(THREAD_OVERRIDES.get(), normalized);
+        if (extra != null) {
+            return extra;
         }
-        Double global = GLOBAL_PARAMETERS.get(normalized);
-        if (global != null) {
-            return global;
+        extra = lookupExtra(GLOBAL_OVERRIDE, normalized);
+        if (extra != null) {
+            return extra;
+        }
+        Integer index = indices.get(normalized);
+        if (index != null) {
+            return resolve(index, defaultValue);
         }
         Double fallback = DEFAULT_CACHE.get(normalized);
         return fallback != null ? fallback : defaultValue;
@@ -51,19 +90,27 @@ public final class NumericTuningParameters {
 
     public static AutoCloseable use(Map<String, Double> parameters) {
         Map<String, Double> normalized = normalize(parameters);
-        Map<String, Double> previous = THREAD_PARAMETERS.get();
-        THREAD_PARAMETERS.set(normalized);
+        OverrideValues overrides = createOverrides(normalized);
+        OverrideValues previous = THREAD_OVERRIDES.get();
+        if (overrides == OverrideValues.EMPTY) {
+            THREAD_OVERRIDES.remove();
+        } else {
+            THREAD_OVERRIDES.set(overrides);
+        }
         return () -> {
-            if (previous == null) {
-                THREAD_PARAMETERS.remove();
+            if (previous == null || previous == OverrideValues.EMPTY) {
+                THREAD_OVERRIDES.remove();
             } else {
-                THREAD_PARAMETERS.set(previous);
+                THREAD_OVERRIDES.set(previous);
             }
         };
     }
 
     public static void setGlobal(Map<String, Double> parameters) {
-        GLOBAL_PARAMETERS = normalize(parameters);
+        Map<String, Double> normalized = normalize(parameters);
+        GLOBAL_PARAMETERS = normalized;
+        OverrideValues overrides = createOverrides(normalized);
+        GLOBAL_OVERRIDE = overrides == OverrideValues.EMPTY ? OverrideValues.EMPTY : overrides;
     }
 
     private static Map<String, Double> normalize(Map<String, Double> parameters) {
@@ -109,5 +156,119 @@ public final class NumericTuningParameters {
         }
         String trimmed = (start == 0 && end == length) ? key : key.substring(start, end);
         return needsLowerCase ? trimmed.toLowerCase(Locale.ROOT) : trimmed;
+    }
+
+    private static OverrideValues createOverrides(Map<String, Double> normalized) {
+        if (normalized == null || normalized.isEmpty()) {
+            return OverrideValues.EMPTY;
+        }
+        Map<String, Integer> indices = KEY_INDEX_CACHE;
+        double[] overrides = null;
+        int allocatedLength = 0;
+        Map<String, Double> extras = null;
+        for (Map.Entry<String, Double> entry : normalized.entrySet()) {
+            String key = entry.getKey();
+            Double value = entry.getValue();
+            if (value == null || value.isNaN()) {
+                continue;
+            }
+            Integer index = indices.get(key);
+            if (index != null) {
+                if (overrides == null) {
+                    allocatedLength = DEFAULT_VALUES.length;
+                    overrides = new double[Math.max(allocatedLength, index + 1)];
+                    Arrays.fill(overrides, UNSET);
+                    allocatedLength = overrides.length;
+                } else if (index >= allocatedLength) {
+                    int previousLength = allocatedLength;
+                    allocatedLength = Math.max(DEFAULT_VALUES.length, index + 1);
+                    overrides = Arrays.copyOf(overrides, allocatedLength);
+                    Arrays.fill(overrides, previousLength, allocatedLength, UNSET);
+                }
+                overrides[index] = value;
+            } else {
+                if (extras == null) {
+                    extras = new LinkedHashMap<>();
+                }
+                extras.put(key, value);
+            }
+        }
+        if (overrides != null) {
+            overrides = trimTrailingUnset(overrides);
+        }
+        Map<String, Double> extraValues = (extras == null)
+                ? Map.of()
+                : Collections.unmodifiableMap(extras);
+        if (overrides == null && extraValues.isEmpty()) {
+            return OverrideValues.EMPTY;
+        }
+        return new OverrideValues(overrides, extraValues);
+    }
+
+    private static double valueAt(OverrideValues overrides, int index) {
+        if (overrides == null) {
+            return Double.NaN;
+        }
+        double[] values = overrides.values;
+        if (values != null && index < values.length) {
+            return values[index];
+        }
+        return Double.NaN;
+    }
+
+    private static Double lookupExtra(OverrideValues overrides, String key) {
+        if (overrides == null) {
+            return null;
+        }
+        Map<String, Double> extras = overrides.extras;
+        if (extras == null || extras.isEmpty()) {
+            return null;
+        }
+        return extras.get(key);
+    }
+
+    private static double[] ensureCapacity(double[] values, int size, double fillValue) {
+        if (values.length >= size) {
+            return values;
+        }
+        double[] expanded = Arrays.copyOf(values, size);
+        Arrays.fill(expanded, values.length, size, fillValue);
+        return expanded;
+    }
+
+    private static double[] trimTrailingUnset(double[] values) {
+        int last = values.length - 1;
+        while (last >= 0 && Double.isNaN(values[last])) {
+            last--;
+        }
+        if (last < 0) {
+            return null;
+        }
+        if (last == values.length - 1) {
+            return values;
+        }
+        return Arrays.copyOf(values, last + 1);
+    }
+
+    private static final class OverrideValues {
+        static final OverrideValues EMPTY = new OverrideValues(null, Map.of());
+
+        final double[] values;
+        final Map<String, Double> extras;
+
+        OverrideValues(double[] values, Map<String, Double> extras) {
+            this.values = values;
+            this.extras = extras;
+        }
+
+        OverrideValues expandTo(int size) {
+            double[] current = values;
+            if (current == null || current.length >= size) {
+                return this;
+            }
+            double[] expanded = Arrays.copyOf(current, size);
+            Arrays.fill(expanded, current.length, size, UNSET);
+            return new OverrideValues(expanded, extras);
+        }
     }
 }

--- a/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
@@ -41,7 +41,17 @@ public final class NumericTuningParameters {
         DEFAULT_CACHE = Collections.unmodifiableMap(new LinkedHashMap<>(DEFAULTS));
         DEFAULT_VALUES = ensureCapacity(DEFAULT_VALUES, index + 1, UNSET);
         DEFAULT_VALUES[index] = defaultValue;
-        GLOBAL_OVERRIDE = GLOBAL_OVERRIDE.expandTo(index + 1);
+        GLOBAL_OVERRIDE = applyLateBoundOverride(GLOBAL_OVERRIDE.expandTo(index + 1), key, index);
+        OverrideValues threadOverrides = THREAD_OVERRIDES.get();
+        if (threadOverrides != null && threadOverrides != OverrideValues.EMPTY) {
+            OverrideValues expanded = threadOverrides.expandTo(index + 1);
+            OverrideValues updated = applyLateBoundOverride(expanded, key, index);
+            if (updated != expanded) {
+                THREAD_OVERRIDES.set(updated);
+            } else if (expanded != threadOverrides) {
+                THREAD_OVERRIDES.set(expanded);
+            }
+        }
         return index;
     }
 
@@ -225,6 +235,43 @@ public final class NumericTuningParameters {
             return null;
         }
         return extras.get(key);
+    }
+
+    private static OverrideValues applyLateBoundOverride(OverrideValues overrides, String key, int index) {
+        if (overrides == null || overrides == OverrideValues.EMPTY) {
+            return overrides;
+        }
+        Map<String, Double> extras = overrides.extras;
+        if (extras == null || extras.isEmpty()) {
+            return overrides;
+        }
+        Double pending = extras.get(key);
+        if (pending == null) {
+            return overrides;
+        }
+        int requiredLength = Math.max(DEFAULT_VALUES.length, index + 1);
+        double[] values = overrides.values;
+        double[] updatedValues;
+        if (values == null) {
+            updatedValues = new double[requiredLength];
+            Arrays.fill(updatedValues, UNSET);
+        } else if (values.length < requiredLength) {
+            updatedValues = Arrays.copyOf(values, requiredLength);
+            Arrays.fill(updatedValues, values.length, requiredLength, UNSET);
+        } else {
+            updatedValues = Arrays.copyOf(values, values.length);
+        }
+        updatedValues[index] = pending;
+        updatedValues = trimTrailingUnset(updatedValues);
+        Map<String, Double> remaining;
+        if (extras.size() == 1) {
+            remaining = Map.of();
+        } else {
+            Map<String, Double> copy = new LinkedHashMap<>(extras);
+            copy.remove(key);
+            remaining = Collections.unmodifiableMap(copy);
+        }
+        return new OverrideValues(updatedValues, remaining);
     }
 
     private static double[] ensureCapacity(double[] values, int size, double fillValue) {

--- a/src/main/java/julius/game/chessengine/tuning/TunableParameter.java
+++ b/src/main/java/julius/game/chessengine/tuning/TunableParameter.java
@@ -8,6 +8,7 @@ package julius.game.chessengine.tuning;
 public final class TunableParameter {
 
     private final String key;
+    private final int index;
     private final double defaultValue;
     private final Double minValue;
     private final Double maxValue;
@@ -17,10 +18,10 @@ public final class TunableParameter {
             throw new IllegalArgumentException("Parameter key must not be blank");
         }
         this.key = NumericTuningParameters.normalizeKey(key);
+        this.index = NumericTuningParameters.registerDefault(this.key, defaultValue);
         this.defaultValue = defaultValue;
         this.minValue = minValue;
         this.maxValue = maxValue;
-        NumericTuningParameters.registerDefault(this.key, defaultValue);
     }
 
     public static TunableParameter of(String key, double defaultValue) {
@@ -35,7 +36,7 @@ public final class TunableParameter {
     }
 
     public double get() {
-        double value = NumericTuningParameters.resolve(key, defaultValue);
+        double value = NumericTuningParameters.resolve(index, defaultValue);
         if (!Double.isFinite(value)) {
             value = defaultValue;
         }


### PR DESCRIPTION
## Summary
- replace runtime string lookups in NumericTuningParameters with cached indices and double arrays for defaults and overrides
- add fast thread-local/global override resolution paths that fall back to the existing default map
- update TunableParameter to resolve parameters by cached index instead of by key

## Testing
- mvn -q -DskipTests package *(fails: Fatal error compiling: error: release version 25 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3cc67794832ab55263833ec5cb52