### PR TITLE
Avoid generating captures on the opposing king

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -1333,6 +1333,7 @@ public class BitBoard {
         final long knights = whitesTurn ? whiteKnights : blackKnights;
         final long ownPieces = whitesTurn ? whitePieces : blackPieces;
         final long oppPiecesNoKing = whitesTurn ? (blackPieces & ~blackKing) : (whitePieces & ~whiteKing);
+        final long opponentKing = whitesTurn ? blackKing : whiteKing;
         // KNIGHT
 
         long k = knights;
@@ -1340,7 +1341,7 @@ public class BitBoard {
             int from = Long.numberOfTrailingZeros(k);
             k &= k - 1;
 
-            long potential = KnightHelper.knightMoveTable[from] & ~ownPieces;
+            long potential = KnightHelper.knightMoveTable[from] & ~ownPieces & ~opponentKing;
 
             final boolean mustRespectPin =
                     pinState != null && pinState.whiteSide() == whitesTurn &&
@@ -1355,11 +1356,8 @@ public class BitBoard {
                 long toMask = 1L << to;
                 boolean isCapture = (oppPiecesNoKing & toMask) != 0;
                 if (isCapture) {
-                    int capBits = pieceBitsAt(to, !whitesTurn);
-                    // capBits cannot be 6 here (king masked out), but be safe:
-                    if (capBits == 6) continue;
                     moves.add(createMoveInt(from, to, PieceType.KNIGHT, whitesTurn,
-                            true, false, false, null, pieceTypeFromBits(capBits),
+                            true, false, false, null, pieceTypeFromBits(pieceBitsAt(to, !whitesTurn)),
                             false, false, castlingState));
                 } else {
                     moves.add(createMoveInt(from, to, PieceType.KNIGHT, whitesTurn,
@@ -1374,6 +1372,7 @@ public class BitBoard {
         long bishops = whitesTurn ? whiteBishops : blackBishops;
         final long ownPieces = whitesTurn ? whitePieces : blackPieces;
         final long oppPiecesNoKing = whitesTurn ? (blackPieces & ~blackKing) : (whitePieces & ~whiteKing);
+        final long opponentKing = whitesTurn ? blackKing : whiteKing;
         // BISHOP
 
         while (bishops != 0) {
@@ -1381,7 +1380,7 @@ public class BitBoard {
             bishops &= bishops - 1;
 
             long occ = allPieces & bishopHelper.bishopMasks[from];
-            long attacks = bishopHelper.calculateMovesUsingBishopMagic(from, occ) & ~ownPieces;
+            long attacks = bishopHelper.calculateMovesUsingBishopMagic(from, occ) & ~ownPieces & ~opponentKing;
 
             boolean pinned = pinState != null && pinState.whiteSide() == whitesTurn
                     && ((pinState.getAllPinned() & (1L << from)) != 0);
@@ -1399,13 +1398,10 @@ public class BitBoard {
                 long toMask = 1L << to;
                 boolean isCapture = (oppPiecesNoKing & toMask) != 0;
                 if (isCapture) {
-                    int capBits = pieceBitsAt(to, !whitesTurn);
-                    if (capBits == 6) continue; // should not happen (king masked), but guard
-
-                    if (pinned && pri.pinnerSquare() != to) continue;
+                    if (pinned && pri != null && pri.pinnerSquare() != to) continue;
 
                     moves.add(createMoveInt(from, to, PieceType.BISHOP, whitesTurn,
-                            true, false, false, null, pieceTypeFromBits(capBits),
+                            true, false, false, null, pieceTypeFromBits(pieceBitsAt(to, !whitesTurn)),
                             false, false, castlingState));
                 } else {
                     moves.add(createMoveInt(from, to, PieceType.BISHOP, whitesTurn,
@@ -1420,6 +1416,7 @@ public class BitBoard {
         long rooks = whitesTurn ? whiteRooks : blackRooks;
         final long ownPieces = whitesTurn ? whitePieces : blackPieces;
         final long oppPiecesNoKing = whitesTurn ? (blackPieces & ~blackKing) : (whitePieces & ~whiteKing);
+        final long opponentKing = whitesTurn ? blackKing : whiteKing;
         // ROOK
 
         while (rooks != 0) {
@@ -1427,7 +1424,7 @@ public class BitBoard {
             rooks &= rooks - 1;
 
             long occ = allPieces & rookHelper.rookMasks[from];
-            long attacks = rookHelper.calculateMovesUsingRookMagic(from, occ) & ~ownPieces;
+            long attacks = rookHelper.calculateMovesUsingRookMagic(from, occ) & ~ownPieces & ~opponentKing;
 
             boolean pinned = pinState != null && pinState.whiteSide() == whitesTurn
                     && ((pinState.getAllPinned() & (1L << from)) != 0);
@@ -1447,12 +1444,10 @@ public class BitBoard {
                 long toMask = 1L << to;
                 boolean isCapture = (oppPiecesNoKing & toMask) != 0;
                 if (isCapture) {
-                    int capBits = pieceBitsAt(to, !whitesTurn);
-                    if (capBits == 6) continue;
-                    if (pinned && pri.pinnerSquare() != to) continue;
+                    if (pinned && pri != null && pri.pinnerSquare() != to) continue;
 
                     moves.add(createMoveInt(from, to, PieceType.ROOK, whitesTurn,
-                            true, false, false, null, pieceTypeFromBits(capBits),
+                            true, false, false, null, pieceTypeFromBits(pieceBitsAt(to, !whitesTurn)),
                             false, isFirstRookMove, castlingState));
                 } else {
                     moves.add(createMoveInt(from, to, PieceType.ROOK, whitesTurn,
@@ -1467,6 +1462,7 @@ public class BitBoard {
         long queens = whitesTurn ? whiteQueens : blackQueens;
         final long ownPieces = whitesTurn ? whitePieces : blackPieces;
         final long oppPiecesNoKing = whitesTurn ? (blackPieces & ~blackKing) : (whitePieces & ~whiteKing);
+        final long opponentKing = whitesTurn ? blackKing : whiteKing;
         // QUEEN
 
         while (queens != 0) {
@@ -1476,7 +1472,7 @@ public class BitBoard {
             long occB = allPieces & bishopHelper.bishopMasks[from];
             long occR = allPieces & rookHelper.rookMasks[from];
             long attacks = (bishopHelper.calculateMovesUsingBishopMagic(from, occB)
-                    | rookHelper.calculateMovesUsingRookMagic(from, occR)) & ~ownPieces;
+                    | rookHelper.calculateMovesUsingRookMagic(from, occR)) & ~ownPieces & ~opponentKing;
 
             boolean pinned = pinState != null && pinState.whiteSide() == whitesTurn
                     && ((pinState.getAllPinned() & (1L << from)) != 0);
@@ -1494,12 +1490,10 @@ public class BitBoard {
                 long toMask = 1L << to;
                 boolean isCapture = (oppPiecesNoKing & toMask) != 0;
                 if (isCapture) {
-                    int capBits = pieceBitsAt(to, !whitesTurn);
-                    if (capBits == 6) continue;
-                    if (pinned && pri.pinnerSquare() != to) continue;
+                    if (pinned && pri != null && pri.pinnerSquare() != to) continue;
 
                     moves.add(createMoveInt(from, to, PieceType.QUEEN, whitesTurn,
-                            true, false, false, null, pieceTypeFromBits(capBits),
+                            true, false, false, null, pieceTypeFromBits(pieceBitsAt(to, !whitesTurn)),
                             false, false, castlingState));
                 } else {
                     moves.add(createMoveInt(from, to, PieceType.QUEEN, whitesTurn,
@@ -1517,12 +1511,13 @@ public class BitBoard {
         final int from = Long.numberOfTrailingZeros(kingBitboard);
         final long ownPieces = whitesTurn ? whitePieces : blackPieces;
         final long oppPiecesNoKing = whitesTurn ? (blackPieces & ~blackKing) : (whitePieces & ~whiteKing);
+        final long opponentKing = whitesTurn ? blackKing : whiteKing;
         final boolean isFirstKingMove = hasKingNotMoved(whitesTurn);
 
         // Recompute opponent attacks once (lazy inside getAttackBitboard)
         final long oppAttacks = getAttackBitboard(!whitesTurn);
 
-        long legal = KING_ATTACKS[from] & ~ownPieces;
+        long legal = KING_ATTACKS[from] & ~ownPieces & ~opponentKing;
 
         while (legal != 0) {
             int to = Long.numberOfTrailingZeros(legal);
@@ -1533,10 +1528,8 @@ public class BitBoard {
 
             boolean isCapture = (oppPiecesNoKing & toMask) != 0;
             if (isCapture) {
-                int capBits = pieceBitsAt(to, !whitesTurn);
-                if (capBits == 6) continue; // masked, but guard anyway
                 moves.add(createMoveInt(from, to, PieceType.KING, whitesTurn,
-                        true, false, false, null, pieceTypeFromBits(capBits), isFirstKingMove, false, castlingState));
+                        true, false, false, null, pieceTypeFromBits(pieceBitsAt(to, !whitesTurn)), isFirstKingMove, false, castlingState));
             } else {
                 moves.add(createMoveInt(from, to, PieceType.KING, whitesTurn,
                         false, false, false, null, null, isFirstKingMove, false, castlingState));


### PR DESCRIPTION
## Summary
- filter knight, sliding piece, and king move generation so pseudo-legal moves never target the opposing king square
- retain standard capture encoding for genuine captures while preserving pin restrictions

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine=--enable-preview test *(fails: BestMoveSearchTest, MateSearchTest, ScoreEvaluationTest)*

------
https://chatgpt.com/codex/tasks/task_e_68e26dc5520c832a84c14f012f8199dc