### PR TITLE
Add space control evaluation module and tuning parameters

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -115,6 +115,7 @@ Agents should compute `S, L, R, TT` via the heuristics above and substitute into
 ### AI search & evaluation notes
 * Quiescence delta pruning now compares against the alpha window captured before the stand-pat update. Earlier builds raised `alpha` first, which meant `standPat + Δ < alpha` never triggered and the pruning shortcut was effectively disabled.
 * Static evaluation adds a lightweight knight placement adjustment (central bonuses) plus a tempo tie-breaker on top of the pipeline score. Future positional tweaks should extend `computePositionalAdjustment` so the orientation logic stays centralised.
+* Space control is handled by `SpaceControlModule`, which blends safe territory, pawn-supported outposts, and cramping pressure. Add new space-related tunables via `ParamId` and mirror the defaults in `tuning/seed-tunings.yaml` whenever you extend this module.
 * Aspiration windows now derive their initial span from recent score volatility and decay as searches stabilise. Repeated fail-high/low streaks widen the relevant side of the window more aggressively before conceding to a full-window retry, reducing the number of depth≥3 re-searches that fall back immediately to `(-∞, +∞)`.
 
 ### 2025-10-07 Time management + evaluation notes

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationParameterRegistry.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationParameterRegistry.java
@@ -22,6 +22,7 @@ public final class EvaluationParameterRegistry {
         initialize(PawnStructureModule.class);
         initialize(ActivityModule.class);
         initialize(KingSafetyModule.class);
+        initialize(SpaceControlModule.class);
         initialize(ThreatModule.class);
         initialize(EvaluationPipeline.class);
     }

--- a/src/main/java/julius/game/chessengine/evaluation/SpaceControlModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/SpaceControlModule.java
@@ -1,0 +1,160 @@
+package julius.game.chessengine.evaluation;
+
+import julius.game.chessengine.helper.BitHelper;
+import julius.game.chessengine.tuning.Tuning;
+
+import java.util.Objects;
+
+/**
+ * Measures safe territory, outposts, and cramping pressure to capture long-term space advantages
+ * that are not fully reflected in mobility or pawn-structure scores.
+ */
+public final class SpaceControlModule implements EvaluationModule {
+
+    private static final long FILE_A = BitHelper.FileMasks[0];
+    private static final long FILE_H = BitHelper.FileMasks[7];
+
+    private static final long WHITE_FRONT_HALF = BitHelper.RankMasks[4]
+            | BitHelper.RankMasks[5]
+            | BitHelper.RankMasks[6]
+            | BitHelper.RankMasks[7];
+    private static final long BLACK_FRONT_HALF = BitHelper.RankMasks[0]
+            | BitHelper.RankMasks[1]
+            | BitHelper.RankMasks[2]
+            | BitHelper.RankMasks[3];
+
+    private static final long WHITE_HOME_HALF = BitHelper.RankMasks[0]
+            | BitHelper.RankMasks[1]
+            | BitHelper.RankMasks[2]
+            | BitHelper.RankMasks[3];
+    private static final long BLACK_HOME_HALF = BitHelper.RankMasks[4]
+            | BitHelper.RankMasks[5]
+            | BitHelper.RankMasks[6]
+            | BitHelper.RankMasks[7];
+
+    private static final long WHITE_OUTPOST_MASK = BitHelper.RankMasks[3]
+            | BitHelper.RankMasks[4]
+            | BitHelper.RankMasks[5];
+    private static final long BLACK_OUTPOST_MASK = BitHelper.RankMasks[2]
+            | BitHelper.RankMasks[3]
+            | BitHelper.RankMasks[4];
+
+    private int midgameScore;
+    private int endgameScore;
+    private boolean dirty = true;
+    private boolean initialized;
+
+    @Override
+    public void initialize(EvaluationContext context) {
+        recompute(Objects.requireNonNull(context, "context"));
+        initialized = true;
+    }
+
+    @Override
+    public void evaluate(EvaluationContext context) {
+        if (!dirty) {
+            return;
+        }
+        recompute(Objects.requireNonNull(context, "context"));
+    }
+
+    @Override
+    public void applyMove(MoveContext moveContext) {
+        Objects.requireNonNull(moveContext, "moveContext");
+        if (!ensureInitialized(moveContext)) {
+            return;
+        }
+        dirty = true;
+    }
+
+    @Override
+    public void undoMove(MoveContext moveContext) {
+        Objects.requireNonNull(moveContext, "moveContext");
+        applyMove(moveContext);
+    }
+
+    @Override
+    public int getMidgameScore() {
+        return midgameScore;
+    }
+
+    @Override
+    public int getEndgameScore() {
+        return endgameScore;
+    }
+
+    @Override
+    public boolean isDirty() {
+        return dirty;
+    }
+
+    @Override
+    public void markDirty() {
+        dirty = true;
+    }
+
+    private void recompute(EvaluationContext context) {
+        long whiteAttack = context.getWhiteAttackMap();
+        long blackAttack = context.getBlackAttackMap();
+        long emptySquares = ~context.getAllPieces();
+
+        long whiteSafe = WHITE_FRONT_HALF & emptySquares & whiteAttack & ~blackAttack;
+        long blackSafe = BLACK_FRONT_HALF & emptySquares & blackAttack & ~whiteAttack;
+        int safeDelta = Long.bitCount(whiteSafe) - Long.bitCount(blackSafe);
+
+        long whiteCramped = WHITE_HOME_HALF & blackAttack & ~whiteAttack;
+        long blackCramped = BLACK_HOME_HALF & whiteAttack & ~blackAttack;
+        int crampDelta = Long.bitCount(blackCramped) - Long.bitCount(whiteCramped);
+
+        long whitePawnAttacks = computeWhitePawnAttacks(context.getWhitePawns());
+        long blackPawnAttacks = computeBlackPawnAttacks(context.getBlackPawns());
+
+        long whiteOutpostCandidates = (context.getWhiteKnights() | context.getWhiteBishops())
+                & WHITE_OUTPOST_MASK;
+        long blackOutpostCandidates = (context.getBlackKnights() | context.getBlackBishops())
+                & BLACK_OUTPOST_MASK;
+
+        int whiteOutposts = countOutposts(whiteOutpostCandidates, whitePawnAttacks, blackPawnAttacks);
+        int blackOutposts = countOutposts(blackOutpostCandidates, blackPawnAttacks, whitePawnAttacks);
+        int outpostDelta = whiteOutposts - blackOutposts;
+
+        midgameScore = safeDelta * Tuning.spaceSafeSquareMidgame()
+                + crampDelta * Tuning.spaceCrampMidgame()
+                + outpostDelta * Tuning.spaceOutpostMidgame();
+        endgameScore = safeDelta * Tuning.spaceSafeSquareEndgame()
+                + crampDelta * Tuning.spaceCrampEndgame()
+                + outpostDelta * Tuning.spaceOutpostEndgame();
+
+        dirty = false;
+    }
+
+    private boolean ensureInitialized(MoveContext moveContext) {
+        if (initialized) {
+            return true;
+        }
+        EvaluationContext context = moveContext.getCurrentContext();
+        if (context == null) {
+            return false;
+        }
+        initialize(context);
+        return true;
+    }
+
+    private static int countOutposts(long candidates, long friendlyPawnAttacks, long enemyPawnAttacks) {
+        long supported = candidates & friendlyPawnAttacks;
+        long safeFromEnemyPawns = supported & ~enemyPawnAttacks;
+        return Long.bitCount(safeFromEnemyPawns);
+    }
+
+    private static long computeWhitePawnAttacks(long pawns) {
+        long west = (pawns << 7) & ~FILE_H;
+        long east = (pawns << 9) & ~FILE_A;
+        return west | east;
+    }
+
+    private static long computeBlackPawnAttacks(long pawns) {
+        long west = (pawns >>> 7) & ~FILE_A;
+        long east = (pawns >>> 9) & ~FILE_H;
+        return west | east;
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/ParamId.java
+++ b/src/main/java/julius/game/chessengine/tuning/ParamId.java
@@ -70,6 +70,13 @@ public enum ParamId {
     THREAT_PAWN_THREAT_ROOK_PENALTY("threat.pawnThreatRookPenalty", -18),
     THREAT_PAWN_THREAT_QUEEN_PENALTY("threat.pawnThreatQueenPenalty", -25),
 
+    SPACE_SAFE_SQUARE_MIDGAME("space.safeSquareMidgame", 6),
+    SPACE_SAFE_SQUARE_ENDGAME("space.safeSquareEndgame", 4),
+    SPACE_OUTPOST_MIDGAME("space.outpostMidgame", 12),
+    SPACE_OUTPOST_ENDGAME("space.outpostEndgame", 8),
+    SPACE_CRAMP_MIDGAME("space.crampMidgame", 5),
+    SPACE_CRAMP_ENDGAME("space.crampEndgame", 3),
+
     EVALUATION_BLEND_SCALE("evaluation.blendScale", 256, 1.0, 1024.0),
 
     MOVE_ORDERING_KILLER_MOVE_SCORE("moveOrdering.killerMoveScore", 10_000),

--- a/src/main/java/julius/game/chessengine/tuning/Tuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/Tuning.java
@@ -74,6 +74,13 @@ public final class Tuning {
     private static int pawnThreatRookPenalty;
     private static int pawnThreatQueenPenalty;
 
+    private static int spaceSafeSquareMidgame;
+    private static int spaceSafeSquareEndgame;
+    private static int spaceOutpostMidgame;
+    private static int spaceOutpostEndgame;
+    private static int spaceCrampMidgame;
+    private static int spaceCrampEndgame;
+
     private static int developmentPhaseThreshold;
     private static int queenDevelopmentPhaseThreshold;
     private static int undevelopedMinorPenalty;
@@ -341,6 +348,30 @@ public final class Tuning {
         return pawnThreatQueenPenalty;
     }
 
+    public static int spaceSafeSquareMidgame() {
+        return spaceSafeSquareMidgame;
+    }
+
+    public static int spaceSafeSquareEndgame() {
+        return spaceSafeSquareEndgame;
+    }
+
+    public static int spaceOutpostMidgame() {
+        return spaceOutpostMidgame;
+    }
+
+    public static int spaceOutpostEndgame() {
+        return spaceOutpostEndgame;
+    }
+
+    public static int spaceCrampMidgame() {
+        return spaceCrampMidgame;
+    }
+
+    public static int spaceCrampEndgame() {
+        return spaceCrampEndgame;
+    }
+
     public static int developmentPhaseThreshold() {
         return developmentPhaseThreshold;
     }
@@ -479,6 +510,13 @@ public final class Tuning {
             pawnThreatBishopPenalty = loadInt(ParamId.THREAT_PAWN_THREAT_BISHOP_PENALTY);
             pawnThreatRookPenalty = loadInt(ParamId.THREAT_PAWN_THREAT_ROOK_PENALTY);
             pawnThreatQueenPenalty = loadInt(ParamId.THREAT_PAWN_THREAT_QUEEN_PENALTY);
+
+            spaceSafeSquareMidgame = loadInt(ParamId.SPACE_SAFE_SQUARE_MIDGAME);
+            spaceSafeSquareEndgame = loadInt(ParamId.SPACE_SAFE_SQUARE_ENDGAME);
+            spaceOutpostMidgame = loadInt(ParamId.SPACE_OUTPOST_MIDGAME);
+            spaceOutpostEndgame = loadInt(ParamId.SPACE_OUTPOST_ENDGAME);
+            spaceCrampMidgame = loadInt(ParamId.SPACE_CRAMP_MIDGAME);
+            spaceCrampEndgame = loadInt(ParamId.SPACE_CRAMP_ENDGAME);
 
             evaluationBlendScale = loadInt(ParamId.EVALUATION_BLEND_SCALE);
 

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -11,6 +11,7 @@ import julius.game.chessengine.evaluation.KingSafetyModule;
 import julius.game.chessengine.evaluation.MaterialModule;
 import julius.game.chessengine.evaluation.MoveContext;
 import julius.game.chessengine.evaluation.PawnStructureModule;
+import julius.game.chessengine.evaluation.SpaceControlModule;
 import julius.game.chessengine.evaluation.ThreatModule;
 import julius.game.chessengine.tuning.EngineTuningBootstrap;
 import julius.game.chessengine.tuning.MoveOrderingParameters;
@@ -43,6 +44,7 @@ public class Score {
     private final PawnStructureModule pawnStructureModule = new PawnStructureModule();
     private final ActivityModule activityModule = new ActivityModule();
     private final KingSafetyModule kingSafetyModule = new KingSafetyModule();
+    private final SpaceControlModule spaceControlModule = new SpaceControlModule();
     private final ThreatModule threatModule = new ThreatModule();
 
     @JsonIgnore
@@ -64,6 +66,7 @@ public class Score {
                 materialModule,
                 pawnStructureModule,
                 activityModule,
+                spaceControlModule,
                 kingSafetyModule,
                 threatModule
         ), this.weights);

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -17,6 +17,9 @@ population:
         threatmodule:
           midgame: 1.0
           endgame: 1.0
+        spacecontrolmodule:
+          midgame: 1.0
+          endgame: 1.0
     numericParameters:
       evaluation.blendscale: 320
       material.pawnvalue: 100
@@ -47,6 +50,12 @@ population:
       threat.pawnthreatbishoppenalty: -12
       threat.pawnthreatrookpenalty: -22
       threat.pawnthreatqueenpenalty: -30
+      space.safesquaremidgame: 6
+      space.safesquareendgame: 4
+      space.outpostmidgame: 12
+      space.outpostendgame: 8
+      space.crampmidgame: 5
+      space.crampendgame: 3
       activity.midgamemobilityknight: 4
       activity.midgamemobilitybishop: 7
       activity.midgamemobilityrook: 3

--- a/src/test/java/julius/game/chessengine/evaluation/EvaluationModuleTuningAlignmentTest.java
+++ b/src/test/java/julius/game/chessengine/evaluation/EvaluationModuleTuningAlignmentTest.java
@@ -81,7 +81,13 @@ class EvaluationModuleTuningAlignmentTest {
                 Map.entry("activity.midgamemobilityknight", Tuning::activityMidgameKnightMobility),
                 Map.entry("kingsafety.missingpawnshieldpenalty", Tuning::missingPawnShieldPenalty),
                 Map.entry("kingsafety.attackweightqueen", Tuning::kingSafetyQueenAttackWeight),
-                Map.entry("evaluation.blendscale", Tuning::evaluationBlendScale)
+                Map.entry("evaluation.blendscale", Tuning::evaluationBlendScale),
+                Map.entry("space.safesquaremidgame", Tuning::spaceSafeSquareMidgame),
+                Map.entry("space.safesquareendgame", Tuning::spaceSafeSquareEndgame),
+                Map.entry("space.outpostmidgame", Tuning::spaceOutpostMidgame),
+                Map.entry("space.outpostendgame", Tuning::spaceOutpostEndgame),
+                Map.entry("space.crampmidgame", Tuning::spaceCrampMidgame),
+                Map.entry("space.crampendgame", Tuning::spaceCrampEndgame)
         );
 
         trackedParameters.forEach((key, supplier) -> {
@@ -263,6 +269,7 @@ class EvaluationModuleTuningAlignmentTest {
                 material,
                 pawnStructure,
                 new ActivityModule(),
+                new SpaceControlModule(),
                 new KingSafetyModule(),
                 new ThreatModule()
         );

--- a/src/test/java/julius/game/chessengine/evaluation/SpaceControlModuleTest.java
+++ b/src/test/java/julius/game/chessengine/evaluation/SpaceControlModuleTest.java
@@ -1,0 +1,36 @@
+package julius.game.chessengine.evaluation;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.engine.GameStateEnum;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpaceControlModuleTest {
+
+    private static final String WHITE_SPACE_ADVANTAGE =
+            "4k3/8/8/8/2PP4/2N5/PP3PPP/4K3 w - - 0 1";
+    private static final String BLACK_SPACE_ADVANTAGE =
+            "4k3/ppp3pp/2n5/2pp4/8/8/8/4K3 w - - 0 1";
+
+    @Test
+    void spaceControlRewardsWhiteTerritorialEdge() {
+        int spacious = blendedScore(WHITE_SPACE_ADVANTAGE);
+        int cramped = blendedScore(BLACK_SPACE_ADVANTAGE);
+
+        assertThat(spacious).isPositive();
+        assertThat(cramped).isNegative();
+        assertThat(spacious).isGreaterThan(cramped);
+    }
+
+    private static int blendedScore(String fen) {
+        BitBoard board = FEN.translateFENtoBitBoard(fen);
+        SpaceControlModule module = new SpaceControlModule();
+        EvaluationPipeline pipeline = new EvaluationPipeline(List.of(module));
+        pipeline.initialize(EvaluationContext.from(board, GameStateEnum.PLAY));
+        return pipeline.getBlendedScore();
+    }
+}

--- a/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
+++ b/src/test/java/julius/game/chessengine/utils/ScoreEvaluationTest.java
@@ -13,6 +13,8 @@ import julius.game.chessengine.evaluation.MaterialModule;
 import julius.game.chessengine.evaluation.PawnStructureModule;
 import julius.game.chessengine.evaluation.KingSafetyModule.KingSafetyView;
 import julius.game.chessengine.evaluation.PawnStructureModule.PawnStructureView;
+import julius.game.chessengine.evaluation.SpaceControlModule;
+import julius.game.chessengine.evaluation.ThreatModule;
 import julius.game.chessengine.figures.PieceType;
 import org.junit.jupiter.api.Test;
 
@@ -169,7 +171,9 @@ public class ScoreEvaluationTest {
                 material,
                 pawns,
                 activity,
-                kingSafety
+                new SpaceControlModule(),
+                kingSafety,
+                new ThreatModule()
         ));
         pipeline.initialize(EvaluationContext.from(board, state));
         return new ScoreSnapshot(


### PR DESCRIPTION
## Summary
- add a dedicated `SpaceControlModule` that scores safe territory, pawn-supported outposts, and cramping pressure for both phases
- integrate the module into `Score`, register its parameters, and expose tapered numeric knobs through tuning plus seed defaults
- extend evaluation tests, add targeted coverage for space control, and document the new module guidance in `Agents.md`

## Testing
- `mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" test` *(aborted after extended `BestMoveSearchTest` diagnostics; known long-running failures)*
- `mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=SpaceControlModuleTest test`


------
https://chatgpt.com/codex/tasks/task_e_68e54f0c75e0832ab96deaacb14072e1