### PR TITLE
Ensure helper threads observe active search task

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1194,10 +1194,13 @@ public class AI {
         for (int i = 1; i <= fanout; i++) {
             final int moveInt = orderedMoves.getInt(i);
             futures.add(ecs.submit(() -> {
-                if (stopRef.get() || abortRequested(deadline)) return null;
-                Heuristics helperHeuristics = prepareHelperHeuristics(task, depth);
+                SearchTask previousTask = threadSearchTask.get();
+                threadSearchTask.set(task);
+                Heuristics helperHeuristics = null;
                 Engine workerEngine = null;
                 try {
+                    if (stopRef.get() || task.isStopRequested() || abortRequested(deadline)) return null;
+                    helperHeuristics = prepareHelperHeuristics(task, depth);
                     workerEngine = borrowWorkerSimulation(simulatorEngine);
                     workerEngine.performMove(moveInt);
 
@@ -1263,9 +1266,15 @@ public class AI {
 
                     return new MoveAndScore(moveInt, finalScore);
                 } finally {
-                    releaseWorkerSimulation(workerEngine, task.getRootSnapshot());
-                    if (helperHeuristics.hasUpdates()) mergeThreadHeuristics(helperHeuristics);
-                    else helperHeuristics.resetUpdates();
+                    try {
+                        releaseWorkerSimulation(workerEngine, task.getRootSnapshot());
+                    } finally {
+                        if (helperHeuristics != null) {
+                            if (helperHeuristics.hasUpdates()) mergeThreadHeuristics(helperHeuristics);
+                            else helperHeuristics.resetUpdates();
+                        }
+                        threadSearchTask.set(previousTask);
+                    }
                 }
             }));
         }


### PR DESCRIPTION
## Summary
- register the current SearchTask with worker threads so abort checks see stop requests
- safely restore previous thread-local state while merging helper heuristics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1a0697458832a8354a34e1080b9b1