### PR TITLE
Refactor tuning parameter access to array-backed registry

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
@@ -5,7 +5,8 @@ import java.util.Objects;
 
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.figures.PieceType;
-import julius.game.chessengine.tuning.TunableParameter;
+import julius.game.chessengine.tuning.ParamId;
+import julius.game.chessengine.tuning.ParameterRegistry;
 /**
  * Tracks per-side material using incremental updates so the evaluation pipeline can
  * access midgame and endgame material totals without rescanning the board.
@@ -18,13 +19,6 @@ public final class MaterialModule implements EvaluationModule {
     public static final int DEFAULT_ROOK_VALUE = 500;
     public static final int DEFAULT_QUEEN_VALUE = 900;
     public static final int DEFAULT_BISHOP_PAIR_BONUS = 40;
-
-    private static final TunableParameter PAWN_VALUE = TunableParameter.of("material.pawnValue", DEFAULT_PAWN_VALUE);
-    private static final TunableParameter KNIGHT_VALUE = TunableParameter.of("material.knightValue", DEFAULT_KNIGHT_VALUE);
-    private static final TunableParameter BISHOP_VALUE = TunableParameter.of("material.bishopValue", DEFAULT_BISHOP_VALUE);
-    private static final TunableParameter ROOK_VALUE = TunableParameter.of("material.rookValue", DEFAULT_ROOK_VALUE);
-    private static final TunableParameter QUEEN_VALUE = TunableParameter.of("material.queenValue", DEFAULT_QUEEN_VALUE);
-    private static final TunableParameter BISHOP_PAIR_BONUS = TunableParameter.of("material.bishopPairBonus", DEFAULT_BISHOP_PAIR_BONUS);
 
     public interface PawnChangeListener {
         void onPawnAdded(boolean isWhite, int squareIndex);
@@ -71,27 +65,27 @@ public final class MaterialModule implements EvaluationModule {
     }
 
     public static int pawnValue() {
-        return PAWN_VALUE.getInt();
+        return ParameterRegistry.getInt(ParamId.MATERIAL_PAWN_VALUE);
     }
 
     public static int knightValue() {
-        return KNIGHT_VALUE.getInt();
+        return ParameterRegistry.getInt(ParamId.MATERIAL_KNIGHT_VALUE);
     }
 
     public static int bishopValue() {
-        return BISHOP_VALUE.getInt();
+        return ParameterRegistry.getInt(ParamId.MATERIAL_BISHOP_VALUE);
     }
 
     public static int rookValue() {
-        return ROOK_VALUE.getInt();
+        return ParameterRegistry.getInt(ParamId.MATERIAL_ROOK_VALUE);
     }
 
     public static int queenValue() {
-        return QUEEN_VALUE.getInt();
+        return ParameterRegistry.getInt(ParamId.MATERIAL_QUEEN_VALUE);
     }
 
     public static int bishopPairBonus() {
-        return BISHOP_PAIR_BONUS.getInt();
+        return ParameterRegistry.getInt(ParamId.MATERIAL_BISHOP_PAIR_BONUS);
     }
 
     @Override

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -5,6 +5,8 @@ import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.PawnHelper;
+import julius.game.chessengine.tuning.ParamId;
+import julius.game.chessengine.tuning.ParameterRegistry;
 import julius.game.chessengine.tuning.TunableParameter;
 
 import java.util.Arrays;
@@ -539,6 +541,7 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     }
 
     private static int calculateBackwardPawnPenalty(long pawns, long enemyPawns, long allPieces, boolean isWhite, int phase) {
+        int backwardPenalty = ParameterRegistry.getInt(ParamId.PAWN_STRUCTURE_BACKWARD_PAWN_PENALTY);
         int penalty = 0;
         long remaining = pawns;
         while (remaining != 0) {
@@ -548,7 +551,7 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
                 int forwardIndex = Long.numberOfTrailingZeros(forward);
                 long enemyAttack = PAWN_ATTACKS[isWhite ? WHITE : BLACK][forwardIndex] & enemyPawns;
                 if (enemyAttack != 0) {
-                    penalty += BACKWARD_PAWN_PENALTY.getInt();
+                    penalty += backwardPenalty;
                 }
             }
             remaining &= remaining - 1;

--- a/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
@@ -1,11 +1,6 @@
 package julius.game.chessengine.tuning;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Central registry for numeric tuning parameters. Supports thread-local overrides so that
@@ -13,82 +8,43 @@ import java.util.Objects;
  */
 public final class NumericTuningParameters {
 
-    private static final double UNSET = Double.NaN;
+    private static final ParameterSnapshot DEFAULT_SNAPSHOT = ParameterSnapshot.defaultSnapshot();
+    private static final Map<String, Double> DEFAULT_CACHE = DEFAULT_SNAPSHOT.asMap();
 
-    private static final Map<String, Double> DEFAULTS = new LinkedHashMap<>();
-    private static final Map<String, Integer> KEY_INDICES = new LinkedHashMap<>();
-
-    private static volatile Map<String, Integer> KEY_INDEX_CACHE = Map.of();
     private static volatile Map<String, Double> GLOBAL_PARAMETERS = Map.of();
-    private static volatile Map<String, Double> DEFAULT_CACHE = Map.of();
-    private static volatile double[] DEFAULT_VALUES = new double[0];
-    private static volatile OverrideValues GLOBAL_OVERRIDE = OverrideValues.EMPTY;
-
-    private static final ThreadLocal<OverrideValues> THREAD_OVERRIDES = new ThreadLocal<>();
 
     private NumericTuningParameters() {
     }
 
     static synchronized int registerDefault(String key, double defaultValue) {
-        Integer existing = KEY_INDICES.get(key);
-        if (existing != null) {
-            return existing;
+        ParamId id = ParamId.forKey(key);
+        if (id == null) {
+            throw new IllegalArgumentException("Unknown parameter key: " + key);
         }
-        int index = KEY_INDICES.size();
-        KEY_INDICES.put(key, index);
-        KEY_INDEX_CACHE = Collections.unmodifiableMap(new LinkedHashMap<>(KEY_INDICES));
-        DEFAULTS.put(key, defaultValue);
-        DEFAULT_CACHE = Collections.unmodifiableMap(new LinkedHashMap<>(DEFAULTS));
-        DEFAULT_VALUES = ensureCapacity(DEFAULT_VALUES, index + 1, UNSET);
-        DEFAULT_VALUES[index] = defaultValue;
-        GLOBAL_OVERRIDE = applyLateBoundOverride(GLOBAL_OVERRIDE.expandTo(index + 1), key, index);
-        OverrideValues threadOverrides = THREAD_OVERRIDES.get();
-        if (threadOverrides != null && threadOverrides != OverrideValues.EMPTY) {
-            OverrideValues expanded = threadOverrides.expandTo(index + 1);
-            OverrideValues updated = applyLateBoundOverride(expanded, key, index);
-            if (updated != expanded) {
-                THREAD_OVERRIDES.set(updated);
-            } else if (expanded != threadOverrides) {
-                THREAD_OVERRIDES.set(expanded);
-            }
+        if (Double.doubleToLongBits(id.defaultValue()) != Double.doubleToLongBits(defaultValue)) {
+            throw new IllegalArgumentException(
+                    "Default value mismatch for " + key + ": expected " + id.defaultValue() + " but was " + defaultValue);
         }
-        return index;
+        return id.ordinal();
     }
 
     static double resolve(int index, double defaultValue) {
-        double override = valueAt(THREAD_OVERRIDES.get(), index);
-        if (!Double.isNaN(override)) {
-            return override;
+        ParamId[] ids = ParamId.values();
+        if (index < 0 || index >= ids.length) {
+            return defaultValue;
         }
-        override = valueAt(GLOBAL_OVERRIDE, index);
-        if (!Double.isNaN(override)) {
-            return override;
-        }
-        double[] defaults = DEFAULT_VALUES;
-        if (index < defaults.length) {
-            double value = defaults[index];
-            if (!Double.isNaN(value)) {
-                return value;
-            }
-        }
-        return defaultValue;
+        return ParameterRegistry.get(ids[index]);
     }
 
     static double resolve(String key, double defaultValue) {
-        Objects.requireNonNull(key, "key");
         String normalized = normalizeKey(key);
-        Map<String, Integer> indices = KEY_INDEX_CACHE;
-        Double extra = lookupExtra(THREAD_OVERRIDES.get(), normalized);
+        ParamId id = ParamId.forKey(normalized);
+        if (id != null) {
+            return ParameterRegistry.get(id);
+        }
+        Double extra = ParameterRegistry.lookupExtra(normalized);
         if (extra != null) {
             return extra;
-        }
-        extra = lookupExtra(GLOBAL_OVERRIDE, normalized);
-        if (extra != null) {
-            return extra;
-        }
-        Integer index = indices.get(normalized);
-        if (index != null) {
-            return resolve(index, defaultValue);
         }
         Double fallback = DEFAULT_CACHE.get(normalized);
         return fallback != null ? fallback : defaultValue;
@@ -99,223 +55,42 @@ public final class NumericTuningParameters {
     }
 
     public static AutoCloseable use(Map<String, Double> parameters) {
-        Map<String, Double> normalized = normalize(parameters);
-        OverrideValues overrides = createOverrides(normalized);
-        OverrideValues previous = THREAD_OVERRIDES.get();
-        if (overrides == OverrideValues.EMPTY) {
-            THREAD_OVERRIDES.remove();
+        Map<String, Double> normalized = ParameterNormalizer.normalize(parameters);
+        ParameterSnapshot previous = ParameterRegistry.threadSnapshot();
+        if (normalized.isEmpty()) {
+            ParameterRegistry.clearThreadSnapshot();
         } else {
-            THREAD_OVERRIDES.set(overrides);
-        }
-        return () -> {
-            if (previous == null || previous == OverrideValues.EMPTY) {
-                THREAD_OVERRIDES.remove();
+            ParameterSnapshot base = ParameterRegistry.globalSnapshot();
+            ParameterSnapshot overrides = ParameterSnapshot.apply(base, normalized);
+            if (overrides == base) {
+                ParameterRegistry.clearThreadSnapshot();
             } else {
-                THREAD_OVERRIDES.set(previous);
+                ParameterRegistry.setThreadSnapshot(overrides);
             }
-        };
+        }
+        return () -> restore(previous);
+    }
+
+    private static void restore(ParameterSnapshot previous) {
+        if (previous == null) {
+            ParameterRegistry.clearThreadSnapshot();
+        } else {
+            ParameterRegistry.setThreadSnapshot(previous);
+        }
     }
 
     public static void setGlobal(Map<String, Double> parameters) {
-        Map<String, Double> normalized = normalize(parameters);
+        Map<String, Double> normalized = ParameterNormalizer.normalize(parameters);
         GLOBAL_PARAMETERS = normalized;
-        OverrideValues overrides = createOverrides(normalized);
-        GLOBAL_OVERRIDE = overrides == OverrideValues.EMPTY ? OverrideValues.EMPTY : overrides;
+        ParameterSnapshot snapshot = ParameterSnapshot.apply(DEFAULT_SNAPSHOT, normalized);
+        ParameterRegistry.setGlobalSnapshot(snapshot);
     }
 
-    private static Map<String, Double> normalize(Map<String, Double> parameters) {
-        if (parameters == null || parameters.isEmpty()) {
-            return Map.of();
-        }
-        Map<String, Double> normalized = new LinkedHashMap<>();
-        parameters.forEach((key, value) -> {
-            if (key == null || key.isBlank() || value == null || value.isNaN()) {
-                return;
-            }
-            normalized.put(normalizeKey(key), value);
-        });
-        return Collections.unmodifiableMap(normalized);
+    public static void hotReload(Map<String, Double> parameters) {
+        setGlobal(parameters);
     }
 
     static String normalizeKey(String key) {
-        if (key == null) {
-            throw new IllegalArgumentException("Key must not be null");
-        }
-        int length = key.length();
-        int start = 0;
-        int end = length;
-        while (start < length && Character.isWhitespace(key.charAt(start))) {
-            start++;
-        }
-        while (end > start && Character.isWhitespace(key.charAt(end - 1))) {
-            end--;
-        }
-        if (start == end) {
-            throw new IllegalArgumentException("Key must not be blank");
-        }
-        boolean needsLowerCase = false;
-        for (int i = start; i < end; i++) {
-            char c = key.charAt(i);
-            if (Character.toLowerCase(c) != c) {
-                needsLowerCase = true;
-                break;
-            }
-        }
-        if (start == 0 && end == length && !needsLowerCase) {
-            return key;
-        }
-        String trimmed = (start == 0 && end == length) ? key : key.substring(start, end);
-        return needsLowerCase ? trimmed.toLowerCase(Locale.ROOT) : trimmed;
-    }
-
-    private static OverrideValues createOverrides(Map<String, Double> normalized) {
-        if (normalized == null || normalized.isEmpty()) {
-            return OverrideValues.EMPTY;
-        }
-        Map<String, Integer> indices = KEY_INDEX_CACHE;
-        double[] overrides = null;
-        int allocatedLength = 0;
-        Map<String, Double> extras = null;
-        for (Map.Entry<String, Double> entry : normalized.entrySet()) {
-            String key = entry.getKey();
-            Double value = entry.getValue();
-            if (value == null || value.isNaN()) {
-                continue;
-            }
-            Integer index = indices.get(key);
-            if (index != null) {
-                if (overrides == null) {
-                    allocatedLength = DEFAULT_VALUES.length;
-                    overrides = new double[Math.max(allocatedLength, index + 1)];
-                    Arrays.fill(overrides, UNSET);
-                    allocatedLength = overrides.length;
-                } else if (index >= allocatedLength) {
-                    int previousLength = allocatedLength;
-                    allocatedLength = Math.max(DEFAULT_VALUES.length, index + 1);
-                    overrides = Arrays.copyOf(overrides, allocatedLength);
-                    Arrays.fill(overrides, previousLength, allocatedLength, UNSET);
-                }
-                overrides[index] = value;
-            } else {
-                if (extras == null) {
-                    extras = new LinkedHashMap<>();
-                }
-                extras.put(key, value);
-            }
-        }
-        if (overrides != null) {
-            overrides = trimTrailingUnset(overrides);
-        }
-        Map<String, Double> extraValues = (extras == null)
-                ? Map.of()
-                : Collections.unmodifiableMap(extras);
-        if (overrides == null && extraValues.isEmpty()) {
-            return OverrideValues.EMPTY;
-        }
-        return new OverrideValues(overrides, extraValues);
-    }
-
-    private static double valueAt(OverrideValues overrides, int index) {
-        if (overrides == null) {
-            return Double.NaN;
-        }
-        double[] values = overrides.values;
-        if (values != null && index < values.length) {
-            return values[index];
-        }
-        return Double.NaN;
-    }
-
-    private static Double lookupExtra(OverrideValues overrides, String key) {
-        if (overrides == null) {
-            return null;
-        }
-        Map<String, Double> extras = overrides.extras;
-        if (extras == null || extras.isEmpty()) {
-            return null;
-        }
-        return extras.get(key);
-    }
-
-    private static OverrideValues applyLateBoundOverride(OverrideValues overrides, String key, int index) {
-        if (overrides == null || overrides == OverrideValues.EMPTY) {
-            return overrides;
-        }
-        Map<String, Double> extras = overrides.extras;
-        if (extras == null || extras.isEmpty()) {
-            return overrides;
-        }
-        Double pending = extras.get(key);
-        if (pending == null) {
-            return overrides;
-        }
-        int requiredLength = Math.max(DEFAULT_VALUES.length, index + 1);
-        double[] values = overrides.values;
-        double[] updatedValues;
-        if (values == null) {
-            updatedValues = new double[requiredLength];
-            Arrays.fill(updatedValues, UNSET);
-        } else if (values.length < requiredLength) {
-            updatedValues = Arrays.copyOf(values, requiredLength);
-            Arrays.fill(updatedValues, values.length, requiredLength, UNSET);
-        } else {
-            updatedValues = Arrays.copyOf(values, values.length);
-        }
-        updatedValues[index] = pending;
-        updatedValues = trimTrailingUnset(updatedValues);
-        Map<String, Double> remaining;
-        if (extras.size() == 1) {
-            remaining = Map.of();
-        } else {
-            Map<String, Double> copy = new LinkedHashMap<>(extras);
-            copy.remove(key);
-            remaining = Collections.unmodifiableMap(copy);
-        }
-        return new OverrideValues(updatedValues, remaining);
-    }
-
-    private static double[] ensureCapacity(double[] values, int size, double fillValue) {
-        if (values.length >= size) {
-            return values;
-        }
-        double[] expanded = Arrays.copyOf(values, size);
-        Arrays.fill(expanded, values.length, size, fillValue);
-        return expanded;
-    }
-
-    private static double[] trimTrailingUnset(double[] values) {
-        int last = values.length - 1;
-        while (last >= 0 && Double.isNaN(values[last])) {
-            last--;
-        }
-        if (last < 0) {
-            return null;
-        }
-        if (last == values.length - 1) {
-            return values;
-        }
-        return Arrays.copyOf(values, last + 1);
-    }
-
-    private static final class OverrideValues {
-        static final OverrideValues EMPTY = new OverrideValues(null, Map.of());
-
-        final double[] values;
-        final Map<String, Double> extras;
-
-        OverrideValues(double[] values, Map<String, Double> extras) {
-            this.values = values;
-            this.extras = extras;
-        }
-
-        OverrideValues expandTo(int size) {
-            double[] current = values;
-            if (current == null || current.length >= size) {
-                return this;
-            }
-            double[] expanded = Arrays.copyOf(current, size);
-            Arrays.fill(expanded, current.length, size, UNSET);
-            return new OverrideValues(expanded, extras);
-        }
+        return ParameterNormalizer.normalizeKey(key);
     }
 }

--- a/src/main/java/julius/game/chessengine/tuning/ParamId.java
+++ b/src/main/java/julius/game/chessengine/tuning/ParamId.java
@@ -1,0 +1,143 @@
+package julius.game.chessengine.tuning;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ParamId {
+    MATERIAL_PAWN_VALUE("material.pawnValue", 100),
+    MATERIAL_KNIGHT_VALUE("material.knightValue", 320),
+    MATERIAL_BISHOP_VALUE("material.bishopValue", 330),
+    MATERIAL_ROOK_VALUE("material.rookValue", 500),
+    MATERIAL_QUEEN_VALUE("material.queenValue", 900),
+    MATERIAL_BISHOP_PAIR_BONUS("material.bishopPairBonus", 40),
+
+    PAWN_STRUCTURE_CENTER_PAWN_BONUS("pawnStructure.centerPawnBonus", 15),
+    PAWN_STRUCTURE_PASSED_PAWN_BONUS("pawnStructure.passedPawnBonus", 60),
+    PAWN_STRUCTURE_CONNECTED_PAWN_BONUS("pawnStructure.connectedPawnBonus", 8),
+    PAWN_STRUCTURE_ISLAND_PENALTY("pawnStructure.islandPenalty", -5),
+    PAWN_STRUCTURE_DOUBLED_PAWN_PENALTY("pawnStructure.doubledPawnPenalty", -12),
+    PAWN_STRUCTURE_ISOLATED_PAWN_PENALTY("pawnStructure.isolatedPawnPenalty", -10),
+    PAWN_STRUCTURE_ADVANCED_PAWN_BONUS("pawnStructure.advancedPawnBonus", 8),
+    PAWN_STRUCTURE_BLOCKED_PAWN_PENALTY("pawnStructure.blockedPawnPenalty", -10),
+    PAWN_STRUCTURE_BACKWARD_PAWN_PENALTY("pawnStructure.backwardPawnPenalty", -12),
+    PAWN_STRUCTURE_OWN_KING_BLOCKS_PASSED_PAWN_PENALTY("pawnStructure.ownKingBlocksPassedPawnPenalty", -150),
+    PAWN_STRUCTURE_PASSED_PAWN_FREE_PATH_BONUS_PER_RANK("pawnStructure.passedPawnFreePathBonusPerRank", 12),
+    PAWN_STRUCTURE_ROOK_HALF_OPEN_FILE_BONUS("pawnStructure.rookHalfOpenFileBonus", 15),
+    PAWN_STRUCTURE_ROOK_OPEN_FILE_BONUS("pawnStructure.rookOpenFileBonus", 25),
+
+    ACTIVITY_MIDGAME_MOBILITY_KNIGHT("activity.midgameMobilityKnight", 2),
+    ACTIVITY_MIDGAME_MOBILITY_BISHOP("activity.midgameMobilityBishop", 4),
+    ACTIVITY_MIDGAME_MOBILITY_ROOK("activity.midgameMobilityRook", 2),
+    ACTIVITY_MIDGAME_MOBILITY_QUEEN("activity.midgameMobilityQueen", 1),
+    ACTIVITY_MIDGAME_MOBILITY_KING("activity.midgameMobilityKing", 0),
+    ACTIVITY_ENDGAME_MOBILITY_KNIGHT("activity.endgameMobilityKnight", 2),
+    ACTIVITY_ENDGAME_MOBILITY_BISHOP("activity.endgameMobilityBishop", 4),
+    ACTIVITY_ENDGAME_MOBILITY_ROOK("activity.endgameMobilityRook", 2),
+    ACTIVITY_ENDGAME_MOBILITY_QUEEN("activity.endgameMobilityQueen", 1),
+    ACTIVITY_ENDGAME_MOBILITY_KING("activity.endgameMobilityKing", 2),
+    ACTIVITY_MIDGAME_CENTER_KNIGHT("activity.midgameCenterKnight", 3),
+    ACTIVITY_MIDGAME_CENTER_BISHOP("activity.midgameCenterBishop", 3),
+    ACTIVITY_MIDGAME_CENTER_ROOK("activity.midgameCenterRook", 3),
+    ACTIVITY_MIDGAME_CENTER_QUEEN("activity.midgameCenterQueen", 3),
+    ACTIVITY_MIDGAME_CENTER_KING("activity.midgameCenterKing", 0),
+    ACTIVITY_ENDGAME_CENTER_KNIGHT("activity.endgameCenterKnight", 3),
+    ACTIVITY_ENDGAME_CENTER_BISHOP("activity.endgameCenterBishop", 3),
+    ACTIVITY_ENDGAME_CENTER_ROOK("activity.endgameCenterRook", 3),
+    ACTIVITY_ENDGAME_CENTER_QUEEN("activity.endgameCenterQueen", 3),
+    ACTIVITY_ENDGAME_CENTER_KING("activity.endgameCenterKing", 2),
+
+    KING_SAFETY_MISSING_PAWN_SHIELD_PENALTY("kingSafety.missingPawnShieldPenalty", -15),
+    KING_SAFETY_HALF_OPEN_FILE_PENALTY("kingSafety.halfOpenFilePenalty", -15),
+    KING_SAFETY_OPEN_FILE_PENALTY("kingSafety.openFilePenalty", -25),
+    KING_SAFETY_DEFENDER_BONUS("kingSafety.defenderBonus", 5),
+    KING_SAFETY_QUEEN_ATTACKED_PENALTY("kingSafety.queenAttackedPenalty", -75),
+    KING_SAFETY_BACKRANK_WEAKNESS_MIDGAME_PENALTY("kingSafety.backrankWeaknessMidgamePenalty", -100),
+    KING_SAFETY_BACKRANK_WEAKNESS_ENDGAME_PENALTY("kingSafety.backrankWeaknessEndgamePenalty", -50),
+    KING_SAFETY_ATTACK_WEIGHT_PAWN("kingSafety.attackWeightPawn", 5),
+    KING_SAFETY_ATTACK_WEIGHT_KNIGHT("kingSafety.attackWeightKnight", 10),
+    KING_SAFETY_ATTACK_WEIGHT_BISHOP("kingSafety.attackWeightBishop", 10),
+    KING_SAFETY_ATTACK_WEIGHT_ROOK("kingSafety.attackWeightRook", 15),
+    KING_SAFETY_ATTACK_WEIGHT_QUEEN("kingSafety.attackWeightQueen", 20),
+
+    THREAT_HANGING_PAWN_PENALTY("threat.hangingPawnPenalty", -12),
+    THREAT_HANGING_KNIGHT_PENALTY("threat.hangingKnightPenalty", -30),
+    THREAT_HANGING_BISHOP_PENALTY("threat.hangingBishopPenalty", -30),
+    THREAT_HANGING_ROOK_PENALTY("threat.hangingRookPenalty", -45),
+    THREAT_HANGING_QUEEN_PENALTY("threat.hangingQueenPenalty", -70),
+    THREAT_PAWN_THREAT_KNIGHT_PENALTY("threat.pawnThreatKnightPenalty", -10),
+    THREAT_PAWN_THREAT_BISHOP_PENALTY("threat.pawnThreatBishopPenalty", -10),
+    THREAT_PAWN_THREAT_ROOK_PENALTY("threat.pawnThreatRookPenalty", -18),
+    THREAT_PAWN_THREAT_QUEEN_PENALTY("threat.pawnThreatQueenPenalty", -25),
+
+    PIECE_SQUARE_DEVELOPMENT_PHASE_THRESHOLD("pieceSquare.developmentPhaseThreshold", 64, 0.0, 256.0),
+    PIECE_SQUARE_QUEEN_DEVELOPMENT_PHASE_THRESHOLD("pieceSquare.queenDevelopmentPhaseThreshold", 80, 0.0, 256.0),
+    PIECE_SQUARE_UNDEVELOPED_MINOR_PENALTY("pieceSquare.undevelopedMinorPenalty", -20),
+    PIECE_SQUARE_EARLY_QUEEN_DEVELOPMENT_PENALTY_PER_MINOR("pieceSquare.earlyQueenDevelopmentPenaltyPerMinor", -15),
+    PIECE_SQUARE_MIN_UNDEVELOPED_MINORS_FOR_QUEEN_PENALTY("pieceSquare.minUndevelopedMinorsForQueenPenalty", 2, 0.0, 8.0),
+    PIECE_SQUARE_START_POSITION_PENALTY("pieceSquare.startPositionPenalty", -40),
+    PIECE_SQUARE_BLEND_SCALE("pieceSquare.blendScale", 256, 1.0, 1024.0),
+    PIECE_SQUARE_CASTLING_BONUS("pieceSquare.castlingBonus", 20),
+    PIECE_SQUARE_NOT_CASTLED_ROOK_MOVE_PENALTY("pieceSquare.notCastledRookMovePenalty", -10),
+
+    EVALUATION_BLEND_SCALE("evaluation.blendScale", 256, 1.0, 1024.0),
+
+    MOVE_ORDERING_KILLER_MOVE_SCORE("moveOrdering.killerMoveScore", 10_000),
+    MOVE_ORDERING_PROMOTION_BONUS("moveOrdering.promotionBonus", 900),
+    MOVE_ORDERING_KILLER0_BONUS("moveOrdering.killer0Bonus", 50),
+    MOVE_ORDERING_KILLER1_BONUS("moveOrdering.killer1Bonus", 30),
+    MOVE_ORDERING_COUNTER_MOVE_BONUS("moveOrdering.counterMoveBonus", 400),
+    MOVE_ORDERING_CAPTURE_MVV_MULTIPLIER("moveOrdering.captureMvvMultiplier", 16),
+    MOVE_ORDERING_CAPTURE_SEE_MULTIPLIER("moveOrdering.captureSeeMultiplier", 32),
+    MOVE_ORDERING_PROMOTION_SEE_MULTIPLIER("moveOrdering.promotionSeeMultiplier", 16);
+
+    private final String key;
+    private final double defaultValue;
+    private final Double minValue;
+    private final Double maxValue;
+
+    private static final Map<String, ParamId> BY_KEY;
+
+    static {
+        Map<String, ParamId> map = new HashMap<>();
+        for (ParamId id : values()) {
+            String normalized = ParameterNormalizer.normalizeKey(id.key);
+            map.put(normalized, id);
+        }
+        BY_KEY = Collections.unmodifiableMap(map);
+    }
+
+    ParamId(String key, double defaultValue) {
+        this(key, defaultValue, null, null);
+    }
+
+    ParamId(String key, double defaultValue, Double minValue, Double maxValue) {
+        this.key = key;
+        this.defaultValue = defaultValue;
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public double defaultValue() {
+        return defaultValue;
+    }
+
+    public Double minValue() {
+        return minValue;
+    }
+
+    public Double maxValue() {
+        return maxValue;
+    }
+
+    public static ParamId forKey(String key) {
+        if (key == null) {
+            return null;
+        }
+        return BY_KEY.get(ParameterNormalizer.normalizeKey(key));
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/ParameterNormalizer.java
+++ b/src/main/java/julius/game/chessengine/tuning/ParameterNormalizer.java
@@ -1,0 +1,57 @@
+package julius.game.chessengine.tuning;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+final class ParameterNormalizer {
+
+    private ParameterNormalizer() {
+    }
+
+    static String normalizeKey(String key) {
+        if (key == null) {
+            throw new IllegalArgumentException("Key must not be null");
+        }
+        int length = key.length();
+        int start = 0;
+        int end = length;
+        while (start < length && Character.isWhitespace(key.charAt(start))) {
+            start++;
+        }
+        while (end > start && Character.isWhitespace(key.charAt(end - 1))) {
+            end--;
+        }
+        if (start == end) {
+            throw new IllegalArgumentException("Key must not be blank");
+        }
+        boolean needsLowerCase = false;
+        for (int i = start; i < end; i++) {
+            char c = key.charAt(i);
+            if (Character.toLowerCase(c) != c) {
+                needsLowerCase = true;
+                break;
+            }
+        }
+        if (start == 0 && end == length && !needsLowerCase) {
+            return key;
+        }
+        String trimmed = (start == 0 && end == length) ? key : key.substring(start, end);
+        return needsLowerCase ? trimmed.toLowerCase(Locale.ROOT) : trimmed;
+    }
+
+    static Map<String, Double> normalize(Map<String, Double> parameters) {
+        if (parameters == null || parameters.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Double> normalized = new LinkedHashMap<>();
+        parameters.forEach((key, value) -> {
+            if (key == null || key.isBlank() || value == null || value.isNaN()) {
+                return;
+            }
+            normalized.put(normalizeKey(key), value);
+        });
+        return Collections.unmodifiableMap(normalized);
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/ParameterRegistry.java
+++ b/src/main/java/julius/game/chessengine/tuning/ParameterRegistry.java
@@ -1,0 +1,66 @@
+package julius.game.chessengine.tuning;
+
+import java.util.Map;
+import java.util.Objects;
+
+public final class ParameterRegistry {
+
+    private static final ThreadLocal<ParameterSnapshot> THREAD_OVERRIDE = new ThreadLocal<>();
+    private static volatile ParameterSnapshot GLOBAL_SNAPSHOT = ParameterSnapshot.defaultSnapshot();
+
+    private ParameterRegistry() {
+    }
+
+    static ParameterSnapshot globalSnapshot() {
+        return GLOBAL_SNAPSHOT;
+    }
+
+    static ParameterSnapshot threadSnapshot() {
+        return THREAD_OVERRIDE.get();
+    }
+
+    static void setThreadSnapshot(ParameterSnapshot snapshot) {
+        if (snapshot == null) {
+            THREAD_OVERRIDE.remove();
+        } else {
+            THREAD_OVERRIDE.set(snapshot);
+        }
+    }
+
+    static void clearThreadSnapshot() {
+        THREAD_OVERRIDE.remove();
+    }
+
+    static void setGlobalSnapshot(ParameterSnapshot snapshot) {
+        GLOBAL_SNAPSHOT = Objects.requireNonNull(snapshot, "snapshot");
+    }
+
+    static Double lookupExtra(String normalizedKey) {
+        ParameterSnapshot override = THREAD_OVERRIDE.get();
+        if (override != null) {
+            Double value = override.extraValue(normalizedKey);
+            if (value != null) {
+                return value;
+            }
+        }
+        return GLOBAL_SNAPSHOT.extraValue(normalizedKey);
+    }
+
+    public static double get(ParamId id) {
+        Objects.requireNonNull(id, "id");
+        ParameterSnapshot snapshot = THREAD_OVERRIDE.get();
+        if (snapshot == null) {
+            snapshot = GLOBAL_SNAPSHOT;
+        }
+        double value = snapshot.value(id);
+        return Double.isFinite(value) ? value : id.defaultValue();
+    }
+
+    public static int getInt(ParamId id) {
+        return (int) Math.round(get(id));
+    }
+
+    public static void hotReload(Map<String, Double> parameters) {
+        NumericTuningParameters.hotReload(parameters);
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/ParameterSnapshot.java
+++ b/src/main/java/julius/game/chessengine/tuning/ParameterSnapshot.java
@@ -1,0 +1,119 @@
+package julius.game.chessengine.tuning;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+final class ParameterSnapshot {
+
+    private static final ParamId[] IDS = ParamId.values();
+    private static final ParameterSnapshot DEFAULT = createDefault();
+
+    private final double[] values;
+    private final Map<String, Double> extras;
+
+    private ParameterSnapshot(double[] values, Map<String, Double> extras) {
+        this.values = Objects.requireNonNull(values, "values");
+        this.extras = Objects.requireNonNull(extras, "extras");
+    }
+
+    static ParameterSnapshot defaultSnapshot() {
+        return DEFAULT;
+    }
+
+    private static ParameterSnapshot createDefault() {
+        double[] values = new double[IDS.length];
+        for (ParamId id : IDS) {
+            values[id.ordinal()] = id.defaultValue();
+        }
+        return new ParameterSnapshot(values, Map.of());
+    }
+
+    double value(ParamId id) {
+        return values[id.ordinal()];
+    }
+
+    Double extraValue(String normalizedKey) {
+        return extras.get(normalizedKey);
+    }
+
+    Map<String, Double> asMap() {
+        Map<String, Double> all = new LinkedHashMap<>(values.length + extras.size());
+        for (ParamId id : IDS) {
+            all.put(id.key(), values[id.ordinal()]);
+        }
+        if (!extras.isEmpty()) {
+            all.putAll(extras);
+        }
+        return Collections.unmodifiableMap(all);
+    }
+
+    Map<String, Double> extras() {
+        return extras;
+    }
+
+    static ParameterSnapshot apply(ParameterSnapshot base, Map<String, Double> overrides) {
+        if (overrides == null || overrides.isEmpty()) {
+            return base;
+        }
+        double[] baseValues = base.values;
+        double[] updatedValues = null;
+        Map<String, Double> baseExtras = base.extras;
+        Map<String, Double> updatedExtras = null;
+        boolean changed = false;
+
+        for (Map.Entry<String, Double> entry : overrides.entrySet()) {
+            String key = entry.getKey();
+            Double value = entry.getValue();
+            if (value == null || value.isNaN()) {
+                continue;
+            }
+            ParamId id = ParamId.forKey(key);
+            if (id != null) {
+                double current = baseValues[id.ordinal()];
+                if (Double.doubleToLongBits(current) == Double.doubleToLongBits(value)) {
+                    continue;
+                }
+                if (updatedValues == null) {
+                    updatedValues = Arrays.copyOf(baseValues, baseValues.length);
+                }
+                updatedValues[id.ordinal()] = value;
+                changed = true;
+            } else {
+                Double existing = baseExtras.get(key);
+                if (existing != null && Double.doubleToLongBits(existing) == Double.doubleToLongBits(value)) {
+                    continue;
+                }
+                if (updatedExtras == null) {
+                    updatedExtras = baseExtras.isEmpty()
+                            ? new LinkedHashMap<>()
+                            : new LinkedHashMap<>(baseExtras);
+                }
+                updatedExtras.put(key, value);
+                changed = true;
+            }
+        }
+
+        if (!changed) {
+            return base;
+        }
+
+        double[] finalValues = (updatedValues != null) ? updatedValues : baseValues;
+        Map<String, Double> finalExtras;
+        if (updatedExtras != null) {
+            finalExtras = updatedExtras.isEmpty()
+                    ? Map.of()
+                    : Collections.unmodifiableMap(updatedExtras);
+        } else {
+            finalExtras = baseExtras;
+        }
+
+        if (finalValues == baseValues && finalExtras == baseExtras) {
+            return base;
+        }
+
+        return new ParameterSnapshot(finalValues, finalExtras);
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/TunableParameter.java
+++ b/src/main/java/julius/game/chessengine/tuning/TunableParameter.java
@@ -8,6 +8,7 @@ package julius.game.chessengine.tuning;
 public final class TunableParameter {
 
     private final String key;
+    private final ParamId id;
     private final int index;
     private final double defaultValue;
     private final Double minValue;
@@ -17,7 +18,13 @@ public final class TunableParameter {
         if (key == null || key.isBlank()) {
             throw new IllegalArgumentException("Parameter key must not be blank");
         }
-        this.key = NumericTuningParameters.normalizeKey(key);
+        String normalized = NumericTuningParameters.normalizeKey(key);
+        ParamId resolved = ParamId.forKey(normalized);
+        if (resolved == null) {
+            throw new IllegalArgumentException("Unknown parameter key: " + key);
+        }
+        this.key = normalized;
+        this.id = resolved;
         this.index = NumericTuningParameters.registerDefault(this.key, defaultValue);
         this.defaultValue = defaultValue;
         this.minValue = minValue;
@@ -36,7 +43,7 @@ public final class TunableParameter {
     }
 
     public double get() {
-        double value = NumericTuningParameters.resolve(index, defaultValue);
+        double value = ParameterRegistry.get(id);
         if (!Double.isFinite(value)) {
             value = defaultValue;
         }
@@ -63,5 +70,13 @@ public final class TunableParameter {
 
     public double defaultValue() {
         return defaultValue;
+    }
+
+    ParamId id() {
+        return id;
+    }
+
+    int index() {
+        return index;
     }
 }


### PR DESCRIPTION
## Summary
- introduce an enum-driven ParamId catalog together with a ParameterRegistry/ParameterSnapshot pair to hold array-backed parameter snapshots
- refactor NumericTuningParameters and TunableParameter to delegate to the registry instead of per-call map lookups
- update MaterialModule and PawnStructureModule hot paths to read parameter values through the new registry helpers

## Testing
- mvn -q -DskipTests package *(fails: release version 25 not supported in container JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68dc468c5b30832ab3baf7759617df7f