### PR TITLE
Optimize check handling during legal move filtering

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -80,6 +80,13 @@ public class BitBoard {
         }
     }
 
+    public record CheckInfo(long checkingPieces, boolean doubleCheck, long responseMask) {
+
+        public boolean inCheck() {
+            return checkingPieces != 0L;
+        }
+    }
+
     private record PinRayInfo(long rayMask, int pinnerSquare) {
     }
 
@@ -2272,6 +2279,51 @@ public class BitBoard {
     public boolean isInCheck(boolean white) {
         int kingIndex = findKingIndex(white);
         return isSquareUnderAttack(kingIndex, white);
+    }
+
+    public CheckInfo analyzeCheck(boolean whiteSide, PinState pins) {
+        int kingSquare;
+        if (pins != null && pins.whiteSide() == whiteSide) {
+            kingSquare = pins.kingSquare();
+        } else {
+            kingSquare = findKingIndex(whiteSide);
+        }
+
+        long occ = allPieces;
+        long enemyKnights = whiteSide ? blackKnights : whiteKnights;
+        long enemyBishops = whiteSide ? blackBishops : whiteBishops;
+        long enemyRooks = whiteSide ? blackRooks : whiteRooks;
+        long enemyQueens = whiteSide ? blackQueens : whiteQueens;
+        long enemyKing = whiteSide ? blackKing : whiteKing;
+
+        long pawnCheckers = pawnAttackersToSquare(kingSquare, !whiteSide, whitePawns, blackPawns);
+        long knightCheckers = knightMoveTable[kingSquare] & enemyKnights;
+        long bishopAttacks = bishopAttacksFromWithOcc(kingSquare, occ);
+        long rookAttacks = rookAttacksFromWithOcc(kingSquare, occ);
+        long diagonalCheckers = bishopAttacks & (enemyBishops | enemyQueens);
+        long straightCheckers = rookAttacks & (enemyRooks | enemyQueens);
+        long kingCheckers = KING_ATTACKS[kingSquare] & enemyKing;
+
+        long checkingPieces = pawnCheckers | knightCheckers | diagonalCheckers | straightCheckers | kingCheckers;
+        if (checkingPieces == 0L) {
+            return new CheckInfo(0L, false, 0L);
+        }
+
+        long sliderCheckers = diagonalCheckers | straightCheckers;
+        boolean doubleCheck = (checkingPieces & (checkingPieces - 1)) != 0;
+        long responseMask = 0L;
+
+        if (!doubleCheck) {
+            if (sliderCheckers != 0L) {
+                int checkerSquare = Long.numberOfTrailingZeros(sliderCheckers);
+                long between = BitboardHelper.lineBetweenIndices(kingSquare, checkerSquare);
+                responseMask = between | (1L << checkerSquare);
+            } else {
+                responseMask = checkingPieces;
+            }
+        }
+
+        return new CheckInfo(checkingPieces, doubleCheck, responseMask);
     }
 
 

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -255,8 +255,11 @@ public class Engine {
             pseudoMoves.clear();
             BitBoard.PinState pinState = bitBoard.generateAllPossibleMovesInto(bitBoard.whitesTurn, pseudoMoves);
 
-            // NEW: detect check once
-            boolean inCheck = bitBoard.isInCheck(bitBoard.whitesTurn);
+            BitBoard.CheckInfo checkInfo = bitBoard.analyzeCheck(bitBoard.whitesTurn, pinState);
+            boolean inCheck = checkInfo.inCheck();
+            boolean doubleCheck = checkInfo.doubleCheck();
+            long responseMask = checkInfo.responseMask();
+            long checkingPieces = checkInfo.checkingPieces();
 
             int[] pseudoElements = pseudoMoves.elements();
             final int pseudoCount = pseudoMoves.size();
@@ -268,22 +271,33 @@ public class Engine {
             for (int i = 0; i < pseudoCount; i++) {
                 int move = pseudoElements[i];
 
-                // Fast path when NOT in check:
-                // - pins already enforced during generation
-                // - king steps were prefiltered in generateKingMoves (see §2)
-                // So only EP needs a special legality test.
+                boolean isEnPassant = MoveHelper.isEnPassantMove(move);
+                int pieceBits = MoveHelper.derivePieceTypeBits(move);
+
                 if (!inCheck) {
-                    if (MoveHelper.isEnPassantMove(move)) {
-                        if (bitBoard.isMoveLegalFast(move, pinState)) {
-                            pseudoElements[writeIdx++] = move;
-                        }
-                    } else {
+                    if (!isEnPassant || bitBoard.isMoveLegalFast(move, pinState)) {
                         pseudoElements[writeIdx++] = move;
                     }
                     continue;
                 }
 
-                // If in check, fall back to the full legality test
+                if (pieceBits != 6) {
+                    if (doubleCheck) {
+                        continue;
+                    }
+                    int to = MoveHelper.deriveToIndex(move);
+                    long toMask = 1L << to;
+                    boolean allowed = (responseMask & toMask) != 0L;
+                    if (!allowed && isEnPassant) {
+                        int captureSquare = MoveHelper.isWhitesMove(move) ? to - 8 : to + 8;
+                        long captureMask = 1L << captureSquare;
+                        allowed = (checkingPieces & captureMask) != 0L;
+                    }
+                    if (!allowed) {
+                        continue;
+                    }
+                }
+
                 if (bitBoard.isMoveLegalFast(move, pinState)) {
                     pseudoElements[writeIdx++] = move;
                 }

--- a/src/test/java/julius/game/chessengine/engine/EngineLegalMoveFilteringTest.java
+++ b/src/test/java/julius/game/chessengine/engine/EngineLegalMoveFilteringTest.java
@@ -1,0 +1,90 @@
+package julius.game.chessengine.engine;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.board.MoveHelper;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EngineLegalMoveFilteringTest {
+
+    @Test
+    void singleCheckUsesResponseMask() {
+        String fen = "4r3/8/8/8/8/8/Q7/4K3 w - - 0 1";
+        Engine engine = new Engine();
+        engine.importBoardFromFen(fen);
+
+        IntArrayList legal = engine.getAllLegalMoves();
+        IntArrayList legacy = legacyMovesFor(fen);
+
+        assertMoveListsEqual(legacy, legal);
+
+        boolean hasNonKingBlock = legal.intStream().anyMatch(move -> {
+            if (MoveHelper.derivePieceTypeBits(move) == 6) {
+                return false;
+            }
+            return MoveHelper.deriveToIndex(move) == MoveHelper.convertStringToIndex("e2");
+        });
+        assertTrue(hasNonKingBlock, "Expected queen block move to be retained");
+    }
+
+    @Test
+    void doubleCheckAllowsOnlyKingMoves() {
+        String fen = "4k3/8/8/8/1b6/5n2/8/4K3 w - - 0 1";
+        Engine engine = new Engine();
+        engine.importBoardFromFen(fen);
+
+        IntArrayList legal = engine.getAllLegalMoves();
+        IntArrayList legacy = legacyMovesFor(fen);
+
+        assertMoveListsEqual(legacy, legal);
+        assertTrue(legal.intStream().allMatch(move -> MoveHelper.derivePieceTypeBits(move) == 6),
+                "Double check should yield king moves only");
+    }
+
+    @Test
+    void enPassantCaptureWhileInCheckIsPreserved() {
+        String fen = "4k3/8/8/3pP3/4K3/8/8/8 w - d6 0 1";
+        Engine engine = new Engine();
+        engine.importBoardFromFen(fen);
+
+        IntArrayList legal = engine.getAllLegalMoves();
+        IntArrayList legacy = legacyMovesFor(fen);
+
+        assertMoveListsEqual(legacy, legal);
+
+        boolean hasEnPassant = legal.intStream().anyMatch(MoveHelper::isEnPassantMove);
+        assertTrue(hasEnPassant, "En passant capture should remain legal while in check");
+    }
+
+    private static IntArrayList legacyMovesFor(String fen) {
+        BitBoard board = FEN.translateFENtoBitBoard(fen);
+        IntArrayList pseudo = new IntArrayList();
+        board.generateAllPossibleMovesInto(board.whitesTurn, pseudo);
+        IntArrayList legal = new IntArrayList();
+        int[] elements = pseudo.elements();
+        int count = pseudo.size();
+        for (int i = 0; i < count; i++) {
+            int move = elements[i];
+            board.performMove(move);
+            if (!board.isInCheck(MoveHelper.isWhitesMove(move))) {
+                legal.add(move);
+            }
+            board.undoMove(move);
+        }
+        return legal;
+    }
+
+    private static void assertMoveListsEqual(IntArrayList expected, IntArrayList actual) {
+        int[] expectedArr = expected.toIntArray();
+        int[] actualArr = actual.toIntArray();
+        Arrays.sort(expectedArr);
+        Arrays.sort(actualArr);
+        assertArrayEquals(expectedArr, actualArr, "Legal moves diverge from legacy filtering");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a CheckInfo helper in BitBoard to compute checking pieces and response masks
- short-circuit Engine legal move generation using the precomputed check analysis, including en passant handling
- add regression tests covering single-check, double-check, and en-passant-under-check scenarios

## Testing
- `./mvnw -q test` *(fails: Maven wrapper cannot download distribution in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e00b20e9fc832a9d6640a62d1ca9c3