### PR TITLE
Refactor pawn structure evaluation

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -1,13 +1,9 @@
 package julius.game.chessengine.evaluation;
 
-import julius.game.chessengine.board.BitBoard;
-import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.board.ImmutableBoardView;
-import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.helper.PawnHelper;
 import julius.game.chessengine.tuning.Tuning;
 
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -25,18 +21,59 @@ import static julius.game.chessengine.helper.PawnMoveTables.PAWN_PUSHES;
 public final class PawnStructureModule implements EvaluationModule, MaterialModule.PawnChangeListener {
     private static final int WHITE = 0;
     private static final int BLACK = 1;
-    private static final int PAWN = MoveHelper.pieceTypeToInt(PieceType.PAWN);
+    private static final long WHITE_ADVANCED_RANKS = RankMasks[3] | RankMasks[4] | RankMasks[5] | RankMasks[6];
+    private static final long BLACK_ADVANCED_RANKS = RankMasks[4] | RankMasks[3] | RankMasks[2] | RankMasks[1];
+
+    private static final long[] ADJACENT_FILE_MASKS = new long[64];
+    private static final long[] FORWARD_RANK_MASKS_WHITE = new long[64];
+    private static final long[] FORWARD_RANK_MASKS_BLACK = new long[64];
+    private static final int[] PASSED_RANK_WEIGHT_WHITE = new int[64];
+    private static final int[] PASSED_RANK_WEIGHT_BLACK = new int[64];
+    private static final int[] DISTANCE_TO_PROMOTION_WHITE = new int[64];
+    private static final int[] DISTANCE_TO_PROMOTION_BLACK = new int[64];
+    private static final int[] ADVANCED_RANK_WEIGHT_WHITE = new int[64];
+    private static final int[] ADVANCED_RANK_WEIGHT_BLACK = new int[64];
+
+    static {
+        for (int square = 0; square < 64; square++) {
+            int file = square & 7;
+            long adjacent = FileMasks[file];
+            if (file > 0) {
+                adjacent |= FileMasks[file - 1];
+            }
+            if (file < 7) {
+                adjacent |= FileMasks[file + 1];
+            }
+            ADJACENT_FILE_MASKS[square] = adjacent;
+
+            int rankZero = square >>> 3;
+            int rankIndex = rankZero + 1;
+
+            long forwardWhite = 0L;
+            for (int r = rankZero + 1; r < 8; r++) {
+                forwardWhite |= RankMasks[r];
+            }
+            long forwardBlack = 0L;
+            for (int r = rankZero - 1; r >= 0; r--) {
+                forwardBlack |= RankMasks[r];
+            }
+            FORWARD_RANK_MASKS_WHITE[square] = forwardWhite;
+            FORWARD_RANK_MASKS_BLACK[square] = forwardBlack;
+
+            PASSED_RANK_WEIGHT_WHITE[square] = rankIndex - 1;
+            PASSED_RANK_WEIGHT_BLACK[square] = 8 - rankIndex;
+            DISTANCE_TO_PROMOTION_WHITE[square] = 8 - rankIndex;
+            DISTANCE_TO_PROMOTION_BLACK[square] = rankIndex - 1;
+            ADVANCED_RANK_WEIGHT_WHITE[square] = Math.max(0, rankIndex - 3);
+            ADVANCED_RANK_WEIGHT_BLACK[square] = Math.max(0, 6 - rankIndex);
+        }
+    }
 
     private final ConcurrentMap<PawnStructureKey, CachedStructure> structureCache = new ConcurrentHashMap<>();
 
-    private final FileState[] fileStates = new FileState[8];
-    private final boolean[] dirtyFiles = new boolean[8];
-
-    private PawnStructureView currentView = PawnStructureView.empty();
     private int midgameScoreCache;
     private int endgameScoreCache;
     private boolean dirty = true;
-    private boolean metadataDirty = true;
 
     private final int centerPawnBonus;
     private final int passedPawnBonus;
@@ -53,235 +90,129 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     private final int rookOpenFileBonus;
 
     public PawnStructureModule() {
-        this.centerPawnBonus = centerPawnBonus();
-        this.passedPawnBonus = passedPawnBonus();
-        this.connectedPawnBonus = connectedPawnBonus();
-        this.pawnIslandPenalty = pawnIslandPenalty();
-        this.doubledPawnPenalty = doubledPawnPenalty();
-        this.isolatedPawnPenalty = isolatedPawnPenalty();
-        this.advancedPawnBonus = advancedPawnBonus();
-        this.blockedPawnPenalty = blockedPawnPenalty();
-        this.backwardPawnPenalty = backwardPawnPenalty();
-        this.ownKingBlocksPassedPawnPenalty = ownKingBlocksPassedPawnPenalty();
-        this.passedPawnFreePathBonusPerRank = passedPawnFreePathBonusPerRank();
-        this.rookHalfOpenFileBonus = rookHalfOpenFileBonus();
-        this.rookOpenFileBonus = rookOpenFileBonus();
-        for (int file = 0; file < fileStates.length; file++) {
-            fileStates[file] = new FileState(file);
-            dirtyFiles[file] = true;
-        }
-    }
-
-    public static int centerPawnBonus() {
-        return Tuning.centerPawnBonus();
-    }
-
-    public static int passedPawnBonus() {
-        return Tuning.passedPawnBonus();
-    }
-
-    public static int connectedPawnBonus() {
-        return Tuning.connectedPawnBonus();
-    }
-
-    public static int pawnIslandPenalty() {
-        return Tuning.pawnIslandPenalty();
-    }
-
-    public static int doubledPawnPenalty() {
-        return Tuning.doubledPawnPenalty();
-    }
-
-    public static int isolatedPawnPenalty() {
-        return Tuning.isolatedPawnPenalty();
-    }
-
-    public static int advancedPawnBonus() {
-        return Tuning.advancedPawnBonus();
-    }
-
-    public static int blockedPawnPenalty() {
-        return Tuning.blockedPawnPenalty();
-    }
-
-    public static int backwardPawnPenalty() {
-        return Tuning.backwardPawnPenalty();
-    }
-
-    public static int ownKingBlocksPassedPawnPenalty() {
-        return Tuning.ownKingBlocksPassedPawnPenalty();
-    }
-
-    public static int passedPawnFreePathBonusPerRank() {
-        return Tuning.passedPawnFreePathBonusPerRank();
-    }
-
-    public static int rookHalfOpenFileBonus() {
-        return Tuning.rookHalfOpenFileBonus();
-    }
-
-    public static int rookOpenFileBonus() {
-        return Tuning.rookOpenFileBonus();
+        this.centerPawnBonus = Tuning.centerPawnBonus();
+        this.passedPawnBonus = Tuning.passedPawnBonus();
+        this.connectedPawnBonus = Tuning.connectedPawnBonus();
+        this.pawnIslandPenalty = Tuning.pawnIslandPenalty();
+        this.doubledPawnPenalty = Tuning.doubledPawnPenalty();
+        this.isolatedPawnPenalty = Tuning.isolatedPawnPenalty();
+        this.advancedPawnBonus = Tuning.advancedPawnBonus();
+        this.blockedPawnPenalty = Tuning.blockedPawnPenalty();
+        this.backwardPawnPenalty = Tuning.backwardPawnPenalty();
+        this.ownKingBlocksPassedPawnPenalty = Tuning.ownKingBlocksPassedPawnPenalty();
+        this.passedPawnFreePathBonusPerRank = Tuning.passedPawnFreePathBonusPerRank();
+        this.rookHalfOpenFileBonus = Tuning.rookHalfOpenFileBonus();
+        this.rookOpenFileBonus = Tuning.rookOpenFileBonus();
     }
 
     @Override
     public void initialize(EvaluationContext context) {
-        markAllFilesDirty();
         evaluateContext(Objects.requireNonNull(context, "context"));
     }
 
     @Override
     public void evaluate(EvaluationContext context) {
-        evaluateContext(Objects.requireNonNull(context, "context"));
+        Objects.requireNonNull(context, "context");
+        if (!dirty) {
+            return;
+        }
+        evaluateContext(context);
     }
 
-    private PawnStructureView evaluateContext(EvaluationContext context) {
-        if (context == null) {
-            currentView = PawnStructureView.empty();
-            midgameScoreCache = 0;
-            endgameScoreCache = 0;
-            dirty = false;
-            metadataDirty = false;
-            return currentView;
-        }
+    private void evaluateContext(EvaluationContext context) {
         ImmutableBoardView board = context.getBoardView();
         if (board == null) {
-            currentView = PawnStructureView.empty();
-            midgameScoreCache = 0;
-            endgameScoreCache = 0;
-            dirty = false;
-            metadataDirty = false;
-            return currentView;
-        }
-        refreshFileMetadata(board);
-        if (!dirty) {
-            return currentView;
+            reset();
+            return;
         }
 
         long whitePawns = board.getWhitePawns();
         long blackPawns = board.getBlackPawns();
+        long allPawns = whitePawns | blackPawns;
         long allPieces = board.getAllPieces();
         long whiteRooks = board.getWhiteRooks();
         long blackRooks = board.getBlackRooks();
-        long whiteAttacks = context.getWhiteAttackMap();
-        long blackAttacks = context.getBlackAttackMap();
         long whiteKing = board.getWhiteKing();
         long blackKing = board.getBlackKing();
+        long whiteAttacks = context.getWhiteAttackMap();
+        long blackAttacks = context.getBlackAttackMap();
 
         CachedStructure structure = getStructure(whitePawns, blackPawns);
 
-        PhaseScore whiteCenter = PhaseScore.constant(structure.whiteCenterPawnBonus);
-        PhaseScore blackCenter = PhaseScore.constant(structure.blackCenterPawnBonus);
-        PhaseScore whiteDoubled = PhaseScore.constant(structure.whiteDoubledPawnPenalty);
-        PhaseScore blackDoubled = PhaseScore.constant(structure.blackDoubledPawnPenalty);
-        PhaseScore whiteIsolated = PhaseScore.constant(structure.whiteIsolatedPawnPenalty);
-        PhaseScore blackIsolated = PhaseScore.constant(structure.blackIsolatedPawnPenalty);
-        PhaseScore whiteConnected = PhaseScore.constant(structure.whiteConnectedPawnBonus);
-        PhaseScore blackConnected = PhaseScore.constant(structure.blackConnectedPawnBonus);
-        PhaseScore whiteIslands = PhaseScore.constant(structure.whitePawnIslandPenalty);
-        PhaseScore blackIslands = PhaseScore.constant(structure.blackPawnIslandPenalty);
+        int whiteHalfOpen = countHalfOpenFilesWithRooks(whiteRooks, whitePawns, blackPawns) * rookHalfOpenFileBonus;
+        int blackHalfOpen = countHalfOpenFilesWithRooks(blackRooks, blackPawns, whitePawns) * rookHalfOpenFileBonus;
+        int whiteOpenFiles = countOpenFilesWithRooks(whiteRooks, allPawns) * rookOpenFileBonus;
+        int blackOpenFiles = countOpenFilesWithRooks(blackRooks, allPawns) * rookOpenFileBonus;
 
-        PhaseScore whiteRookHalfOpen = PhaseScore.constant(
-                countHalfOpenFilesWithRooks(board, whiteRooks, true) * rookHalfOpenFileBonus);
-        PhaseScore blackRookHalfOpen = PhaseScore.constant(
-                countHalfOpenFilesWithRooks(board, blackRooks, false) * rookHalfOpenFileBonus);
+        int whitePassed = calculatePassedPawnBonus(whitePawns, blackPawns, allPieces, whiteKing, true);
+        int blackPassed = calculatePassedPawnBonus(blackPawns, whitePawns, allPieces, blackKing, false);
 
-        PhaseScore whiteRookOpen = PhaseScore.constant(
-                countOpenFilesWithRooks(board, whiteRooks) * rookOpenFileBonus);
-        PhaseScore blackRookOpen = PhaseScore.constant(
-                countOpenFilesWithRooks(board, blackRooks) * rookOpenFileBonus);
+        int whiteAdvanceBase = calculatePawnAdvanceBonus(whitePawns, allPieces, blackAttacks, true);
+        int blackAdvanceBase = calculatePawnAdvanceBonus(blackPawns, allPieces, whiteAttacks, false);
 
-        PhaseScore whitePassed = PhaseScore.constant(
-                calculatePassedPawnBonus(whitePawns, blackPawns, allPieces, whiteKing, true));
-        PhaseScore blackPassed = PhaseScore.constant(
-                calculatePassedPawnBonus(blackPawns, whitePawns, allPieces, blackKing, false));
+        int whiteBlockedBase = calculateBlockedPawnPenalty(whitePawns, allPieces, true);
+        int blackBlockedBase = calculateBlockedPawnPenalty(blackPawns, allPieces, false);
 
-        PhaseScore whiteAdvance = PhaseScore.of(
-                calculatePawnAdvanceBonus(whitePawns, allPieces, blackAttacks, true, 0),
-                calculatePawnAdvanceBonus(whitePawns, allPieces, blackAttacks, true, 256));
-        PhaseScore blackAdvance = PhaseScore.of(
-                calculatePawnAdvanceBonus(blackPawns, allPieces, whiteAttacks, false, 0),
-                calculatePawnAdvanceBonus(blackPawns, allPieces, whiteAttacks, false, 256));
+        int whiteBackwardBase = calculateBackwardPawnPenalty(whitePawns, blackPawns, allPieces, true, backwardPawnPenalty);
+        int blackBackwardBase = calculateBackwardPawnPenalty(blackPawns, whitePawns, allPieces, false, backwardPawnPenalty);
 
-        PhaseScore whiteBlocked = PhaseScore.of(
-                calculateBlockedPawnPenalty(whitePawns, allPieces, true, 0),
-                calculateBlockedPawnPenalty(whitePawns, allPieces, true, 256));
-        PhaseScore blackBlocked = PhaseScore.of(
-                calculateBlockedPawnPenalty(blackPawns, allPieces, false, 0),
-                calculateBlockedPawnPenalty(blackPawns, allPieces, false, 256));
+        int whiteMidgameTotal = structure.whiteCenterPawnBonus
+                + structure.whiteDoubledPawnPenalty
+                + structure.whiteIsolatedPawnPenalty
+                + structure.whiteConnectedPawnBonus
+                + whiteHalfOpen
+                + whiteOpenFiles
+                + structure.whitePawnIslandPenalty
+                + whitePassed
+                + whiteAdvanceBase
+                + whiteBlockedBase
+                + whiteBackwardBase;
 
-        PhaseScore whiteBackward = PhaseScore.of(
-                calculateBackwardPawnPenalty(whitePawns, blackPawns, allPieces, true, 0, backwardPawnPenalty),
-                calculateBackwardPawnPenalty(whitePawns, blackPawns, allPieces, true, 256, backwardPawnPenalty));
-        PhaseScore blackBackward = PhaseScore.of(
-                calculateBackwardPawnPenalty(blackPawns, whitePawns, allPieces, false, 0, backwardPawnPenalty),
-                calculateBackwardPawnPenalty(blackPawns, whitePawns, allPieces, false, 256, backwardPawnPenalty));
+        int whiteEndgameTotal = structure.whiteCenterPawnBonus
+                + structure.whiteDoubledPawnPenalty
+                + structure.whiteIsolatedPawnPenalty
+                + structure.whiteConnectedPawnBonus
+                + whiteHalfOpen
+                + whiteOpenFiles
+                + structure.whitePawnIslandPenalty
+                + whitePassed
+                + scaleEndgame(whiteAdvanceBase)
+                + scaleEndgame(whiteBlockedBase)
+                + scaleEndgame(whiteBackwardBase);
 
-        PhaseScore[] whiteComponents = new PhaseScore[]{
-                whiteCenter,
-                whiteDoubled,
-                whiteIsolated,
-                whiteConnected,
-                whiteRookHalfOpen,
-                whiteRookOpen,
-                whiteIslands,
-                whitePassed,
-                whiteAdvance,
-                whiteBlocked,
-                whiteBackward
-        };
-        PhaseScore[] blackComponents = new PhaseScore[]{
-                blackCenter,
-                blackDoubled,
-                blackIsolated,
-                blackConnected,
-                blackRookHalfOpen,
-                blackRookOpen,
-                blackIslands,
-                blackPassed,
-                blackAdvance,
-                blackBlocked,
-                blackBackward
-        };
+        int blackMidgameTotal = structure.blackCenterPawnBonus
+                + structure.blackDoubledPawnPenalty
+                + structure.blackIsolatedPawnPenalty
+                + structure.blackConnectedPawnBonus
+                + blackHalfOpen
+                + blackOpenFiles
+                + structure.blackPawnIslandPenalty
+                + blackPassed
+                + blackAdvanceBase
+                + blackBlockedBase
+                + blackBackwardBase;
 
-        int whiteMidgameTotal = sumMidgame(whiteComponents);
-        int whiteEndgameTotal = sumEndgame(whiteComponents);
-        int blackMidgameTotal = sumMidgame(blackComponents);
-        int blackEndgameTotal = sumEndgame(blackComponents);
-
-        currentView = new PawnStructureView(
-                whiteCenter,
-                blackCenter,
-                whiteDoubled,
-                blackDoubled,
-                whiteIsolated,
-                blackIsolated,
-                whiteConnected,
-                blackConnected,
-                whiteRookHalfOpen,
-                blackRookHalfOpen,
-                whiteRookOpen,
-                blackRookOpen,
-                whiteIslands,
-                blackIslands,
-                whitePassed,
-                blackPassed,
-                whiteAdvance,
-                blackAdvance,
-                whiteBlocked,
-                blackBlocked,
-                whiteBackward,
-                blackBackward,
-                whiteMidgameTotal,
-                whiteEndgameTotal,
-                blackMidgameTotal,
-                blackEndgameTotal
-        );
+        int blackEndgameTotal = structure.blackCenterPawnBonus
+                + structure.blackDoubledPawnPenalty
+                + structure.blackIsolatedPawnPenalty
+                + structure.blackConnectedPawnBonus
+                + blackHalfOpen
+                + blackOpenFiles
+                + structure.blackPawnIslandPenalty
+                + blackPassed
+                + scaleEndgame(blackAdvanceBase)
+                + scaleEndgame(blackBlockedBase)
+                + scaleEndgame(blackBackwardBase);
 
         midgameScoreCache = whiteMidgameTotal - blackMidgameTotal;
         endgameScoreCache = whiteEndgameTotal - blackEndgameTotal;
         dirty = false;
-        return currentView;
+    }
+
+    private void reset() {
+        midgameScoreCache = 0;
+        endgameScoreCache = 0;
+        dirty = false;
     }
 
     @Override
@@ -312,156 +243,20 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     @Override
     public void markDirty() {
         dirty = true;
-        metadataDirty = true;
-        markAllFilesDirty();
     }
 
     @Override
     public void onPawnAdded(boolean isWhite, int squareIndex) {
-        markFileDirty(squareIndex & 7);
         dirty = true;
     }
 
     @Override
     public void onPawnRemoved(boolean isWhite, int squareIndex) {
-        markFileDirty(squareIndex & 7);
         dirty = true;
-    }
-
-    public PawnStructureView getView(BitBoard board) {
-        if (board == null) {
-            return evaluateContext(null);
-        }
-        EvaluationContext context = EvaluationContext.from(board, null);
-        return evaluateContext(context);
-    }
-
-    public int countHalfOpenFilesWithRooks(BitBoard board, long rooksBitboard, boolean isWhite) {
-        if (board == null) {
-            return 0;
-        }
-        return countHalfOpenFilesWithRooks(ImmutableBoardView.from(board), rooksBitboard, isWhite);
-    }
-
-    private int countHalfOpenFilesWithRooks(ImmutableBoardView board, long rooksBitboard, boolean isWhite) {
-        if (rooksBitboard == 0L) {
-            return 0;
-        }
-        refreshFileMetadata(board);
-        int count = 0;
-        for (int file = 0; file < 8; file++) {
-            long fileMask = FileMasks[file];
-            if ((rooksBitboard & fileMask) == 0) {
-                continue;
-            }
-            if (isWhite) {
-                if (fileStates[file].halfOpenForWhite) {
-                    count++;
-                }
-            } else {
-                if (fileStates[file].halfOpenForBlack) {
-                    count++;
-                }
-            }
-        }
-        return count;
-    }
-
-    public int countOpenFilesWithRooks(BitBoard board, long rooksBitboard) {
-        if (board == null) {
-            return 0;
-        }
-        return countOpenFilesWithRooks(ImmutableBoardView.from(board), rooksBitboard);
-    }
-
-    private int countOpenFilesWithRooks(ImmutableBoardView board, long rooksBitboard) {
-        if (rooksBitboard == 0L) {
-            return 0;
-        }
-        refreshFileMetadata(board);
-        int count = 0;
-        for (int file = 0; file < 8; file++) {
-            if ((rooksBitboard & FileMasks[file]) == 0) {
-                continue;
-            }
-            if (fileStates[file].open) {
-                count++;
-            }
-        }
-        return count;
     }
 
     private void handleMove(int move) {
         dirty = true;
-        int movedPiece = MoveHelper.derivePieceTypeBits(move);
-        int capturedPiece = MoveHelper.deriveCapturedPieceTypeBits(move);
-        int promotionPiece = MoveHelper.derivePromotionPieceTypeBits(move);
-
-        if (movedPiece == PAWN) {
-            markFileDirty(MoveHelper.deriveFromIndex(move) & 7);
-            markFileDirty(MoveHelper.deriveToIndex(move) & 7);
-            if (MoveHelper.isEnPassantMove(move)) {
-                int captureIndex = enPassantCaptureIndex(move);
-                markFileDirty(captureIndex & 7);
-            }
-        }
-        if (capturedPiece == PAWN) {
-            if (MoveHelper.isEnPassantMove(move)) {
-                int captureIndex = enPassantCaptureIndex(move);
-                markFileDirty(captureIndex & 7);
-            } else {
-                markFileDirty(MoveHelper.deriveToIndex(move) & 7);
-            }
-        }
-        if (promotionPiece != 0) {
-            markFileDirty(MoveHelper.deriveFromIndex(move) & 7);
-        }
-    }
-
-    private void refreshFileMetadata(ImmutableBoardView board) {
-        if (!metadataDirty || board == null) {
-            return;
-        }
-        long whitePawns = board.getWhitePawns();
-        long blackPawns = board.getBlackPawns();
-        boolean touched = false;
-        for (int file = 0; file < 8; file++) {
-            if (!dirtyFiles[file]) {
-                continue;
-            }
-            fileStates[file].refresh(whitePawns, blackPawns);
-            dirtyFiles[file] = false;
-            touched = true;
-        }
-        if (touched) {
-            metadataDirty = false;
-            for (boolean fileDirty : dirtyFiles) {
-                if (fileDirty) {
-                    metadataDirty = true;
-                    break;
-                }
-            }
-        } else {
-            metadataDirty = false;
-        }
-    }
-
-    private void markFileDirty(int file) {
-        if (file < 0 || file >= dirtyFiles.length) {
-            return;
-        }
-        dirtyFiles[file] = true;
-        metadataDirty = true;
-    }
-
-    private void markAllFilesDirty() {
-        Arrays.fill(dirtyFiles, true);
-        metadataDirty = true;
-    }
-
-    private static int enPassantCaptureIndex(int move) {
-        int toIndex = MoveHelper.deriveToIndex(move);
-        return MoveHelper.isWhitesMove(move) ? toIndex - 8 : toIndex + 8;
     }
 
     private CachedStructure getStructure(long whitePawns, long blackPawns) {
@@ -476,144 +271,139 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
                 pawnIslandPenalty));
     }
 
-    private int calculatePawnAdvanceBonus(long pawns, long allPieces, long enemyAttacks, boolean isWhite, int phase) {
+    private int calculatePawnAdvanceBonus(long pawns, long allPieces, long enemyAttacks, boolean isWhite) {
+        long advancedPawns = pawns & (isWhite ? WHITE_ADVANCED_RANKS : BLACK_ADVANCED_RANKS);
+        if (advancedPawns == 0) {
+            return 0;
+        }
         int bonus = 0;
-        long advancedRanks = isWhite
-                ? (RankMasks[3] | RankMasks[4] | RankMasks[5] | RankMasks[6])
-                : (RankMasks[4] | RankMasks[3] | RankMasks[2] | RankMasks[1]);
-        long advancedPawns = pawns & advancedRanks;
+        int color = isWhite ? WHITE : BLACK;
+        int[] rankWeights = isWhite ? ADVANCED_RANK_WEIGHT_WHITE : ADVANCED_RANK_WEIGHT_BLACK;
         while (advancedPawns != 0) {
             int square = Long.numberOfTrailingZeros(advancedPawns);
-            long forward = PAWN_PUSHES[isWhite ? WHITE : BLACK][square];
-            if ((forward & (allPieces | enemyAttacks)) == 0) {
-                int rank = square / 8 + 1;
-                int rankBonus = isWhite ? (rank - 3) : (6 - rank);
-                bonus += advancedPawnBonus * rankBonus;
-            }
             advancedPawns &= advancedPawns - 1;
+            long forward = PAWN_PUSHES[color][square];
+            if (forward == 0L || (forward & (allPieces | enemyAttacks)) != 0) {
+                continue;
+            }
+            bonus += advancedPawnBonus * rankWeights[square];
         }
-        return scaleByPhase(bonus, phase);
+        return bonus;
     }
 
-    private int calculateBlockedPawnPenalty(long pawns, long allPieces, boolean isWhite, int phase) {
+    private int calculateBlockedPawnPenalty(long pawns, long allPieces, boolean isWhite) {
+        if (pawns == 0) {
+            return 0;
+        }
         int penalty = 0;
+        int color = isWhite ? WHITE : BLACK;
         long remaining = pawns;
         while (remaining != 0) {
             int square = Long.numberOfTrailingZeros(remaining);
-            long forward = PAWN_PUSHES[isWhite ? WHITE : BLACK][square];
-            if ((forward & allPieces) != 0) {
+            remaining &= remaining - 1;
+            long forward = PAWN_PUSHES[color][square];
+            if (forward != 0L && (forward & allPieces) != 0) {
                 penalty += blockedPawnPenalty;
             }
-            remaining &= remaining - 1;
         }
-        return scaleByPhase(penalty, phase);
+        return penalty;
     }
 
-    private static int calculateBackwardPawnPenalty(long pawns, long enemyPawns, long allPieces, boolean isWhite, int phase,
+    private static int calculateBackwardPawnPenalty(long pawns, long enemyPawns, long allPieces, boolean isWhite,
             int backwardPenalty) {
+        if (pawns == 0 || backwardPenalty == 0) {
+            return 0;
+        }
         int penalty = 0;
+        int color = isWhite ? WHITE : BLACK;
         long remaining = pawns;
         while (remaining != 0) {
             int square = Long.numberOfTrailingZeros(remaining);
-            long forward = PAWN_PUSHES[isWhite ? WHITE : BLACK][square];
-            if ((forward & allPieces) == 0) {
-                int forwardIndex = Long.numberOfTrailingZeros(forward);
-                long enemyAttack = PAWN_ATTACKS[isWhite ? WHITE : BLACK][forwardIndex] & enemyPawns;
-                if (enemyAttack != 0) {
-                    penalty += backwardPenalty;
-                }
-            }
             remaining &= remaining - 1;
-        }
-        return scaleByPhase(penalty, phase);
-    }
-
-    private static int sumMidgame(PhaseScore... scores) {
-        int total = 0;
-        if (scores == null) {
-            return total;
-        }
-        for (PhaseScore score : scores) {
-            if (score != null) {
-                total += score.midgame();
+            long forward = PAWN_PUSHES[color][square];
+            if (forward == 0L || (forward & allPieces) != 0) {
+                continue;
+            }
+            int forwardIndex = Long.numberOfTrailingZeros(forward);
+            if (forwardIndex >= 64) {
+                continue;
+            }
+            long enemyAttack = PAWN_ATTACKS[color][forwardIndex] & enemyPawns;
+            if (enemyAttack != 0) {
+                penalty += backwardPenalty;
             }
         }
-        return total;
-    }
-
-    private static int sumEndgame(PhaseScore... scores) {
-        int total = 0;
-        if (scores == null) {
-            return total;
-        }
-        for (PhaseScore score : scores) {
-            if (score != null) {
-                total += score.endgame();
-            }
-        }
-        return total;
+        return penalty;
     }
 
     private int calculatePassedPawnBonus(long pawns, long opponentPawns, long allPieces, long ownKing, boolean isWhite) {
+        if (pawns == 0) {
+            return 0;
+        }
         int bonus = 0;
+        long[] forwardMasks = isWhite ? FORWARD_RANK_MASKS_WHITE : FORWARD_RANK_MASKS_BLACK;
+        int[] rankWeights = isWhite ? PASSED_RANK_WEIGHT_WHITE : PASSED_RANK_WEIGHT_BLACK;
+        int[] distances = isWhite ? DISTANCE_TO_PROMOTION_WHITE : DISTANCE_TO_PROMOTION_BLACK;
+        int color = isWhite ? WHITE : BLACK;
         long remaining = pawns;
-
         while (remaining != 0) {
-            long pawn = remaining & -remaining;
-            remaining ^= pawn;
+            int square = Long.numberOfTrailingZeros(remaining);
+            remaining &= remaining - 1;
 
-            int square = Long.numberOfTrailingZeros(pawn);
-            int file = square % 8;
-            int rank = square / 8 + 1;
-
-            long fileMask = FileMasks[file];
-            long adjFilesMask = fileMask;
-            if (file > 0) {
-                adjFilesMask |= FileMasks[file - 1];
-            }
-            if (file < 7) {
-                adjFilesMask |= FileMasks[file + 1];
-            }
-
-            long forwardRanksMask = 0L;
-            if (isWhite) {
-                for (int r = rank + 1; r <= 8; r++) {
-                    forwardRanksMask |= RankMasks[r - 1];
-                }
-            } else {
-                for (int r = rank - 1; r >= 1; r--) {
-                    forwardRanksMask |= RankMasks[r - 1];
-                }
-            }
-
-            boolean isPassed = (opponentPawns & (adjFilesMask & forwardRanksMask)) == 0;
-            if (!isPassed) {
+            long forwardRanks = forwardMasks[square];
+            if ((opponentPawns & (ADJACENT_FILE_MASKS[square] & forwardRanks)) != 0) {
                 continue;
             }
 
-            int base = passedPawnBonus * (isWhite ? (rank - 1) : (8 - rank));
+            int base = passedPawnBonus * rankWeights[square];
+            long filePathAhead = forwardRanks & FileMasks[square & 7];
+            long oneStep = PAWN_PUSHES[color][square];
 
-            long filePathAhead = fileMask & forwardRanksMask;
-            long oneStep = isWhite ? (pawn << 8) : (pawn >>> 8);
-
-            if ((oneStep & ownKing) != 0L) {
+            if ((oneStep & ownKing) != 0) {
                 base += ownKingBlocksPassedPawnPenalty;
             }
-
-            if ((filePathAhead & allPieces) == 0L) {
-                int distToPromo = isWhite ? (8 - rank) : (rank - 1);
-                base += passedPawnFreePathBonusPerRank * distToPromo;
+            if (filePathAhead != 0 && (filePathAhead & allPieces) == 0) {
+                base += passedPawnFreePathBonusPerRank * distances[square];
             }
 
             bonus += base;
         }
-
         return bonus;
     }
 
-    private static int scaleByPhase(int value, int phase) {
-        int clamped = Math.max(0, Math.min(256, phase));
-        return value * (256 + clamped) / 256;
+    private int countHalfOpenFilesWithRooks(long rooksBitboard, long friendlyPawns, long enemyPawns) {
+        if (rooksBitboard == 0L) {
+            return 0;
+        }
+        int count = 0;
+        for (int file = 0; file < 8; file++) {
+            long fileMask = FileMasks[file];
+            if ((rooksBitboard & fileMask) == 0) {
+                continue;
+            }
+            if ((friendlyPawns & fileMask) == 0 && (enemyPawns & fileMask) != 0) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private int countOpenFilesWithRooks(long rooksBitboard, long allPawns) {
+        if (rooksBitboard == 0L) {
+            return 0;
+        }
+        int count = 0;
+        for (int file = 0; file < 8; file++) {
+            long fileMask = FileMasks[file];
+            if ((rooksBitboard & fileMask) != 0 && (allPawns & fileMask) == 0) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static int scaleEndgame(int value) {
+        return value << 1;
     }
 
     private record PawnStructureKey(long white, long black) { }
@@ -647,256 +437,6 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
             this.blackConnectedPawnBonus = PawnHelper.countConnectedPawns(blackPawns) * connectedBonus;
             this.whitePawnIslandPenalty = Math.max(0, PawnHelper.countPawnIslands(whitePawns) - 1) * islandPenalty;
             this.blackPawnIslandPenalty = Math.max(0, PawnHelper.countPawnIslands(blackPawns) - 1) * islandPenalty;
-        }
-    }
-
-    public static final class PhaseScore {
-        private final int midgame;
-        private final int endgame;
-
-        private PhaseScore(int midgame, int endgame) {
-            this.midgame = midgame;
-            this.endgame = endgame;
-        }
-
-        public static PhaseScore of(int midgame, int endgame) {
-            return new PhaseScore(midgame, endgame);
-        }
-
-        public static PhaseScore constant(int value) {
-            return new PhaseScore(value, value);
-        }
-
-        public int blend(int phase) {
-            int clamped = Math.max(0, Math.min(256, phase));
-            int midWeight = 256 - clamped;
-            int endWeight = clamped;
-            long blended = (long) midgame * midWeight + (long) endgame * endWeight;
-            return (int) (blended / 256);
-        }
-
-        public int midgame() {
-            return midgame;
-        }
-
-        public int endgame() {
-            return endgame;
-        }
-    }
-
-    public static final class PawnStructureView {
-        private final PhaseScore whiteCenter;
-        private final PhaseScore blackCenter;
-        private final PhaseScore whiteDoubled;
-        private final PhaseScore blackDoubled;
-        private final PhaseScore whiteIsolated;
-        private final PhaseScore blackIsolated;
-        private final PhaseScore whiteConnected;
-        private final PhaseScore blackConnected;
-        private final PhaseScore whiteRookHalfOpen;
-        private final PhaseScore blackRookHalfOpen;
-        private final PhaseScore whiteRookOpen;
-        private final PhaseScore blackRookOpen;
-        private final PhaseScore whiteIslands;
-        private final PhaseScore blackIslands;
-        private final PhaseScore whitePassed;
-        private final PhaseScore blackPassed;
-        private final PhaseScore whiteAdvance;
-        private final PhaseScore blackAdvance;
-        private final PhaseScore whiteBlocked;
-        private final PhaseScore blackBlocked;
-        private final PhaseScore whiteBackward;
-        private final PhaseScore blackBackward;
-
-        private final int whiteMidgameTotal;
-        private final int whiteEndgameTotal;
-        private final int blackMidgameTotal;
-        private final int blackEndgameTotal;
-
-        private PawnStructureView(
-                PhaseScore whiteCenter,
-                PhaseScore blackCenter,
-                PhaseScore whiteDoubled,
-                PhaseScore blackDoubled,
-                PhaseScore whiteIsolated,
-                PhaseScore blackIsolated,
-                PhaseScore whiteConnected,
-                PhaseScore blackConnected,
-                PhaseScore whiteRookHalfOpen,
-                PhaseScore blackRookHalfOpen,
-                PhaseScore whiteRookOpen,
-                PhaseScore blackRookOpen,
-                PhaseScore whiteIslands,
-                PhaseScore blackIslands,
-                PhaseScore whitePassed,
-                PhaseScore blackPassed,
-                PhaseScore whiteAdvance,
-                PhaseScore blackAdvance,
-                PhaseScore whiteBlocked,
-                PhaseScore blackBlocked,
-                PhaseScore whiteBackward,
-                PhaseScore blackBackward,
-                int whiteMidgameTotal,
-                int whiteEndgameTotal,
-                int blackMidgameTotal,
-                int blackEndgameTotal) {
-            this.whiteCenter = whiteCenter;
-            this.blackCenter = blackCenter;
-            this.whiteDoubled = whiteDoubled;
-            this.blackDoubled = blackDoubled;
-            this.whiteIsolated = whiteIsolated;
-            this.blackIsolated = blackIsolated;
-            this.whiteConnected = whiteConnected;
-            this.blackConnected = blackConnected;
-            this.whiteRookHalfOpen = whiteRookHalfOpen;
-            this.blackRookHalfOpen = blackRookHalfOpen;
-            this.whiteRookOpen = whiteRookOpen;
-            this.blackRookOpen = blackRookOpen;
-            this.whiteIslands = whiteIslands;
-            this.blackIslands = blackIslands;
-            this.whitePassed = whitePassed;
-            this.blackPassed = blackPassed;
-            this.whiteAdvance = whiteAdvance;
-            this.blackAdvance = blackAdvance;
-            this.whiteBlocked = whiteBlocked;
-            this.blackBlocked = blackBlocked;
-            this.whiteBackward = whiteBackward;
-            this.blackBackward = blackBackward;
-            this.whiteMidgameTotal = whiteMidgameTotal;
-            this.whiteEndgameTotal = whiteEndgameTotal;
-            this.blackMidgameTotal = blackMidgameTotal;
-            this.blackEndgameTotal = blackEndgameTotal;
-        }
-
-        public static PawnStructureView empty() {
-            PhaseScore zero = PhaseScore.constant(0);
-            return new PawnStructureView(zero, zero, zero, zero, zero, zero, zero, zero,
-            zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, zero, zero,
-                    0, 0, 0, 0);
-        }
-
-        public PhaseScore whiteCenter() {
-            return whiteCenter;
-        }
-
-        public PhaseScore blackCenter() {
-            return blackCenter;
-        }
-
-        public PhaseScore whiteDoubled() {
-            return whiteDoubled;
-        }
-
-        public PhaseScore blackDoubled() {
-            return blackDoubled;
-        }
-
-        public PhaseScore whiteIsolated() {
-            return whiteIsolated;
-        }
-
-        public PhaseScore blackIsolated() {
-            return blackIsolated;
-        }
-
-        public PhaseScore whiteConnected() {
-            return whiteConnected;
-        }
-
-        public PhaseScore blackConnected() {
-            return blackConnected;
-        }
-
-        public PhaseScore whiteRookHalfOpen() {
-            return whiteRookHalfOpen;
-        }
-
-        public PhaseScore blackRookHalfOpen() {
-            return blackRookHalfOpen;
-        }
-
-        public PhaseScore whiteRookOpen() {
-            return whiteRookOpen;
-        }
-
-        public PhaseScore blackRookOpen() {
-            return blackRookOpen;
-        }
-
-        public PhaseScore whiteIslands() {
-            return whiteIslands;
-        }
-
-        public PhaseScore blackIslands() {
-            return blackIslands;
-        }
-
-        public PhaseScore whitePassed() {
-            return whitePassed;
-        }
-
-        public PhaseScore blackPassed() {
-            return blackPassed;
-        }
-
-        public PhaseScore whiteAdvance() {
-            return whiteAdvance;
-        }
-
-        public PhaseScore blackAdvance() {
-            return blackAdvance;
-        }
-
-        public PhaseScore whiteBlocked() {
-            return whiteBlocked;
-        }
-
-        public PhaseScore blackBlocked() {
-            return blackBlocked;
-        }
-
-        public PhaseScore whiteBackward() {
-            return whiteBackward;
-        }
-
-        public PhaseScore blackBackward() {
-            return blackBackward;
-        }
-
-        public int blendWhiteTotal(int phase) {
-            return blendTotal(whiteMidgameTotal, whiteEndgameTotal, phase);
-        }
-
-        public int blendBlackTotal(int phase) {
-            return blendTotal(blackMidgameTotal, blackEndgameTotal, phase);
-        }
-
-        private static int blendTotal(int midgame, int endgame, int phase) {
-            int clamped = Math.max(0, Math.min(256, phase));
-            int midWeight = 256 - clamped;
-            int endWeight = clamped;
-            long blended = (long) midgame * midWeight + (long) endgame * endWeight;
-            return (int) (blended / 256);
-        }
-    }
-
-    private static final class FileState {
-        private final int file;
-        private boolean open;
-        private boolean halfOpenForWhite;
-        private boolean halfOpenForBlack;
-
-        private FileState(int file) {
-            this.file = file;
-        }
-
-        private void refresh(long whitePawns, long blackPawns) {
-            long mask = FileMasks[file];
-            long whiteMask = whitePawns & mask;
-            long blackMask = blackPawns & mask;
-            open = (whiteMask | blackMask) == 0;
-            halfOpenForWhite = whiteMask == 0 && blackMask != 0;
-            halfOpenForBlack = blackMask == 0 && whiteMask != 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- streamline `PawnStructureModule` by removing unused view/phase scaffolding and caching only tapered totals
- precompute pawn masks and reuse them to speed up passed, backward, and advanced pawn calculations while eliminating redundant scaling passes
- simplify rook file bookkeeping with direct bitboard checks so the module just marks itself dirty on move notifications

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=EvaluationModuleTuningAlignmentTest test

------
https://chatgpt.com/codex/tasks/task_e_68e55df3ed28832aa4801e97fa8373b4