### PR TITLE
Align evaluation tuning tests with runtime behavior

### DIFF
--- a/src/test/java/julius/game/chessengine/evaluation/EvaluationModuleTuningAlignmentTest.java
+++ b/src/test/java/julius/game/chessengine/evaluation/EvaluationModuleTuningAlignmentTest.java
@@ -91,7 +91,7 @@ class EvaluationModuleTuningAlignmentTest {
                     .withFailMessage("Missing numeric parameter %s in seed YAML", key)
                     .isNotNull();
             int actual = supplier.getAsInt();
-            int expectedInt = expected.intValue();
+            int expectedInt = (int) Math.round(expected);
             Assertions.assertThat(actual)
                     .withFailMessage("Mismatch for %s", key)
                     .isEqualTo(expectedInt);
@@ -203,9 +203,11 @@ class EvaluationModuleTuningAlignmentTest {
         Assertions.assertThat(result.midgame()).isEqualTo(expectedMid);
         Assertions.assertThat(result.endgame()).isEqualTo(expectedEnd);
 
-        long numerator = (long) expectedMid * (result.blendScale() - result.phase())
-                + (long) expectedEnd * result.phase();
-        int expectedBlended = (int) (numerator / result.blendScale());
+        int blendScale = result.blendScale();
+        int phase = Math.max(0, Math.min(result.phase(), blendScale));
+        long numerator = (long) expectedMid * (blendScale - phase)
+                + (long) expectedEnd * phase;
+        int expectedBlended = (int) (numerator / blendScale);
         Assertions.assertThat(result.blended()).isEqualTo(expectedBlended);
     }
 


### PR DESCRIPTION
## Summary
- match numeric-parameter assertions with the rounding used by Tuning.loadInt
- clamp the phase before recomputing expected blended scores to mirror EvaluationPipeline

## Testing
- mvn -Dtest=EvaluationModuleTuningAlignmentTest test *(fails: Fatal error compiling: error: release version 25 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdb7493f8832a91b150721ec5431f