### PR TITLE
Cap root fanout to executor capacity

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,10 @@
+## 🧩 Testing Policy
+All tests must be executed using Java 21 preview features.
+
+### Default test command
+```bash
+mvn -Djava.version=21 \
+    -Dmaven.compiler.release=21 \
+    -Dmaven.compiler.enablePreview=true \
+    -DargLine=--enable-preview \
+    test

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1237,6 +1237,22 @@ public class AI {
         IntArrayList legal = simulatorEngine.getAllLegalMoves();
         IntArrayList orderedMoves = sortMovesByEfficiency(legal, depth, simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
         if (orderedMoves.isEmpty()) return RootSearchResult.completed(null);
+
+        int baseFanout = Math.min(ROOT_PARALLEL_LIMIT, orderedMoves.size() - 1);
+        ExecutorService pool = this.searchPool;
+        int helperCapacity = 0;
+        if (pool instanceof ThreadPoolExecutor) {
+            helperCapacity = ((ThreadPoolExecutor) pool).getMaximumPoolSize();
+        } else if (searchThreads > 0) {
+            helperCapacity = searchThreads;
+        }
+
+        if (helperCapacity <= 0 && baseFanout > 0) {
+            return getBestMove(simulatorEngine, isWhitesTurn, depth, deadline, alpha, beta, rng);
+        }
+
+        final int fanout = helperCapacity > 0 ? Math.min(baseFanout, helperCapacity) : baseFanout;
+
         maybeRotateRootMoves(orderedMoves, rng);
 
         int firstMove = orderedMoves.getInt(0);
@@ -1276,7 +1292,6 @@ public class AI {
             return RootSearchResult.completed(candidate);
         }
 
-        final int fanout = Math.min(ROOT_PARALLEL_LIMIT, orderedMoves.size() - 1);
         if (fanout <= 0) {
             MoveAndScore candidate = createCandidate(bestMove, bestScore);
             return RootSearchResult.completed(candidate);

--- a/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
@@ -247,7 +247,14 @@ class AITest_ConcurrencyAndStops {
                     IntArrayList legal = sim.getAllLegalMoves();
                     IntArrayList ordered = parallelAi.sortMovesByEfficiency(legal, searchDepth, sim.getBoardStateHash(), -1, sim);
                     int fanout = Math.min(rootLimit, ordered.size() - 1);
-                    assertTrue(fanout >= 2, "Test position should trigger parallel fan-out");
+                    int helperCapacity = parallelAi.getSearchThreads();
+                    if (helperCapacity <= 0 && fanout > 0) {
+                        fanout = 0;
+                    } else if (helperCapacity > 0) {
+                        fanout = Math.min(fanout, helperCapacity);
+                    }
+                    assertTrue(fanout >= 2 || helperCapacity <= 0,
+                            "Test position should trigger parallel fan-out when capacity allows");
                     barrierExecutor.setParties(fanout);
 
                     RootSearchResult result = parallelAi.searchRootMoves(


### PR DESCRIPTION
## Summary
- cap the parallel root fan-out by the executor capacity and fall back to the sequential path when no helper threads are available
- update the concurrency regression to expect the capacity-aware fan-out before synchronising helper workers

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine=--enable-preview -Dtest=AITest_ConcurrencyAndStops#parallelRootSearchKeepsBestMoveStable test
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine=--enable-preview -Dtest=AITest*,AITest_* test

------
https://chatgpt.com/codex/tasks/task_e_68e264361338832a9e534232b5525c49