### PR TITLE
Fix autoplay request handling and relax SEE pruning near root

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -54,7 +54,7 @@ public class AI {
     private Thread[] calculationThreads;
 
     private static final int MAX_CHECK_EXTENSIONS_IN_A_ROW = 2;
-    private static final int SEE_PRUNE_NEAR_ROOT_PLY = 2;
+    private static final int SEE_PRUNE_NEAR_ROOT_PLY = 3;
     private static final int ABS_PLY_LIMIT_MARGIN = 32;
 
     private final AtomicReference<SearchTask> activeSearch = new AtomicReference<>();
@@ -1041,6 +1041,7 @@ public class AI {
             previousBestMove = -1;
             previousBestMoveHash = -1;
             searchResultReady = false;
+            enqueueCalculationRequest();
             return;
         }
 


### PR DESCRIPTION
## Summary
- ensure auto-play reschedules analysis when the stored best move is for the wrong side to move
- extend the SEE near-root guard so sacrificial captures within the first three plies are always considered

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITest_ConcurrencyAndStops#autoplayRespectsSideToMove,SeePruningRegressionTest test

------
https://chatgpt.com/codex/tasks/task_e_68e3cb354510832a978a182e8bc0ddcd