### PR TITLE
Add diagnostics writers for search regression suites

### DIFF
--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import testsupport.TestReportWriter;
+
 /**
  * Verifies that the AI selects the expected best move from a set of FEN
  * positions within a small time budget. Similar in spirit to
@@ -30,6 +32,8 @@ import java.util.stream.Stream;
 public class BestMoveSearchTest {
 
     private final List<DecisionStatistics> decisionSummaries = new ArrayList<>();
+    private final List<String> decisionJsonLines = new ArrayList<>();
+    private final List<String> decisionTextBlocks = new ArrayList<>();
 
     /**
      * Test matrix: (fen, expected moves in algebraic notation). Some positions
@@ -327,6 +331,9 @@ public class BestMoveSearchTest {
         System.out.println(humanReadable);
         System.out.println(statistics.toJsonLine());
 
+        decisionJsonLines.add(statistics.toJsonLine());
+        decisionTextBlocks.add(humanReadable);
+
         Assertions.assertTrue(expectedMoves.contains(moveString),
                 "Expected one of " + expectedMoves + " but got " + moveString + " for FEN: " + fen
                         + humanReadable);
@@ -419,6 +426,23 @@ public class BestMoveSearchTest {
         AggregateStatistics summary = AggregateStatistics.from(decisionSummaries);
         System.out.println(summary.toHumanReadable());
         System.out.println(summary.toJsonLine());
+
+        TestReportWriter.writeLines(
+                "best-move-search-decisions.jsonl",
+                decisionJsonLines
+        );
+        TestReportWriter.writeLines(
+                "best-move-search-decisions.txt",
+                decisionTextBlocks
+        );
+        TestReportWriter.writeLines(
+                "best-move-search-summary.json",
+                List.of(summary.toJsonLine())
+        );
+        TestReportWriter.writeLines(
+                "best-move-search-summary.txt",
+                List.of(summary.toHumanReadable())
+        );
     }
 
     private record DecisionStatistics(

--- a/src/test/java/julius/game/chessengine/ai/MateInThreeToSevenTest.java
+++ b/src/test/java/julius/game/chessengine/ai/MateInThreeToSevenTest.java
@@ -3,6 +3,7 @@ package julius.game.chessengine.ai;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.engine.GameStateEnum;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -10,6 +11,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import testsupport.TestReportWriter;
 
 /**
  * Focused regression covering deeper forced mates (N = 3..7).
@@ -23,6 +29,8 @@ import java.util.stream.Stream;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MateInThreeToSevenTest {
+
+    private final List<MateObservation> observations = new ArrayList<>();
 
     private Stream<Object[]> matePuzzles() {
         return Stream.of(
@@ -86,6 +94,18 @@ class MateInThreeToSevenTest {
         ai.stopCalculation();
 
         GameState state = engine.getGameState();
+        MateObservation observation = new MateObservation(
+                fen,
+                mateInMoves,
+                expectedWinner,
+                state.getState(),
+                observedPlies,
+                maxPlies,
+                timeLimitMs,
+                state.getState() == expectedWinner && observedPlies <= maxPlies
+        );
+        observations.add(observation);
+
         String failInfo = String.format(
                 "FEN='%s', mateIn=%d, plies=%d/%d, expected=%s, actual=%s",
                 fen, mateInMoves, observedPlies, maxPlies, expectedWinner, state.getState()
@@ -93,6 +113,57 @@ class MateInThreeToSevenTest {
 
         Assertions.assertEquals(expectedWinner, state.getState(), failInfo);
         Assertions.assertTrue(observedPlies <= maxPlies, "Exceeded ply cap: " + failInfo);
+    }
+
+    @AfterAll
+    void writeDiagnostics() {
+        if (observations.isEmpty()) {
+            return;
+        }
+        List<String> jsonLines = observations.stream()
+                .map(MateObservation::toJsonLine)
+                .toList();
+        List<String> textLines = observations.stream()
+                .map(MateObservation::toHumanReadable)
+                .toList();
+
+        TestReportWriter.writeLines("mate-in-three-to-seven.jsonl", jsonLines);
+        TestReportWriter.writeLines("mate-in-three-to-seven.txt", textLines);
+    }
+
+    private record MateObservation(
+            String fen,
+            int mateIn,
+            GameStateEnum expected,
+            GameStateEnum actual,
+            int plies,
+            int maxPlies,
+            long timeLimitMs,
+            boolean success
+    ) {
+        String toHumanReadable() {
+            return String.format(
+                    "FEN=%s | mateIn=%d | plies=%d/%d | expected=%s | actual=%s | success=%s",
+                    fen, mateIn, plies, maxPlies, expected, actual, success
+            );
+        }
+
+        String toJsonLine() {
+            return "{"
+                    + "\"fen\":\"" + escape(fen) + "\"," 
+                    + "\"mateIn\":" + mateIn + ','
+                    + "\"expected\":\"" + expected + "\"," 
+                    + "\"actual\":\"" + actual + "\"," 
+                    + "\"plies\":" + plies + ','
+                    + "\"maxPlies\":" + maxPlies + ','
+                    + "\"timeLimitMs\":" + timeLimitMs + ','
+                    + "\"success\":" + success
+                    + "}";
+        }
+
+        private static String escape(String input) {
+            return input.replace("\\", "\\\\").replace("\"", "\\\"");
+        }
     }
 }
 

--- a/src/test/java/testsupport/TestReportWriter.java
+++ b/src/test/java/testsupport/TestReportWriter.java
@@ -1,0 +1,83 @@
+package testsupport;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Utility used by diagnostic-heavy tests to persist structured log output under
+ * {@code target/test-diagnostics}. The goal is to make it trivial for humans
+ * (and future agents) to aggregate per-position telemetry even when individual
+ * parameterised runs fail.
+ */
+public final class TestReportWriter {
+
+    private static final Path OUTPUT_DIR = Paths.get("target", "test-diagnostics");
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ISO_INSTANT;
+
+    private TestReportWriter() {
+    }
+
+    /**
+     * Writes the provided lines to {@code target/test-diagnostics/<fileName>}. The
+     * file is replaced on every invocation so consecutive Maven runs always
+     * produce a clean artifact. If the write fails, the error is printed to
+     * {@code System.err} but no exception bubbles up to the caller.
+     */
+    public static synchronized Path writeLines(String fileName, List<String> lines) {
+        Objects.requireNonNull(fileName, "fileName");
+        if (lines == null || lines.isEmpty()) {
+            return null;
+        }
+        Path file = OUTPUT_DIR.resolve(fileName);
+        try {
+            Files.createDirectories(OUTPUT_DIR);
+            Files.writeString(
+                    file,
+                    String.join(System.lineSeparator(), lines) + System.lineSeparator(),
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING,
+                    StandardOpenOption.WRITE
+            );
+            return file;
+        } catch (IOException ioe) {
+            System.err.println("[TestReportWriter] Failed to write diagnostics to " + file + ": " + ioe.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Appends a single JSON (or text) line to the specified diagnostics file.
+     * The file is created on demand and timestamped entries are prepended to
+     * make correlation with console output easier.
+     */
+    public static synchronized void appendLine(String fileName, String line) {
+        Objects.requireNonNull(fileName, "fileName");
+        if (line == null || line.isEmpty()) {
+            return;
+        }
+        Path file = OUTPUT_DIR.resolve(fileName);
+        try {
+            Files.createDirectories(OUTPUT_DIR);
+            String payload = TIMESTAMP_FORMAT.format(Instant.now()) + " " + line + System.lineSeparator();
+            Files.writeString(
+                    file,
+                    payload,
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.APPEND,
+                    StandardOpenOption.WRITE
+            );
+        } catch (IOException ioe) {
+            System.err.println("[TestReportWriter] Failed to append diagnostics to " + file + ": " + ioe.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `TestReportWriter` helper to persist structured diagnostics under `target/test-diagnostics`
- extend `BestMoveSearchTest` so every decision and aggregate summary is written to JSONL/TXT artifacts for later inspection
- capture `MateInThreeToSevenTest` observations in matching JSON/TXT reports to aid mate search triage

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e3b43bbb94832a9f51433f0467c3a3