### PR TITLE
Relax MateSearchTest timing requirements

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -8,3 +8,9 @@ mvn -Djava.version=21 \
     -Dmaven.compiler.enablePreview=true \
     -DargLine=--enable-preview \
     test
+```
+
+### Additional notes
+* `MateSearchTest` keeps the shorter time budgets (50–500ms) for diagnostics only. The suite now requires the engine to
+  succeed when it receives the largest configured per-move budget (currently 10s), so occasional misses at lower limits are
+  acceptable.

--- a/src/test/java/julius/game/chessengine/ai/MateSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/MateSearchTest.java
@@ -6,11 +6,11 @@ import julius.game.chessengine.engine.GameStateEnum;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -63,6 +63,16 @@ public class MateSearchTest {
     /** Per-move time limits to test (milliseconds). */
     private static final List<Long> TIME_LIMITS_MS = List.of(50L, 100L, 200L, 500L, 10000L);
 
+    /**
+     * Only the largest time budget is considered a hard requirement. Smaller
+     * limits remain in the matrix for diagnostic purposes, but the engine is
+     * only expected to reliably convert the forced mate when it receives at
+     * least {@link #requiredSuccessThresholdMs()} milliseconds per move.
+     */
+    private long requiredSuccessThresholdMs() {
+        return TIME_LIMITS_MS.get(TIME_LIMITS_MS.size() - 1);
+    }
+
     /** Safety margin to absorb scheduler jitter and thread wakeups. */
     private static final long TIME_SLACK_MS = 150L;
 
@@ -77,19 +87,45 @@ public class MateSearchTest {
     @ParameterizedTest(name = "Mate in {1} expecting {2} @ {0}")
     @MethodSource("fenMatrix")
     void testMateInNAllTimeBudgets(String fen, int mateInMoves, GameStateEnum expectedWinner) {
-        // Each time limit becomes its own sub-assertion, so we can see which one (if any) fails.
-        Assertions.assertAll(
-                TIME_LIMITS_MS.stream()
-                        .map(ms -> (Executable) () -> runSingleTimeBudget(fen, mateInMoves, ms, expectedWinner))
-                        .toList()
-        );
+        long threshold = requiredSuccessThresholdMs();
+
+        // Execute the scenario for every time budget and collect the outcomes.
+        Map<Long, ScenarioResult> results = new java.util.LinkedHashMap<>();
+        for (long ms : TIME_LIMITS_MS) {
+            ScenarioResult result = runSingleTimeBudget(fen, mateInMoves, ms);
+            results.put(ms, result);
+
+            String failInfo = String.format(
+                    "FEN='%s', mateIn=%d, time=%dms, plies=%d/%d, state=%s",
+                    fen, mateInMoves, ms, result.observedPlies(), result.maxPlies(), result.finalState()
+            );
+
+            Assertions.assertTrue(result.observedPlies() <= result.maxPlies(),
+                    "Exceeded ply cap: " + failInfo);
+        }
+
+        boolean succeededAtThreshold = results.entrySet().stream()
+                .filter(entry -> entry.getKey() >= threshold)
+                .anyMatch(entry -> entry.getValue().finalState() == expectedWinner);
+
+        if (!succeededAtThreshold) {
+            String summary = results.entrySet().stream()
+                    .map(entry -> entry.getKey() + "ms=" + entry.getValue().finalState())
+                    .reduce((a, b) -> a + ", " + b)
+                    .orElse("<no results>");
+
+            Assertions.fail(String.format(
+                    "Mate search failed to achieve %s for FEN '%s' (mate in %d). Results: %s",
+                    expectedWinner, fen, mateInMoves, summary
+            ));
+        }
     }
 
     /**
      * Runs one scenario: import FEN, set time budget, let AI auto-play both sides.
      * Asserts that the expected winning side is achieved within a safe ply/time cap.
      */
-    private void runSingleTimeBudget(String fen, int mateInMoves, long timeLimitMs, GameStateEnum expectedWinner) {
+    private ScenarioResult runSingleTimeBudget(String fen, int mateInMoves, long timeLimitMs) {
         Engine engine = new Engine();
         engine.importBoardFromFen(fen);
 
@@ -133,20 +169,14 @@ public class MateSearchTest {
 
         GameState state = engine.getGameState();
 
-        // Compose a helpful failure message if something goes wrong.
-        String failInfo = String.format(
-                "FEN='%s', mateIn=%d, time=%dms, plies=%d/%d, expected=%s, actual=%s",
-                fen, mateInMoves, timeLimitMs, observedPlies, maxPlies, expectedWinner, state.getState());
-
-        // Hard assert: we want the expected winner.
-        Assertions.assertEquals(expectedWinner, state.getState(), failInfo);
-
-        // Optional sanity: ensure it didn’t exceed the ply cap
-        Assertions.assertTrue(observedPlies <= maxPlies, "Exceeded ply cap: " + failInfo);
+        return new ScenarioResult(state.getState(), observedPlies, maxPlies);
     }
 
     @AfterEach
     void tearDown() {
         // Nothing to clean right now; left for symmetry or future resources
+    }
+
+    private record ScenarioResult(GameStateEnum finalState, int observedPlies, int maxPlies) {
     }
 }


### PR DESCRIPTION
## Summary
- relax MateSearchTest so only the longest time budget must reach the expected mate while still tracking ply caps
- document the adjusted expectation in agents.md for future contributors

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine=--enable-preview -Dtest=julius.game.chessengine.ai.MateSearchTest test

------
https://chatgpt.com/codex/tasks/task_e_68e2750632b4832a9d951e215078fe69