### PR TITLE
Add PGN reader and MoveStack unit tests

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -28,6 +28,13 @@ mvn -Djava.version=21     -Dmaven.compiler.release=21     -Dmaven.compiler.enabl
   mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true       -DargLine="--enable-preview"       -Dtest=BestMoveSearchTest#shouldFindSameBestMoveUnderParallelLoad       test
   ```
 
+- **PGN & utility smoke tests** (quick verification for PGN ingestion and move history utilities)
+  ```bash
+  mvn -Djava.version=21       -Dmaven.compiler.release=21       -Dmaven.compiler.enablePreview=true       -DargLine="--enable-preview"       -Dtest=OpeningPgnReaderTest,MoveStackTest       test
+  ```
+
+  These focused tests parse representative PGN samples (including comments, nested variations, SAN promotions, and `0-0` castling tokens) and exercise `MoveStack` growth/copy semantics. Review their logs when diagnosing PGN import or move-history regressions.
+
 > Keep `--enable-preview` in **`argLine`** so the test JVM receives it.
 
 ---

--- a/src/test/java/julius/game/chessengine/pgn/OpeningPgnReaderTest.java
+++ b/src/test/java/julius/game/chessengine/pgn/OpeningPgnReaderTest.java
@@ -1,0 +1,90 @@
+package julius.game.chessengine.pgn;
+
+import julius.game.chessengine.engine.Engine;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OpeningPgnReaderTest {
+
+    private final OpeningPgnReader reader = new OpeningPgnReader();
+
+    @Test
+    void shouldParseMultipleGamesAndProvideMoveHashes() {
+        String pgn = """
+                [Event \"Ruy Lopez\"]
+                [Site \"Somewhere\"]
+                [Date \"2024.01.01\"]
+                [Round \"1\"]
+                [White \"Alpha\"]
+                [Black \"Beta\"]
+                [Result \"1-0\"]
+
+                1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 { comment } 4. Ba4 (4... Be7?!) Nf6
+                5. O-O Be7 6. Re1 b5 ; inline comment
+                7. Bb3 d6 8. c3 0-0 9. h3 Nb8 10. d4 Nbd7 1-0
+
+                [Event \"Promotion test\"]
+                [Site \"-\"]
+                [Date \"2024.01.02\"]
+                [Round \"1\"]
+                [White \"Gamma\"]
+                [Black \"Delta\"]
+                [Result \"*\"]
+
+                1. a4 h5 2. a5 h4 3. a6 h3 4. axb7 hxg2 5. bxa8=Q+ gxf1=Q+ *
+                """;
+
+        List<OpeningPgnReader.ParsedGame> games = reader.parse(pgn);
+
+        assertEquals(2, games.size(), "Expected two games to be parsed");
+
+        OpeningPgnReader.ParsedGame first = games.get(0);
+        assertEquals("Ruy Lopez", first.headers().get("Event"));
+        assertEquals("Alpha", first.headers().get("White"));
+        assertEquals("Beta", first.headers().get("Black"));
+
+        assertEquals(20, first.moves().size(), "First game should have ten full moves");
+        assertEquals(first.moves().size(), first.hashes().size(), "Each move should have a pre-move hash");
+
+        Engine engine = new Engine();
+        engine.startNewGame();
+        for (int i = 0; i < first.moves().size(); i++) {
+            int move = first.moves().get(i);
+            long expectedHash = first.hashes().get(i);
+            assertEquals(engine.getBoardStateHash(), expectedHash, "Hash should match engine state before move");
+            assertTrue(engine.getAllLegalMoves().contains(move), "Move should be legal in current position");
+            engine.performMove(move);
+        }
+
+        OpeningPgnReader.ParsedGame second = games.get(1);
+        assertEquals(10, second.moves().size(), "Promotion game should have five full moves");
+        assertEquals(second.moves().size(), second.hashes().size());
+
+        engine.startNewGame();
+        for (int move : second.moves()) {
+            assertTrue(engine.getAllLegalMoves().contains(move));
+            engine.performMove(move);
+        }
+    }
+
+    @Test
+    void shouldParseFromBytesAndGenerateStableFingerprint() {
+        String content = "[Event \"Minimal\"]\n\n1. e4 e5 *";
+        List<OpeningPgnReader.ParsedGame> games = reader.parse(content.getBytes(StandardCharsets.UTF_8));
+        assertEquals(1, games.size());
+
+        String fingerprint = reader.fingerprint(List.of(
+                "alpha".getBytes(StandardCharsets.UTF_8),
+                "beta".getBytes(StandardCharsets.UTF_8)
+        ));
+        assertEquals(64, fingerprint.length(), "SHA-256 fingerprint should be 64 hex characters");
+        assertEquals(fingerprint, reader.fingerprint(List.of(
+                "alpha".getBytes(StandardCharsets.UTF_8),
+                "beta".getBytes(StandardCharsets.UTF_8)
+        )));
+    }
+}

--- a/src/test/java/julius/game/chessengine/utils/MoveStackTest.java
+++ b/src/test/java/julius/game/chessengine/utils/MoveStackTest.java
@@ -1,0 +1,60 @@
+package julius.game.chessengine.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MoveStackTest {
+
+    @Test
+    void shouldPushAndPopInLifoOrder() {
+        MoveStack stack = new MoveStack();
+        stack.push(1);
+        stack.push(2);
+        stack.push(3);
+
+        assertEquals(3, stack.size());
+        assertEquals(3, stack.peek());
+        assertEquals(3, stack.pop());
+        assertEquals(2, stack.pop());
+        assertEquals(1, stack.pop());
+        assertTrue(stack.isEmpty());
+    }
+
+    @Test
+    void shouldGrowBeyondInitialCapacity() {
+        MoveStack stack = new MoveStack(1);
+        for (int i = 0; i < 10; i++) {
+            stack.push(i);
+        }
+        assertEquals(10, stack.size());
+        assertArrayEquals(new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, stack.toArray());
+    }
+
+    @Test
+    void shouldCopyFromAnotherStack() {
+        MoveStack source = new MoveStack();
+        source.push(5);
+        source.push(6);
+
+        MoveStack target = new MoveStack();
+        target.push(1);
+        target.push(2);
+        target.copyFrom(source);
+
+        assertEquals(2, target.size());
+        assertArrayEquals(source.toArray(), target.toArray());
+
+        source.push(7);
+        assertNotEquals(source.size(), target.size(), "Copy should be independent after modification");
+    }
+
+    @Test
+    void shouldThrowWhenPoppingEmptyStack() {
+        MoveStack stack = new MoveStack();
+        assertThrows(NoSuchElementException.class, stack::pop);
+        assertThrows(NoSuchElementException.class, stack::peek);
+    }
+}


### PR DESCRIPTION
## Summary
- add regression coverage for `OpeningPgnReader`, exercising PGN metadata parsing, SAN translation, and hash snapshots
- add `MoveStackTest` to verify growth, copy semantics, and empty stack guards
- document a targeted "PGN & utility" smoke-test command in `Agents.md`

## Testing
- `mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" test` *(fails: existing `BestMoveSearchTest` expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68e3aea06ea0832aa129b5dc1552d9fe