### PR TITLE
Expand opening repertoire with additional PGNs

### DIFF
--- a/src/test/resources/opening/benko_gambit.pgn
+++ b/src/test/resources/opening/benko_gambit.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. d4 Nf6 2. c4 c5 3. d5 b5 4. cxb5 a6 5. bxa6 g6 *

--- a/src/test/resources/opening/gioco_piano.pgn
+++ b/src/test/resources/opening/gioco_piano.pgn
@@ -2,4 +2,4 @@
 [Site "Local"]
 [Result "*"]
 
-1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 *
+1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. c3 Nf6 5. d4 exd4 *

--- a/src/test/resources/opening/grunfeld_defense.pgn
+++ b/src/test/resources/opening/grunfeld_defense.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. d4 Nf6 2. c4 g6 3. Nc3 d5 4. cxd5 Nxd5 5. e4 Nxc3 *

--- a/src/test/resources/opening/ruy_lopez.pgn
+++ b/src/test/resources/opening/ruy_lopez.pgn
@@ -2,4 +2,4 @@
 [Site "Local"]
 [Result "*"]
 
-1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 *
+1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 *

--- a/src/test/resources/opening/scotch_game.pgn
+++ b/src/test/resources/opening/scotch_game.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. d4 exd4 4. Nxd4 Nf6 5. Nxc6 bxc6 *

--- a/src/test/resources/opening/slav_defense.pgn
+++ b/src/test/resources/opening/slav_defense.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. d4 d5 2. c4 c6 3. Nf3 Nf6 4. Nc3 dxc4 5. a4 Bf5 *

--- a/src/test/resources/opening/vienna_gambit.pgn
+++ b/src/test/resources/opening/vienna_gambit.pgn
@@ -2,4 +2,4 @@
 [Site "Local"]
 [Result "*"]
 
-1. e4 e5 2. Nc3 Nc6 3. f4 d5 *
+1. e4 e5 2. Nc3 Nc6 3. f4 d5 4. exd5 Nd4 5. fxe5 Bc5 *


### PR DESCRIPTION
## Summary
- extend existing Gioco Piano, Ruy Lopez, and Vienna Gambit lines to cover five full moves
- add Benko Gambit, Grunfeld Defense, Scotch Game, and Slav Defense PGNs with theoretical five-move sequences

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd94ab0020832a956a5c33e1ee4827