### PR TITLE
Reuse cached legal move buffer

### DIFF
--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -310,9 +310,14 @@ public class Engine {
     }
 
     private void cacheLegalMoves(long boardHash, IntArrayList legalMoves) {
+        int size = legalMoves.size();
+        if (cachedLegalMoves.length < size) {
+            cachedLegalMoves = new int[size];
+        }
+        legalMoves.getElements(0, cachedLegalMoves, 0, size);
+
         this.cachedLegalMovesHash = boardHash;
-        this.cachedLegalMoveCount = legalMoves.size();
-        this.cachedLegalMoves = legalMoves.toIntArray();
+        this.cachedLegalMoveCount = size;
         this.legalMovesNeedUpdate = false;
     }
 
@@ -321,7 +326,6 @@ public class Engine {
     }
 
     private void resetCachedLegalMoves() {
-        cachedLegalMoves = new int[0];
         cachedLegalMoveCount = 0;
         cachedLegalMovesHash = Long.MIN_VALUE;
         legalMovesNeedUpdate = true;


### PR DESCRIPTION
## Summary
- reuse the cached legal move buffer instead of re-allocating on every update
- copy legal moves into the buffer via getElements and retain the backing array across resets

## Testing
- `./mvnw -q -DskipITs test` *(fails: java.net.SocketException Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68dffc64e450832a86703f2235f2f7c8