### PR TITLE
Improve pawn structure cache hashing performance

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -406,7 +406,15 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         return value << 1;
     }
 
-    private record PawnStructureKey(long white, long black) { }
+    private record PawnStructureKey(long white, long black) {
+
+        @Override
+        public int hashCode() {
+            int whiteHash = Long.hashCode(white);
+            int blackHash = Long.hashCode(black);
+            return 31 * whiteHash + blackHash;
+        }
+    }
 
     private static final class CachedStructure {
         private final int whiteCenterPawnBonus;


### PR DESCRIPTION
## Summary
- override the `PawnStructureKey` hash code to avoid the `Objects.hash` allocations generated by the record default implementation

## Testing
- `mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=ScoreEvaluationTest test` *(fails: No tests matching pattern "ScoreEvaluationTest")*

------
https://chatgpt.com/codex/tasks/task_e_68e568f4ac1c832aa06b9df32dc5e94e