### PR TITLE
Add PGN parser coverage and fix SAN disambiguation

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -19,6 +19,10 @@ mvn -Djava.version=21     -Dmaven.compiler.release=21     -Dmaven.compiler.enabl
   ```bash
   mvn -Djava.version=21       -Dmaven.compiler.release=21       -Dmaven.compiler.enablePreview=true       -DargLine="--enable-preview"       -Dtest=AITest*,AITest_*       test
   ```
+- **PGN module smoke tests**
+  ```bash
+  mvn -Djava.version=21       -Dmaven.compiler.release=21       -Dmaven.compiler.enablePreview=true       -DargLine="--enable-preview"       -Dtest=PgnParserTest,OpeningPgnReaderTest       test
+  ```
 - **Single class / method**
   ```bash
   # Class
@@ -93,3 +97,4 @@ Agents should compute `S, L, R, TT` via the heuristics above and substitute into
   Define them in the corresponding evaluation module (where the feature is computed).
   Add the same weights (with sensible defaults) to seed-tunings.yaml.
   Expose and apply them via the tuning module so they are loaded and propagated into the evaluation at runtime.
+* Full-suite runs currently fail in `BestMoveSearchTest` due to long-horizon move selection mismatches. Use the PGN smoke tests above when focusing on PGN changes, or investigate the AI regressions separately before expecting a green build.

--- a/src/main/java/julius/game/chessengine/pgn/PgnParser.java
+++ b/src/main/java/julius/game/chessengine/pgn/PgnParser.java
@@ -135,12 +135,13 @@ public class PgnParser {
                 AmbiguityType ambiguityType = isMoveAmbiguous(pieceType, fromIndex, toIndex);
 
                 if (ambiguityType != AmbiguityType.NONE) {
-                    if (ambiguityType == AmbiguityType.BOTH) {
-                        movePgn += from; // Include full 'from' position
-                    } else if (ambiguityType == AmbiguityType.FILE || ambiguityType == AmbiguityType.NONE_BUT_SAME_TO_SQUARE) {
-                        movePgn += from.charAt(1); // Include only 'from' rank
-                    } else if (ambiguityType == AmbiguityType.RANK) {
-                        movePgn += from.charAt(0); // Include only 'from' file
+                    switch (ambiguityType) {
+                        case BOTH -> movePgn += from; // Include full 'from' position
+                        case FILE -> movePgn += from.charAt(1); // Same file -> disambiguate by rank
+                        case RANK -> movePgn += from.charAt(0); // Same rank -> disambiguate by file
+                        case NONE_BUT_SAME_TO_SQUARE -> movePgn += from.charAt(0); // Prefer file when only target overlaps
+                        default -> {
+                        }
                     }
                 }
                 if (MoveHelper.isCapture(moveInt)) {

--- a/src/test/java/julius/game/chessengine/pgn/OpeningPgnReaderTest.java
+++ b/src/test/java/julius/game/chessengine/pgn/OpeningPgnReaderTest.java
@@ -1,0 +1,71 @@
+package julius.game.chessengine.pgn;
+
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.utils.MoveStack;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OpeningPgnReaderTest {
+
+    @Test
+    void parseExtractsHeadersMovesAndHashes() {
+        String pgn = """
+                [Event \"Test Match\"]
+                [Site \"Example\"]
+                [Result \"1-0\"]
+
+                1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 {Morphy Defense} (3... Nf6 4. O-O) 4. Ba4 Nf6 5. 0-0 Be7 1-0
+                """;
+
+        OpeningPgnReader reader = new OpeningPgnReader();
+        List<OpeningPgnReader.ParsedGame> games = reader.parse(pgn);
+
+        assertEquals(1, games.size());
+        OpeningPgnReader.ParsedGame game = games.get(0);
+
+        Map<String, String> headers = game.headers();
+        assertEquals("Test Match", headers.get("Event"));
+        assertEquals("Example", headers.get("Site"));
+        assertEquals("1-0", headers.get("Result"));
+
+        List<Integer> moves = game.moves();
+        assertEquals(10, moves.size(), "Result token should not be treated as a move");
+
+        List<Long> hashes = game.hashes();
+        assertEquals(moves.size(), hashes.size());
+
+        Engine engine = new Engine();
+        engine.startNewGame();
+        for (int move : moves) {
+            engine.performMove(move);
+        }
+
+        assertEquals(moves.size(), engine.getLine().size(), "Every SAN token should translate to a performed move");
+
+        String san = new PgnParser(new MoveStack(engine.getLine())).parseToPgn().getPgn();
+        String movesSan = san.substring(san.indexOf("\n\n") + 2);
+        assertEquals("1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7", movesSan);
+    }
+
+    @Test
+    void fingerprintCombinesResourcesDeterministically() {
+        OpeningPgnReader reader = new OpeningPgnReader();
+        List<byte[]> resources = List.of(
+                "first".getBytes(StandardCharsets.UTF_8),
+                "second".getBytes(StandardCharsets.UTF_8));
+
+        String fingerprint = reader.fingerprint(resources);
+        assertEquals(64, fingerprint.length());
+        assertEquals(fingerprint, reader.fingerprint(resources));
+
+        List<byte[]> reversed = List.of(
+                "second".getBytes(StandardCharsets.UTF_8),
+                "first".getBytes(StandardCharsets.UTF_8));
+        assertNotEquals(fingerprint, reader.fingerprint(reversed), "Order of resources should impact fingerprint");
+    }
+}

--- a/src/test/java/julius/game/chessengine/pgn/PgnParserTest.java
+++ b/src/test/java/julius/game/chessengine/pgn/PgnParserTest.java
@@ -1,0 +1,77 @@
+package julius.game.chessengine.pgn;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.utils.MoveStack;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PgnParserTest {
+
+    @Test
+    void parseToPgnProducesMetadataAndSanMoves() {
+        Engine engine = new Engine();
+        engine.startNewGame();
+        MoveStack line = new MoveStack();
+
+        pushMove(engine, line, "e2", "e4");
+        pushMove(engine, line, "e7", "e5");
+        pushMove(engine, line, "d1", "h5");
+        pushMove(engine, line, "b8", "c6");
+        pushMove(engine, line, "f1", "c4");
+        pushMove(engine, line, "g8", "f6");
+        pushMove(engine, line, "h5", "f7");
+
+        PGN result = new PgnParser(line).parseToPgn();
+        String text = result.getPgn();
+
+        assertTrue(text.startsWith("[Event \"Alieknek testing\"]\n[Site \"Neulengbach\"]\n[Date \""));
+        assertTrue(text.contains("\n[Round \"1\"]\n[White \"Alieknek\"]\n[Black \"Alieknek\"]\n[Result \"-\"]\n\n"));
+
+        int movesStart = text.indexOf("\n\n");
+        assertNotEquals(-1, movesStart, "PGN text should contain a blank line before moves");
+        String moves = text.substring(movesStart + 2);
+        assertEquals("1. e4 e5 2. Qh5 Nc6 3. Bc4 Nf6 4. Qxf7#", moves);
+    }
+
+    @Test
+    void parseToPgnDisambiguatesKnightsByFileWhenNeeded() {
+        Engine engine = new Engine();
+        engine.startNewGame();
+        MoveStack line = new MoveStack();
+
+        pushMove(engine, line, "g1", "f3");
+        pushMove(engine, line, "d7", "d5");
+        pushMove(engine, line, "d2", "d4");
+        pushMove(engine, line, "g8", "f6");
+        pushMove(engine, line, "b1", "d2");
+
+        PGN result = new PgnParser(line).parseToPgn();
+        String moves = result.getPgn().substring(result.getPgn().indexOf("\n\n") + 2);
+        assertEquals("1. Nf3 d5 2. d4 Nf6 3. Nbd2", moves);
+        assertFalse(moves.contains("N1d2"), "Rank-based disambiguation must not be used when file is required");
+    }
+
+    private void pushMove(Engine engine, MoveStack line, String from, String to) {
+        pushMove(engine, line, from, to, 0);
+    }
+
+    private void pushMove(Engine engine, MoveStack line, String from, String to, int promotionPieceBits) {
+        IntArrayList legalMoves = engine.getAllLegalMoves();
+        int fromIndex = MoveHelper.convertStringToIndex(from);
+        int toIndex = MoveHelper.convertStringToIndex(to);
+        for (int i = 0; i < legalMoves.size(); i++) {
+            int move = legalMoves.getInt(i);
+            if (MoveHelper.deriveFromIndex(move) == fromIndex &&
+                    MoveHelper.deriveToIndex(move) == toIndex &&
+                    MoveHelper.derivePromotionPieceTypeBits(move) == promotionPieceBits) {
+                engine.performMove(move);
+                line.push(move);
+                return;
+            }
+        }
+        fail("Move " + from + to + " not legal in current position");
+    }
+}


### PR DESCRIPTION
## Summary
- add focused unit tests covering PGN export and opening reader parsing scenarios
- fix SAN disambiguation to prefer file when only target square matches
- document a lightweight PGN smoke test command and note existing BestMoveSearchTest instability

## Testing
- `mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=PgnParserTest,OpeningPgnReaderTest test`


------
https://chatgpt.com/codex/tasks/task_e_68e3aea06ea0832aa129b5dc1552d9fe