### PR TITLE
Cache tuning parameters at startup

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
@@ -7,7 +7,7 @@ import julius.game.chessengine.helper.BishopHelper;
 import julius.game.chessengine.helper.KingHelper;
 import julius.game.chessengine.helper.KnightHelper;
 import julius.game.chessengine.helper.RookHelper;
-import julius.game.chessengine.tuning.TunableParameter;
+import julius.game.chessengine.tuning.Tuning;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -28,30 +28,6 @@ public final class ActivityModule implements EvaluationModule {
     private static final int ROOK = MoveHelper.pieceTypeToInt(PieceType.ROOK);
     private static final int QUEEN = MoveHelper.pieceTypeToInt(PieceType.QUEEN);
     private static final int KING = MoveHelper.pieceTypeToInt(PieceType.KING);
-
-    private static final TunableParameter MIDGAME_KNIGHT_MOBILITY = TunableParameter.of("activity.midgameMobilityKnight", 2);
-    private static final TunableParameter MIDGAME_BISHOP_MOBILITY = TunableParameter.of("activity.midgameMobilityBishop", 4);
-    private static final TunableParameter MIDGAME_ROOK_MOBILITY = TunableParameter.of("activity.midgameMobilityRook", 2);
-    private static final TunableParameter MIDGAME_QUEEN_MOBILITY = TunableParameter.of("activity.midgameMobilityQueen", 1);
-    private static final TunableParameter MIDGAME_KING_MOBILITY = TunableParameter.of("activity.midgameMobilityKing", 0);
-
-    private static final TunableParameter ENDGAME_KNIGHT_MOBILITY = TunableParameter.of("activity.endgameMobilityKnight", 2);
-    private static final TunableParameter ENDGAME_BISHOP_MOBILITY = TunableParameter.of("activity.endgameMobilityBishop", 4);
-    private static final TunableParameter ENDGAME_ROOK_MOBILITY = TunableParameter.of("activity.endgameMobilityRook", 2);
-    private static final TunableParameter ENDGAME_QUEEN_MOBILITY = TunableParameter.of("activity.endgameMobilityQueen", 1);
-    private static final TunableParameter ENDGAME_KING_MOBILITY = TunableParameter.of("activity.endgameMobilityKing", 2);
-
-    private static final TunableParameter MIDGAME_KNIGHT_CENTER = TunableParameter.of("activity.midgameCenterKnight", 3);
-    private static final TunableParameter MIDGAME_BISHOP_CENTER = TunableParameter.of("activity.midgameCenterBishop", 3);
-    private static final TunableParameter MIDGAME_ROOK_CENTER = TunableParameter.of("activity.midgameCenterRook", 3);
-    private static final TunableParameter MIDGAME_QUEEN_CENTER = TunableParameter.of("activity.midgameCenterQueen", 3);
-    private static final TunableParameter MIDGAME_KING_CENTER = TunableParameter.of("activity.midgameCenterKing", 0);
-
-    private static final TunableParameter ENDGAME_KNIGHT_CENTER = TunableParameter.of("activity.endgameCenterKnight", 3);
-    private static final TunableParameter ENDGAME_BISHOP_CENTER = TunableParameter.of("activity.endgameCenterBishop", 3);
-    private static final TunableParameter ENDGAME_ROOK_CENTER = TunableParameter.of("activity.endgameCenterRook", 3);
-    private static final TunableParameter ENDGAME_QUEEN_CENTER = TunableParameter.of("activity.endgameCenterQueen", 3);
-    private static final TunableParameter ENDGAME_KING_CENTER = TunableParameter.of("activity.endgameCenterKing", 2);
 
     private static final long CENTRAL_SQUARES;
 
@@ -132,29 +108,29 @@ public final class ActivityModule implements EvaluationModule {
         for (int i = 0; i < activities.length; i++) {
             activities[i] = new PieceActivity();
         }
-        midgameMobilityWeights[KNIGHT] = MIDGAME_KNIGHT_MOBILITY.getInt();
-        midgameMobilityWeights[BISHOP] = MIDGAME_BISHOP_MOBILITY.getInt();
-        midgameMobilityWeights[ROOK] = MIDGAME_ROOK_MOBILITY.getInt();
-        midgameMobilityWeights[QUEEN] = MIDGAME_QUEEN_MOBILITY.getInt();
-        midgameMobilityWeights[KING] = MIDGAME_KING_MOBILITY.getInt();
+        midgameMobilityWeights[KNIGHT] = Tuning.activityMidgameKnightMobility();
+        midgameMobilityWeights[BISHOP] = Tuning.activityMidgameBishopMobility();
+        midgameMobilityWeights[ROOK] = Tuning.activityMidgameRookMobility();
+        midgameMobilityWeights[QUEEN] = Tuning.activityMidgameQueenMobility();
+        midgameMobilityWeights[KING] = Tuning.activityMidgameKingMobility();
 
-        endgameMobilityWeights[KNIGHT] = ENDGAME_KNIGHT_MOBILITY.getInt();
-        endgameMobilityWeights[BISHOP] = ENDGAME_BISHOP_MOBILITY.getInt();
-        endgameMobilityWeights[ROOK] = ENDGAME_ROOK_MOBILITY.getInt();
-        endgameMobilityWeights[QUEEN] = ENDGAME_QUEEN_MOBILITY.getInt();
-        endgameMobilityWeights[KING] = ENDGAME_KING_MOBILITY.getInt();
+        endgameMobilityWeights[KNIGHT] = Tuning.activityEndgameKnightMobility();
+        endgameMobilityWeights[BISHOP] = Tuning.activityEndgameBishopMobility();
+        endgameMobilityWeights[ROOK] = Tuning.activityEndgameRookMobility();
+        endgameMobilityWeights[QUEEN] = Tuning.activityEndgameQueenMobility();
+        endgameMobilityWeights[KING] = Tuning.activityEndgameKingMobility();
 
-        midgameCenterWeights[KNIGHT] = MIDGAME_KNIGHT_CENTER.getInt();
-        midgameCenterWeights[BISHOP] = MIDGAME_BISHOP_CENTER.getInt();
-        midgameCenterWeights[ROOK] = MIDGAME_ROOK_CENTER.getInt();
-        midgameCenterWeights[QUEEN] = MIDGAME_QUEEN_CENTER.getInt();
-        midgameCenterWeights[KING] = MIDGAME_KING_CENTER.getInt();
+        midgameCenterWeights[KNIGHT] = Tuning.activityMidgameKnightCenter();
+        midgameCenterWeights[BISHOP] = Tuning.activityMidgameBishopCenter();
+        midgameCenterWeights[ROOK] = Tuning.activityMidgameRookCenter();
+        midgameCenterWeights[QUEEN] = Tuning.activityMidgameQueenCenter();
+        midgameCenterWeights[KING] = Tuning.activityMidgameKingCenter();
 
-        endgameCenterWeights[KNIGHT] = ENDGAME_KNIGHT_CENTER.getInt();
-        endgameCenterWeights[BISHOP] = ENDGAME_BISHOP_CENTER.getInt();
-        endgameCenterWeights[ROOK] = ENDGAME_ROOK_CENTER.getInt();
-        endgameCenterWeights[QUEEN] = ENDGAME_QUEEN_CENTER.getInt();
-        endgameCenterWeights[KING] = ENDGAME_KING_CENTER.getInt();
+        endgameCenterWeights[KNIGHT] = Tuning.activityEndgameKnightCenter();
+        endgameCenterWeights[BISHOP] = Tuning.activityEndgameBishopCenter();
+        endgameCenterWeights[ROOK] = Tuning.activityEndgameRookCenter();
+        endgameCenterWeights[QUEEN] = Tuning.activityEndgameQueenCenter();
+        endgameCenterWeights[KING] = Tuning.activityEndgameKingCenter();
     }
 
     @Override

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
@@ -2,7 +2,7 @@ package julius.game.chessengine.evaluation;
 
 import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.utils.Score;
-import julius.game.chessengine.tuning.TunableParameter;
+import julius.game.chessengine.tuning.Tuning;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -15,8 +15,6 @@ import java.util.Objects;
  * recomputing unrelated features.
  */
 public final class EvaluationPipeline {
-
-    private static final TunableParameter BLEND_SCALE_PARAM = TunableParameter.of("evaluation.blendScale", 256, 1, 1024);
 
     private static final class ModuleState {
         private final EvaluationModule module;
@@ -49,7 +47,7 @@ public final class EvaluationPipeline {
             throw new IllegalArgumentException("At least one evaluation module is required");
         }
         this.weights = (weights != null ? weights : EvaluationWeights.identity());
-        this.blendScale = BLEND_SCALE_PARAM.getInt();
+        this.blendScale = Tuning.evaluationBlendScale();
         List<ModuleState> moduleStates = new ArrayList<>(modules.size());
         for (EvaluationModule module : modules) {
             EvaluationWeights.ModuleWeight weight = this.weights.weightFor(module.getClass());

--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -6,7 +6,7 @@ import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.BishopHelper;
 import julius.game.chessengine.helper.RookHelper;
-import julius.game.chessengine.tuning.TunableParameter;
+import julius.game.chessengine.tuning.Tuning;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -41,20 +41,6 @@ public final class KingSafetyModule implements EvaluationModule {
     private static final int DEFAULT_BACKRANK_WEAKNESS_MIDGAME_PENALTY = -100;
     private static final int DEFAULT_BACKRANK_WEAKNESS_ENDGAME_PENALTY = -50;
 
-    private static final TunableParameter MISSING_PAWN_SHIELD_PENALTY = TunableParameter.of("kingSafety.missingPawnShieldPenalty", DEFAULT_MISSING_PAWN_SHIELD_PENALTY);
-    private static final TunableParameter HALF_OPEN_FILE_PENALTY = TunableParameter.of("kingSafety.halfOpenFilePenalty", DEFAULT_HALF_OPEN_FILE_PENALTY);
-    private static final TunableParameter OPEN_FILE_PENALTY = TunableParameter.of("kingSafety.openFilePenalty", DEFAULT_OPEN_FILE_PENALTY);
-    private static final TunableParameter DEFENDER_BONUS = TunableParameter.of("kingSafety.defenderBonus", DEFAULT_DEFENDER_BONUS);
-    private static final TunableParameter QUEEN_ATTACKED_PENALTY = TunableParameter.of("kingSafety.queenAttackedPenalty", DEFAULT_QUEEN_ATTACKED_PENALTY);
-    private static final TunableParameter BACKRANK_WEAKNESS_MIDGAME_PENALTY = TunableParameter.of("kingSafety.backrankWeaknessMidgamePenalty", DEFAULT_BACKRANK_WEAKNESS_MIDGAME_PENALTY);
-    private static final TunableParameter BACKRANK_WEAKNESS_ENDGAME_PENALTY = TunableParameter.of("kingSafety.backrankWeaknessEndgamePenalty", DEFAULT_BACKRANK_WEAKNESS_ENDGAME_PENALTY);
-
-    private static final TunableParameter PAWN_ATTACK_WEIGHT = TunableParameter.of("kingSafety.attackWeightPawn", 5);
-    private static final TunableParameter KNIGHT_ATTACK_WEIGHT = TunableParameter.of("kingSafety.attackWeightKnight", 10);
-    private static final TunableParameter BISHOP_ATTACK_WEIGHT = TunableParameter.of("kingSafety.attackWeightBishop", 10);
-    private static final TunableParameter ROOK_ATTACK_WEIGHT = TunableParameter.of("kingSafety.attackWeightRook", 15);
-    private static final TunableParameter QUEEN_ATTACK_WEIGHT = TunableParameter.of("kingSafety.attackWeightQueen", 20);
-
     private static final long NOT_A_FILE = ~FileMasks[0];
     private static final long NOT_H_FILE = ~FileMasks[7];
 
@@ -78,18 +64,18 @@ public final class KingSafetyModule implements EvaluationModule {
     private int endgameScoreCache;
 
     public KingSafetyModule() {
-        this.missingPawnShieldPenalty = MISSING_PAWN_SHIELD_PENALTY.getInt();
-        this.halfOpenFilePenalty = HALF_OPEN_FILE_PENALTY.getInt();
-        this.openFilePenalty = OPEN_FILE_PENALTY.getInt();
-        this.defenderBonus = DEFENDER_BONUS.getInt();
-        this.queenAttackedPenalty = QUEEN_ATTACKED_PENALTY.getInt();
-        this.backrankWeaknessMidgamePenalty = BACKRANK_WEAKNESS_MIDGAME_PENALTY.getInt();
-        this.backrankWeaknessEndgamePenalty = BACKRANK_WEAKNESS_ENDGAME_PENALTY.getInt();
-        attackWeights[PAWN] = PAWN_ATTACK_WEIGHT.getInt();
-        attackWeights[KNIGHT] = KNIGHT_ATTACK_WEIGHT.getInt();
-        attackWeights[BISHOP] = BISHOP_ATTACK_WEIGHT.getInt();
-        attackWeights[ROOK] = ROOK_ATTACK_WEIGHT.getInt();
-        attackWeights[QUEEN] = QUEEN_ATTACK_WEIGHT.getInt();
+        this.missingPawnShieldPenalty = Tuning.missingPawnShieldPenalty();
+        this.halfOpenFilePenalty = Tuning.halfOpenFilePenalty();
+        this.openFilePenalty = Tuning.openFilePenalty();
+        this.defenderBonus = Tuning.defenderBonus();
+        this.queenAttackedPenalty = Tuning.queenAttackedPenalty();
+        this.backrankWeaknessMidgamePenalty = Tuning.backrankWeaknessMidgamePenalty();
+        this.backrankWeaknessEndgamePenalty = Tuning.backrankWeaknessEndgamePenalty();
+        attackWeights[PAWN] = Tuning.kingSafetyPawnAttackWeight();
+        attackWeights[KNIGHT] = Tuning.kingSafetyKnightAttackWeight();
+        attackWeights[BISHOP] = Tuning.kingSafetyBishopAttackWeight();
+        attackWeights[ROOK] = Tuning.kingSafetyRookAttackWeight();
+        attackWeights[QUEEN] = Tuning.kingSafetyQueenAttackWeight();
     }
 
     @Override

--- a/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
@@ -5,8 +5,7 @@ import java.util.Objects;
 
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.figures.PieceType;
-import julius.game.chessengine.tuning.ParamId;
-import julius.game.chessengine.tuning.ParameterRegistry;
+import julius.game.chessengine.tuning.Tuning;
 /**
  * Tracks per-side material using incremental updates so the evaluation pipeline can
  * access midgame and endgame material totals without rescanning the board.
@@ -65,27 +64,27 @@ public final class MaterialModule implements EvaluationModule {
     }
 
     public static int pawnValue() {
-        return ParameterRegistry.getInt(ParamId.MATERIAL_PAWN_VALUE);
+        return Tuning.pawnValue();
     }
 
     public static int knightValue() {
-        return ParameterRegistry.getInt(ParamId.MATERIAL_KNIGHT_VALUE);
+        return Tuning.knightValue();
     }
 
     public static int bishopValue() {
-        return ParameterRegistry.getInt(ParamId.MATERIAL_BISHOP_VALUE);
+        return Tuning.bishopValue();
     }
 
     public static int rookValue() {
-        return ParameterRegistry.getInt(ParamId.MATERIAL_ROOK_VALUE);
+        return Tuning.rookValue();
     }
 
     public static int queenValue() {
-        return ParameterRegistry.getInt(ParamId.MATERIAL_QUEEN_VALUE);
+        return Tuning.queenValue();
     }
 
     public static int bishopPairBonus() {
-        return ParameterRegistry.getInt(ParamId.MATERIAL_BISHOP_PAIR_BONUS);
+        return Tuning.bishopPairBonus();
     }
 
     @Override

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -5,9 +5,7 @@ import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.PawnHelper;
-import julius.game.chessengine.tuning.ParamId;
-import julius.game.chessengine.tuning.ParameterRegistry;
-import julius.game.chessengine.tuning.TunableParameter;
+import julius.game.chessengine.tuning.Tuning;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -39,20 +37,6 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     public static final int DEFAULT_PASSED_PAWN_FREE_PATH_BONUS_PER_RANK = 12;
     public static final int DEFAULT_ROOK_HALF_OPEN_FILE_BONUS = 15;
     public static final int DEFAULT_ROOK_OPEN_FILE_BONUS = 25;
-
-    private static final TunableParameter CENTER_PAWN_BONUS = TunableParameter.of("pawnStructure.centerPawnBonus", DEFAULT_CENTER_PAWN_BONUS);
-    private static final TunableParameter PASSED_PAWN_BONUS = TunableParameter.of("pawnStructure.passedPawnBonus", DEFAULT_PASSED_PAWN_BONUS);
-    private static final TunableParameter CONNECTED_PAWN_BONUS = TunableParameter.of("pawnStructure.connectedPawnBonus", DEFAULT_CONNECTED_PAWN_BONUS);
-    private static final TunableParameter PAWN_ISLAND_PENALTY = TunableParameter.of("pawnStructure.islandPenalty", DEFAULT_PAWN_ISLAND_PENALTY);
-    private static final TunableParameter DOUBLED_PAWN_PENALTY = TunableParameter.of("pawnStructure.doubledPawnPenalty", DEFAULT_DOUBLED_PAWN_PENALTY);
-    private static final TunableParameter ISOLATED_PAWN_PENALTY = TunableParameter.of("pawnStructure.isolatedPawnPenalty", DEFAULT_ISOLATED_PAWN_PENALTY);
-    private static final TunableParameter ADVANCED_PAWN_BONUS = TunableParameter.of("pawnStructure.advancedPawnBonus", DEFAULT_ADVANCED_PAWN_BONUS);
-    private static final TunableParameter BLOCKED_PAWN_PENALTY = TunableParameter.of("pawnStructure.blockedPawnPenalty", DEFAULT_BLOCKED_PAWN_PENALTY);
-    private static final TunableParameter BACKWARD_PAWN_PENALTY = TunableParameter.of("pawnStructure.backwardPawnPenalty", DEFAULT_BACKWARD_PAWN_PENALTY);
-    private static final TunableParameter OWN_KING_BLOCKS_PASSED_PAWN_PENALTY = TunableParameter.of("pawnStructure.ownKingBlocksPassedPawnPenalty", DEFAULT_OWN_KING_BLOCKS_PASSED_PAWN_PENALTY);
-    private static final TunableParameter PASSED_PAWN_FREE_PATH_BONUS_PER_RANK = TunableParameter.of("pawnStructure.passedPawnFreePathBonusPerRank", DEFAULT_PASSED_PAWN_FREE_PATH_BONUS_PER_RANK);
-    private static final TunableParameter ROOK_HALF_OPEN_FILE_BONUS = TunableParameter.of("pawnStructure.rookHalfOpenFileBonus", DEFAULT_ROOK_HALF_OPEN_FILE_BONUS);
-    private static final TunableParameter ROOK_OPEN_FILE_BONUS = TunableParameter.of("pawnStructure.rookOpenFileBonus", DEFAULT_ROOK_OPEN_FILE_BONUS);
 
     private static final int WHITE = 0;
     private static final int BLACK = 1;
@@ -104,55 +88,55 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     }
 
     public static int centerPawnBonus() {
-        return CENTER_PAWN_BONUS.getInt();
+        return Tuning.centerPawnBonus();
     }
 
     public static int passedPawnBonus() {
-        return PASSED_PAWN_BONUS.getInt();
+        return Tuning.passedPawnBonus();
     }
 
     public static int connectedPawnBonus() {
-        return CONNECTED_PAWN_BONUS.getInt();
+        return Tuning.connectedPawnBonus();
     }
 
     public static int pawnIslandPenalty() {
-        return PAWN_ISLAND_PENALTY.getInt();
+        return Tuning.pawnIslandPenalty();
     }
 
     public static int doubledPawnPenalty() {
-        return DOUBLED_PAWN_PENALTY.getInt();
+        return Tuning.doubledPawnPenalty();
     }
 
     public static int isolatedPawnPenalty() {
-        return ISOLATED_PAWN_PENALTY.getInt();
+        return Tuning.isolatedPawnPenalty();
     }
 
     public static int advancedPawnBonus() {
-        return ADVANCED_PAWN_BONUS.getInt();
+        return Tuning.advancedPawnBonus();
     }
 
     public static int blockedPawnPenalty() {
-        return BLOCKED_PAWN_PENALTY.getInt();
+        return Tuning.blockedPawnPenalty();
     }
 
     public static int backwardPawnPenalty() {
-        return BACKWARD_PAWN_PENALTY.getInt();
+        return Tuning.backwardPawnPenalty();
     }
 
     public static int ownKingBlocksPassedPawnPenalty() {
-        return OWN_KING_BLOCKS_PASSED_PAWN_PENALTY.getInt();
+        return Tuning.ownKingBlocksPassedPawnPenalty();
     }
 
     public static int passedPawnFreePathBonusPerRank() {
-        return PASSED_PAWN_FREE_PATH_BONUS_PER_RANK.getInt();
+        return Tuning.passedPawnFreePathBonusPerRank();
     }
 
     public static int rookHalfOpenFileBonus() {
-        return ROOK_HALF_OPEN_FILE_BONUS.getInt();
+        return Tuning.rookHalfOpenFileBonus();
     }
 
     public static int rookOpenFileBonus() {
-        return ROOK_OPEN_FILE_BONUS.getInt();
+        return Tuning.rookOpenFileBonus();
     }
 
     @Override
@@ -242,11 +226,11 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
                 calculateBlockedPawnPenalty(blackPawns, allPieces, false, 256));
 
         PhaseScore whiteBackward = PhaseScore.of(
-                calculateBackwardPawnPenalty(whitePawns, blackPawns, allPieces, true, 0),
-                calculateBackwardPawnPenalty(whitePawns, blackPawns, allPieces, true, 256));
+                calculateBackwardPawnPenalty(whitePawns, blackPawns, allPieces, true, 0, backwardPawnPenalty),
+                calculateBackwardPawnPenalty(whitePawns, blackPawns, allPieces, true, 256, backwardPawnPenalty));
         PhaseScore blackBackward = PhaseScore.of(
-                calculateBackwardPawnPenalty(blackPawns, whitePawns, allPieces, false, 0),
-                calculateBackwardPawnPenalty(blackPawns, whitePawns, allPieces, false, 256));
+                calculateBackwardPawnPenalty(blackPawns, whitePawns, allPieces, false, 0, backwardPawnPenalty),
+                calculateBackwardPawnPenalty(blackPawns, whitePawns, allPieces, false, 256, backwardPawnPenalty));
 
         PhaseScore[] whiteComponents = new PhaseScore[]{
                 whiteCenter,
@@ -540,8 +524,8 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         return scaleByPhase(penalty, phase);
     }
 
-    private static int calculateBackwardPawnPenalty(long pawns, long enemyPawns, long allPieces, boolean isWhite, int phase) {
-        int backwardPenalty = ParameterRegistry.getInt(ParamId.PAWN_STRUCTURE_BACKWARD_PAWN_PENALTY);
+    private static int calculateBackwardPawnPenalty(long pawns, long enemyPawns, long allPieces, boolean isWhite, int phase,
+            int backwardPenalty) {
         int penalty = 0;
         long remaining = pawns;
         while (remaining != 0) {

--- a/src/main/java/julius/game/chessengine/evaluation/PieceSquareModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PieceSquareModule.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
-import julius.game.chessengine.tuning.TunableParameter;
+import julius.game.chessengine.tuning.Tuning;
 
 import static julius.game.chessengine.helper.BishopHelper.BISHOP_ENDGAME_POSITIONAL_VALUES;
 import static julius.game.chessengine.helper.BishopHelper.BISHOP_MIDGAME_POSITIONAL_VALUES;
@@ -52,16 +52,6 @@ public final class PieceSquareModule implements EvaluationModule {
     private static final int DEFAULT_BLEND_SCALE = 256;
     private static final int DEFAULT_CASTLING_BONUS = 20;
     private static final int DEFAULT_NOT_CASTLED_AND_ROOK_MOVE_PENALTY = -10;
-
-    private static final TunableParameter DEVELOPMENT_PHASE_THRESHOLD = TunableParameter.of("pieceSquare.developmentPhaseThreshold", DEFAULT_DEVELOPMENT_PHASE_THRESHOLD, 0, 256);
-    private static final TunableParameter QUEEN_DEVELOPMENT_PHASE_THRESHOLD = TunableParameter.of("pieceSquare.queenDevelopmentPhaseThreshold", DEFAULT_QUEEN_DEVELOPMENT_PHASE_THRESHOLD, 0, 256);
-    private static final TunableParameter UNDEVELOPED_MINOR_PENALTY = TunableParameter.of("pieceSquare.undevelopedMinorPenalty", DEFAULT_UNDEVELOPED_MINOR_PENALTY);
-    private static final TunableParameter EARLY_QUEEN_DEVELOPMENT_PENALTY_PER_MINOR = TunableParameter.of("pieceSquare.earlyQueenDevelopmentPenaltyPerMinor", DEFAULT_EARLY_QUEEN_DEVELOPMENT_PENALTY_PER_MINOR);
-    private static final TunableParameter MIN_UNDEVELOPED_MINORS_FOR_QUEEN_PENALTY = TunableParameter.of("pieceSquare.minUndevelopedMinorsForQueenPenalty", DEFAULT_MIN_UNDEVELOPED_MINORS_FOR_QUEEN_PENALTY, 0, 8);
-    private static final TunableParameter START_POSITION_PENALTY = TunableParameter.of("pieceSquare.startPositionPenalty", DEFAULT_START_POSITION_PENALTY);
-    private static final TunableParameter BLEND_SCALE = TunableParameter.of("pieceSquare.blendScale", DEFAULT_BLEND_SCALE, 1, 1024);
-    private static final TunableParameter CASTLING_BONUS = TunableParameter.of("pieceSquare.castlingBonus", DEFAULT_CASTLING_BONUS);
-    private static final TunableParameter NOT_CASTLED_AND_ROOK_MOVE_PENALTY = TunableParameter.of("pieceSquare.notCastledRookMovePenalty", DEFAULT_NOT_CASTLED_AND_ROOK_MOVE_PENALTY);
 
     private static final long NOT_A_FILE = ~FileMasks[0];
     private static final long NOT_H_FILE = ~FileMasks[7];
@@ -157,28 +147,28 @@ public final class PieceSquareModule implements EvaluationModule {
     private boolean castlingDirty = true;
 
     public PieceSquareModule() {
-        this.developmentPhaseThreshold = DEVELOPMENT_PHASE_THRESHOLD.getInt();
-        this.queenDevelopmentPhaseThreshold = QUEEN_DEVELOPMENT_PHASE_THRESHOLD.getInt();
-        this.undevelopedMinorPenalty = UNDEVELOPED_MINOR_PENALTY.getInt();
-        this.earlyQueenDevelopmentPenaltyPerMinor = EARLY_QUEEN_DEVELOPMENT_PENALTY_PER_MINOR.getInt();
-        this.minUndevelopedMinorsForQueenPenalty = MIN_UNDEVELOPED_MINORS_FOR_QUEEN_PENALTY.getInt();
-        this.startPositionPenalty = START_POSITION_PENALTY.getInt();
-        this.blendScale = BLEND_SCALE.getInt();
-        this.castlingBonus = CASTLING_BONUS.getInt();
-        this.notCastledRookMovePenalty = NOT_CASTLED_AND_ROOK_MOVE_PENALTY.getInt();
+        this.developmentPhaseThreshold = Tuning.developmentPhaseThreshold();
+        this.queenDevelopmentPhaseThreshold = Tuning.queenDevelopmentPhaseThreshold();
+        this.undevelopedMinorPenalty = Tuning.undevelopedMinorPenalty();
+        this.earlyQueenDevelopmentPenaltyPerMinor = Tuning.earlyQueenDevelopmentPenaltyPerMinor();
+        this.minUndevelopedMinorsForQueenPenalty = Tuning.minUndevelopedMinorsForQueenPenalty();
+        this.startPositionPenalty = Tuning.startPositionPenalty();
+        this.blendScale = Tuning.pieceSquareBlendScale();
+        this.castlingBonus = Tuning.castlingBonus();
+        this.notCastledRookMovePenalty = Tuning.notCastledRookMovePenalty();
         Arrays.fill(occupantColor, -1);
     }
 
     public static int castlingBonus() {
-        return CASTLING_BONUS.getInt();
+        return Tuning.castlingBonus();
     }
 
     public static int notCastledRookMovePenalty() {
-        return NOT_CASTLED_AND_ROOK_MOVE_PENALTY.getInt();
+        return Tuning.notCastledRookMovePenalty();
     }
 
     public static int blendScale() {
-        return BLEND_SCALE.getInt();
+        return Tuning.pieceSquareBlendScale();
     }
 
     @Override

--- a/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
@@ -3,7 +3,7 @@ package julius.game.chessengine.evaluation;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
-import julius.game.chessengine.tuning.TunableParameter;
+import julius.game.chessengine.tuning.Tuning;
 
 import java.util.Objects;
 
@@ -26,31 +26,20 @@ public final class ThreatModule implements EvaluationModule {
     private static final int QUEEN = MoveHelper.pieceTypeToInt(PieceType.QUEEN);
     private static final int KING = MoveHelper.pieceTypeToInt(PieceType.KING);
 
-    private static final TunableParameter HANGING_PAWN_PENALTY = TunableParameter.of("threat.hangingPawnPenalty", -12);
-    private static final TunableParameter HANGING_KNIGHT_PENALTY = TunableParameter.of("threat.hangingKnightPenalty", -30);
-    private static final TunableParameter HANGING_BISHOP_PENALTY = TunableParameter.of("threat.hangingBishopPenalty", -30);
-    private static final TunableParameter HANGING_ROOK_PENALTY = TunableParameter.of("threat.hangingRookPenalty", -45);
-    private static final TunableParameter HANGING_QUEEN_PENALTY = TunableParameter.of("threat.hangingQueenPenalty", -70);
-
-    private static final TunableParameter PAWN_THREAT_KNIGHT_PENALTY = TunableParameter.of("threat.pawnThreatKnightPenalty", -10);
-    private static final TunableParameter PAWN_THREAT_BISHOP_PENALTY = TunableParameter.of("threat.pawnThreatBishopPenalty", -10);
-    private static final TunableParameter PAWN_THREAT_ROOK_PENALTY = TunableParameter.of("threat.pawnThreatRookPenalty", -18);
-    private static final TunableParameter PAWN_THREAT_QUEEN_PENALTY = TunableParameter.of("threat.pawnThreatQueenPenalty", -25);
-
     private final int[] hangingPenalties = new int[7];
     private final int[] pawnThreatPenalties = new int[7];
 
     public ThreatModule() {
-        hangingPenalties[PAWN] = HANGING_PAWN_PENALTY.getInt();
-        hangingPenalties[KNIGHT] = HANGING_KNIGHT_PENALTY.getInt();
-        hangingPenalties[BISHOP] = HANGING_BISHOP_PENALTY.getInt();
-        hangingPenalties[ROOK] = HANGING_ROOK_PENALTY.getInt();
-        hangingPenalties[QUEEN] = HANGING_QUEEN_PENALTY.getInt();
+        hangingPenalties[PAWN] = Tuning.hangingPawnPenalty();
+        hangingPenalties[KNIGHT] = Tuning.hangingKnightPenalty();
+        hangingPenalties[BISHOP] = Tuning.hangingBishopPenalty();
+        hangingPenalties[ROOK] = Tuning.hangingRookPenalty();
+        hangingPenalties[QUEEN] = Tuning.hangingQueenPenalty();
 
-        pawnThreatPenalties[KNIGHT] = PAWN_THREAT_KNIGHT_PENALTY.getInt();
-        pawnThreatPenalties[BISHOP] = PAWN_THREAT_BISHOP_PENALTY.getInt();
-        pawnThreatPenalties[ROOK] = PAWN_THREAT_ROOK_PENALTY.getInt();
-        pawnThreatPenalties[QUEEN] = PAWN_THREAT_QUEEN_PENALTY.getInt();
+        pawnThreatPenalties[KNIGHT] = Tuning.pawnThreatKnightPenalty();
+        pawnThreatPenalties[BISHOP] = Tuning.pawnThreatBishopPenalty();
+        pawnThreatPenalties[ROOK] = Tuning.pawnThreatRookPenalty();
+        pawnThreatPenalties[QUEEN] = Tuning.pawnThreatQueenPenalty();
     }
 
     private int midgameScoreCache;

--- a/src/main/java/julius/game/chessengine/tuning/MoveOrderingParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/MoveOrderingParameters.java
@@ -4,61 +4,45 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+
 /**
  * Registry for move-ordering heuristics used by the search. The parameters are exposed as
- * {@link TunableParameter}s so the genetic tuner can mutate them alongside the evaluation
- * weights. Consumers capture a {@link Snapshot} at construction time to obtain a stable view of
- * the configuration for the duration of a search.
+ * tuning parameters so the genetic tuner can mutate them alongside the evaluation weights.
+ * Consumers capture a {@link Snapshot} at construction time to obtain a stable view of the
+ * configuration for the duration of a search.
  */
 public final class MoveOrderingParameters {
-
-    private static final TunableParameter KILLER_MOVE_SCORE =
-            TunableParameter.of("moveOrdering.killerMoveScore", 10_000);
-    private static final TunableParameter PROMOTION_BONUS =
-            TunableParameter.of("moveOrdering.promotionBonus", 900);
-    private static final TunableParameter KILLER0_BONUS =
-            TunableParameter.of("moveOrdering.killer0Bonus", 50);
-    private static final TunableParameter KILLER1_BONUS =
-            TunableParameter.of("moveOrdering.killer1Bonus", 30);
-    private static final TunableParameter COUNTER_MOVE_BONUS =
-            TunableParameter.of("moveOrdering.counterMoveBonus", 400);
-    private static final TunableParameter CAPTURE_MVV_MULTIPLIER =
-            TunableParameter.of("moveOrdering.captureMvvMultiplier", 16);
-    private static final TunableParameter CAPTURE_SEE_MULTIPLIER =
-            TunableParameter.of("moveOrdering.captureSeeMultiplier", 32);
-    private static final TunableParameter PROMOTION_SEE_MULTIPLIER =
-            TunableParameter.of("moveOrdering.promotionSeeMultiplier", 16);
 
     private MoveOrderingParameters() {
     }
 
     public static Snapshot snapshot() {
         return new Snapshot(
-                KILLER_MOVE_SCORE.getInt(),
-                PROMOTION_BONUS.getInt(),
-                KILLER0_BONUS.getInt(),
-                KILLER1_BONUS.getInt(),
-                COUNTER_MOVE_BONUS.getInt(),
-                CAPTURE_MVV_MULTIPLIER.getInt(),
-                CAPTURE_SEE_MULTIPLIER.getInt(),
-                PROMOTION_SEE_MULTIPLIER.getInt()
+                Tuning.moveOrderingKillerMoveScore(),
+                Tuning.moveOrderingPromotionBonus(),
+                Tuning.moveOrderingKiller0Bonus(),
+                Tuning.moveOrderingKiller1Bonus(),
+                Tuning.moveOrderingCounterMoveBonus(),
+                Tuning.moveOrderingCaptureMvvMultiplier(),
+                Tuning.moveOrderingCaptureSeeMultiplier(),
+                Tuning.moveOrderingPromotionSeeMultiplier()
         );
     }
 
     public static int killerMoveScore() {
-        return KILLER_MOVE_SCORE.getInt();
+        return Tuning.moveOrderingKillerMoveScore();
     }
 
     public static Map<String, Double> defaults() {
         Map<String, Double> defaults = new LinkedHashMap<>();
-        defaults.put(KILLER_MOVE_SCORE.key(), KILLER_MOVE_SCORE.defaultValue());
-        defaults.put(PROMOTION_BONUS.key(), PROMOTION_BONUS.defaultValue());
-        defaults.put(KILLER0_BONUS.key(), KILLER0_BONUS.defaultValue());
-        defaults.put(KILLER1_BONUS.key(), KILLER1_BONUS.defaultValue());
-        defaults.put(COUNTER_MOVE_BONUS.key(), COUNTER_MOVE_BONUS.defaultValue());
-        defaults.put(CAPTURE_MVV_MULTIPLIER.key(), CAPTURE_MVV_MULTIPLIER.defaultValue());
-        defaults.put(CAPTURE_SEE_MULTIPLIER.key(), CAPTURE_SEE_MULTIPLIER.defaultValue());
-        defaults.put(PROMOTION_SEE_MULTIPLIER.key(), PROMOTION_SEE_MULTIPLIER.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_KILLER_MOVE_SCORE.key(), ParamId.MOVE_ORDERING_KILLER_MOVE_SCORE.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_PROMOTION_BONUS.key(), ParamId.MOVE_ORDERING_PROMOTION_BONUS.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_KILLER0_BONUS.key(), ParamId.MOVE_ORDERING_KILLER0_BONUS.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_KILLER1_BONUS.key(), ParamId.MOVE_ORDERING_KILLER1_BONUS.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_COUNTER_MOVE_BONUS.key(), ParamId.MOVE_ORDERING_COUNTER_MOVE_BONUS.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_CAPTURE_MVV_MULTIPLIER.key(), ParamId.MOVE_ORDERING_CAPTURE_MVV_MULTIPLIER.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_CAPTURE_SEE_MULTIPLIER.key(), ParamId.MOVE_ORDERING_CAPTURE_SEE_MULTIPLIER.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_PROMOTION_SEE_MULTIPLIER.key(), ParamId.MOVE_ORDERING_PROMOTION_SEE_MULTIPLIER.defaultValue());
         return Collections.unmodifiableMap(defaults);
     }
 

--- a/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/NumericTuningParameters.java
@@ -84,6 +84,7 @@ public final class NumericTuningParameters {
         GLOBAL_PARAMETERS = normalized;
         ParameterSnapshot snapshot = ParameterSnapshot.apply(DEFAULT_SNAPSHOT, normalized);
         ParameterRegistry.setGlobalSnapshot(snapshot);
+        Tuning.refresh();
     }
 
     public static void hotReload(Map<String, Double> parameters) {

--- a/src/main/java/julius/game/chessengine/tuning/Tuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/Tuning.java
@@ -1,0 +1,530 @@
+package julius.game.chessengine.tuning;
+
+/**
+ * Caches all numeric tuning parameters so evaluation and search code can read plain primitives
+ * without consulting {@link ParameterRegistry} during hot paths. Values are loaded once at class
+ * initialization time and can be refreshed explicitly when hot reload is triggered.
+ */
+public final class Tuning {
+
+    private static final Object LOCK = new Object();
+
+    private static int pawnValue;
+    private static int knightValue;
+    private static int bishopValue;
+    private static int rookValue;
+    private static int queenValue;
+    private static int bishopPairBonus;
+
+    private static int centerPawnBonus;
+    private static int passedPawnBonus;
+    private static int connectedPawnBonus;
+    private static int pawnIslandPenalty;
+    private static int doubledPawnPenalty;
+    private static int isolatedPawnPenalty;
+    private static int advancedPawnBonus;
+    private static int blockedPawnPenalty;
+    private static int backwardPawnPenalty;
+    private static int ownKingBlocksPassedPawnPenalty;
+    private static int passedPawnFreePathBonusPerRank;
+    private static int rookHalfOpenFileBonus;
+    private static int rookOpenFileBonus;
+
+    private static int activityMidgameKnightMobility;
+    private static int activityMidgameBishopMobility;
+    private static int activityMidgameRookMobility;
+    private static int activityMidgameQueenMobility;
+    private static int activityMidgameKingMobility;
+    private static int activityEndgameKnightMobility;
+    private static int activityEndgameBishopMobility;
+    private static int activityEndgameRookMobility;
+    private static int activityEndgameQueenMobility;
+    private static int activityEndgameKingMobility;
+    private static int activityMidgameKnightCenter;
+    private static int activityMidgameBishopCenter;
+    private static int activityMidgameRookCenter;
+    private static int activityMidgameQueenCenter;
+    private static int activityMidgameKingCenter;
+    private static int activityEndgameKnightCenter;
+    private static int activityEndgameBishopCenter;
+    private static int activityEndgameRookCenter;
+    private static int activityEndgameQueenCenter;
+    private static int activityEndgameKingCenter;
+
+    private static int missingPawnShieldPenalty;
+    private static int halfOpenFilePenalty;
+    private static int openFilePenalty;
+    private static int defenderBonus;
+    private static int queenAttackedPenalty;
+    private static int backrankWeaknessMidgamePenalty;
+    private static int backrankWeaknessEndgamePenalty;
+    private static int kingSafetyPawnAttackWeight;
+    private static int kingSafetyKnightAttackWeight;
+    private static int kingSafetyBishopAttackWeight;
+    private static int kingSafetyRookAttackWeight;
+    private static int kingSafetyQueenAttackWeight;
+
+    private static int hangingPawnPenalty;
+    private static int hangingKnightPenalty;
+    private static int hangingBishopPenalty;
+    private static int hangingRookPenalty;
+    private static int hangingQueenPenalty;
+    private static int pawnThreatKnightPenalty;
+    private static int pawnThreatBishopPenalty;
+    private static int pawnThreatRookPenalty;
+    private static int pawnThreatQueenPenalty;
+
+    private static int developmentPhaseThreshold;
+    private static int queenDevelopmentPhaseThreshold;
+    private static int undevelopedMinorPenalty;
+    private static int earlyQueenDevelopmentPenaltyPerMinor;
+    private static int minUndevelopedMinorsForQueenPenalty;
+    private static int startPositionPenalty;
+    private static int pieceSquareBlendScale;
+    private static int castlingBonus;
+    private static int notCastledRookMovePenalty;
+
+    private static int evaluationBlendScale;
+
+    private static int moveOrderingKillerMoveScore;
+    private static int moveOrderingPromotionBonus;
+    private static int moveOrderingKiller0Bonus;
+    private static int moveOrderingKiller1Bonus;
+    private static int moveOrderingCounterMoveBonus;
+    private static int moveOrderingCaptureMvvMultiplier;
+    private static int moveOrderingCaptureSeeMultiplier;
+    private static int moveOrderingPromotionSeeMultiplier;
+
+    static {
+        refresh();
+    }
+
+    private Tuning() {
+    }
+
+    public static int pawnValue() {
+        return pawnValue;
+    }
+
+    public static int knightValue() {
+        return knightValue;
+    }
+
+    public static int bishopValue() {
+        return bishopValue;
+    }
+
+    public static int rookValue() {
+        return rookValue;
+    }
+
+    public static int queenValue() {
+        return queenValue;
+    }
+
+    public static int bishopPairBonus() {
+        return bishopPairBonus;
+    }
+
+    public static int centerPawnBonus() {
+        return centerPawnBonus;
+    }
+
+    public static int passedPawnBonus() {
+        return passedPawnBonus;
+    }
+
+    public static int connectedPawnBonus() {
+        return connectedPawnBonus;
+    }
+
+    public static int pawnIslandPenalty() {
+        return pawnIslandPenalty;
+    }
+
+    public static int doubledPawnPenalty() {
+        return doubledPawnPenalty;
+    }
+
+    public static int isolatedPawnPenalty() {
+        return isolatedPawnPenalty;
+    }
+
+    public static int advancedPawnBonus() {
+        return advancedPawnBonus;
+    }
+
+    public static int blockedPawnPenalty() {
+        return blockedPawnPenalty;
+    }
+
+    public static int backwardPawnPenalty() {
+        return backwardPawnPenalty;
+    }
+
+    public static int ownKingBlocksPassedPawnPenalty() {
+        return ownKingBlocksPassedPawnPenalty;
+    }
+
+    public static int passedPawnFreePathBonusPerRank() {
+        return passedPawnFreePathBonusPerRank;
+    }
+
+    public static int rookHalfOpenFileBonus() {
+        return rookHalfOpenFileBonus;
+    }
+
+    public static int rookOpenFileBonus() {
+        return rookOpenFileBonus;
+    }
+
+    public static int activityMidgameKnightMobility() {
+        return activityMidgameKnightMobility;
+    }
+
+    public static int activityMidgameBishopMobility() {
+        return activityMidgameBishopMobility;
+    }
+
+    public static int activityMidgameRookMobility() {
+        return activityMidgameRookMobility;
+    }
+
+    public static int activityMidgameQueenMobility() {
+        return activityMidgameQueenMobility;
+    }
+
+    public static int activityMidgameKingMobility() {
+        return activityMidgameKingMobility;
+    }
+
+    public static int activityEndgameKnightMobility() {
+        return activityEndgameKnightMobility;
+    }
+
+    public static int activityEndgameBishopMobility() {
+        return activityEndgameBishopMobility;
+    }
+
+    public static int activityEndgameRookMobility() {
+        return activityEndgameRookMobility;
+    }
+
+    public static int activityEndgameQueenMobility() {
+        return activityEndgameQueenMobility;
+    }
+
+    public static int activityEndgameKingMobility() {
+        return activityEndgameKingMobility;
+    }
+
+    public static int activityMidgameKnightCenter() {
+        return activityMidgameKnightCenter;
+    }
+
+    public static int activityMidgameBishopCenter() {
+        return activityMidgameBishopCenter;
+    }
+
+    public static int activityMidgameRookCenter() {
+        return activityMidgameRookCenter;
+    }
+
+    public static int activityMidgameQueenCenter() {
+        return activityMidgameQueenCenter;
+    }
+
+    public static int activityMidgameKingCenter() {
+        return activityMidgameKingCenter;
+    }
+
+    public static int activityEndgameKnightCenter() {
+        return activityEndgameKnightCenter;
+    }
+
+    public static int activityEndgameBishopCenter() {
+        return activityEndgameBishopCenter;
+    }
+
+    public static int activityEndgameRookCenter() {
+        return activityEndgameRookCenter;
+    }
+
+    public static int activityEndgameQueenCenter() {
+        return activityEndgameQueenCenter;
+    }
+
+    public static int activityEndgameKingCenter() {
+        return activityEndgameKingCenter;
+    }
+
+    public static int missingPawnShieldPenalty() {
+        return missingPawnShieldPenalty;
+    }
+
+    public static int halfOpenFilePenalty() {
+        return halfOpenFilePenalty;
+    }
+
+    public static int openFilePenalty() {
+        return openFilePenalty;
+    }
+
+    public static int defenderBonus() {
+        return defenderBonus;
+    }
+
+    public static int queenAttackedPenalty() {
+        return queenAttackedPenalty;
+    }
+
+    public static int backrankWeaknessMidgamePenalty() {
+        return backrankWeaknessMidgamePenalty;
+    }
+
+    public static int backrankWeaknessEndgamePenalty() {
+        return backrankWeaknessEndgamePenalty;
+    }
+
+    public static int kingSafetyPawnAttackWeight() {
+        return kingSafetyPawnAttackWeight;
+    }
+
+    public static int kingSafetyKnightAttackWeight() {
+        return kingSafetyKnightAttackWeight;
+    }
+
+    public static int kingSafetyBishopAttackWeight() {
+        return kingSafetyBishopAttackWeight;
+    }
+
+    public static int kingSafetyRookAttackWeight() {
+        return kingSafetyRookAttackWeight;
+    }
+
+    public static int kingSafetyQueenAttackWeight() {
+        return kingSafetyQueenAttackWeight;
+    }
+
+    public static int hangingPawnPenalty() {
+        return hangingPawnPenalty;
+    }
+
+    public static int hangingKnightPenalty() {
+        return hangingKnightPenalty;
+    }
+
+    public static int hangingBishopPenalty() {
+        return hangingBishopPenalty;
+    }
+
+    public static int hangingRookPenalty() {
+        return hangingRookPenalty;
+    }
+
+    public static int hangingQueenPenalty() {
+        return hangingQueenPenalty;
+    }
+
+    public static int pawnThreatKnightPenalty() {
+        return pawnThreatKnightPenalty;
+    }
+
+    public static int pawnThreatBishopPenalty() {
+        return pawnThreatBishopPenalty;
+    }
+
+    public static int pawnThreatRookPenalty() {
+        return pawnThreatRookPenalty;
+    }
+
+    public static int pawnThreatQueenPenalty() {
+        return pawnThreatQueenPenalty;
+    }
+
+    public static int developmentPhaseThreshold() {
+        return developmentPhaseThreshold;
+    }
+
+    public static int queenDevelopmentPhaseThreshold() {
+        return queenDevelopmentPhaseThreshold;
+    }
+
+    public static int undevelopedMinorPenalty() {
+        return undevelopedMinorPenalty;
+    }
+
+    public static int earlyQueenDevelopmentPenaltyPerMinor() {
+        return earlyQueenDevelopmentPenaltyPerMinor;
+    }
+
+    public static int minUndevelopedMinorsForQueenPenalty() {
+        return minUndevelopedMinorsForQueenPenalty;
+    }
+
+    public static int startPositionPenalty() {
+        return startPositionPenalty;
+    }
+
+    public static int pieceSquareBlendScale() {
+        return pieceSquareBlendScale;
+    }
+
+    public static int castlingBonus() {
+        return castlingBonus;
+    }
+
+    public static int notCastledRookMovePenalty() {
+        return notCastledRookMovePenalty;
+    }
+
+    public static int evaluationBlendScale() {
+        return evaluationBlendScale;
+    }
+
+    public static int moveOrderingKillerMoveScore() {
+        return moveOrderingKillerMoveScore;
+    }
+
+    public static int moveOrderingPromotionBonus() {
+        return moveOrderingPromotionBonus;
+    }
+
+    public static int moveOrderingKiller0Bonus() {
+        return moveOrderingKiller0Bonus;
+    }
+
+    public static int moveOrderingKiller1Bonus() {
+        return moveOrderingKiller1Bonus;
+    }
+
+    public static int moveOrderingCounterMoveBonus() {
+        return moveOrderingCounterMoveBonus;
+    }
+
+    public static int moveOrderingCaptureMvvMultiplier() {
+        return moveOrderingCaptureMvvMultiplier;
+    }
+
+    public static int moveOrderingCaptureSeeMultiplier() {
+        return moveOrderingCaptureSeeMultiplier;
+    }
+
+    public static int moveOrderingPromotionSeeMultiplier() {
+        return moveOrderingPromotionSeeMultiplier;
+    }
+
+    /**
+     * Reloads all cached tuning values from the current {@link ParameterRegistry} snapshot.
+     * Callers should invoke this once after applying a new parameter set (e.g. via hot reload).
+     */
+    public static void refresh() {
+        synchronized (LOCK) {
+            pawnValue = loadInt(ParamId.MATERIAL_PAWN_VALUE);
+            knightValue = loadInt(ParamId.MATERIAL_KNIGHT_VALUE);
+            bishopValue = loadInt(ParamId.MATERIAL_BISHOP_VALUE);
+            rookValue = loadInt(ParamId.MATERIAL_ROOK_VALUE);
+            queenValue = loadInt(ParamId.MATERIAL_QUEEN_VALUE);
+            bishopPairBonus = loadInt(ParamId.MATERIAL_BISHOP_PAIR_BONUS);
+
+            centerPawnBonus = loadInt(ParamId.PAWN_STRUCTURE_CENTER_PAWN_BONUS);
+            passedPawnBonus = loadInt(ParamId.PAWN_STRUCTURE_PASSED_PAWN_BONUS);
+            connectedPawnBonus = loadInt(ParamId.PAWN_STRUCTURE_CONNECTED_PAWN_BONUS);
+            pawnIslandPenalty = loadInt(ParamId.PAWN_STRUCTURE_ISLAND_PENALTY);
+            doubledPawnPenalty = loadInt(ParamId.PAWN_STRUCTURE_DOUBLED_PAWN_PENALTY);
+            isolatedPawnPenalty = loadInt(ParamId.PAWN_STRUCTURE_ISOLATED_PAWN_PENALTY);
+            advancedPawnBonus = loadInt(ParamId.PAWN_STRUCTURE_ADVANCED_PAWN_BONUS);
+            blockedPawnPenalty = loadInt(ParamId.PAWN_STRUCTURE_BLOCKED_PAWN_PENALTY);
+            backwardPawnPenalty = loadInt(ParamId.PAWN_STRUCTURE_BACKWARD_PAWN_PENALTY);
+            ownKingBlocksPassedPawnPenalty = loadInt(ParamId.PAWN_STRUCTURE_OWN_KING_BLOCKS_PASSED_PAWN_PENALTY);
+            passedPawnFreePathBonusPerRank = loadInt(ParamId.PAWN_STRUCTURE_PASSED_PAWN_FREE_PATH_BONUS_PER_RANK);
+            rookHalfOpenFileBonus = loadInt(ParamId.PAWN_STRUCTURE_ROOK_HALF_OPEN_FILE_BONUS);
+            rookOpenFileBonus = loadInt(ParamId.PAWN_STRUCTURE_ROOK_OPEN_FILE_BONUS);
+
+            activityMidgameKnightMobility = loadInt(ParamId.ACTIVITY_MIDGAME_MOBILITY_KNIGHT);
+            activityMidgameBishopMobility = loadInt(ParamId.ACTIVITY_MIDGAME_MOBILITY_BISHOP);
+            activityMidgameRookMobility = loadInt(ParamId.ACTIVITY_MIDGAME_MOBILITY_ROOK);
+            activityMidgameQueenMobility = loadInt(ParamId.ACTIVITY_MIDGAME_MOBILITY_QUEEN);
+            activityMidgameKingMobility = loadInt(ParamId.ACTIVITY_MIDGAME_MOBILITY_KING);
+            activityEndgameKnightMobility = loadInt(ParamId.ACTIVITY_ENDGAME_MOBILITY_KNIGHT);
+            activityEndgameBishopMobility = loadInt(ParamId.ACTIVITY_ENDGAME_MOBILITY_BISHOP);
+            activityEndgameRookMobility = loadInt(ParamId.ACTIVITY_ENDGAME_MOBILITY_ROOK);
+            activityEndgameQueenMobility = loadInt(ParamId.ACTIVITY_ENDGAME_MOBILITY_QUEEN);
+            activityEndgameKingMobility = loadInt(ParamId.ACTIVITY_ENDGAME_MOBILITY_KING);
+            activityMidgameKnightCenter = loadInt(ParamId.ACTIVITY_MIDGAME_CENTER_KNIGHT);
+            activityMidgameBishopCenter = loadInt(ParamId.ACTIVITY_MIDGAME_CENTER_BISHOP);
+            activityMidgameRookCenter = loadInt(ParamId.ACTIVITY_MIDGAME_CENTER_ROOK);
+            activityMidgameQueenCenter = loadInt(ParamId.ACTIVITY_MIDGAME_CENTER_QUEEN);
+            activityMidgameKingCenter = loadInt(ParamId.ACTIVITY_MIDGAME_CENTER_KING);
+            activityEndgameKnightCenter = loadInt(ParamId.ACTIVITY_ENDGAME_CENTER_KNIGHT);
+            activityEndgameBishopCenter = loadInt(ParamId.ACTIVITY_ENDGAME_CENTER_BISHOP);
+            activityEndgameRookCenter = loadInt(ParamId.ACTIVITY_ENDGAME_CENTER_ROOK);
+            activityEndgameQueenCenter = loadInt(ParamId.ACTIVITY_ENDGAME_CENTER_QUEEN);
+            activityEndgameKingCenter = loadInt(ParamId.ACTIVITY_ENDGAME_CENTER_KING);
+
+            missingPawnShieldPenalty = loadInt(ParamId.KING_SAFETY_MISSING_PAWN_SHIELD_PENALTY);
+            halfOpenFilePenalty = loadInt(ParamId.KING_SAFETY_HALF_OPEN_FILE_PENALTY);
+            openFilePenalty = loadInt(ParamId.KING_SAFETY_OPEN_FILE_PENALTY);
+            defenderBonus = loadInt(ParamId.KING_SAFETY_DEFENDER_BONUS);
+            queenAttackedPenalty = loadInt(ParamId.KING_SAFETY_QUEEN_ATTACKED_PENALTY);
+            backrankWeaknessMidgamePenalty = loadInt(ParamId.KING_SAFETY_BACKRANK_WEAKNESS_MIDGAME_PENALTY);
+            backrankWeaknessEndgamePenalty = loadInt(ParamId.KING_SAFETY_BACKRANK_WEAKNESS_ENDGAME_PENALTY);
+            kingSafetyPawnAttackWeight = loadInt(ParamId.KING_SAFETY_ATTACK_WEIGHT_PAWN);
+            kingSafetyKnightAttackWeight = loadInt(ParamId.KING_SAFETY_ATTACK_WEIGHT_KNIGHT);
+            kingSafetyBishopAttackWeight = loadInt(ParamId.KING_SAFETY_ATTACK_WEIGHT_BISHOP);
+            kingSafetyRookAttackWeight = loadInt(ParamId.KING_SAFETY_ATTACK_WEIGHT_ROOK);
+            kingSafetyQueenAttackWeight = loadInt(ParamId.KING_SAFETY_ATTACK_WEIGHT_QUEEN);
+
+            hangingPawnPenalty = loadInt(ParamId.THREAT_HANGING_PAWN_PENALTY);
+            hangingKnightPenalty = loadInt(ParamId.THREAT_HANGING_KNIGHT_PENALTY);
+            hangingBishopPenalty = loadInt(ParamId.THREAT_HANGING_BISHOP_PENALTY);
+            hangingRookPenalty = loadInt(ParamId.THREAT_HANGING_ROOK_PENALTY);
+            hangingQueenPenalty = loadInt(ParamId.THREAT_HANGING_QUEEN_PENALTY);
+            pawnThreatKnightPenalty = loadInt(ParamId.THREAT_PAWN_THREAT_KNIGHT_PENALTY);
+            pawnThreatBishopPenalty = loadInt(ParamId.THREAT_PAWN_THREAT_BISHOP_PENALTY);
+            pawnThreatRookPenalty = loadInt(ParamId.THREAT_PAWN_THREAT_ROOK_PENALTY);
+            pawnThreatQueenPenalty = loadInt(ParamId.THREAT_PAWN_THREAT_QUEEN_PENALTY);
+
+            developmentPhaseThreshold = loadInt(ParamId.PIECE_SQUARE_DEVELOPMENT_PHASE_THRESHOLD);
+            queenDevelopmentPhaseThreshold = loadInt(ParamId.PIECE_SQUARE_QUEEN_DEVELOPMENT_PHASE_THRESHOLD);
+            undevelopedMinorPenalty = loadInt(ParamId.PIECE_SQUARE_UNDEVELOPED_MINOR_PENALTY);
+            earlyQueenDevelopmentPenaltyPerMinor = loadInt(ParamId.PIECE_SQUARE_EARLY_QUEEN_DEVELOPMENT_PENALTY_PER_MINOR);
+            minUndevelopedMinorsForQueenPenalty = loadInt(ParamId.PIECE_SQUARE_MIN_UNDEVELOPED_MINORS_FOR_QUEEN_PENALTY);
+            startPositionPenalty = loadInt(ParamId.PIECE_SQUARE_START_POSITION_PENALTY);
+            pieceSquareBlendScale = loadInt(ParamId.PIECE_SQUARE_BLEND_SCALE);
+            castlingBonus = loadInt(ParamId.PIECE_SQUARE_CASTLING_BONUS);
+            notCastledRookMovePenalty = loadInt(ParamId.PIECE_SQUARE_NOT_CASTLED_ROOK_MOVE_PENALTY);
+
+            evaluationBlendScale = loadInt(ParamId.EVALUATION_BLEND_SCALE);
+
+            moveOrderingKillerMoveScore = loadInt(ParamId.MOVE_ORDERING_KILLER_MOVE_SCORE);
+            moveOrderingPromotionBonus = loadInt(ParamId.MOVE_ORDERING_PROMOTION_BONUS);
+            moveOrderingKiller0Bonus = loadInt(ParamId.MOVE_ORDERING_KILLER0_BONUS);
+            moveOrderingKiller1Bonus = loadInt(ParamId.MOVE_ORDERING_KILLER1_BONUS);
+            moveOrderingCounterMoveBonus = loadInt(ParamId.MOVE_ORDERING_COUNTER_MOVE_BONUS);
+            moveOrderingCaptureMvvMultiplier = loadInt(ParamId.MOVE_ORDERING_CAPTURE_MVV_MULTIPLIER);
+            moveOrderingCaptureSeeMultiplier = loadInt(ParamId.MOVE_ORDERING_CAPTURE_SEE_MULTIPLIER);
+            moveOrderingPromotionSeeMultiplier = loadInt(ParamId.MOVE_ORDERING_PROMOTION_SEE_MULTIPLIER);
+        }
+    }
+
+    private static int loadInt(ParamId id) {
+        return (int) Math.round(applyBounds(ParameterRegistry.get(id), id));
+    }
+
+    private static double applyBounds(double value, ParamId id) {
+        if (!Double.isFinite(value)) {
+            value = id.defaultValue();
+        }
+        Double min = id.minValue();
+        if (min != null && value < min) {
+            value = min;
+        }
+        Double max = id.maxValue();
+        if (max != null && value > max) {
+            value = max;
+        }
+        return value;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a central Tuning cache that loads all evaluation and move-ordering parameters once
- update evaluation modules and move-ordering helpers to use the cached static getters instead of resolving parameters per call
- refresh the cached values whenever numeric tuning parameters are reapplied

## Testing
- ./mvnw -q -DskipTests package *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4ca618e4832aa0df8b99aaa151b1