### PR TITLE
Reuse pooled engines for parallel root search

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -154,6 +154,13 @@ public class AI {
     private final ThreadLocal<Map<Integer, Integer>> seeCacheThreadLocal =
             ThreadLocal.withInitial(() -> new HashMap<>(64));
 
+    /**
+     * Root-split worker simulations. Each search thread reuses its own clone to avoid
+     * repeated allocations during parallel search fan-out.
+     */
+    private final ThreadLocal<Deque<Engine>> workerSimulationPool =
+            ThreadLocal.withInitial(ArrayDeque::new);
+
     private static final int LMR_MAX_DEPTH = 64;
     private static final int LMR_MAX_MOVES = MAX_MOVE_LIST_SIZE;
     private static final int HISTORY_BUCKETS = 5;
@@ -703,6 +710,47 @@ public class AI {
         return heuristics;
     }
 
+    private Engine borrowWorkerSimulation(Engine template) {
+        Deque<Engine> pool = workerSimulationPool.get();
+        Engine borrowed = pool.pollFirst();
+        if (borrowed == null) {
+            return template.createSimulation();
+        }
+        borrowed.copyFrom(template);
+        return borrowed;
+    }
+
+    private void releaseWorkerSimulation(Engine borrowed, Engine baseline) {
+        if (borrowed == null) {
+            return;
+        }
+        try {
+            while (borrowed.getLastMove() != -1) {
+                borrowed.undoLastMove();
+            }
+        } catch (Exception ex) {
+            log.warn("Failed to rewind pooled simulation engine", ex);
+            try {
+                if (baseline != null) {
+                    borrowed.copyFrom(baseline);
+                } else {
+                    borrowed.startNewGame();
+                }
+            } catch (Exception suppressed) {
+                log.debug("Unable to reset simulation engine via copy", suppressed);
+                try {
+                    borrowed.startNewGame();
+                } catch (Exception ignored) {
+                    log.debug("Unable to reset simulation engine via startNewGame", ignored);
+                }
+            }
+        }
+        workerSimulationPool.get().offerFirst(borrowed);
+        if (Thread.currentThread().isInterrupted()) {
+            workerSimulationPool.remove();
+        }
+    }
+
     protected RootSearchResult searchRootMoves(Engine sim, SearchTask task, int depth, double alpha, double beta, SplittableRandom rng) {
         if (searchThreads > 1) {
             return getBestMoveParallel(sim, task, depth, task.getDeadline(), alpha, beta, rng);
@@ -1148,9 +1196,10 @@ public class AI {
             futures.add(ecs.submit(() -> {
                 if (stopRef.get() || abortRequested(deadline)) return null;
                 Heuristics helperHeuristics = prepareHelperHeuristics(task, depth);
+                Engine workerEngine = null;
                 try {
-                    Engine e = simulatorEngine.createSimulation();
-                    e.performMove(moveInt);
+                    workerEngine = borrowWorkerSimulation(simulatorEngine);
+                    workerEngine.performMove(moveInt);
 
                     double currentAlpha = alphaRef.get();
                     double currentBeta = betaRef.get();
@@ -1164,13 +1213,13 @@ public class AI {
                     }
 
                     double probe;
-                    if (e.getGameState().isInStateCheckMate()) {
+                    if (workerEngine.getGameState().isInStateCheckMate()) {
                         probe = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
-                    } else if (e.getGameState().isTerminal()) { // <-- terminal only
-                        probe = evaluateStaticPosition(e.getGameState(), !isWhitesTurn, depth);
+                    } else if (workerEngine.getGameState().isTerminal()) { // <-- terminal only
+                        probe = evaluateStaticPosition(workerEngine.getGameState(), !isWhitesTurn, depth);
                         if (isWhitesTurn) probe = -probe;
                     } else {
-                        probe = alphaBeta(e, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline, moveInt, 1, 0);
+                        probe = alphaBeta(workerEngine, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline, moveInt, 1, 0);
                         if (probe == EXIT_FLAG || abortRequested(deadline)) return null;
                     }
 
@@ -1182,7 +1231,7 @@ public class AI {
                         try {
                             if (!stopRef.get() && !abortRequested(deadline)) {
                                 double aNow = alphaRef.get(), bNow = betaRef.get();
-                                double full = alphaBeta(e, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt, 1, 0);
+                                double full = alphaBeta(workerEngine, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt, 1, 0);
                                 if (full != EXIT_FLAG) {
                                     finalScore = full;
                                     if (isWhitesTurn) {
@@ -1214,6 +1263,7 @@ public class AI {
 
                     return new MoveAndScore(moveInt, finalScore);
                 } finally {
+                    releaseWorkerSimulation(workerEngine, task.getRootSnapshot());
                     if (helperHeuristics.hasUpdates()) mergeThreadHeuristics(helperHeuristics);
                     else helperHeuristics.resetUpdates();
                 }

--- a/src/test/java/julius/game/chessengine/ai/AITest_MateThreatDiagnostics.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_MateThreatDiagnostics.java
@@ -58,6 +58,18 @@ class AITest_MateThreatDiagnostics {
                 new Object[]{
                         "r1bqk2r/ppp2ppp/2n1p3/3pP3/3P4/2bB1N2/P1P2PPP/R1BQ1RK1 w kq - 0 9",
                         List.of("Rb1")
+                },
+                new Object[]{
+                        "2r3k1/p4p2/3Rp2p/1p2P1pK/8/1P4P1/P3Q2P/1q6 b - - 0 1",
+                        List.of("Qg6")
+                },
+                new Object[]{
+                        "4k2r/1R3R2/p3p1pp/4b3/1BnNr3/8/P1P5/5K2 w - - 1 1",
+                        List.of("Re7")
+                },
+                new Object[]{
+                        "4k2r/1R3R2/p3p1pp/4b3/1BnNr3/8/P1P5/5K2 w - - 1 1",
+                        List.of("Re8")
                 }
         );
     }

--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -244,6 +244,22 @@ public class BestMoveSearchTest {
                 new Object[]{
                         "5k2/5p1p/2p2B2/8/2p2NPP/pr2P3/2q1BK2/3R4 b - - 1 37",
                         List.of("Rb8")
+                },
+                new Object[]{
+                        "2r3k1/p4p2/3Rp2p/1p2P1pK/8/1P4P1/P3Q2P/1q6 b - - 0 1",
+                        List.of("Qg6")
+                },
+                new Object[]{
+                        "4k2r/1R3R2/p3p1pp/4b3/1BnNr3/8/P1P5/5K2 w - - 1 1",
+                        List.of("Re7")
+                },
+                new Object[]{
+                        "4k2r/1R3R2/p3p1pp/4b3/1BnNr3/8/P1P5/5K2 w - - 1 1",
+                        List.of("Re8")
+                },
+                new Object[]{
+                        "r2qkb1r/pppb1ppp/4p3/3pP3/2PQ4/4P3/P1P2PPP/R1B1KB1R b KQkq - 0 9",
+                        List.of("Bb4")
                 }
         );
     }
@@ -341,7 +357,7 @@ public class BestMoveSearchTest {
         evaluations.sort(comparator);
 
         MoveEvaluation chosenEvaluation = evaluationMap.get(chosenMove);
-        MoveEvaluation bestEvaluation = evaluations.isEmpty() ? null : evaluations.get(0);
+        MoveEvaluation bestEvaluation = evaluations.isEmpty() ? null : evaluations.getFirst();
 
         List<MoveEvaluation> expectedEvaluationDetails = new ArrayList<>();
         for (String expected : expectedMoves) {
@@ -508,7 +524,7 @@ public class BestMoveSearchTest {
             boolean first = true;
             first = appendJsonString(sb, "fen", fen, first);
             first = appendJsonString(sb, "side", whiteToMove ? "w" : "b", first);
-            first = appendJsonStringArray(sb, "expected", expectedMoves, first);
+            first = appendJsonStringArray(sb, expectedMoves, first);
             first = appendJsonString(sb, "chosen", chosenEvaluation != null ? chosenEvaluation.move() : null, first);
             first = appendJsonNumber(sb, "chosenScore", chosenEvaluation != null ? chosenEvaluation.score() : null, 2, first);
             first = appendJsonString(sb, "best", bestEvaluation != null ? bestEvaluation.move() : null, first);
@@ -676,11 +692,11 @@ public class BestMoveSearchTest {
         return false;
     }
 
-    private static boolean appendJsonStringArray(StringBuilder sb, String key, List<String> values, boolean first) {
+    private static boolean appendJsonStringArray(StringBuilder sb, List<String> values, boolean first) {
         if (!first) {
             sb.append(',');
         }
-        sb.append('"').append(jsonEscape(key)).append('"').append(':');
+        sb.append('"').append(jsonEscape("expected")).append('"').append(':');
         sb.append('[');
         for (int i = 0; i < values.size(); i++) {
             if (i > 0) {
@@ -785,8 +801,10 @@ public class BestMoveSearchTest {
         if (!Double.isFinite(value)) {
             return null;
         }
-        return String.format(Locale.US, "%." + decimals + "f", value);
+        String format = "%." + decimals + "f";
+        return String.format(Locale.US, format, value);
     }
+
 
     private String renderPrincipalVariation(boolean whiteToMove, List<MoveAndScore> pv) {
         if (pv == null || pv.isEmpty()) {


### PR DESCRIPTION
## Summary
- add a thread-local pool so each root-split worker can reuse its own simulation engine
- refactor parallel root search workers to borrow, search, and release pooled engines safely
- reset pooled engines after use and on interrupted shutdowns to avoid leaking search state

## Testing
- ./mvnw -q -DskipTests compile *(fails: network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e19b2a8664832aae11944ef5026ea8