### PR TITLE
Add missing opening PGNs and sync resource directories

### DIFF
--- a/src/main/resources/opening/alekhine_defense.pgn
+++ b/src/main/resources/opening/alekhine_defense.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 d6 4. Nf3 Bg4 5. Be2 e6 *

--- a/src/main/resources/opening/dutch_defense.pgn
+++ b/src/main/resources/opening/dutch_defense.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. d4 f5 2. g3 Nf6 3. Bg2 e6 4. Nf3 Be7 5. O-O O-O *

--- a/src/main/resources/opening/grunfeld_defense.pgn
+++ b/src/main/resources/opening/grunfeld_defense.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. d4 Nf6 2. c4 g6 3. Nc3 d5 4. cxd5 Nxd5 5. e4 Nxc3 *

--- a/src/main/resources/opening/philidor_defense.pgn
+++ b/src/main/resources/opening/philidor_defense.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 d6 3. d4 Nd7 4. Nc3 Ngf6 5. Bc4 Be7 *

--- a/src/main/resources/opening/queens_gambit_accepted.pgn
+++ b/src/main/resources/opening/queens_gambit_accepted.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. d4 d5 2. c4 dxc4 3. Nf3 Nf6 4. e3 e6 5. Bxc4 c5 *

--- a/src/main/resources/opening/scotch_game.pgn
+++ b/src/main/resources/opening/scotch_game.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. d4 exd4 4. Nxd4 Nf6 5. Nxc6 bxc6 *

--- a/src/test/resources/opening/alekhine_defense.pgn
+++ b/src/test/resources/opening/alekhine_defense.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 Nf6 2. e5 Nd5 3. d4 d6 4. Nf3 Bg4 5. Be2 e6 *

--- a/src/test/resources/opening/dutch_defense.pgn
+++ b/src/test/resources/opening/dutch_defense.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. d4 f5 2. g3 Nf6 3. Bg2 e6 4. Nf3 Be7 5. O-O O-O *

--- a/src/test/resources/opening/kings_gambit_accepted.pgn
+++ b/src/test/resources/opening/kings_gambit_accepted.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. e4 e5 2. f4 exf4 3. Nf3 g5 4. h4 g4 5. Ne5 Nf6 *

--- a/src/test/resources/opening/philidor_defense.pgn
+++ b/src/test/resources/opening/philidor_defense.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 d6 3. d4 Nd7 4. Nc3 Ngf6 5. Bc4 Be7 *

--- a/src/test/resources/opening/pirc_defense.pgn
+++ b/src/test/resources/opening/pirc_defense.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. e4 d6 2. d4 Nf6 3. Nc3 g6 4. Nf3 Bg7 5. Be2 O-O *

--- a/src/test/resources/opening/queens_gambit_accepted.pgn
+++ b/src/test/resources/opening/queens_gambit_accepted.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. d4 d5 2. c4 dxc4 3. Nf3 Nf6 4. e3 e6 5. Bxc4 c5 *

--- a/src/test/resources/opening/scandinavian_defense.pgn
+++ b/src/test/resources/opening/scandinavian_defense.pgn
@@ -1,0 +1,4 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+1. e4 d5 2. exd5 Qxd5 3. Nc3 Qa5 4. d4 Nf6 5. Nf3 c6 *


### PR DESCRIPTION
## Summary
- add Alekhine, Dutch, Philidor, and Queen's Gambit Accepted PGN lines through ply 10 for both main and test resources
- sync opening resource folders by including missing Scotch and Grünfeld lines in main and ensuring test resources mirror available openings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd980c7ff4832a9b4e782eeeb12bf8