### PR TITLE
Fix lazy SMP leadership randomization

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -112,6 +112,10 @@ Agents should compute `S, L, R, TT` via the heuristics above and substitute into
 * Full-suite runs currently fail in `BestMoveSearchTest` due to long-horizon move selection mismatches. Use the PGN smoke tests above when focusing on PGN changes, or investigate the AI regressions separately before expecting a green build.
 * `BestMoveSearchTest` now mirrors the diagnostic harness from `AITest_MateThreatDiagnostics`. Each position prints an in-depth iterative-deepening trace, principal variation, and transposition-table probe summary, with aggregated JSON/TXT artifacts in `target/surefire-reports/best-move-search-*`. Expect a long console log and ~28 known assertion failures; the goal is visibility, not a green suite.
 
+### 2025-10-06 Lazy SMP findings
+* Lazy SMP leader selection previously relied on worker index `0`, so whichever thread dequeued work first would sometimes randomize its root move ordering. Mixing `searchThreads` with `lazySmpThreads > 1` therefore degraded results because the deterministic leader path could become randomized.
+* The search task now tracks leadership explicitly so the first worker to claim a task remains deterministic, and only subsequent workers receive diversification RNG seeds. This allows `searchThreads` and `lazySmpThreads` to cooperate without starving the principal variation.
+
 ### AI search & evaluation notes
 * Quiescence delta pruning now compares against the alpha window captured before the stand-pat update. Earlier builds raised `alpha` first, which meant `standPat + Δ < alpha` never triggered and the pruning shortcut was effectively disabled.
 * Static evaluation adds a lightweight knight placement adjustment (central bonuses) plus a tempo tie-breaker on top of the pipeline score. Future positional tweaks should extend `computePositionalAdjustment` so the orientation logic stays centralised.

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -922,7 +922,10 @@ public class AI {
     }
 
     private SplittableRandom createLazyWorkerRng(SearchTask task, int workerIndex) {
-        if (lazySmpThreads <= 1 || workerIndex <= 0 || task == null) {
+        if (lazySmpThreads <= 1 || task == null) {
+            return null;
+        }
+        if (task.claimLeader()) {
             return null;
         }
         long seed = task.getBoardHash() ^ (0x9E3779B97F4A7C15L * (workerIndex + 1L));

--- a/src/main/java/julius/game/chessengine/ai/SearchTask.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchTask.java
@@ -21,6 +21,7 @@ public final class SearchTask {
     private final long deadline;
     private final CountDownLatch completion;
     private final AtomicBoolean stop = new AtomicBoolean(false);
+    private final AtomicBoolean leaderClaimed = new AtomicBoolean(false);
     private final AtomicReference<BestMoveDepth> best;
     private final AtomicInteger iterationDepth = new AtomicInteger(0);
     private final Engine rootSnapshot;
@@ -46,6 +47,10 @@ public final class SearchTask {
     void workerDone() { completion.countDown(); }
     void requestStop() { stop.set(true); }
     boolean isStopRequested() { return stop.get(); }
+
+    boolean claimLeader() {
+        return !stop.get() && leaderClaimed.compareAndSet(false, true);
+    }
 
     boolean beginIteration(int depth) {
         while (true) {

--- a/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_ConcurrencyAndStops.java
@@ -198,19 +198,19 @@ class AITest_ConcurrencyAndStops {
         Method factory = AI.class.getDeclaredMethod("createLazyWorkerRng", SearchTask.class, int.class);
         factory.setAccessible(true);
 
-        SplittableRandom leader = (SplittableRandom) factory.invoke(ai, task, 0);
-        assertNull(leader, "Leader thread should not randomize search parameters");
+        SplittableRandom leader = (SplittableRandom) factory.invoke(ai, task, 2);
+        assertNull(leader, "First worker to claim leadership should not randomize search parameters");
 
         long baseSeed = task.getBoardHash();
-        SplittableRandom followerOne = (SplittableRandom) factory.invoke(ai, task, 1);
+        SplittableRandom followerOne = (SplittableRandom) factory.invoke(ai, task, 0);
         assertNotNull(followerOne, "Follower threads should receive an RNG");
-        SplittableRandom expectedOne = new SplittableRandom(baseSeed ^ (0x9E3779B97F4A7C15L * 2L));
+        SplittableRandom expectedOne = new SplittableRandom(baseSeed ^ (0x9E3779B97F4A7C15L * 1L));
         assertEquals(expectedOne.nextLong(), followerOne.nextLong(),
-                "Follower one should use deterministic diversification seed");
+                "Follower one should use deterministic diversification seed based on its index");
 
-        SplittableRandom followerTwo = (SplittableRandom) factory.invoke(ai, task, 2);
+        SplittableRandom followerTwo = (SplittableRandom) factory.invoke(ai, task, 1);
         assertNotNull(followerTwo, "Additional followers should also receive RNGs");
-        SplittableRandom expectedTwo = new SplittableRandom(baseSeed ^ (0x9E3779B97F4A7C15L * 3L));
+        SplittableRandom expectedTwo = new SplittableRandom(baseSeed ^ (0x9E3779B97F4A7C15L * 2L));
         assertEquals(expectedTwo.nextLong(), followerTwo.nextLong(),
                 "Follower two should use a unique deterministic seed");
 


### PR DESCRIPTION
## Summary
- track lazy SMP leadership within `SearchTask` and update the worker RNG helper so only non-leaders randomize their searches
- adjust the concurrency diagnostics to assert the new leader-claim semantics and keep RNG seeds deterministic per worker index
- document the lazy SMP leader bug and fix details in `Agents.md`

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITest_ConcurrencyAndStops#lazySmpLeaderRemainsDeterministic test

------
https://chatgpt.com/codex/tasks/task_e_68e426f77d80832a9134f959aa3433a9