### PR TITLE
Rebuild search resources when thread count changes

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -58,6 +58,8 @@ public class AI {
     private final AtomicReference<SearchTask> activeSearch = new AtomicReference<>();
     private final ThreadLocal<SearchTask> threadSearchTask = new ThreadLocal<>();
     private final AtomicLong searchIdGenerator = new AtomicLong();
+    private final Object searchConfigLock = new Object();
+    private boolean reconfiguringSearchThreads = false;
     /**
      * Requested size of the transposition table in megabytes. The current
      * implementation does not dynamically resize the table, but the value is
@@ -414,11 +416,13 @@ public class AI {
         ExecutorService oldPool;
         int previous;
 
-        synchronized (this) {
+        synchronized (searchConfigLock) {
             previous = this.searchThreads;
             if (requested == previous) {
                 return;
             }
+
+            reconfiguringSearchThreads = true;
 
             running = activeSearch.get();
             if (running != null) {
@@ -456,15 +460,20 @@ public class AI {
             }
         }
 
-        synchronized (this) {
+        synchronized (searchConfigLock) {
             this.searchThreads = requested;
-            rebuildTranspositionTables();
-            this.searchPool = createSearchPool();
+            try {
+                rebuildTranspositionTables();
+                this.searchPool = createSearchPool();
 
-            if (searchPool != null) {
-                log.info("Search threads updated from {} to {} (parallel pool recreated)", previous, requested);
-            } else {
-                log.info("Search threads updated from {} to {} (parallel pool disabled)", previous, requested);
+                if (searchPool != null) {
+                    log.info("Search threads updated from {} to {} (parallel pool recreated)", previous, requested);
+                } else {
+                    log.info("Search threads updated from {} to {} (parallel pool disabled)", previous, requested);
+                }
+            } finally {
+                reconfiguringSearchThreads = false;
+                searchConfigLock.notifyAll();
             }
         }
     }
@@ -836,24 +845,36 @@ public class AI {
             long boardStateHash = simulatorEngine.getBoardStateHash();
             long deadline = System.nanoTime() + this.timeLimit * 1_000_000L;
 
-            SearchTask task = new SearchTask(
-                    searchIdGenerator.incrementAndGet(),
-                    boardStateHash,
-                    simulatorEngine.whitesTurn(),
-                    deadline,
-                    1,
-                    simulatorEngine.createSimulation()
-            );
+            SearchTask task;
+            synchronized (searchConfigLock) {
+                while (reconfiguringSearchThreads) {
+                    try {
+                        searchConfigLock.wait();
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return null;
+                    }
+                }
 
-            activeSearch.set(task);
-            currentBoardState = boardStateHash;
-            beforeCalculationBoardState = boardStateHash;
-            currentBestMove = -1;
-            bestMoveForHash = -1;
-            previousBestMove = -1;
-            previousBestMoveHash = -1;
-            searchResultReady = false;
-            this.calculatedLine = Collections.synchronizedList(new ArrayList<>());
+                task = new SearchTask(
+                        searchIdGenerator.incrementAndGet(),
+                        boardStateHash,
+                        simulatorEngine.whitesTurn(),
+                        deadline,
+                        1,
+                        simulatorEngine.createSimulation()
+                );
+
+                activeSearch.set(task);
+                currentBoardState = boardStateHash;
+                beforeCalculationBoardState = boardStateHash;
+                currentBestMove = -1;
+                bestMoveForHash = -1;
+                previousBestMove = -1;
+                previousBestMoveHash = -1;
+                searchResultReady = false;
+                this.calculatedLine = Collections.synchronizedList(new ArrayList<>());
+            }
 
             SplittableRandom rng = (lazySmpThreads > 1)
                     ? new SplittableRandom(boardStateHash ^ System.nanoTime())
@@ -1082,19 +1103,31 @@ public class AI {
                 return;
             }
 
-            SearchTask task = new SearchTask(searchIdGenerator.incrementAndGet(), boardStateHash, isWhite, deadline, lazySmpThreads, simulatorEngine);
-            activeSearch.set(task);
-            if (bestMoveForHash == boardStateHash && currentBestMove != -1) {
-                previousBestMove = currentBestMove;
-                previousBestMoveHash = bestMoveForHash;
-            } else {
-                previousBestMove = -1;
-                previousBestMoveHash = -1;
+            SearchTask task;
+            synchronized (searchConfigLock) {
+                while (reconfiguringSearchThreads) {
+                    try {
+                        searchConfigLock.wait();
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+
+                task = new SearchTask(searchIdGenerator.incrementAndGet(), boardStateHash, isWhite, deadline, lazySmpThreads, simulatorEngine);
+                activeSearch.set(task);
+                if (bestMoveForHash == boardStateHash && currentBestMove != -1) {
+                    previousBestMove = currentBestMove;
+                    previousBestMoveHash = bestMoveForHash;
+                } else {
+                    previousBestMove = -1;
+                    previousBestMoveHash = -1;
+                }
+                currentBestMove = -1;
+                bestMoveForHash = -1;
+                searchResultReady = false;
+                this.calculatedLine = Collections.synchronizedList(new ArrayList<>());
             }
-            currentBestMove = -1;
-            bestMoveForHash = -1;
-            searchResultReady = false;
-            this.calculatedLine = Collections.synchronizedList(new ArrayList<>());
             dispatchSearchTask(task);
             task.awaitCompletion();
             completeSearchTask(task, simulatorEngine);

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -43,8 +43,7 @@ public class AI {
      * can be adjusted at runtime via the UCI "Threads" option.
      */
     @Getter
-    @Setter
-    private int searchThreads = Integer.getInteger("chessengine.searchThreads", 1);
+    private volatile int searchThreads = Integer.getInteger("chessengine.searchThreads", 1);
 
     // number of Lazy SMP workers (≥1)
     @Getter
@@ -96,7 +95,7 @@ public class AI {
     /**
      * Thread pool for root-split parallel search (created only if searchThreads > 1).
      */
-    private final ExecutorService searchPool;
+    private volatile ExecutorService searchPool;
 
     /**
      * Limit how many root moves we fan out in parallel to avoid oversubscription.
@@ -399,6 +398,75 @@ public class AI {
 
         // next power-of-two (safe because value <= 2^30)
         return hib << 1;
+    }
+
+    /**
+     * Update the number of threads used for root-split search. The method stops any
+     * running search before replacing the executor service and rebuilding the
+     * transposition tables so workers never observe disposed infrastructure.
+     *
+     * @param threads requested number of search threads (values &lt;= 0 are treated as 1)
+     */
+    public void setSearchThreads(int threads) {
+        int requested = Math.max(1, threads);
+
+        SearchTask running;
+        ExecutorService oldPool;
+        int previous;
+
+        synchronized (this) {
+            previous = this.searchThreads;
+            if (requested == previous) {
+                return;
+            }
+
+            running = activeSearch.get();
+            if (running != null) {
+                running.requestStop();
+            }
+
+            oldPool = this.searchPool;
+        }
+
+        if (running != null) {
+            running.awaitCompletion();
+
+            while (activeSearch.get() == running) {
+                if (Thread.currentThread().isInterrupted()) {
+                    break;
+                }
+                try {
+                    Thread.sleep(1L);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+
+        if (oldPool != null) {
+            oldPool.shutdown();
+            try {
+                if (!oldPool.awaitTermination(5, TimeUnit.SECONDS)) {
+                    oldPool.shutdownNow();
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                oldPool.shutdownNow();
+            }
+        }
+
+        synchronized (this) {
+            this.searchThreads = requested;
+            rebuildTranspositionTables();
+            this.searchPool = createSearchPool();
+
+            if (searchPool != null) {
+                log.info("Search threads updated from {} to {} (parallel pool recreated)", previous, requested);
+            } else {
+                log.info("Search threads updated from {} to {} (parallel pool disabled)", previous, requested);
+            }
+        }
     }
 
     /**

--- a/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
@@ -20,6 +20,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Phaser;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -75,6 +76,56 @@ class AITest_ConcurrencyAndStops {
         assertEquals(-1, TestUtils.readField(ai, "currentBestMove"));
         assertNull(TestUtils.readField(ai, "calculationThreads"));
         assertNull(TestUtils.readField(ai, "calculationCoordinator"));
+    }
+
+    @Test
+    @Timeout(15)
+    @DisplayName("Updating Threads option rebuilds parallel infrastructure")
+    void switchingThreadsReconfiguresExecutorAndTables() throws Exception {
+        Engine engine = new Engine();
+        AI ai = new AI(engine, AiTuning.defaults());
+        ai.setMaxDepth(4);
+        ai.setTimeLimit(300);
+
+        Object initialMain = TestUtils.readField(ai, "transpositionTable");
+        Object initialCapture = TestUtils.readField(ai, "captureTranspositionTable");
+
+        assertTrue(initialMain instanceof PlainFixedSizeTranspositionTable,
+                "Single-thread mode should use the plain transposition table");
+        assertTrue(initialCapture instanceof PlainFixedSizeTranspositionTable,
+                "Single-thread mode should use the plain capture table");
+        assertNull(TestUtils.readField(ai, "searchPool"),
+                "Single-thread mode must not allocate a search pool");
+
+        try {
+            ai.setSearchThreads(3);
+
+            Object concurrentMain = TestUtils.readField(ai, "transpositionTable");
+            Object concurrentCapture = TestUtils.readField(ai, "captureTranspositionTable");
+
+            assertTrue(concurrentMain instanceof FixedSizeTranspositionTable,
+                    "Multi-thread mode should use the concurrent main table");
+            assertTrue(concurrentCapture instanceof FixedSizeTranspositionTable,
+                    "Multi-thread mode should use the concurrent capture table");
+
+            ExecutorService pool = (ExecutorService) TestUtils.readField(ai, "searchPool");
+            assertNotNull(pool, "Multi-thread mode must allocate a search pool");
+            assertFalse(pool.isShutdown(), "New search pool should be active");
+
+            ThreadPoolExecutor executor = (ThreadPoolExecutor) pool;
+            assertEquals(3, executor.getCorePoolSize(),
+                    "Search pool should match configured thread count");
+
+            long completedBefore = executor.getCompletedTaskCount();
+            MoveAndScore result = ai.searchBestMoveBlocking(300);
+            assertNotNull(result, "Search should produce a move when time remains");
+
+            long completedAfter = executor.getCompletedTaskCount();
+            assertTrue(completedAfter > completedBefore,
+                    "Parallel search must submit work to the executor");
+        } finally {
+            ai.shutdown();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- replace the Lombok-generated setter with logic that stops the active search, rebuilds the transposition tables and recreates the executor when the thread count changes
- wait for in-flight work to finish before disposing the previous search pool so no tasks see a torn-down executor
- add a regression test that flips the Threads option, verifies the concurrent table is selected and observes parallel work being submitted

## Testing
- mvn -Dtest=AITest_ConcurrencyAndStops#switchingThreadsReconfiguresExecutorAndTables test *(fails: fatal error compiling, release version 25 not supported in the container JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68e252228c14832a8f24738ebb510a6a