### PR TITLE
Refine parallel root search synchronization

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1184,10 +1184,9 @@ public class AI {
         final CompletionService<MoveAndScore> ecs = new ExecutorCompletionService<>(searchPool);
         final List<Future<MoveAndScore>> futures = new ArrayList<>(fanout);
 
-        final AtomicReference<Double> alphaRef = new AtomicReference<>(alpha);
-        final AtomicReference<Double> betaRef = new AtomicReference<>(beta);
-        final java.util.concurrent.atomic.AtomicInteger bestMoveRef = new java.util.concurrent.atomic.AtomicInteger(bestMove);
-        final AtomicReference<Double> bestScoreRef = new AtomicReference<>(bestScore);
+        final AtomicReference<RootSearchState> stateRef = new AtomicReference<>(
+                new RootSearchState(alpha, beta, new MoveAndScore(bestMove, bestScore))
+        );
         final AtomicBoolean stopRef = new AtomicBoolean(false);
         final java.util.concurrent.locks.ReentrantLock fullResLock = new java.util.concurrent.locks.ReentrantLock();
 
@@ -1204,8 +1203,9 @@ public class AI {
                         workerEngine = borrowWorkerSimulation(simulatorEngine);
                         workerEngine.performMove(moveInt);
 
-                        double currentAlpha = alphaRef.get();
-                        double currentBeta = betaRef.get();
+                        RootSearchState snapshot = stateRef.get();
+                        double currentAlpha = snapshot.alpha();
+                        double currentBeta = snapshot.beta();
                         double pAlpha, pBeta;
                         if (isWhitesTurn) {
                             pAlpha = currentAlpha;
@@ -1226,42 +1226,27 @@ public class AI {
                             if (probe == EXIT_FLAG || abortRequested(deadline)) return null;
                         }
 
-                        boolean needsFull = isWhitesTurn ? (probe > alphaRef.get()) : (probe < betaRef.get());
+                        boolean needsFull = isWhitesTurn ? (probe > snapshot.alpha()) : (probe < snapshot.beta());
                         double finalScore = probe;
 
                         if (needsFull && !stopRef.get()) {
                             fullResLock.lock();
                             try {
                                 if (!stopRef.get() && !abortRequested(deadline)) {
-                                    double aNow = alphaRef.get(), bNow = betaRef.get();
+                                    RootSearchState locked = stateRef.get();
+                                    double aNow = locked.alpha();
+                                    double bNow = locked.beta();
                                     double full = alphaBeta(workerEngine, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt, 1, 0);
                                     if (full != EXIT_FLAG) {
                                         finalScore = full;
-                                        if (isWhitesTurn) {
-                                            if (full > aNow) alphaRef.set(full);
-                                        } else {
-                                            if (full < bNow) betaRef.set(full);
-                                        }
-                                        Double curBest = bestScoreRef.get();
-                                        if (isBetterScore(isWhitesTurn, full, curBest)) {
-                                            bestScoreRef.set(full);
-                                            bestMoveRef.set(moveInt);
-                                        }
-                                        if (alphaRef.get() >= betaRef.get()) stopRef.set(true);
+                                        updateRootState(stateRef, isWhitesTurn, moveInt, full, stopRef);
                                     }
                                 }
                             } finally {
                                 fullResLock.unlock();
                             }
                         } else {
-                            Double curBest = bestScoreRef.get();
-                            if (isBetterScore(isWhitesTurn, finalScore, curBest)) {
-                                bestScoreRef.set(finalScore);
-                                bestMoveRef.set(moveInt);
-                                if (isWhitesTurn && finalScore > alphaRef.get()) alphaRef.set(finalScore);
-                                if (!isWhitesTurn && finalScore < betaRef.get()) betaRef.set(finalScore);
-                                if (alphaRef.get() >= betaRef.get()) stopRef.set(true);
-                            }
+                            updateRootState(stateRef, isWhitesTurn, moveInt, finalScore, stopRef);
                         }
 
                         return new MoveAndScore(moveInt, finalScore);
@@ -1293,10 +1278,14 @@ public class AI {
                 MoveAndScore res = f.get();
                 if (res == null) continue;
 
-                alpha = alphaRef.get();
-                beta = betaRef.get();
-                bestMove = bestMoveRef.get();
-                bestScore = bestScoreRef.get();
+                RootSearchState state = stateRef.get();
+                alpha = state.alpha();
+                beta = state.beta();
+                MoveAndScore best = state.best();
+                if (best != null) {
+                    bestMove = best.move;
+                    bestScore = best.score;
+                }
 
                 if (alpha >= beta) {
                     stopRef.set(true);
@@ -1312,11 +1301,72 @@ public class AI {
             for (Future<MoveAndScore> f : futures) if (!f.isDone()) f.cancel(true);
         }
 
+        RootSearchState finalState = stateRef.get();
+        MoveAndScore bestCandidate = finalState.best();
+        if (bestCandidate != null) {
+            bestMove = bestCandidate.move;
+            bestScore = bestCandidate.score;
+        }
         MoveAndScore candidate = bestMove != -1 ? createCandidate(bestMove, bestScore) : null;
         if (abortRequested(deadline)) {
             aborted = true;
         }
         return aborted ? RootSearchResult.aborted(candidate) : RootSearchResult.completed(candidate);
+    }
+
+
+    private void updateRootState(AtomicReference<RootSearchState> stateRef,
+                                 boolean isWhiteToMove,
+                                 int move,
+                                 double score,
+                                 AtomicBoolean stopRef) {
+        while (true) {
+            RootSearchState current = stateRef.get();
+            double nextAlpha = current.alpha();
+            double nextBeta = current.beta();
+            MoveAndScore currentBest = current.best();
+            boolean changed = false;
+
+            if (isWhiteToMove) {
+                if (score > nextAlpha) {
+                    nextAlpha = score;
+                    changed = true;
+                }
+            } else {
+                if (score < nextBeta) {
+                    nextBeta = score;
+                    changed = true;
+                }
+            }
+
+            MoveAndScore nextBest = currentBest;
+            if (currentBest == null || isBetterScore(isWhiteToMove, score, currentBest.score)) {
+                if (currentBest == null || currentBest.move != move || Double.compare(currentBest.score, score) != 0) {
+                    nextBest = new MoveAndScore(move, score);
+                    changed = true;
+                }
+            }
+
+            if (!changed) {
+                return;
+            }
+
+            RootSearchState updated = new RootSearchState(nextAlpha, nextBeta, nextBest);
+            if (stateRef.compareAndSet(current, updated)) {
+                if (updated.alpha() >= updated.beta()) {
+                    stopRef.set(true);
+                }
+                return;
+            }
+        }
+    }
+
+    private record RootSearchState(double alpha, double beta, MoveAndScore best) {
+        private RootSearchState {
+            if (best == null) {
+                throw new IllegalArgumentException("best must not be null");
+            }
+        }
     }
 
 

--- a/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
@@ -3,6 +3,7 @@ package julius.game.chessengine.ai;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.tuning.AiTuning;
+import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import testsupport.TestUtils;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -290,6 +292,7 @@ class AITest_ConcurrencyAndStops {
             delegate.shutdown();
         }
 
+        @NonNull
         @Override
         public List<Runnable> shutdownNow() {
             shutdown = true;
@@ -307,12 +310,12 @@ class AITest_ConcurrencyAndStops {
         }
 
         @Override
-        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        public boolean awaitTermination(long timeout, @NonNull TimeUnit unit) throws InterruptedException {
             return delegate.awaitTermination(timeout, unit);
         }
 
         @Override
-        public void execute(Runnable command) {
+        public void execute(@NonNull Runnable command) {
             delegate.execute(() -> {
                 Phaser phaser = phaserRef.get();
                 if (phaser != null) {

--- a/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
@@ -12,9 +12,14 @@ import testsupport.FakeScheduler;
 import testsupport.TestLoggingExtension;
 import testsupport.TestUtils;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -101,6 +106,123 @@ class AITest_ConcurrencyAndStops {
         assertFalse(requests.isEmpty(), "Auto-play should enqueue a new calculation request after executing a move");
     }
 
+    @Test
+    @Timeout(15)
+    @DisplayName("Parallel root search keeps best move monotonically improving")
+    void parallelRootSearchKeepsBestMoveStable() throws Exception {
+        int searchDepth = 3;
+
+        AiTuning singleThreadTuning = AiTuning.builder()
+                .searchThreads(1)
+                .lazySmpThreads(1)
+                .maxDepth(6)
+                .timeLimitMillis(500)
+                .build();
+
+        Engine singleEngine = new Engine();
+        AI singleThreadAi = new AI(singleEngine, singleThreadTuning);
+
+        Engine singleSim = singleEngine.createSimulation();
+        SearchTask singleTask = new SearchTask(
+                1L,
+                singleSim.getBoardStateHash(),
+                singleSim.whitesTurn(),
+                System.nanoTime() + TimeUnit.SECONDS.toNanos(5),
+                1,
+                singleSim.createSimulation()
+        );
+
+        @SuppressWarnings("unchecked")
+        ThreadLocal<SearchTask> singleThreadLocal = (ThreadLocal<SearchTask>) TestUtils.readField(singleThreadAi, "threadSearchTask");
+        SearchTask previousSingle = singleThreadLocal.get();
+        MoveAndScore baselineBest;
+        try {
+            singleThreadLocal.set(singleTask);
+            RootSearchResult baseline = singleThreadAi.searchRootMoves(
+                    singleSim,
+                    singleTask,
+                    searchDepth,
+                    Double.NEGATIVE_INFINITY,
+                    Double.POSITIVE_INFINITY,
+                    null
+            );
+            assertTrue(baseline.hasCandidate(), "Baseline search should provide a best move");
+            baselineBest = baseline.bestMove();
+        } finally {
+            if (previousSingle != null) {
+                singleThreadLocal.set(previousSingle);
+            } else {
+                singleThreadLocal.remove();
+            }
+        }
+
+        AiTuning parallelTuning = AiTuning.builder()
+                .searchThreads(4)
+                .lazySmpThreads(1)
+                .maxDepth(6)
+                .timeLimitMillis(500)
+                .build();
+
+        Engine parallelEngine = new Engine();
+        AI parallelAi = new AI(parallelEngine, parallelTuning);
+
+        BarrierExecutor barrierExecutor = new BarrierExecutor(parallelAi.getSearchThreads());
+        TestUtils.writeField(parallelAi, "searchPool", barrierExecutor);
+
+        Field rootLimitField = AI.class.getDeclaredField("ROOT_PARALLEL_LIMIT");
+        rootLimitField.setAccessible(true);
+        int rootLimit = rootLimitField.getInt(null);
+
+        @SuppressWarnings("unchecked")
+        ThreadLocal<SearchTask> parallelThreadLocal = (ThreadLocal<SearchTask>) TestUtils.readField(parallelAi, "threadSearchTask");
+
+        try {
+            for (int iteration = 0; iteration < 8; iteration++) {
+                Engine sim = parallelEngine.createSimulation();
+                SearchTask task = new SearchTask(
+                        10_000L + iteration,
+                        sim.getBoardStateHash(),
+                        sim.whitesTurn(),
+                        System.nanoTime() + TimeUnit.SECONDS.toNanos(5),
+                        parallelAi.getSearchThreads(),
+                        sim.createSimulation()
+                );
+
+                SearchTask previous = parallelThreadLocal.get();
+                parallelThreadLocal.set(task);
+                try {
+                    IntArrayList legal = sim.getAllLegalMoves();
+                    IntArrayList ordered = parallelAi.sortMovesByEfficiency(legal, searchDepth, sim.getBoardStateHash(), -1, sim);
+                    int fanout = Math.min(rootLimit, ordered.size() - 1);
+                    assertTrue(fanout >= 2, "Test position should trigger parallel fan-out");
+                    barrierExecutor.setParties(fanout);
+
+                    RootSearchResult result = parallelAi.searchRootMoves(
+                            sim,
+                            task,
+                            searchDepth,
+                            Double.NEGATIVE_INFINITY,
+                            Double.POSITIVE_INFINITY,
+                            null
+                    );
+
+                    assertTrue(result.hasCandidate(), "Parallel search should produce a best move");
+                    MoveAndScore best = result.bestMove();
+                    assertEquals(baselineBest.move, best.move, "Best move must not regress under contention");
+                    assertEquals(baselineBest.score, best.score, 1e-9, "Best score should remain stable");
+                } finally {
+                    if (previous != null) {
+                        parallelThreadLocal.set(previous);
+                    } else {
+                        parallelThreadLocal.remove();
+                    }
+                }
+            }
+        } finally {
+            barrierExecutor.shutdownNow();
+        }
+    }
+
     private static class FakeAutoAI extends AI {
         private final FakeScheduler scheduler = new FakeScheduler();
 
@@ -142,6 +264,62 @@ class AITest_ConcurrencyAndStops {
                     throw new IllegalStateException(e);
                 }
             }, 0, 50, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private static final class BarrierExecutor extends java.util.concurrent.AbstractExecutorService {
+        private final ExecutorService delegate;
+        private final AtomicReference<Phaser> phaserRef = new AtomicReference<>();
+        private volatile boolean shutdown;
+
+        BarrierExecutor(int threads) {
+            this.delegate = Executors.newFixedThreadPool(threads);
+        }
+
+        void setParties(int parties) {
+            if (parties <= 1) {
+                phaserRef.set(null);
+            } else {
+                phaserRef.set(new Phaser(parties));
+            }
+        }
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+            delegate.shutdown();
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown = true;
+            return delegate.shutdownNow();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return delegate.isTerminated();
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            return delegate.awaitTermination(timeout, unit);
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            delegate.execute(() -> {
+                Phaser phaser = phaserRef.get();
+                if (phaser != null) {
+                    phaser.arriveAndAwaitAdvance();
+                }
+                command.run();
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary
- collapse the parallel root search alpha/beta/best tracking into a single CAS-protected state record
- add a helper to publish worker results with compare-and-set semantics so cutoffs only occur on consistent updates
- add a regression test that drives several synchronized parallel root searches to ensure the best move never regresses

## Testing
- `./mvnw -Dtest=AITest_ConcurrencyAndStops test` *(fails: Maven wrapper could not download dependencies because the network is unreachable in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b4e4bf3c832aa8dae9d0af113d2e