### PR TITLE
Add back-rank weakness detection improvements

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -246,8 +246,13 @@ public final class KingSafetyModule implements EvaluationModule {
             }
             queenMask ^= q;
         }
-        if (state.backrankMask != 0 && ((prevFriendlyAttacks ^ currFriendlyAttacks) & state.backrankMask) != 0) {
-            return true;
+        if (state.backrankMask != 0) {
+            if (((prevEnemyAttacks ^ currEnemyAttacks) & state.backrankMask) != 0) {
+                return true;
+            }
+            if (((prevFriendlyAttacks ^ currFriendlyAttacks) & state.backrankMask) != 0) {
+                return true;
+            }
         }
         return false;
     }
@@ -302,7 +307,7 @@ public final class KingSafetyModule implements EvaluationModule {
         int shieldPenalty = state.missingShield * missingPawnShieldPenalty;
         int attackPenalty = -state.totalAttackWeight;
         int defenderBonus = state.defenderCount * this.defenderBonus;
-        computeBackrankWeaknessPenalty(state, board, isWhite);
+        computeBackrankWeaknessPenalty(state, board, isWhite, enemyAttacks);
         int baseMidgame = shieldPenalty + state.filePenalty + attackPenalty + defenderBonus;
         state.midgameKingSafety = baseMidgame + state.backrankWeaknessMidgame;
         state.endgameKingSafety = baseMidgame / 2 + state.backrankWeaknessEndgame;
@@ -323,7 +328,8 @@ public final class KingSafetyModule implements EvaluationModule {
         state.endgameQueenPenalty = queenEnd;
     }
 
-    private void computeBackrankWeaknessPenalty(SideState state, ImmutableBoardView board, boolean isWhite) {
+    private void computeBackrankWeaknessPenalty(SideState state, ImmutableBoardView board, boolean isWhite,
+                                                long enemyAttacks) {
         state.backrankWeaknessMidgame = 0;
         state.backrankWeaknessEndgame = 0;
         if (state.kingSquare < 0) {
@@ -336,8 +342,8 @@ public final class KingSafetyModule implements EvaluationModule {
 
         long kingMask = 1L << state.kingSquare;
         long escapeSquares = computeEscapeSquares(kingMask, isWhite);
-        long occupiedEscape = escapeSquares & board.getAllPieces();
-        if ((escapeSquares & ~occupiedEscape) != 0) {
+        long safeEscapes = escapeSquares & ~board.getAllPieces() & ~enemyAttacks;
+        if (safeEscapes != 0) {
             return;
         }
 
@@ -346,13 +352,36 @@ public final class KingSafetyModule implements EvaluationModule {
             return;
         }
 
-        long friendlyNonKingAttacks = computeFriendlyNonKingAttacks(board, isWhite);
-        if ((friendlyNonKingAttacks & backrankMask) != 0) {
+        long friendlyPieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
+        if (((friendlyPieces & backrankMask) ^ kingMask) != 0) {
+            return;
+        }
+
+        if (!enemyBackrankLineOfSight(board, isWhite, backrankMask)) {
             return;
         }
 
         state.backrankWeaknessMidgame = backrankWeaknessMidgamePenalty;
         state.backrankWeaknessEndgame = backrankWeaknessEndgamePenalty;
+    }
+
+    private boolean enemyBackrankLineOfSight(ImmutableBoardView board, boolean isWhite, long backrankMask) {
+        long occupancy = board.getAllPieces();
+        long enemyRooks = isWhite ? board.getBlackRooks() : board.getWhiteRooks();
+        long enemyQueens = isWhite ? board.getBlackQueens() : board.getWhiteQueens();
+        long sliders = enemyRooks | enemyQueens;
+        long remaining = sliders;
+        while (remaining != 0) {
+            long piece = remaining & -remaining;
+            int index = Long.numberOfTrailingZeros(piece);
+            long rookMask = ROOK_HELPER.rookMasks[index];
+            long attacks = ROOK_HELPER.calculateMovesUsingRookMagic(index, occupancy & rookMask);
+            if ((attacks & backrankMask) != 0) {
+                return true;
+            }
+            remaining ^= piece;
+        }
+        return false;
     }
 
     private static long computeEscapeSquares(long kingMask, boolean isWhite) {
@@ -389,64 +418,6 @@ public final class KingSafetyModule implements EvaluationModule {
         return mask;
     }
 
-    private long computeFriendlyNonKingAttacks(ImmutableBoardView board, boolean isWhite) {
-        long attacks = 0L;
-        long occupancy = board.getAllPieces();
-
-        long pawns = isWhite ? board.getWhitePawns() : board.getBlackPawns();
-        int pawnColor = isWhite ? WHITE : BLACK;
-        long remaining = pawns;
-        while (remaining != 0) {
-            long pawn = remaining & -remaining;
-            int index = Long.numberOfTrailingZeros(pawn);
-            attacks |= PAWN_ATTACKS[pawnColor][index];
-            remaining ^= pawn;
-        }
-
-        long knights = isWhite ? board.getWhiteKnights() : board.getBlackKnights();
-        remaining = knights;
-        while (remaining != 0) {
-            long knight = remaining & -remaining;
-            int index = Long.numberOfTrailingZeros(knight);
-            attacks |= knightMoveTable[index];
-            remaining ^= knight;
-        }
-
-        long bishops = isWhite ? board.getWhiteBishops() : board.getBlackBishops();
-        remaining = bishops;
-        while (remaining != 0) {
-            long bishop = remaining & -remaining;
-            int index = Long.numberOfTrailingZeros(bishop);
-            long mask = BISHOP_HELPER.bishopMasks[index];
-            attacks |= BISHOP_HELPER.calculateMovesUsingBishopMagic(index, occupancy & mask);
-            remaining ^= bishop;
-        }
-
-        long rooks = isWhite ? board.getWhiteRooks() : board.getBlackRooks();
-        remaining = rooks;
-        while (remaining != 0) {
-            long rook = remaining & -remaining;
-            int index = Long.numberOfTrailingZeros(rook);
-            long mask = ROOK_HELPER.rookMasks[index];
-            attacks |= ROOK_HELPER.calculateMovesUsingRookMagic(index, occupancy & mask);
-            remaining ^= rook;
-        }
-
-        long queens = isWhite ? board.getWhiteQueens() : board.getBlackQueens();
-        remaining = queens;
-        while (remaining != 0) {
-            long queen = remaining & -remaining;
-            int index = Long.numberOfTrailingZeros(queen);
-            long bishopMask = BISHOP_HELPER.bishopMasks[index];
-            long rookMask = ROOK_HELPER.rookMasks[index];
-            long diagonal = BISHOP_HELPER.calculateMovesUsingBishopMagic(index, occupancy & bishopMask);
-            long straight = ROOK_HELPER.calculateMovesUsingRookMagic(index, occupancy & rookMask);
-            attacks |= diagonal | straight;
-            remaining ^= queen;
-        }
-
-        return attacks;
-    }
 
     private void accumulatePawnAttacks(SideState state, long pawns, boolean pawnsAreWhite) {
         if (pawns == 0 || state.kingZone == 0) {
@@ -569,7 +540,9 @@ public final class KingSafetyModule implements EvaluationModule {
                 PhaseScore.of(sideStates[WHITE].midgameKingSafety, sideStates[WHITE].endgameKingSafety),
                 PhaseScore.of(sideStates[BLACK].midgameKingSafety, sideStates[BLACK].endgameKingSafety),
                 PhaseScore.of(sideStates[WHITE].midgameQueenPenalty, sideStates[WHITE].endgameQueenPenalty),
-                PhaseScore.of(sideStates[BLACK].midgameQueenPenalty, sideStates[BLACK].endgameQueenPenalty)
+                PhaseScore.of(sideStates[BLACK].midgameQueenPenalty, sideStates[BLACK].endgameQueenPenalty),
+                PhaseScore.of(sideStates[WHITE].backrankWeaknessMidgame, sideStates[WHITE].backrankWeaknessEndgame),
+                PhaseScore.of(sideStates[BLACK].backrankWeaknessMidgame, sideStates[BLACK].backrankWeaknessEndgame)
         );
     }
 
@@ -582,18 +555,23 @@ public final class KingSafetyModule implements EvaluationModule {
         private final PhaseScore blackKing;
         private final PhaseScore whiteQueen;
         private final PhaseScore blackQueen;
+        private final PhaseScore whiteBackrankWeakness;
+        private final PhaseScore blackBackrankWeakness;
 
         private KingSafetyView(PhaseScore whiteKing, PhaseScore blackKing,
-                               PhaseScore whiteQueen, PhaseScore blackQueen) {
+                               PhaseScore whiteQueen, PhaseScore blackQueen,
+                               PhaseScore whiteBackrankWeakness, PhaseScore blackBackrankWeakness) {
             this.whiteKing = whiteKing;
             this.blackKing = blackKing;
             this.whiteQueen = whiteQueen;
             this.blackQueen = blackQueen;
+            this.whiteBackrankWeakness = whiteBackrankWeakness;
+            this.blackBackrankWeakness = blackBackrankWeakness;
         }
 
         public static KingSafetyView empty() {
             PhaseScore zero = PhaseScore.of(0, 0);
-            return new KingSafetyView(zero, zero, zero, zero);
+            return new KingSafetyView(zero, zero, zero, zero, zero, zero);
         }
 
         public PhaseScore whiteKing() {
@@ -610,6 +588,14 @@ public final class KingSafetyModule implements EvaluationModule {
 
         public PhaseScore blackQueen() {
             return blackQueen;
+        }
+
+        public PhaseScore whiteBackrankWeakness() {
+            return whiteBackrankWeakness;
+        }
+
+        public PhaseScore blackBackrankWeakness() {
+            return blackBackrankWeakness;
         }
 
         public int whiteMidgameTotal() {

--- a/src/test/java/julius/game/chessengine/evaluation/KingSafetyBackrankWeaknessTest.java
+++ b/src/test/java/julius/game/chessengine/evaluation/KingSafetyBackrankWeaknessTest.java
@@ -1,0 +1,66 @@
+package julius.game.chessengine.evaluation;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.evaluation.KingSafetyModule.KingSafetyView;
+import julius.game.chessengine.tuning.Tuning;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KingSafetyBackrankWeaknessTest {
+
+    private static final String UNSTOPPABLE_WHITE = "6k1/4q3/8/8/8/8/3P1P2/4K3 w - - 0 1";
+    private static final String SAFE_ESCAPE = "6k1/4q3/8/8/8/8/3P4/4K3 w - - 0 1";
+    private static final String BLOCKED_LINE = "6k1/4q3/8/8/8/8/3PRP2/4K3 w - - 0 1";
+
+    @Test
+    void penaltyAppliedWhenBackrankMateThreatExists() {
+        BitBoard board = FEN.translateFENtoBitBoard(UNSTOPPABLE_WHITE);
+        KingSafetyModule module = new KingSafetyModule();
+
+        KingSafetyView view = module.getView(board);
+        int midgamePenalty = view.whiteBackrankWeakness().blend(0);
+        int endgamePenalty = view.whiteBackrankWeakness().blend(256);
+
+        assertEquals(Tuning.backrankWeaknessMidgamePenalty(), midgamePenalty);
+        assertEquals(Tuning.backrankWeaknessEndgamePenalty(), endgamePenalty);
+        assertTrue(view.whiteBackrankWeakness().blend(board.getPhase()) < 0);
+    }
+
+    @Test
+    void penaltyClearedWhenLuftIsAvailable() {
+        BitBoard board = FEN.translateFENtoBitBoard(SAFE_ESCAPE);
+        KingSafetyModule module = new KingSafetyModule();
+
+        KingSafetyView view = module.getView(board);
+        assertEquals(0, view.whiteBackrankWeakness().blend(0));
+        assertEquals(0, view.whiteBackrankWeakness().blend(256));
+    }
+
+    @Test
+    void penaltyClearedWhenHeavyPieceIsBlocked() {
+        BitBoard board = FEN.translateFENtoBitBoard(BLOCKED_LINE);
+        KingSafetyModule module = new KingSafetyModule();
+
+        KingSafetyView view = module.getView(board);
+        assertEquals(0, view.whiteBackrankWeakness().blend(0));
+        assertEquals(0, view.whiteBackrankWeakness().blend(256));
+    }
+
+    @Test
+    void evaluateBackrankWeaknessMicroBenchmark() {
+        BitBoard board = FEN.translateFENtoBitBoard(UNSTOPPABLE_WHITE);
+        KingSafetyModule module = new KingSafetyModule();
+
+        assertTimeoutPreemptively(Duration.ofMillis(500), () -> {
+            for (int i = 0; i < 2048; i++) {
+                module.evaluate(board);
+            }
+        });
+    }
+}

--- a/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
@@ -27,8 +27,8 @@ public class ScoreEvaluationTest {
 
     @Test
     void boxedInKingTriggersBackrankPenalty() {
-        BitBoard boxed = FEN.translateFENtoBitBoard("6k1/5ppp/8/8/8/8/8/6K1 w - - 0 1");
-        BitBoard defended = FEN.translateFENtoBitBoard("6k1/4qppp/8/8/8/8/8/6K1 w - - 0 1");
+        BitBoard boxed = FEN.translateFENtoBitBoard("4k3/3p1p2/8/8/8/8/4Q3/6K1 w - - 0 1");
+        BitBoard defended = FEN.translateFENtoBitBoard("4k3/3prp2/8/8/8/8/4Q3/6K1 w - - 0 1");
 
         KingSafetyView boxedView = kingSafetyView(boxed);
         KingSafetyView defendedView = kingSafetyView(defended);
@@ -37,6 +37,8 @@ public class ScoreEvaluationTest {
         int defendedScore = defendedView.blackKing().blend(defended.getPhase());
 
         assertTrue(boxedScore < defendedScore);
+        assertTrue(boxedView.blackBackrankWeakness().blend(boxed.getPhase())
+                < defendedView.blackBackrankWeakness().blend(defended.getPhase()));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- tighten king safety back-rank weakness detection so it only triggers with no safe luft and open heavy-piece lines
- expose back-rank weakness phase scores through the king-safety view for tuning consumers
- add regression tests and a micro-benchmark covering the new back-rank logic

## Testing
- mvn -q test *(fails: release version 25 not supported in container JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4472f42c832a8e43ee35f3ab802c