### PR TITLE
Add legal move timing instrumentation and tests

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -568,9 +568,12 @@ public class AI {
     private void iterativeDeepening(SearchTask task, Engine simulatorEngine, SplittableRandom rng) {
         Double lastIterScore = null;
         Heuristics heuristics = threadHeuristics.get();
+        boolean timingEnabled = log.isDebugEnabled();
 
         for (int currentDepth = 1; currentDepth <= maxDepth; currentDepth++) {
             if (shouldStopCalculating(task.getDeadline())) break;
+
+            long iterationStart = timingEnabled ? System.nanoTime() : 0L;
 
             boolean firstAtDepth = task.beginIteration(currentDepth);
             prepareIterationState(task, heuristics, currentDepth, firstAtDepth);
@@ -635,6 +638,7 @@ public class AI {
                 if (!result.isCompleted() && currentDepth == 1) {
                     // Depth-1 special-case still requires a candidate; none here.
                 }
+                if (timingEnabled) logIterationTiming(currentDepth, iterationStart, result);
                 break;
             }
 
@@ -646,6 +650,7 @@ public class AI {
                     task.publishBest(sealed, currentDepth, simulatorEngine);
                 }
                 if (heuristics.hasUpdates()) mergeThreadHeuristics(heuristics);
+                if (timingEnabled) logIterationTiming(currentDepth, iterationStart, result);
                 break;
             }
 
@@ -653,7 +658,11 @@ public class AI {
             task.publishBest(sealed, currentDepth, simulatorEngine);
 
             if (heuristics.hasUpdates()) mergeThreadHeuristics(heuristics);
-            if (task.isStopRequested()) break;
+            if (task.isStopRequested()) {
+                if (timingEnabled) logIterationTiming(currentDepth, iterationStart, result);
+                break;
+            }
+            if (timingEnabled) logIterationTiming(currentDepth, iterationStart, result);
         }
     }
 
@@ -716,6 +725,12 @@ public class AI {
         if (timeLimitMillis > 0) {
             this.timeLimit = timeLimitMillis;
         }
+        long effectiveTimeLimit = timeLimitMillis > 0 ? timeLimitMillis : previousTimeLimit;
+
+        boolean timingEnabled = log.isDebugEnabled();
+        long totalStart = timingEnabled ? System.nanoTime() : 0L;
+        MoveAndScore result = null;
+
         try {
             Engine simulatorEngine = mainEngine.createSimulation();
             long boardStateHash = simulatorEngine.getBoardStateHash();
@@ -756,16 +771,27 @@ public class AI {
             task.requestStop();
 
             if (searchResultReady && currentBestMove != -1 && bestMoveForHash == boardStateHash) {
-                return new MoveAndScore(currentBestMove, task.getBest().score);
+                result = new MoveAndScore(currentBestMove, task.getBest().score);
             }
-            return null;
         } catch (RuntimeException ex) {
             log.error("Synchronous search failed", ex);
-            return null;
         } finally {
             activeSearch.set(null);
             this.timeLimit = previousTimeLimit;
+            if (timingEnabled) {
+                long duration = System.nanoTime() - totalStart;
+                String moveNotation = result != null
+                        ? Move.convertIntToMove(result.getMove()).toString()
+                        : "none";
+                String score = result != null ? String.format("%.2f", result.getScore()) : "n/a";
+                log.debug("searchBestMoveBlocking completed in {} ms (limit={} ms, move={}, score={})",
+                        nanosToMillis(duration),
+                        effectiveTimeLimit,
+                        moveNotation,
+                        score);
+            }
         }
+        return result;
     }
 
 
@@ -1074,6 +1100,58 @@ public class AI {
         return t != null && t.isStopRequested();
     }
 
+    private static double nanosToMillis(long nanos) {
+        return nanos / 1_000_000.0;
+    }
+
+    private RootSearchResult logRootResult(String mode,
+                                           boolean isWhitesTurn,
+                                           int depth,
+                                           long totalStart,
+                                           long legalDuration,
+                                           long sortDuration,
+                                           int legalCount,
+                                           RootSearchResult result) {
+        if (log.isDebugEnabled()) {
+            long totalDuration = System.nanoTime() - totalStart;
+            MoveAndScore best = result != null ? result.bestMove() : null;
+            String moveNotation = best != null
+                    ? Move.convertIntToMove(best.getMove()).toString()
+                    : "none";
+            String score = best != null ? String.format("%.2f", best.getScore()) : "n/a";
+            log.debug("Root search {} [{} depth {}] total={} ms (legal={} ms, sort={} ms, moves={}, completed={}, move={}, score={})",
+                    mode,
+                    isWhitesTurn ? "white" : "black",
+                    depth,
+                    nanosToMillis(totalDuration),
+                    nanosToMillis(legalDuration),
+                    nanosToMillis(sortDuration),
+                    legalCount,
+                    result != null && result.isCompleted(),
+                    moveNotation,
+                    score);
+        }
+        return result;
+    }
+
+    private void logIterationTiming(int depth, long iterationStart, RootSearchResult result) {
+        if (!log.isDebugEnabled()) {
+            return;
+        }
+        long duration = System.nanoTime() - iterationStart;
+        MoveAndScore candidate = result != null && result.hasCandidate() ? result.bestMove() : null;
+        String moveNotation = candidate != null
+                ? Move.convertIntToMove(candidate.getMove()).toString()
+                : "none";
+        String score = candidate != null ? String.format("%.2f", candidate.getScore()) : "n/a";
+        log.debug("Iterative deepening depth {} finished in {} ms (completed={}, candidate={}, score={})",
+                depth,
+                nanosToMillis(duration),
+                result != null && result.isCompleted(),
+                moveNotation,
+                score);
+    }
+
     private RootSearchResult getBestMoveParallel(Engine simulatorEngine,
                                                  SearchTask task,
                                                  int depth,
@@ -1086,10 +1164,40 @@ public class AI {
         }
 
         final boolean isWhitesTurn = task.isWhiteToMove();
-        IntArrayList legal = simulatorEngine.getAllLegalMoves();
-        IntArrayList orderedMoves = sortMovesByEfficiency(legal, depth, simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
-        if (orderedMoves.isEmpty()) return RootSearchResult.completed(null);
+        boolean timingEnabled = log.isDebugEnabled();
+        long totalStart = timingEnabled ? System.nanoTime() : 0L;
+        long legalDuration = 0L;
+        long sortDuration = 0L;
+
+        IntArrayList legal;
+        if (timingEnabled) {
+            long legalStart = System.nanoTime();
+            legal = simulatorEngine.getAllLegalMoves();
+            legalDuration = System.nanoTime() - legalStart;
+        } else {
+            legal = simulatorEngine.getAllLegalMoves();
+        }
+        int legalCount = legal.size();
+
+        IntArrayList orderedMoves;
+        if (timingEnabled) {
+            long sortStart = System.nanoTime();
+            orderedMoves = sortMovesByEfficiency(legal, depth, simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
+            sortDuration = System.nanoTime() - sortStart;
+        } else {
+            orderedMoves = sortMovesByEfficiency(legal, depth, simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
+        }
+
+        if (orderedMoves.isEmpty()) {
+            RootSearchResult result = RootSearchResult.completed(null);
+            return timingEnabled
+                    ? logRootResult("parallel(root=0,fanout=0)", isWhitesTurn, depth, totalStart, legalDuration, sortDuration, legalCount, result)
+                    : result;
+        }
         maybeRotateRootMoves(orderedMoves, rng);
+
+        final int fanout = Math.max(0, Math.min(ROOT_PARALLEL_LIMIT, orderedMoves.size() - 1));
+        final String modeLabel = String.format("parallel(root=%d,fanout=%d)", orderedMoves.size(), fanout);
 
         int firstMove = orderedMoves.getInt(0);
         int bestMove;
@@ -1098,7 +1206,10 @@ public class AI {
         boolean aborted = false;
 
         if (abortRequested(deadline)) {
-            return RootSearchResult.aborted(null);
+            RootSearchResult result = RootSearchResult.aborted(null);
+            return timingEnabled
+                    ? logRootResult(modeLabel, isWhitesTurn, depth, totalStart, legalDuration, sortDuration, legalCount, result)
+                    : result;
         }
 
         simulatorEngine.performMove(firstMove);
@@ -1113,7 +1224,10 @@ public class AI {
             firstScore = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, firstMove, 1, 0);
             if (firstScore == EXIT_FLAG || abortRequested(deadline)) {
                 simulatorEngine.undoLastMove();
-                return RootSearchResult.aborted(null);
+                RootSearchResult result = RootSearchResult.aborted(null);
+                return timingEnabled
+                        ? logRootResult(modeLabel, isWhitesTurn, depth, totalStart, legalDuration, sortDuration, legalCount, result)
+                        : result;
             }
         }
         simulatorEngine.undoLastMove();
@@ -1125,13 +1239,18 @@ public class AI {
         else beta = Math.min(beta, firstScore);
         if (alpha >= beta) {
             MoveAndScore candidate = createCandidate(bestMove, bestScore);
-            return RootSearchResult.completed(candidate);
+            RootSearchResult result = RootSearchResult.completed(candidate);
+            return timingEnabled
+                    ? logRootResult(modeLabel, isWhitesTurn, depth, totalStart, legalDuration, sortDuration, legalCount, result)
+                    : result;
         }
 
-        final int fanout = Math.min(ROOT_PARALLEL_LIMIT, orderedMoves.size() - 1);
         if (fanout <= 0) {
             MoveAndScore candidate = createCandidate(bestMove, bestScore);
-            return RootSearchResult.completed(candidate);
+            RootSearchResult result = RootSearchResult.completed(candidate);
+            return timingEnabled
+                    ? logRootResult(modeLabel, isWhitesTurn, depth, totalStart, legalDuration, sortDuration, legalCount, result)
+                    : result;
         }
 
         final CompletionService<MoveAndScore> ecs = new ExecutorCompletionService<>(searchPool);
@@ -1257,7 +1376,10 @@ public class AI {
         if (abortRequested(deadline)) {
             aborted = true;
         }
-        return aborted ? RootSearchResult.aborted(candidate) : RootSearchResult.completed(candidate);
+        RootSearchResult result = aborted ? RootSearchResult.aborted(candidate) : RootSearchResult.completed(candidate);
+        return timingEnabled
+                ? logRootResult(modeLabel, isWhitesTurn, depth, totalStart, legalDuration, sortDuration, legalCount, result)
+                : result;
     }
 
 
@@ -1370,14 +1492,36 @@ public class AI {
 
     private RootSearchResult getBestMove(Engine simulatorEngine, boolean isWhitesTurn, int depth, long deadline,
                                          double alpha, double beta, SplittableRandom rng) {
+        boolean timingEnabled = log.isDebugEnabled();
+        long totalStart = timingEnabled ? System.nanoTime() : 0L;
+        long legalDuration = 0L;
+        long sortDuration = 0L;
+
+        IntArrayList legal;
+        if (timingEnabled) {
+            long legalStart = System.nanoTime();
+            legal = simulatorEngine.getAllLegalMoves();
+            legalDuration = System.nanoTime() - legalStart;
+        } else {
+            legal = simulatorEngine.getAllLegalMoves();
+        }
+        int legalCount = legal.size();
+
+        IntArrayList sortedMoves;
+        if (timingEnabled) {
+            long sortStart = System.nanoTime();
+            sortedMoves = sortMovesByEfficiency(legal, depth,
+                    simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
+            sortDuration = System.nanoTime() - sortStart;
+        } else {
+            sortedMoves = sortMovesByEfficiency(legal, depth,
+                    simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
+        }
+        maybeRotateRootMoves(sortedMoves, rng);
+
         int bestMove = -1;
         double bestScore = isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
-
         boolean aborted = false;
-
-        IntArrayList sortedMoves = sortMovesByEfficiency(simulatorEngine.getAllLegalMoves(), depth,
-                simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
-        maybeRotateRootMoves(sortedMoves, rng);
 
         for (int idx = 0; idx < sortedMoves.size(); idx++) {
             int moveInt = sortedMoves.getInt(idx);
@@ -1415,7 +1559,10 @@ public class AI {
             if (alpha >= beta) break;
         }
         MoveAndScore candidate = bestMove != -1 ? createCandidate(bestMove, bestScore) : null;
-        return aborted ? RootSearchResult.aborted(candidate) : RootSearchResult.completed(candidate);
+        RootSearchResult result = aborted ? RootSearchResult.aborted(candidate) : RootSearchResult.completed(candidate);
+        return timingEnabled
+                ? logRootResult("sequential", isWhitesTurn, depth, totalStart, legalDuration, sortDuration, legalCount, result)
+                : result;
     }
 
     private MoveAndScore createCandidate(int move, double score) {

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -97,19 +97,41 @@ public class Engine {
     }
 
     public IntArrayList getAllLegalMoves() {
+        boolean timingEnabled = log.isDebugEnabled();
+        long start = timingEnabled ? System.nanoTime() : 0L;
+
+        IntArrayList moves;
+        boolean fromCache;
+        boolean whitesTurn;
+
         synchronized (boardLock) {
+            whitesTurn = bitBoard.whitesTurn;
             long boardHash = getBoardStateHash();
             if (legalMovesNeedUpdate || cachedLegalMovesHash != boardHash) {
                 // Gate on terminality only (checkmate, stalemate, 50-move, threefold).
                 if (gameState.isTerminal()) {
-                    IntArrayList empty = new IntArrayList(0);
-                    cacheLegalMoves(boardHash, empty);
-                    return empty;
+                    moves = new IntArrayList(0);
+                    cacheLegalMoves(boardHash, moves);
+                } else {
+                    moves = generateLegalMoves();
                 }
-                return generateLegalMoves();
+                fromCache = false;
+            } else {
+                moves = copyCachedLegalMoves();
+                fromCache = true;
             }
-            return copyCachedLegalMoves();
         }
+
+        if (timingEnabled) {
+            long duration = System.nanoTime() - start;
+            log.debug("getAllLegalMoves [{}] -> {} moves in {} ms (cached={})",
+                    whitesTurn ? "white" : "black",
+                    moves.size(),
+                    nanosToMillis(duration),
+                    fromCache);
+        }
+
+        return moves;
     }
 
     public void performMove(int move) {
@@ -246,18 +268,35 @@ public class Engine {
     }
 
     private IntArrayList generateLegalMoves() {
+        boolean timingEnabled = log.isDebugEnabled();
+        long totalStart = timingEnabled ? System.nanoTime() : 0L;
+        long pseudoDuration = 0L;
+        long checkDuration = 0L;
+        long filterDuration = 0L;
+        long verifyDuration = 0L;
+        long cacheDuration = 0L;
+
         synchronized (boardLock) {
             final long boardStateHash = getBoardStateHash();
+            final boolean whitesTurn = bitBoard.whitesTurn;
 
             // Get pseudo moves + the already-computed PinState in one shot
             IntArrayList pseudoMoves = pseudoMoveBuffer;
             pseudoMoves.clear();
+            long pseudoStart = timingEnabled ? System.nanoTime() : 0L;
             BitBoard.PinState pinState = bitBoard.generateAllPossibleMovesInto(bitBoard.whitesTurn, pseudoMoves);
+            if (timingEnabled) {
+                pseudoDuration = System.nanoTime() - pseudoStart;
+            }
 
-            // NEW: detect check once
+            long checkStart = timingEnabled ? System.nanoTime() : 0L;
             boolean inCheck = bitBoard.isInCheck(bitBoard.whitesTurn);
+            if (timingEnabled) {
+                checkDuration = System.nanoTime() - checkStart;
+            }
 
             IntArrayList legalMoves = new IntArrayList(pseudoMoves.size());
+            long filterStart = timingEnabled ? System.nanoTime() : 0L;
             for (int i = 0; i < pseudoMoves.size(); i++) {
                 int move = pseudoMoves.getInt(i);
 
@@ -281,8 +320,12 @@ public class Engine {
                     legalMoves.add(move);
                 }
             }
+            if (timingEnabled) {
+                filterDuration = System.nanoTime() - filterStart;
+            }
 
             if (VERIFY_LEGAL_MOVES) {
+                long verifyStart = timingEnabled ? System.nanoTime() : 0L;
                 // Optional self-check retained for debugging
                 IntArrayList legacy = new IntArrayList(legalMoves.size());
                 for (int i = 0; i < pseudoMoves.size(); i++) {
@@ -293,13 +336,32 @@ public class Engine {
                     }
                     bitBoard.undoMove(move);
                 }
+                if (timingEnabled) {
+                    verifyDuration = System.nanoTime() - verifyStart;
+                }
                 if (!moveListsEqual(legalMoves, legacy)) {
                     throw new IllegalStateException(
                             "Mismatch between fast and legacy legal move filtering: fast=" + legalMoves + ", legacy=" + legacy
                     );
                 }
             }
+
+            long cacheStart = timingEnabled ? System.nanoTime() : 0L;
             cacheLegalMoves(boardStateHash, legalMoves);
+            if (timingEnabled) {
+                cacheDuration = System.nanoTime() - cacheStart;
+                long totalDuration = System.nanoTime() - totalStart;
+                log.debug("generateLegalMoves [{}] -> {} moves from {} pseudo in {} ms (pseudo={} ms, inCheck={} ms, filter={} ms, verify={} ms, cache={} ms)",
+                        whitesTurn ? "white" : "black",
+                        legalMoves.size(),
+                        pseudoMoves.size(),
+                        nanosToMillis(totalDuration),
+                        nanosToMillis(pseudoDuration),
+                        nanosToMillis(checkDuration),
+                        nanosToMillis(filterDuration),
+                        nanosToMillis(verifyDuration),
+                        nanosToMillis(cacheDuration));
+            }
             return legalMoves;
         }
     }
@@ -330,6 +392,10 @@ public class Engine {
     private boolean moveListsEqual(IntArrayList a, IntArrayList b) {
         return a.size() == b.size()
                 && java.util.Arrays.equals(a.elements(), 0, a.size(), b.elements(), 0, b.size());
+    }
+
+    private static double nanosToMillis(long nanos) {
+        return nanos / 1_000_000.0;
     }
 
     // Each of these methods would need to be implemented to handle the specific move generation for each piece type.

--- a/src/test/java/julius/game/chessengine/ai/LegalMoveGenerationTimingTest.java
+++ b/src/test/java/julius/game/chessengine/ai/LegalMoveGenerationTimingTest.java
@@ -1,0 +1,78 @@
+package julius.game.chessengine.ai;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import julius.game.chessengine.board.Move;
+import julius.game.chessengine.engine.Engine;
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import testsupport.TestLoggingExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Log4j2
+@ExtendWith(TestLoggingExtension.class)
+class LegalMoveGenerationTimingTest {
+
+    private static final List<String> POSITIONS = List.of(
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            "r2q1rk1/ppp2ppp/2npbn2/3Np3/2B1P3/2P2N2/PP3PPP/R1BQ1RK1 w - - 0 1",
+            "8/8/2k5/8/8/4K3/5P2/8 w - - 0 1"
+    );
+
+    @Test
+    void measureLegalMoveGenerationAndAiHandlingTimings() {
+        Engine engine = new Engine();
+        AI ai = new AI(engine);
+        ai.setMaxDepth(2);
+
+        try {
+            for (String fen : POSITIONS) {
+                engine.importBoardFromFen(fen);
+                Engine measurementEngine = engine.createSimulation();
+
+                long freshStart = System.nanoTime();
+                IntArrayList freshMoves = measurementEngine.getAllLegalMoves();
+                long freshDuration = System.nanoTime() - freshStart;
+                assertNotNull(freshMoves, "Legal moves must not be null");
+                assertTrue(freshMoves.size() > 0, "Expected legal moves for FEN " + fen);
+
+                long cachedStart = System.nanoTime();
+                IntArrayList cachedMoves = measurementEngine.getAllLegalMoves();
+                long cachedDuration = System.nanoTime() - cachedStart;
+                assertEquals(freshMoves.size(), cachedMoves.size(), "Cached move count differs for FEN " + fen);
+
+                log.info("FEN {} -> fresh={} ms cached={} ms moves={}",
+                        fen,
+                        formatMillis(freshDuration),
+                        formatMillis(cachedDuration),
+                        freshMoves.size());
+
+                long aiStart = System.nanoTime();
+                MoveAndScore best = ai.searchBestMoveBlocking(100);
+                long aiDuration = System.nanoTime() - aiStart;
+
+                String moveNotation = best != null
+                        ? Move.convertIntToMove(best.getMove()).toString()
+                        : "none";
+                String scoreNotation = best != null ? String.format("%.2f", best.getScore()) : "n/a";
+
+                log.info("AI search for FEN {} -> duration={} ms, move={}, score={}",
+                        fen,
+                        formatMillis(aiDuration),
+                        moveNotation,
+                        scoreNotation);
+            }
+        } finally {
+            ai.shutdown();
+        }
+    }
+
+    private static String formatMillis(long nanos) {
+        return String.format("%.3f", nanos / 1_000_000.0);
+    }
+}


### PR DESCRIPTION
## Summary
- add debug timing instrumentation to Engine legal move generation and caching paths
- extend AI search routines with detailed timing logs for blocking, sequential, and parallel search flows
- introduce LegalMoveGenerationTimingTest to benchmark legal move generation and AI handling

## Testing
- ./mvnw -q test *(fails: java.net.SocketException Network is unreachable while downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68df9348eeec832a8801749d25d504b1