### PR TITLE
Reduce evaluation module allocations

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -49,7 +49,7 @@ public final class KingSafetyModule implements EvaluationModule {
     private final int[] attackWeights = new int[7];
 
     private final SideState[] sideStates = {new SideState(), new SideState()};
-    private KingSafetyView currentView = KingSafetyView.empty();
+    private final KingSafetyView currentView = new KingSafetyView();
     private boolean initialized;
     private boolean dirty = true;
     private int midgameScoreCache;
@@ -146,7 +146,7 @@ public final class KingSafetyModule implements EvaluationModule {
             }
             midgameScoreCache = 0;
             endgameScoreCache = 0;
-            currentView = KingSafetyView.empty();
+            currentView.reset();
             dirty = false;
             return currentView;
         }
@@ -558,11 +558,11 @@ public final class KingSafetyModule implements EvaluationModule {
         int blackEnd = sideStates[BLACK].endgameKingSafety + sideStates[BLACK].endgameQueenPenalty;
         midgameScoreCache = whiteMid - blackMid;
         endgameScoreCache = whiteEnd - blackEnd;
-        currentView = new KingSafetyView(
-                PhaseScore.of(sideStates[WHITE].midgameKingSafety, sideStates[WHITE].endgameKingSafety),
-                PhaseScore.of(sideStates[BLACK].midgameKingSafety, sideStates[BLACK].endgameKingSafety),
-                PhaseScore.of(sideStates[WHITE].midgameQueenPenalty, sideStates[WHITE].endgameQueenPenalty),
-                PhaseScore.of(sideStates[BLACK].midgameQueenPenalty, sideStates[BLACK].endgameQueenPenalty)
+        currentView.update(
+                sideStates[WHITE].midgameKingSafety, sideStates[WHITE].endgameKingSafety,
+                sideStates[BLACK].midgameKingSafety, sideStates[BLACK].endgameKingSafety,
+                sideStates[WHITE].midgameQueenPenalty, sideStates[WHITE].endgameQueenPenalty,
+                sideStates[BLACK].midgameQueenPenalty, sideStates[BLACK].endgameQueenPenalty
         );
     }
 
@@ -571,22 +571,23 @@ public final class KingSafetyModule implements EvaluationModule {
     }
 
     public static final class KingSafetyView {
-        private final PhaseScore whiteKing;
-        private final PhaseScore blackKing;
-        private final PhaseScore whiteQueen;
-        private final PhaseScore blackQueen;
+        private final PhaseScore whiteKing = new PhaseScore();
+        private final PhaseScore blackKing = new PhaseScore();
+        private final PhaseScore whiteQueen = new PhaseScore();
+        private final PhaseScore blackQueen = new PhaseScore();
 
-        private KingSafetyView(PhaseScore whiteKing, PhaseScore blackKing,
-                               PhaseScore whiteQueen, PhaseScore blackQueen) {
-            this.whiteKing = whiteKing;
-            this.blackKing = blackKing;
-            this.whiteQueen = whiteQueen;
-            this.blackQueen = blackQueen;
+        private void update(int whiteKingMid, int whiteKingEnd,
+                             int blackKingMid, int blackKingEnd,
+                             int whiteQueenMid, int whiteQueenEnd,
+                             int blackQueenMid, int blackQueenEnd) {
+            whiteKing.update(whiteKingMid, whiteKingEnd);
+            blackKing.update(blackKingMid, blackKingEnd);
+            whiteQueen.update(whiteQueenMid, whiteQueenEnd);
+            blackQueen.update(blackQueenMid, blackQueenEnd);
         }
 
-        public static KingSafetyView empty() {
-            PhaseScore zero = PhaseScore.of(0, 0);
-            return new KingSafetyView(zero, zero, zero, zero);
+        private void reset() {
+            update(0, 0, 0, 0, 0, 0, 0, 0);
         }
 
         public PhaseScore whiteKing() {
@@ -623,16 +624,15 @@ public final class KingSafetyModule implements EvaluationModule {
     }
 
     public static final class PhaseScore {
-        private final int midgame;
-        private final int endgame;
+        private int midgame;
+        private int endgame;
 
-        private PhaseScore(int midgame, int endgame) {
-            this.midgame = midgame;
-            this.endgame = endgame;
+        private PhaseScore() {
         }
 
-        public static PhaseScore of(int midgame, int endgame) {
-            return new PhaseScore(midgame, endgame);
+        private void update(int midgame, int endgame) {
+            this.midgame = midgame;
+            this.endgame = endgame;
         }
 
         public int blend(int phase) {

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -4,7 +4,7 @@ import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.helper.PawnHelper;
 import julius.game.chessengine.tuning.Tuning;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -69,7 +69,15 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         }
     }
 
-    private final Map<PawnStructureKey, CachedStructure> structureCache = new HashMap<>();
+    private static final int MAX_STRUCTURE_CACHE_SIZE = 4096;
+
+    private final Map<PawnStructureKey, CachedStructure> structureCache = new LinkedHashMap<>(256, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<PawnStructureKey, CachedStructure> eldest) {
+            return size() > MAX_STRUCTURE_CACHE_SIZE;
+        }
+    };
+    private final PawnStructureKey lookupKey = new PawnStructureKey();
 
     private int midgameScoreCache;
     private int endgameScoreCache;
@@ -260,15 +268,22 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     }
 
     private CachedStructure getStructure(long whitePawns, long blackPawns) {
-        PawnStructureKey key = new PawnStructureKey(whitePawns, blackPawns);
-        return structureCache.computeIfAbsent(key, k -> new CachedStructure(
+        PawnStructureKey key = lookupKey.set(whitePawns, blackPawns);
+        CachedStructure cached = structureCache.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        PawnStructureKey storedKey = new PawnStructureKey(whitePawns, blackPawns);
+        CachedStructure structure = new CachedStructure(
                 whitePawns,
                 blackPawns,
                 centerPawnBonus,
                 doubledPawnPenalty,
                 isolatedPawnPenalty,
                 connectedPawnBonus,
-                pawnIslandPenalty));
+                pawnIslandPenalty);
+        structureCache.put(storedKey, structure);
+        return structure;
     }
 
     private int calculatePawnAdvanceBonus(long pawns, long allPieces, long enemyAttacks, boolean isWhite) {
@@ -406,15 +421,24 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         return value << 1;
     }
 
-    private static final class PawnStructureKey {
-        private final long white;
-        private final long black;
-        private final int hash;
+    private static class PawnStructureKey {
+        private long white;
+        private long black;
+        private int hash;
+
+        private PawnStructureKey() {
+            this(0L, 0L);
+        }
 
         private PawnStructureKey(long white, long black) {
+            set(white, black);
+        }
+
+        private PawnStructureKey set(long white, long black) {
             this.white = white;
             this.black = black;
             this.hash = computeHash(white, black);
+            return this;
         }
 
         private static int computeHash(long white, long black) {


### PR DESCRIPTION
## Summary
- bound the pawn structure cache with an LRU policy and reuse lookup keys to avoid transient allocations
- reuse the king safety evaluation view objects instead of recreating them on every refresh

## Testing
- ⚠️ `mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" test` *(aborted after running long-running search diagnostics)*

------
https://chatgpt.com/codex/tasks/task_e_68e56f908628832abdc6759b674c345b