### PR TITLE
Improve root work sharing across helper threads

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.IntFunction;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -1298,7 +1299,7 @@ public class AI {
         }
 
         final CompletionService<MoveAndScore> ecs = new ExecutorCompletionService<>(searchPool);
-        final List<Future<MoveAndScore>> futures = new ArrayList<>(fanout);
+        final List<Future<MoveAndScore>> futures = new ArrayList<>();
 
         final AtomicReference<RootSearchState> stateRef = new AtomicReference<>(
                 new RootSearchState(alpha, beta, new MoveAndScore(bestMove, bestScore))
@@ -1306,106 +1307,130 @@ public class AI {
         final AtomicBoolean stopRef = new AtomicBoolean(false);
         final java.util.concurrent.locks.ReentrantLock fullResLock = new java.util.concurrent.locks.ReentrantLock();
 
-        for (int i = 1; i <= fanout; i++) {
-            final int moveInt = orderedMoves.getInt(i);
-            futures.add(ecs.submit(() -> {
-                SearchTask previousTask = threadSearchTask.get();
-                threadSearchTask.set(task);
+        IntFunction<Callable<MoveAndScore>> taskFactory = (moveInt) -> () -> {
+            SearchTask previousTask = threadSearchTask.get();
+            threadSearchTask.set(task);
+            try {
+                if (task.isStopRequested() || stopRef.get() || abortRequested(deadline)) return null;
+                Heuristics helperHeuristics = prepareHelperHeuristics(task, depth);
+                Engine workerEngine = null;
                 try {
-                    if (task.isStopRequested() || stopRef.get() || abortRequested(deadline)) return null;
-                    Heuristics helperHeuristics = prepareHelperHeuristics(task, depth);
-                    Engine workerEngine = null;
-                    try {
-                        workerEngine = borrowWorkerSimulation(simulatorEngine);
-                        workerEngine.performMove(moveInt);
+                    workerEngine = borrowWorkerSimulation(simulatorEngine);
+                    workerEngine.performMove(moveInt);
 
-                        RootSearchState snapshot = stateRef.get();
-                        double currentAlpha = snapshot.alpha();
-                        double currentBeta = snapshot.beta();
-                        double pAlpha, pBeta;
-                        if (isWhitesTurn) {
-                            pAlpha = currentAlpha;
-                            pBeta = currentAlpha + 1;
-                        } else {
-                            pAlpha = currentBeta - 1;
-                            pBeta = currentBeta;
-                        }
-
-                        double probe;
-                        if (workerEngine.getGameState().isInStateCheckMate()) {
-                            probe = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
-                        } else if (workerEngine.getGameState().isTerminal()) { // <-- terminal only
-                            probe = evaluateStaticPosition(workerEngine.getGameState(), !isWhitesTurn, depth);
-                            if (isWhitesTurn) probe = -probe;
-                        } else {
-                            probe = alphaBeta(workerEngine, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline, moveInt, 1, 0);
-                            if (probe == EXIT_FLAG || abortRequested(deadline)) return null;
-                        }
-
-                        boolean needsFull = isWhitesTurn ? (probe > snapshot.alpha()) : (probe < snapshot.beta());
-                        double finalScore = probe;
-
-                        if (needsFull && !stopRef.get()) {
-                            fullResLock.lock();
-                            try {
-                                if (!stopRef.get() && !abortRequested(deadline)) {
-                                    RootSearchState locked = stateRef.get();
-                                    double aNow = locked.alpha();
-                                    double bNow = locked.beta();
-                                    double full = alphaBeta(workerEngine, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt, 1, 0);
-                                    if (full != EXIT_FLAG) {
-                                        finalScore = full;
-                                        updateRootState(stateRef, isWhitesTurn, moveInt, full, stopRef);
-                                    }
-                                }
-                            } finally {
-                                fullResLock.unlock();
-                            }
-                        } else {
-                            updateRootState(stateRef, isWhitesTurn, moveInt, finalScore, stopRef);
-                        }
-
-                        return new MoveAndScore(moveInt, finalScore);
-                    } finally {
-                        releaseWorkerSimulation(workerEngine, task.getRootSnapshot());
-                        if (helperHeuristics.hasUpdates()) mergeThreadHeuristics(helperHeuristics);
-                        else helperHeuristics.resetUpdates();
-                    }
-                } finally {
-                    if (previousTask != null) {
-                        threadSearchTask.set(previousTask);
+                    RootSearchState snapshot = stateRef.get();
+                    double currentAlpha = snapshot.alpha();
+                    double currentBeta = snapshot.beta();
+                    double pAlpha, pBeta;
+                    if (isWhitesTurn) {
+                        pAlpha = currentAlpha;
+                        pBeta = currentAlpha + 1;
                     } else {
-                        threadSearchTask.remove();
+                        pAlpha = currentBeta - 1;
+                        pBeta = currentBeta;
                     }
-                }
-            }));
-        }
 
-        int completed = 0;
+                    double probe;
+                    if (workerEngine.getGameState().isInStateCheckMate()) {
+                        probe = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
+                    } else if (workerEngine.getGameState().isTerminal()) { // <-- terminal only
+                        probe = evaluateStaticPosition(workerEngine.getGameState(), !isWhitesTurn, depth);
+                        if (isWhitesTurn) probe = -probe;
+                    } else {
+                        probe = alphaBeta(workerEngine, depth - 1, pAlpha, pBeta, !isWhitesTurn, deadline, moveInt, 1, 0);
+                        if (probe == EXIT_FLAG || abortRequested(deadline)) return null;
+                    }
+
+                    boolean needsFull = isWhitesTurn ? (probe > snapshot.alpha()) : (probe < snapshot.beta());
+                    double finalScore = probe;
+
+                    if (needsFull && !stopRef.get()) {
+                        fullResLock.lock();
+                        try {
+                            if (!stopRef.get() && !abortRequested(deadline)) {
+                                RootSearchState locked = stateRef.get();
+                                double aNow = locked.alpha();
+                                double bNow = locked.beta();
+                                double full = alphaBeta(workerEngine, depth - 1, aNow, bNow, !isWhitesTurn, deadline, moveInt, 1, 0);
+                                if (full != EXIT_FLAG) {
+                                    finalScore = full;
+                                    updateRootState(stateRef, isWhitesTurn, moveInt, full, stopRef);
+                                }
+                            }
+                        } finally {
+                            fullResLock.unlock();
+                        }
+                    } else {
+                        updateRootState(stateRef, isWhitesTurn, moveInt, finalScore, stopRef);
+                    }
+
+                    return new MoveAndScore(moveInt, finalScore);
+                } finally {
+                    releaseWorkerSimulation(workerEngine, task.getRootSnapshot());
+                    if (helperHeuristics.hasUpdates()) mergeThreadHeuristics(helperHeuristics);
+                    else helperHeuristics.resetUpdates();
+                }
+            } finally {
+                if (previousTask != null) {
+                    threadSearchTask.set(previousTask);
+                } else {
+                    threadSearchTask.remove();
+                }
+            }
+        };
+
+        int nextMoveIndex = 1;
+        int active = 0;
+
         try {
-            while (completed < fanout) {
-                if (stopRef.get()) break;
+            while (active < fanout && nextMoveIndex < orderedMoves.size() && !stopRef.get()) {
                 if (abortRequested(deadline)) {
                     aborted = true;
                     break;
                 }
-                Future<MoveAndScore> f = ecs.take();
-                completed++;
-                MoveAndScore res = f.get();
-                if (res == null) continue;
+                int moveInt = orderedMoves.getInt(nextMoveIndex++);
+                Future<MoveAndScore> submitted = ecs.submit(taskFactory.apply(moveInt));
+                futures.add(submitted);
+                active++;
+            }
 
-                RootSearchState state = stateRef.get();
-                alpha = state.alpha();
-                beta = state.beta();
-                MoveAndScore best = state.best();
-                if (best != null) {
-                    bestMove = best.move;
-                    bestScore = best.score;
+            while (active > 0) {
+                if (abortRequested(deadline)) {
+                    aborted = true;
+                    break;
                 }
 
-                if (alpha >= beta) {
-                    stopRef.set(true);
-                    break;
+                Future<MoveAndScore> future = ecs.take();
+                active--;
+                try {
+                    MoveAndScore res = future.get();
+                    if (res != null) {
+                        RootSearchState state = stateRef.get();
+                        alpha = state.alpha();
+                        beta = state.beta();
+                        MoveAndScore best = state.best();
+                        if (best != null) {
+                            bestMove = best.move;
+                            bestScore = best.score;
+                        }
+                    }
+                } catch (ExecutionException ex) {
+                    log.warn("Parallel root worker failed", ex.getCause());
+                }
+
+                if (stopRef.get()) {
+                    continue;
+                }
+
+                while (active < fanout && nextMoveIndex < orderedMoves.size() && !stopRef.get()) {
+                    if (abortRequested(deadline)) {
+                        aborted = true;
+                        break;
+                    }
+                    int moveInt = orderedMoves.getInt(nextMoveIndex++);
+                    Future<MoveAndScore> submitted = ecs.submit(taskFactory.apply(moveInt));
+                    futures.add(submitted);
+                    active++;
                 }
             }
         } catch (InterruptedException ie) {
@@ -1427,7 +1452,7 @@ public class AI {
         }
 
         if (!stopRef.get()) {
-            for (int i = fanout + 1; i < orderedMoves.size(); i++) {
+            for (int i = nextMoveIndex; i < orderedMoves.size(); i++) {
                 if (abortRequested(deadline)) {
                     aborted = true;
                     break;

--- a/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -283,6 +284,84 @@ class AITest_ConcurrencyAndStops {
         }
     }
 
+    @Test
+    @Timeout(15)
+    @DisplayName("Parallel root search shares remaining work across helpers")
+    void parallelRootSearchSharesRemainingWork() throws Exception {
+        int searchDepth = 3;
+
+        AiTuning tuning = AiTuning.builder()
+                .searchThreads(4)
+                .lazySmpThreads(1)
+                .maxDepth(5)
+                .timeLimitMillis(500)
+                .build();
+
+        Engine engine = new Engine();
+        AI ai = new AI(engine, tuning);
+
+        BarrierExecutor barrierExecutor = new BarrierExecutor(ai.getSearchThreads());
+        TestUtils.writeField(ai, "searchPool", barrierExecutor);
+
+        Field rootLimitField = AI.class.getDeclaredField("ROOT_PARALLEL_LIMIT");
+        rootLimitField.setAccessible(true);
+        int rootLimit = rootLimitField.getInt(null);
+
+        @SuppressWarnings("unchecked")
+        ThreadLocal<SearchTask> threadLocal = (ThreadLocal<SearchTask>) TestUtils.readField(ai, "threadSearchTask");
+
+        Engine sim = engine.createSimulation();
+        SearchTask task = new SearchTask(
+                20_000L,
+                sim.getBoardStateHash(),
+                sim.whitesTurn(),
+                System.nanoTime() + TimeUnit.SECONDS.toNanos(5),
+                ai.getSearchThreads(),
+                sim.createSimulation()
+        );
+
+        SearchTask previous = threadLocal.get();
+        threadLocal.set(task);
+        try {
+            IntArrayList legal = sim.getAllLegalMoves();
+            IntArrayList ordered = ai.sortMovesByEfficiency(legal, searchDepth, sim.getBoardStateHash(), -1, sim);
+
+            int fanout = Math.min(rootLimit, ordered.size() - 1);
+            int helperCapacity = ai.getSearchThreads();
+            if (helperCapacity <= 0 && fanout > 0) {
+                fanout = 0;
+            } else if (helperCapacity > 0) {
+                fanout = Math.min(fanout, helperCapacity);
+            }
+
+            assertTrue(fanout > 0, "Test position should trigger parallel fan-out");
+            assertTrue(ordered.size() - 1 > fanout,
+                    "Position should offer more root moves than the initial helper count");
+
+            barrierExecutor.setParties(fanout);
+
+            RootSearchResult result = ai.searchRootMoves(
+                    sim,
+                    task,
+                    searchDepth,
+                    Double.NEGATIVE_INFINITY,
+                    Double.POSITIVE_INFINITY,
+                    null
+            );
+
+            assertTrue(result.hasCandidate(), "Parallel search should produce a best move");
+            assertTrue(barrierExecutor.getSubmittedTasks() > fanout,
+                    "Parallel search should schedule work beyond the initial fan-out");
+        } finally {
+            if (previous != null) {
+                threadLocal.set(previous);
+            } else {
+                threadLocal.remove();
+            }
+            barrierExecutor.shutdownNow();
+        }
+    }
+
     private static class FakeAutoAI extends AI {
         private final FakeScheduler scheduler = new FakeScheduler();
 
@@ -330,6 +409,8 @@ class AITest_ConcurrencyAndStops {
     private static final class BarrierExecutor extends java.util.concurrent.AbstractExecutorService {
         private final ExecutorService delegate;
         private final AtomicReference<Phaser> phaserRef = new AtomicReference<>();
+        private final AtomicInteger submitted = new AtomicInteger();
+        private final AtomicInteger barrierPermits = new AtomicInteger();
         private volatile boolean shutdown;
 
         BarrierExecutor(int threads) {
@@ -337,11 +418,18 @@ class AITest_ConcurrencyAndStops {
         }
 
         void setParties(int parties) {
+            submitted.set(0);
             if (parties <= 1) {
                 phaserRef.set(null);
-            } else {
-                phaserRef.set(new Phaser(parties));
+                barrierPermits.set(0);
+                return;
             }
+            phaserRef.set(new Phaser(parties));
+            barrierPermits.set(parties);
+        }
+
+        int getSubmittedTasks() {
+            return submitted.get();
         }
 
         @Override
@@ -375,9 +463,16 @@ class AITest_ConcurrencyAndStops {
         @Override
         public void execute(@NonNull Runnable command) {
             delegate.execute(() -> {
+                submitted.incrementAndGet();
                 Phaser phaser = phaserRef.get();
                 if (phaser != null) {
-                    phaser.arriveAndAwaitAdvance();
+                    int remaining = barrierPermits.getAndUpdate(v -> v > 0 ? v - 1 : v);
+                    if (remaining > 0) {
+                        phaser.arriveAndAwaitAdvance();
+                        if (remaining == 1) {
+                            phaserRef.compareAndSet(phaser, null);
+                        }
+                    }
                 }
                 command.run();
             });

--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -264,6 +264,14 @@ public class BestMoveSearchTest {
                 new Object[]{
                         "8/2b5/2k1b3/2p2r2/8/5R1P/PP1N2r1/R1B2K2 b - - 3 48",
                         List.of("Rh2")
+                },
+                new Object[]{
+                        "r2qkb1r/2p1n1pp/bp3p2/p2pp3/P7/1BP1BN2/1PP1QPPP/R4RK1 w kq - 1 12",
+                        List.of("c4")
+                },
+                new Object[]{
+                        "2kr3r/8/1p4np/p1p1qp2/P1Ppp3/1B6/1PP1QPP1/3RN1K1 w - - 0 26",
+                        List.of("Qh5")
                 }
         );
     }


### PR DESCRIPTION
## Summary
- stream root move evaluations to helper threads so the executor can pick up additional root moves once workers finish their first assignments
- preserve per-thread heuristic merges and sequential fallbacks while updating the shared root search state based on dynamic helper results
- add a regression test that confirms remaining root moves are handed to helpers and extend the BarrierExecutor test double to track submissions safely

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITest_ConcurrencyAndStops test

------
https://chatgpt.com/codex/tasks/task_e_68e2d9b02d9c832a8653e05fc6d1fbc8