### PR TITLE
Optimize capture move generation for quiescence

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2251,7 +2251,7 @@ public class AI {
         // Generate moves: evasions if in check, else captures/promotions
         IntArrayList moves = inCheck
                 ? simulatorEngine.getAllLegalMoves()
-                : getPossibleCapturesOrPromotions(simulatorEngine);
+                : simulatorEngine.getLegalCapturesAndPromotions();
 
         // Order them (captures/promotions first etc.)
         IntArrayList ordered = sortMovesByEfficiency(
@@ -2321,11 +2321,6 @@ public class AI {
         }
         double scoreDifference = gameState.getScore().getScoreDifference();
         return isWhitesTurn ? scoreDifference : -scoreDifference;
-    }
-
-    private IntArrayList getPossibleCapturesOrPromotions(Engine simulatorEngine) {
-        IntArrayList allLegalMoves = simulatorEngine.getAllLegalMoves();
-        return MoveContainerUtils.filterCapturesAndPromotions(allLegalMoves);
     }
 
     /**

--- a/src/main/java/julius/game/chessengine/ai/MoveContainerUtils.java
+++ b/src/main/java/julius/game/chessengine/ai/MoveContainerUtils.java
@@ -1,7 +1,6 @@
 package julius.game.chessengine.ai;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import julius.game.chessengine.board.MoveHelper;
 
 final class MoveContainerUtils {
     private MoveContainerUtils() {
@@ -56,17 +55,6 @@ final class MoveContainerUtils {
         }
         int[] elements = target.elements();
         System.arraycopy(buffer, 0, elements, 0, length);
-    }
-
-    static IntArrayList filterCapturesAndPromotions(IntArrayList moves) {
-        IntArrayList filtered = new IntArrayList(moves.size());
-        for (int i = 0; i < moves.size(); i++) {
-            int move = moves.getInt(i);
-            if (MoveHelper.isCapture(move) || MoveHelper.isPawnPromotionMove(move)) {
-                filtered.add(move);
-            }
-        }
-        return filtered;
     }
 
     private static int gcd(int a, int b) {

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -34,6 +34,7 @@ public class Engine {
 
     private static final int MOVE_BUFFER_CAPACITY = 256;
     private final IntArrayList pseudoMoveBuffer = new IntArrayList(MOVE_BUFFER_CAPACITY);
+    private final IntArrayList captureMoveBuffer = new IntArrayList(MOVE_BUFFER_CAPACITY);
     private int[] legalMoveScratch = new int[MOVE_BUFFER_CAPACITY];
 
     @Getter
@@ -110,6 +111,51 @@ public class Engine {
                 return generateLegalMoves();
             }
             return copyCachedLegalMoves();
+        }
+    }
+
+    public IntArrayList getLegalCapturesAndPromotions() {
+        synchronized (boardLock) {
+            if (bitBoard.isInCheck(bitBoard.whitesTurn)) {
+                IntArrayList captures = captureMoveBuffer;
+                captures.clear();
+
+                IntArrayList allLegalMoves = getAllLegalMoves();
+                for (int i = 0; i < allLegalMoves.size(); i++) {
+                    int move = allLegalMoves.getInt(i);
+                    if (MoveHelper.isCapture(move) || MoveHelper.isPawnPromotionMove(move)) {
+                        captures.add(move);
+                    }
+                }
+
+                return new IntArrayList(captures);
+            }
+
+            IntArrayList pseudoMoves = pseudoMoveBuffer;
+            pseudoMoves.clear();
+            BitBoard.PinState pinState = bitBoard.generateAllPossibleMovesInto(bitBoard.whitesTurn, pseudoMoves);
+
+            IntArrayList captures = captureMoveBuffer;
+            captures.clear();
+
+            int[] pseudoElements = pseudoMoves.elements();
+            final int pseudoCount = pseudoMoves.size();
+            for (int i = 0; i < pseudoCount; i++) {
+                int move = pseudoElements[i];
+                if (!MoveHelper.isCapture(move) && !MoveHelper.isPawnPromotionMove(move)) {
+                    continue;
+                }
+
+                if (MoveHelper.isEnPassantMove(move)) {
+                    if (bitBoard.isMoveLegalFast(move, pinState)) {
+                        captures.add(move);
+                    }
+                } else {
+                    captures.add(move);
+                }
+            }
+
+            return new IntArrayList(captures);
         }
     }
 


### PR DESCRIPTION
## Summary
- add a reusable capture move buffer and helper on the engine to generate legal captures/promotions without creating quiet moves
- update the AI quiescence search to call the new helper and remove the redundant capture filter utility
- drop the unused capture filtering helper from MoveContainerUtils

## Testing
- ./mvnw -q test *(fails: network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e00b5c4890832ab613cff8faf81be3