### PR TITLE
Balance root parallel helpers across lazy SMP workers

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -115,3 +115,4 @@ Agents should compute `S, L, R, TT` via the heuristics above and substitute into
 ### AI search & evaluation notes
 * Quiescence delta pruning now compares against the alpha window captured before the stand-pat update. Earlier builds raised `alpha` first, which meant `standPat + Δ < alpha` never triggered and the pruning shortcut was effectively disabled.
 * Static evaluation adds a lightweight knight placement adjustment (central bonuses) plus a tempo tie-breaker on top of the pipeline score. Future positional tweaks should extend `computePositionalAdjustment` so the orientation logic stays centralised.
+* Mixed parallelism fix: lazy SMP workers now split the shared root helper pool instead of each requesting the full `searchThreads` capacity. Earlier builds over-subscribed the helper executor which throttled depth and caused additional `BestMoveSearchTest` regressions when both modes were enabled.

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -59,6 +59,7 @@ public class AI {
 
     private final AtomicReference<SearchTask> activeSearch = new AtomicReference<>();
     private final ThreadLocal<SearchTask> threadSearchTask = new ThreadLocal<>();
+    private final ThreadLocal<Integer> lazyWorkerSlot = new ThreadLocal<>();
     private final AtomicLong searchIdGenerator = new AtomicLong();
     private final Object searchConfigLock = new Object();
     private boolean reconfiguringSearchThreads = false;
@@ -605,43 +606,48 @@ public class AI {
             return;
         }
 
-        while (!Thread.currentThread().isInterrupted()) {
-            SearchJob job;
-            try {
-                job = searchJobs.take();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
+        lazyWorkerSlot.set(workerIndex);
+        try {
+            while (!Thread.currentThread().isInterrupted()) {
+                SearchJob job;
+                try {
+                    job = searchJobs.take();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
 
-            if (job.stop || !keepCalculating) {
-                break;
-            }
+                if (job.stop || !keepCalculating) {
+                    break;
+                }
 
-            SearchTask task = job.task;
-            if (task == null) {
-                continue;
-            }
+                SearchTask task = job.task;
+                if (task == null) {
+                    continue;
+                }
 
-            try {
-                simulator.copyFrom(task.getRootSnapshot());
-            } catch (RuntimeException e) {
-                log.error("Failed to sync simulation for worker {}", workerIndex, e);
-                task.workerDone();
-                continue;
-            }
+                try {
+                    simulator.copyFrom(task.getRootSnapshot());
+                } catch (RuntimeException e) {
+                    log.error("Failed to sync simulation for worker {}", workerIndex, e);
+                    task.workerDone();
+                    continue;
+                }
 
-            SplittableRandom rng = createLazyWorkerRng(task, workerIndex);
+                SplittableRandom rng = createLazyWorkerRng(task, workerIndex);
 
-            threadSearchTask.set(task);
-            try {
-                iterativeDeepening(task, simulator, rng);
-            } catch (Exception e) {
-                log.error("Search worker {} encountered an error", workerIndex, e);
-            } finally {
-                threadSearchTask.remove();
-                task.workerDone();
+                threadSearchTask.set(task);
+                try {
+                    iterativeDeepening(task, simulator, rng);
+                } catch (Exception e) {
+                    log.error("Search worker {} encountered an error", workerIndex, e);
+                } finally {
+                    threadSearchTask.remove();
+                    task.workerDone();
+                }
             }
+        } finally {
+            lazyWorkerSlot.remove();
         }
     }
 
@@ -897,11 +903,13 @@ public class AI {
                     ? new SplittableRandom(boardStateHash ^ System.nanoTime())
                     : null;
 
+            lazyWorkerSlot.set(0);
             threadSearchTask.set(task);
             try {
                 iterativeDeepening(task, simulatorEngine, rng);
             } finally {
                 threadSearchTask.remove();
+                lazyWorkerSlot.remove();
             }
 
             task.workerDone();
@@ -1289,7 +1297,12 @@ public class AI {
             return getBestMove(simulatorEngine, isWhitesTurn, depth, deadline, alpha, beta, rng);
         }
 
-        final int fanout = helperCapacity > 0 ? Math.min(baseFanout, helperCapacity) : baseFanout;
+        int helpersPerWorker = perWorkerHelperBudget(helperCapacity, lazySmpThreads, lazyWorkerSlot.get());
+        if (helpersPerWorker <= 0 && baseFanout > 0) {
+            return getBestMove(simulatorEngine, isWhitesTurn, depth, deadline, alpha, beta, rng);
+        }
+
+        final int fanout = Math.min(baseFanout, helpersPerWorker);
 
         maybeRotateRootMoves(orderedMoves, rng);
 
@@ -1543,6 +1556,24 @@ public class AI {
             aborted = true;
         }
         return aborted ? RootSearchResult.aborted(candidate) : RootSearchResult.completed(candidate);
+    }
+
+    static int perWorkerHelperBudget(int helperCapacity, int lazyWorkers, Integer workerIndex) {
+        if (helperCapacity <= 0) {
+            return 0;
+        }
+        int workers = Math.max(1, lazyWorkers);
+        int index = workerIndex == null ? 0 : Math.max(0, workerIndex);
+        if (index >= workers) {
+            index = workers - 1;
+        }
+        int baseShare = helperCapacity / workers;
+        int remainder = helperCapacity % workers;
+        int budget = baseShare;
+        if (index < remainder) {
+            budget++;
+        }
+        return budget;
     }
 
 

--- a/src/test/java/julius/game/chessengine/ai/AIConcurrencyBudgetTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AIConcurrencyBudgetTest.java
@@ -1,0 +1,40 @@
+package julius.game.chessengine.ai;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AIConcurrencyBudgetTest {
+
+    @Test
+    void leaderGetsFullCapacityWhenNoLazyFollowers() {
+        assertEquals(8, AI.perWorkerHelperBudget(8, 1, null));
+        assertEquals(8, AI.perWorkerHelperBudget(8, 1, 0));
+    }
+
+    @Test
+    void helperCapacityIsSplitAcrossLazyWorkers() {
+        assertEquals(2, AI.perWorkerHelperBudget(5, 3, 0));
+        assertEquals(2, AI.perWorkerHelperBudget(5, 3, 1));
+        assertEquals(1, AI.perWorkerHelperBudget(5, 3, 2));
+    }
+
+    @Test
+    void workersBeyondCapacityReceiveZeroBudget() {
+        assertEquals(1, AI.perWorkerHelperBudget(2, 4, 0));
+        assertEquals(1, AI.perWorkerHelperBudget(2, 4, 1));
+        assertEquals(0, AI.perWorkerHelperBudget(2, 4, 2));
+        assertEquals(0, AI.perWorkerHelperBudget(2, 4, 3));
+    }
+
+    @Test
+    void zeroOrNegativeCapacityDisablesRootHelpers() {
+        assertEquals(0, AI.perWorkerHelperBudget(0, 3, 0));
+        assertEquals(0, AI.perWorkerHelperBudget(-2, 3, 1));
+    }
+
+    @Test
+    void indexesOutsideLazyRangeClampToLastWorker() {
+        assertEquals(2, AI.perWorkerHelperBudget(4, 2, 5));
+    }
+}


### PR DESCRIPTION
## Summary
- track the lazy SMP worker index so only a fair share of root helpers is consumed by each searcher
- split the shared helper pool across workers via `perWorkerHelperBudget` and cover it with a focused unit test
- document the mixed parallelism fix in Agents.md for future runs

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AIConcurrencyBudgetTest test

------
https://chatgpt.com/codex/tasks/task_e_68e426f77d80832a9134f959aa3433a9