### PR TITLE
Clamp hanging piece penalties to material value

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -93,3 +93,5 @@ Agents should compute `S, L, R, TT` via the heuristics above and substitute into
   Define them in the corresponding evaluation module (where the feature is computed).
   Add the same weights (with sensible defaults) to seed-tunings.yaml.
   Expose and apply them via the tuning module so they are loaded and propagated into the evaluation at runtime.
+* King centralisation tuning: `activity.midgameKingPlacementBonus` and `activity.endgameKingPlacementBonus` control the bonus per Chebyshev step that the king receives for moving toward the centre. Increasing these values helps the search prefer active kings in the late middlegame/endgame.
+* Threat evaluation got stricter in this iteration: hanging piece penalties are now floored to the material value of the threatened piece (and pawn threats are floored to the net material loss against a pawn). When tuning `threat.*` parameters in the future, you can still raise the magnitude, but reducing them below that floor will no longer make the engine trade full pieces for pawns (e.g. to avoid `...Bxg5??` in `BestMoveSearchTest`).

--- a/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
@@ -1,9 +1,15 @@
 package julius.game.chessengine.evaluation;
 
-import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.ImmutableBoardView;
+import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.tuning.Tuning;
+
+import static julius.game.chessengine.evaluation.MaterialModule.bishopValue;
+import static julius.game.chessengine.evaluation.MaterialModule.knightValue;
+import static julius.game.chessengine.evaluation.MaterialModule.pawnValue;
+import static julius.game.chessengine.evaluation.MaterialModule.queenValue;
+import static julius.game.chessengine.evaluation.MaterialModule.rookValue;
 
 import java.util.Objects;
 
@@ -137,13 +143,52 @@ public final class ThreatModule implements EvaluationModule {
                 continue;
             }
 
-            penalty += hangingPenalties[typeBits];
+            penalty += ensurePieceLossPenalty(typeBits, hangingPenalties[typeBits]);
             if (typeBits > PAWN && (enemyPawnAttacks & mask) != 0) {
-                penalty += pawnThreatPenalties[typeBits];
+                penalty += ensurePawnThreatPenalty(typeBits, pawnThreatPenalties[typeBits]);
             }
             remaining ^= bit;
         }
         return penalty;
+    }
+
+    private static int ensurePieceLossPenalty(int pieceType, int configuredPenalty) {
+        int materialValue = materialValue(pieceType);
+        if (materialValue <= 0) {
+            return configuredPenalty;
+        }
+        return Math.min(configuredPenalty, -materialValue);
+    }
+
+    private static int ensurePawnThreatPenalty(int pieceType, int configuredPenalty) {
+        int materialValue = materialValue(pieceType);
+        if (materialValue <= 0) {
+            return configuredPenalty;
+        }
+        int pawnTradeLoss = Math.max(0, materialValue - pawnValue());
+        if (pawnTradeLoss == 0) {
+            return configuredPenalty;
+        }
+        return Math.min(configuredPenalty, -pawnTradeLoss);
+    }
+
+    private static int materialValue(int pieceType) {
+        if (pieceType == PAWN) {
+            return pawnValue();
+        }
+        if (pieceType == KNIGHT) {
+            return knightValue();
+        }
+        if (pieceType == BISHOP) {
+            return bishopValue();
+        }
+        if (pieceType == ROOK) {
+            return rookValue();
+        }
+        if (pieceType == QUEEN) {
+            return queenValue();
+        }
+        return 0;
     }
 
     private static long computePawnAttackMask(long pawns, int pawnColor) {


### PR DESCRIPTION
## Summary
- ensure the threat evaluation floor matches the material value of the hanging piece and scales pawn threats by the net trade against a pawn
- document the stricter threat-floor behaviour in Agents.md so future tuning changes take it into account

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=BestMoveSearchTest test *(fails: 22/57, down from 28/57)*

------
https://chatgpt.com/codex/tasks/task_e_68e28f320e08832a966eb668e052d500