### PR TITLE
Optimize legal move filtering under check

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -80,6 +80,13 @@ public class BitBoard {
         }
     }
 
+    public record CheckInfo(long checkerMask, boolean doubleCheck, long responseMask) {
+
+        public boolean inCheck() {
+            return checkerMask != 0L;
+        }
+    }
+
     private record PinRayInfo(long rayMask, int pinnerSquare) {
     }
 
@@ -612,6 +619,106 @@ public class BitBoard {
         }
 
         return new PinState(whiteSide, kingSquare, diagonalPinned, straightPinned);
+    }
+
+    public CheckInfo analyzeCheck(boolean whiteSide, PinState pins) {
+        int kingSquare;
+        if (pins != null && pins.whiteSide() == whiteSide) {
+            kingSquare = pins.kingSquare();
+        } else {
+            kingSquare = findKingIndex(whiteSide);
+        }
+
+        long occ = allPieces;
+        long enemyPawns = whiteSide ? blackPawns : whitePawns;
+        long enemyKnights = whiteSide ? blackKnights : whiteKnights;
+        long enemyBishops = whiteSide ? blackBishops : whiteBishops;
+        long enemyRooks = whiteSide ? blackRooks : whiteRooks;
+        long enemyQueens = whiteSide ? blackQueens : whiteQueens;
+        long enemyKing = whiteSide ? blackKing : whiteKing;
+
+        long checkerMask = 0L;
+        long responseCandidate = 0L;
+        boolean firstCheckerRecorded = false;
+        boolean doubleCheck = false;
+
+        long pawnCheckers = pawnAttackersToSquare(kingSquare, !whiteSide, whitePawns, blackPawns) & enemyPawns;
+        while (pawnCheckers != 0) {
+            long checker = pawnCheckers & -pawnCheckers;
+            pawnCheckers &= pawnCheckers - 1;
+            checkerMask |= checker;
+            if (!firstCheckerRecorded) {
+                firstCheckerRecorded = true;
+                responseCandidate = checker;
+            } else {
+                doubleCheck = true;
+            }
+        }
+
+        long knightCheckers = KnightHelper.knightMoveTable[kingSquare] & enemyKnights;
+        while (knightCheckers != 0) {
+            long checker = knightCheckers & -knightCheckers;
+            knightCheckers &= knightCheckers - 1;
+            checkerMask |= checker;
+            if (!firstCheckerRecorded) {
+                firstCheckerRecorded = true;
+                responseCandidate = checker;
+            } else {
+                doubleCheck = true;
+            }
+        }
+
+        long kingCheckers = KING_ATTACKS[kingSquare] & enemyKing;
+        while (kingCheckers != 0) {
+            long checker = kingCheckers & -kingCheckers;
+            kingCheckers &= kingCheckers - 1;
+            checkerMask |= checker;
+            if (!firstCheckerRecorded) {
+                firstCheckerRecorded = true;
+                responseCandidate = checker;
+            } else {
+                doubleCheck = true;
+            }
+        }
+
+        long bishopSliders = enemyBishops | enemyQueens;
+        long bishopRays = bishopAttacksFromWithOcc(kingSquare, occ) & bishopSliders;
+        long tmpBishops = bishopRays;
+        while (tmpBishops != 0) {
+            long checker = tmpBishops & -tmpBishops;
+            tmpBishops &= tmpBishops - 1;
+            checkerMask |= checker;
+            int checkerSq = Long.numberOfTrailingZeros(checker);
+            long blockMask = BitboardHelper.lineBetweenIndices(kingSquare, checkerSq) | checker;
+            if (!firstCheckerRecorded) {
+                firstCheckerRecorded = true;
+                responseCandidate = blockMask;
+            } else {
+                doubleCheck = true;
+            }
+        }
+
+        long rookSliders = enemyRooks | enemyQueens;
+        long rookRays = rookAttacksFromWithOcc(kingSquare, occ) & rookSliders;
+        // Avoid double-counting queens already registered on diagonal rays.
+        rookRays &= ~bishopRays;
+        long tmpRooks = rookRays;
+        while (tmpRooks != 0) {
+            long checker = tmpRooks & -tmpRooks;
+            tmpRooks &= tmpRooks - 1;
+            checkerMask |= checker;
+            int checkerSq = Long.numberOfTrailingZeros(checker);
+            long blockMask = BitboardHelper.lineBetweenIndices(kingSquare, checkerSq) | checker;
+            if (!firstCheckerRecorded) {
+                firstCheckerRecorded = true;
+                responseCandidate = blockMask;
+            } else {
+                doubleCheck = true;
+            }
+        }
+
+        long responseMask = (!doubleCheck && firstCheckerRecorded) ? responseCandidate : 0L;
+        return new CheckInfo(checkerMask, doubleCheck, responseMask);
     }
 
     private boolean isMoveAllowedByPin(PinState pinState, int from, int to) {

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -256,7 +256,10 @@ public class Engine {
             BitBoard.PinState pinState = bitBoard.generateAllPossibleMovesInto(bitBoard.whitesTurn, pseudoMoves);
 
             // NEW: detect check once
-            boolean inCheck = bitBoard.isInCheck(bitBoard.whitesTurn);
+            BitBoard.CheckInfo checkInfo = bitBoard.analyzeCheck(bitBoard.whitesTurn, pinState);
+            boolean inCheck = checkInfo.inCheck();
+            boolean doubleCheck = checkInfo.doubleCheck();
+            long responseMask = checkInfo.responseMask();
 
             int[] pseudoElements = pseudoMoves.elements();
             final int pseudoCount = pseudoMoves.size();
@@ -283,7 +286,21 @@ public class Engine {
                     continue;
                 }
 
-                // If in check, fall back to the full legality test
+                int pieceBits = MoveHelper.derivePieceTypeBits(move);
+                boolean isKingMove = (pieceBits == 6);
+                boolean isEnPassant = MoveHelper.isEnPassantMove(move);
+
+                if (doubleCheck && !isKingMove) {
+                    continue;
+                }
+
+                if (!isKingMove && !isEnPassant) {
+                    long toMask = 1L << MoveHelper.deriveToIndex(move);
+                    if ((toMask & responseMask) == 0L) {
+                        continue;
+                    }
+                }
+
                 if (bitBoard.isMoveLegalFast(move, pinState)) {
                     pseudoElements[writeIdx++] = move;
                 }

--- a/src/test/java/julius/game/chessengine/engine/EngineMoveFilteringUnderCheckTest.java
+++ b/src/test/java/julius/game/chessengine/engine/EngineMoveFilteringUnderCheckTest.java
@@ -1,0 +1,126 @@
+package julius.game.chessengine.engine;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.board.MoveHelper;
+import org.junit.jupiter.api.Test;
+import testsupport.TestUtils;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EngineMoveFilteringUnderCheckTest {
+
+    private record EngineHarness(Engine engine, CountingBitBoard board) {
+    }
+
+    @Test
+    void singleSliderCheckFiltersToBlocksAndCaptures() throws Exception {
+        EngineHarness harness = setup("4rk2/8/8/8/8/2N5/8/4K3 w - - 0 1");
+        CountingBitBoard board = harness.board();
+
+        IntArrayList pseudo = new IntArrayList();
+        board.generateAllPossibleMovesInto(board.isWhitesTurn(), pseudo);
+        int pseudoCount = pseudo.size();
+
+        board.resetCounter();
+        IntArrayList legal = harness.engine().getAllLegalMoves();
+
+        Set<String> moves = toMoveSet(legal);
+
+        assertEquals(Set.of("e1d1", "e1f1", "e1d2", "e1f2", "c3e2"), moves);
+        assertTrue(board.getCounter() < pseudoCount, "expected fewer legality checks after filtering");
+    }
+
+    @Test
+    void doubleCheckAllowsOnlyKingMoves() throws Exception {
+        EngineHarness harness = setup("4k3/8/8/8/1b6/3n4/8/4K3 w - - 0 1");
+        CountingBitBoard board = harness.board();
+
+        IntArrayList pseudo = new IntArrayList();
+        board.generateAllPossibleMovesInto(board.isWhitesTurn(), pseudo);
+        int pseudoCount = pseudo.size();
+
+        board.resetCounter();
+        IntArrayList legal = harness.engine().getAllLegalMoves();
+
+        Set<String> moves = toMoveSet(legal);
+
+        assertEquals(Set.of("e1d1", "e1f1", "e1e2"), moves);
+        assertTrue(board.getCounter() < pseudoCount, "double-check should skip non-king moves");
+        assertEquals(moves.size(), board.getCounter(), "only king moves should reach legality testing");
+    }
+
+    @Test
+    void enPassantCaptureRemainsAvailableUnderCheck() throws Exception {
+        EngineHarness harness = setup("6kb/8/8/4KpP1/8/8/8/8 w - f6 0 1");
+        CountingBitBoard board = harness.board();
+
+        IntArrayList pseudo = new IntArrayList();
+        board.generateAllPossibleMovesInto(board.isWhitesTurn(), pseudo);
+        int pseudoCount = pseudo.size();
+
+        board.resetCounter();
+        IntArrayList legal = harness.engine().getAllLegalMoves();
+
+        Set<String> moves = toMoveSet(legal);
+
+        assertTrue(moves.contains("g5f6"), "en passant capture should be legal response");
+        assertTrue(board.getCounter() < pseudoCount, "masking should skip irrelevant moves");
+    }
+
+    private EngineHarness setup(String fen) throws Exception {
+        Engine engine = new Engine();
+        BitBoard base = FEN.translateFENtoBitBoard(fen);
+        CountingBitBoard board = new CountingBitBoard(base);
+        GameState state = new GameState(board);
+
+        TestUtils.writeField(engine, "bitBoard", board);
+        TestUtils.writeField(engine, "gameState", state);
+        TestUtils.writeField(engine, "legalMovesNeedUpdate", true);
+        TestUtils.writeField(engine, "cachedLegalMovesHash", Long.MIN_VALUE);
+        TestUtils.writeField(engine, "cachedLegalMoveCount", 0);
+        TestUtils.writeField(engine, "cachedLegalMoves", new int[0]);
+
+        return new EngineHarness(engine, board);
+    }
+
+    private String toCoordinateMove(int move) {
+        int from = MoveHelper.deriveFromIndex(move);
+        int to = MoveHelper.deriveToIndex(move);
+        return MoveHelper.convertIndexToString(from) + MoveHelper.convertIndexToString(to);
+    }
+
+    private Set<String> toMoveSet(IntArrayList moves) {
+        Set<String> result = moves.isEmpty() ? Set.of() : new java.util.HashSet<>();
+        for (int i = 0; i < moves.size(); i++) {
+            result.add(toCoordinateMove(moves.getInt(i)));
+        }
+        return result;
+    }
+
+    private static final class CountingBitBoard extends BitBoard {
+        private int counter;
+
+        CountingBitBoard(BitBoard other) {
+            super(other);
+        }
+
+        @Override
+        public boolean isMoveLegalFast(int move, PinState pinState) {
+            counter++;
+            return super.isMoveLegalFast(move, pinState);
+        }
+
+        void resetCounter() {
+            counter = 0;
+        }
+
+        int getCounter() {
+            return counter;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a BitBoard.CheckInfo helper to analyze checking pieces and response masks
- reuse the helper inside Engine.generateLegalMoves to skip non-viable moves while preserving safety checks
- add targeted tests for single-check, double-check, and en-passant escape scenarios with instrumentation

## Testing
- `mvn -q test` *(fails: compiler configured for release 25 which is unavailable in the container)*
- `./mvnw -q test` *(fails: wrapper cannot download Maven distribution because outbound network is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68e00b20e9fc832a9d6640a62d1ca9c3