### PR TITLE
Ensure parallel root search completes all moves before finalizing

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -16,6 +16,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
@@ -23,6 +24,7 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.StampedLock;
+import java.util.function.IntPredicate;
 
 import static julius.game.chessengine.helper.BitHelper.FileMasks;
 import static julius.game.chessengine.helper.KingHelper.KING_ATTACKS;
@@ -1127,14 +1129,16 @@ public class AI {
             return RootSearchResult.completed(candidate);
         }
 
-        final int fanout = Math.min(ROOT_PARALLEL_LIMIT, orderedMoves.size() - 1);
+        final int totalRootMoves = orderedMoves.size();
+        final int remainingMoves = totalRootMoves - 1;
+        final int fanout = Math.min(ROOT_PARALLEL_LIMIT, remainingMoves);
         if (fanout <= 0) {
             MoveAndScore candidate = createCandidate(bestMove, bestScore);
             return RootSearchResult.completed(candidate);
         }
 
         final CompletionService<MoveAndScore> ecs = new ExecutorCompletionService<>(searchPool);
-        final List<Future<MoveAndScore>> futures = new ArrayList<>(fanout);
+        final List<Future<MoveAndScore>> futures = new ArrayList<>(remainingMoves);
 
         final AtomicReference<Double> alphaRef = new AtomicReference<>(alpha);
         final AtomicReference<Double> betaRef = new AtomicReference<>(beta);
@@ -1142,96 +1146,130 @@ public class AI {
         final AtomicReference<Double> bestScoreRef = new AtomicReference<>(bestScore);
         final AtomicBoolean stopRef = new AtomicBoolean(false);
         final java.util.concurrent.locks.ReentrantLock fullResLock = new java.util.concurrent.locks.ReentrantLock();
+        final AtomicInteger nextMoveIndex = new AtomicInteger(1 + fanout);
 
-        for (int i = 1; i <= fanout; i++) {
-            final int moveInt = orderedMoves.getInt(i);
-            futures.add(ecs.submit(() -> {
-                if (stopRef.get() || abortRequested(deadline)) return null;
-                Heuristics helperHeuristics = prepareHelperHeuristics(task, depth);
-                try {
-                    Engine e = simulatorEngine.createSimulation();
-                    e.performMove(moveInt);
+        IntPredicate scheduleMove = (int moveIndex) -> {
+            final int moveInt = orderedMoves.getInt(moveIndex);
+            try {
+                Future<MoveAndScore> future = ecs.submit(() -> {
+                    if (stopRef.get() || abortRequested(deadline)) return null;
+                    Heuristics helperHeuristics = prepareHelperHeuristics(task, depth);
+                    try {
+                        Engine e = simulatorEngine.createSimulation();
+                        e.performMove(moveInt);
 
-                    double currentAlpha = alphaRef.get();
-                    double currentBeta = betaRef.get();
-                    double pAlpha, pBeta;
-                    if (isWhitesTurn) {
-                        pAlpha = currentAlpha;
-                        pBeta = currentAlpha + 1;
-                    } else {
-                        pAlpha = currentBeta - 1;
-                        pBeta = currentBeta;
-                    }
+                        double currentAlpha = alphaRef.get();
+                        double currentBeta = betaRef.get();
+                        double pAlpha, pBeta;
+                        if (isWhitesTurn) {
+                            pAlpha = currentAlpha;
+                            pBeta = currentAlpha + 1;
+                        } else {
+                            pAlpha = currentBeta - 1;
+                            pBeta = currentBeta;
+                        }
 
-                    double probe;
-                    if (e.getGameState().isInStateCheckMate()) {
-                        probe = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
-                    } else if (e.getGameState().isTerminal()) { // <-- terminal only
-                        probe = evaluateStaticPosition(e.getGameState(), !isWhitesTurn, depth);
-                        if (isWhitesTurn) probe = -probe;
-                    } else {
-                        probe = alphaBeta(e, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline, moveInt, 1, 0);
-                        if (probe == EXIT_FLAG || abortRequested(deadline)) return null;
-                    }
+                        double probe;
+                        if (e.getGameState().isInStateCheckMate()) {
+                            probe = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
+                        } else if (e.getGameState().isTerminal()) { // <-- terminal only
+                            probe = evaluateStaticPosition(e.getGameState(), !isWhitesTurn, depth);
+                            if (isWhitesTurn) probe = -probe;
+                        } else {
+                            probe = alphaBeta(e, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline, moveInt, 1, 0);
+                            if (probe == EXIT_FLAG || abortRequested(deadline)) return null;
+                        }
 
-                    boolean needsFull = isWhitesTurn ? (probe > alphaRef.get()) : (probe < betaRef.get());
-                    double finalScore = probe;
+                        boolean needsFull = isWhitesTurn ? (probe > alphaRef.get()) : (probe < betaRef.get());
+                        double finalScore = probe;
 
-                    if (needsFull && !stopRef.get()) {
-                        fullResLock.lock();
-                        try {
-                            if (!stopRef.get() && !abortRequested(deadline)) {
-                                double aNow = alphaRef.get(), bNow = betaRef.get();
-                                double full = alphaBeta(e, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt, 1, 0);
-                                if (full != EXIT_FLAG) {
-                                    finalScore = full;
-                                    if (isWhitesTurn) {
-                                        if (full > aNow) alphaRef.set(full);
-                                    } else {
-                                        if (full < bNow) betaRef.set(full);
+                        if (needsFull && !stopRef.get()) {
+                            fullResLock.lock();
+                            try {
+                                if (!stopRef.get() && !abortRequested(deadline)) {
+                                    double aNow = alphaRef.get(), bNow = betaRef.get();
+                                    double full = alphaBeta(e, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt, 1, 0);
+                                    if (full != EXIT_FLAG) {
+                                        finalScore = full;
+                                        if (isWhitesTurn) {
+                                            if (full > aNow) alphaRef.set(full);
+                                        } else {
+                                            if (full < bNow) betaRef.set(full);
+                                        }
+                                        Double curBest = bestScoreRef.get();
+                                        if (isBetterScore(isWhitesTurn, full, curBest)) {
+                                            bestScoreRef.set(full);
+                                            bestMoveRef.set(moveInt);
+                                        }
+                                        if (alphaRef.get() >= betaRef.get()) stopRef.set(true);
                                     }
-                                    Double curBest = bestScoreRef.get();
-                                    if (isBetterScore(isWhitesTurn, full, curBest)) {
-                                        bestScoreRef.set(full);
-                                        bestMoveRef.set(moveInt);
-                                    }
-                                    if (alphaRef.get() >= betaRef.get()) stopRef.set(true);
                                 }
+                            } finally {
+                                fullResLock.unlock();
                             }
-                        } finally {
-                            fullResLock.unlock();
+                        } else {
+                            Double curBest = bestScoreRef.get();
+                            if (isBetterScore(isWhitesTurn, finalScore, curBest)) {
+                                bestScoreRef.set(finalScore);
+                                bestMoveRef.set(moveInt);
+                                if (isWhitesTurn && finalScore > alphaRef.get()) alphaRef.set(finalScore);
+                                if (!isWhitesTurn && finalScore < betaRef.get()) betaRef.set(finalScore);
+                                if (alphaRef.get() >= betaRef.get()) stopRef.set(true);
+                            }
                         }
-                    } else {
-                        Double curBest = bestScoreRef.get();
-                        if (isBetterScore(isWhitesTurn, finalScore, curBest)) {
-                            bestScoreRef.set(finalScore);
-                            bestMoveRef.set(moveInt);
-                            if (isWhitesTurn && finalScore > alphaRef.get()) alphaRef.set(finalScore);
-                            if (!isWhitesTurn && finalScore < betaRef.get()) betaRef.set(finalScore);
-                            if (alphaRef.get() >= betaRef.get()) stopRef.set(true);
-                        }
-                    }
 
-                    return new MoveAndScore(moveInt, finalScore);
-                } finally {
-                    if (helperHeuristics.hasUpdates()) mergeThreadHeuristics(helperHeuristics);
-                    else helperHeuristics.resetUpdates();
-                }
-            }));
+                        return new MoveAndScore(moveInt, finalScore);
+                    } finally {
+                        if (helperHeuristics.hasUpdates()) mergeThreadHeuristics(helperHeuristics);
+                        else helperHeuristics.resetUpdates();
+                    }
+                });
+                futures.add(future);
+                return true;
+            } catch (RejectedExecutionException rex) {
+                log.warn("Parallel root executor rejected move {}", moveInt, rex);
+                return false;
+            }
+        };
+
+        int movesInFlight = 0;
+        for (int i = 1; i <= fanout; i++) {
+            if (scheduleMove.test(i)) {
+                movesInFlight++;
+            } else {
+                aborted = true;
+                break;
+            }
         }
 
-        int completed = 0;
+        int fullySearchedMoves = Math.min(1, totalRootMoves);
+        int completedAsyncMoves = 0;
+        boolean cutoffOccurred = false;
+
         try {
-            while (completed < fanout) {
-                if (stopRef.get()) break;
+            while (!aborted && !cutoffOccurred && completedAsyncMoves < remainingMoves) {
+                if (stopRef.get()) {
+                    cutoffOccurred = alphaRef.get() >= betaRef.get();
+                    break;
+                }
                 if (abortRequested(deadline)) {
                     aborted = true;
                     break;
                 }
+                if (movesInFlight <= 0) {
+                    break;
+                }
+
                 Future<MoveAndScore> f = ecs.take();
-                completed++;
+                movesInFlight--;
                 MoveAndScore res = f.get();
-                if (res == null) continue;
+                if (res == null) {
+                    aborted = true;
+                    break;
+                }
+
+                completedAsyncMoves++;
+                fullySearchedMoves++;
 
                 alpha = alphaRef.get();
                 beta = betaRef.get();
@@ -1239,8 +1277,20 @@ public class AI {
                 bestScore = bestScoreRef.get();
 
                 if (alpha >= beta) {
+                    cutoffOccurred = true;
                     stopRef.set(true);
-                    break;
+                }
+
+                if (!cutoffOccurred) {
+                    int next = nextMoveIndex.getAndIncrement();
+                    if (next <= remainingMoves) {
+                        if (scheduleMove.test(next)) {
+                            movesInFlight++;
+                        } else {
+                            aborted = true;
+                            break;
+                        }
+                    }
                 }
             }
         } catch (InterruptedException ie) {
@@ -1248,15 +1298,29 @@ public class AI {
             aborted = true;
         } catch (Exception ex) {
             log.warn("Parallel root YBWC error", ex);
+            aborted = true;
         } finally {
             for (Future<MoveAndScore> f : futures) if (!f.isDone()) f.cancel(true);
+        }
+
+        alpha = alphaRef.get();
+        beta = betaRef.get();
+        bestMove = bestMoveRef.get();
+        bestScore = bestScoreRef.get();
+
+        if (!cutoffOccurred && stopRef.get() && alpha >= beta) {
+            cutoffOccurred = true;
         }
 
         MoveAndScore candidate = bestMove != -1 ? createCandidate(bestMove, bestScore) : null;
         if (abortRequested(deadline)) {
             aborted = true;
         }
-        return aborted ? RootSearchResult.aborted(candidate) : RootSearchResult.completed(candidate);
+
+        boolean allRootMovesSearched = fullySearchedMoves >= totalRootMoves;
+        boolean completedSearch = !aborted && (cutoffOccurred || allRootMovesSearched);
+
+        return completedSearch ? RootSearchResult.completed(candidate) : RootSearchResult.aborted(candidate);
     }
 
 

--- a/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
@@ -13,6 +13,7 @@ import testsupport.TestLoggingExtension;
 import testsupport.TestUtils;
 
 import java.lang.reflect.Method;
+import java.util.SplittableRandom;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -101,6 +102,119 @@ class AITest_ConcurrencyAndStops {
         assertFalse(requests.isEmpty(), "Auto-play should enqueue a new calculation request after executing a move");
     }
 
+    @Test
+    @Timeout(10)
+    @DisplayName("Parallel root search marks depth incomplete when the deadline expires early")
+    void parallelRootSearchMarksDepthIncompleteWhenDeadlineExpiresEarly() throws Exception {
+        SlowEngine engine = new SlowEngine(3);
+        AI ai = new AI(engine, AiTuning.builder().searchThreads(2).build());
+
+        Engine simulator = engine.createSimulation();
+        long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(5);
+        SearchTask task = new SearchTask(
+                1L,
+                simulator.getBoardStateHash(),
+                simulator.whitesTurn(),
+                deadline,
+                ai.getSearchThreads(),
+                simulator.createSimulation()
+        );
+
+        @SuppressWarnings("unchecked")
+        ThreadLocal<SearchTask> threadLocal = (ThreadLocal<SearchTask>) TestUtils.readField(ai, "threadSearchTask");
+        RootSearchResult result;
+        threadLocal.set(task);
+        try {
+            Method method = AI.class.getDeclaredMethod(
+                    "getBestMoveParallel",
+                    Engine.class,
+                    SearchTask.class,
+                    int.class,
+                    long.class,
+                    double.class,
+                    double.class,
+                    SplittableRandom.class
+            );
+            method.setAccessible(true);
+            result = (RootSearchResult) method.invoke(
+                    ai,
+                    simulator,
+                    task,
+                    3,
+                    deadline,
+                    Double.NEGATIVE_INFINITY,
+                    Double.POSITIVE_INFINITY,
+                    new SplittableRandom()
+            );
+        } finally {
+            threadLocal.remove();
+        }
+
+        assertNotNull(result, "Root search should return a result even when aborted");
+        assertTrue(result.hasCandidate(), "Aborted root search should keep the best-so-far move");
+        assertFalse(result.isCompleted(), "Depth must be flagged as incomplete when not all root moves were evaluated");
+    }
+
+    @Test
+    @Timeout(10)
+    @DisplayName("Parallel root search completes after every root move is evaluated")
+    void parallelRootSearchCompletesAfterEveryRootMoveIsEvaluated() throws Exception {
+        String fen = "k7/2Q5/3Q4/4Q3/5Q2/6Q1/7Q/7K w - - 0 1";
+        SlowEngine engine = new SlowEngine(0);
+        engine.importBoardFromFen(fen);
+
+        AI ai = new AI(engine, AiTuning.builder().searchThreads(2).build());
+
+        Engine simulator = engine.createSimulation();
+        int legalMoves = simulator.getAllLegalMoves().size();
+        int rootLimit = Integer.getInteger("chessengine.rootParallelLimit", 24);
+        assertTrue(legalMoves > rootLimit, "Test FEN should have more legal moves than the parallel fan-out limit");
+
+        long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(250);
+        SearchTask task = new SearchTask(
+                2L,
+                simulator.getBoardStateHash(),
+                simulator.whitesTurn(),
+                deadline,
+                ai.getSearchThreads(),
+                simulator.createSimulation()
+        );
+
+        @SuppressWarnings("unchecked")
+        ThreadLocal<SearchTask> threadLocal = (ThreadLocal<SearchTask>) TestUtils.readField(ai, "threadSearchTask");
+        RootSearchResult result;
+        threadLocal.set(task);
+        try {
+            Method method = AI.class.getDeclaredMethod(
+                    "getBestMoveParallel",
+                    Engine.class,
+                    SearchTask.class,
+                    int.class,
+                    long.class,
+                    double.class,
+                    double.class,
+                    SplittableRandom.class
+            );
+            method.setAccessible(true);
+            result = (RootSearchResult) method.invoke(
+                    ai,
+                    simulator,
+                    task,
+                    2,
+                    deadline,
+                    Double.NEGATIVE_INFINITY,
+                    Double.POSITIVE_INFINITY,
+                    new SplittableRandom()
+            );
+        } finally {
+            threadLocal.remove();
+        }
+
+        assertNotNull(result, "Root search should produce a result under ample time");
+        assertTrue(result.hasCandidate(), "Root search should return a best move when completed");
+        assertTrue(result.isCompleted(), "Depth should be marked complete after every root move is evaluated");
+    }
+
     private static class FakeAutoAI extends AI {
         private final FakeScheduler scheduler = new FakeScheduler();
 
@@ -142,6 +256,37 @@ class AITest_ConcurrencyAndStops {
                     throw new IllegalStateException(e);
                 }
             }, 0, 50, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private static final class SlowEngine extends Engine {
+        private final long delayMillis;
+
+        private SlowEngine(long delayMillis) {
+            super();
+            this.delayMillis = delayMillis;
+        }
+
+        private SlowEngine(SlowEngine other) {
+            super(other);
+            this.delayMillis = other.delayMillis;
+        }
+
+        @Override
+        public Engine createSimulation() {
+            return new SlowEngine(this);
+        }
+
+        @Override
+        public void performMove(int move) {
+            if (delayMillis > 0) {
+                try {
+                    Thread.sleep(delayMillis);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            super.performMove(move);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure parallel root search dynamically schedules remaining root moves and only reports completion once every move finishes or a cutoff is triggered
- keep track of root completion state so partial iterations return aborted results instead of marking the depth complete
- add multi-threaded tests with a controllable engine to assert that aborted searches remain incomplete and full searches complete after all moves

## Testing
- `mvn -Dtest=AITest_ConcurrencyAndStops test` *(fails: local JDK does not support release version 25)*

------
https://chatgpt.com/codex/tasks/task_e_68e19efdebf4832abeb756e709164125