### PR TITLE
Improve quiescence pruning heuristics for quiet nodes

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2785,8 +2785,7 @@ public class AI {
     }
 
     private boolean hasImmediateTacticalMoves(Engine simulatorEngine) {
-        IntArrayList allLegalMoves = simulatorEngine.getAllLegalMoves();
-        return MoveContainerUtils.hasCapturesOrPromotions(allLegalMoves);
+        return simulatorEngine.hasAnyCaptureOrPromotion();
     }
 
     private double estimateMaxTacticalSwing(IntArrayList moves) {

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2624,6 +2624,17 @@ public class AI {
             return entry.getScore();
         }
 
+        if (!isSideInCheck(simulatorEngine, isWhitesTurn)
+                && !hasImmediateTacticalMoves(simulatorEngine)) {
+            double quietScore = evaluateStaticPosition(
+                    simulatorEngine.getGameState(), boardStateHash, isWhitesTurn, 0
+            );
+            captureTranspositionTable.put(
+                    boardStateHash, new CaptureTranspositionTableEntry(quietScore, isWhitesTurn), 0
+            );
+            return quietScore;
+        }
+
         double score = quiescenceSearch(simulatorEngine, isWhitesTurn, alpha, beta, deadline, 0);
         if (score != EXIT_FLAG) {
             captureTranspositionTable.put(boardStateHash, new CaptureTranspositionTableEntry(score, isWhitesTurn), 0);
@@ -2653,6 +2664,8 @@ public class AI {
         long boardHash = simulatorEngine.getBoardStateHash();
         double standPat = evaluateStaticPosition(simulatorEngine.getGameState(), boardHash, isWhitesTurn, depth);
 
+        double alphaBeforeStandPat = alpha;
+
         if (!inCheck) {
             // Fail-hard beta cut on stand-pat
             if (standPat >= beta) {
@@ -2662,19 +2675,24 @@ public class AI {
             if (standPat > alpha) {
                 alpha = standPat;
             }
-
-            // Delta (futility-like) pruning in qsearch:
-            // If even the biggest plausible swing can't reach alpha, cut.
-            // (Disabled when in check, already guarded above.)
-            if (standPat + MAX_DELTA_PAWN <= alpha) {
-                return alpha;
-            }
         }
 
         // Move gen: evasions if in check; else captures/promotions (and optional checking moves if you add them)
         IntArrayList moves = inCheck
                 ? simulatorEngine.getAllLegalMoves()                // all evasions
                 : getPossibleCapturesOrPromotions(simulatorEngine);  // tactical moves only
+
+        if (!inCheck) {
+            if (moves.isEmpty()) {
+                return alpha;
+            }
+
+            double optimisticSwing = estimateMaxTacticalSwing(moves);
+            // Delta (futility-like) pruning in qsearch: compare against original alpha window
+            if (standPat + optimisticSwing <= alphaBeforeStandPat) {
+                return alpha;
+            }
+        }
 
         // Order moves (MVV-LVA, history, hash-move etc.)
         IntArrayList ordered = sortMovesByEfficiency(
@@ -2764,6 +2782,53 @@ public class AI {
     private IntArrayList getPossibleCapturesOrPromotions(Engine simulatorEngine) {
         IntArrayList allLegalMoves = simulatorEngine.getAllLegalMoves();
         return MoveContainerUtils.filterCapturesAndPromotions(allLegalMoves);
+    }
+
+    private boolean hasImmediateTacticalMoves(Engine simulatorEngine) {
+        IntArrayList allLegalMoves = simulatorEngine.getAllLegalMoves();
+        return MoveContainerUtils.hasCapturesOrPromotions(allLegalMoves);
+    }
+
+    private double estimateMaxTacticalSwing(IntArrayList moves) {
+        double bestSwing = 0.0;
+        final double pawnValue = Score.getPieceValue(1);
+
+        for (int i = 0; i < moves.size(); i++) {
+            int move = moves.getInt(i);
+            double swing = 0.0;
+
+            if (MoveHelper.isCapture(move)) {
+                int capturedBits = MoveHelper.deriveCapturedPieceTypeBits(move);
+                double captureValue;
+                if (capturedBits != 0) {
+                    captureValue = Score.getPieceValue(capturedBits);
+                } else if (MoveHelper.isEnPassantMove(move)) {
+                    captureValue = pawnValue;
+                } else {
+                    captureValue = 0.0;
+                }
+                swing += captureValue;
+            }
+
+            if (MoveHelper.isPawnPromotionMove(move)) {
+                int promotionBits = MoveHelper.derivePromotionPieceTypeBits(move);
+                if (promotionBits != 0) {
+                    double promotionDelta = Score.getPieceValue(promotionBits) - pawnValue;
+                    if (promotionDelta > 0) {
+                        swing += promotionDelta;
+                    }
+                }
+            }
+
+            if (swing > bestSwing) {
+                bestSwing = swing;
+                if (bestSwing >= MAX_DELTA_PAWN) {
+                    return MAX_DELTA_PAWN;
+                }
+            }
+        }
+
+        return Math.min(bestSwing, MAX_DELTA_PAWN);
     }
 
     /**

--- a/src/main/java/julius/game/chessengine/ai/MoveContainerUtils.java
+++ b/src/main/java/julius/game/chessengine/ai/MoveContainerUtils.java
@@ -58,6 +58,16 @@ final class MoveContainerUtils {
         System.arraycopy(buffer, 0, elements, 0, length);
     }
 
+    static boolean hasCapturesOrPromotions(IntArrayList moves) {
+        for (int i = 0; i < moves.size(); i++) {
+            int move = moves.getInt(i);
+            if (MoveHelper.isCapture(move) || MoveHelper.isPawnPromotionMove(move)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     static IntArrayList filterCapturesAndPromotions(IntArrayList moves) {
         IntArrayList filtered = new IntArrayList(moves.size());
         for (int i = 0; i < moves.size(); i++) {

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -1141,6 +1141,120 @@ public class BitBoard {
         allPieces = whitePieces | blackPieces;
     }
 
+    public boolean hasAnyCaptureOrPromotion() {
+        return hasAnyCaptureOrPromotion(whitesTurn);
+    }
+
+    public boolean hasAnyCaptureOrPromotion(boolean sideToMoveWhite) {
+        long ownPawns = sideToMoveWhite ? whitePawns : blackPawns;
+        long ownKnights = sideToMoveWhite ? whiteKnights : blackKnights;
+        long ownBishops = sideToMoveWhite ? whiteBishops : blackBishops;
+        long ownRooks = sideToMoveWhite ? whiteRooks : blackRooks;
+        long ownQueens = sideToMoveWhite ? whiteQueens : blackQueens;
+        long ownKing = sideToMoveWhite ? whiteKing : blackKing;
+
+        long opponentPieces = sideToMoveWhite ? blackPieces : whitePieces;
+        long opponentPiecesNoKing = sideToMoveWhite
+                ? (blackPieces & ~blackKing)
+                : (whitePieces & ~whiteKing);
+
+        long promotionRank = sideToMoveWhite ? RankMasks[7] : RankMasks[0];
+        long emptySquares = ~allPieces;
+
+        if (ownPawns != 0) {
+            long pushPromotions = sideToMoveWhite
+                    ? ((ownPawns << 8) & emptySquares & promotionRank)
+                    : ((ownPawns >>> 8) & emptySquares & promotionRank);
+            if (pushPromotions != 0) {
+                return true;
+            }
+
+            long pawnLeftAttacks = sideToMoveWhite
+                    ? (ownPawns & ~FileMasks[0]) << 7
+                    : (ownPawns & ~FileMasks[7]) >>> 7;
+            long pawnRightAttacks = sideToMoveWhite
+                    ? (ownPawns & ~FileMasks[7]) << 9
+                    : (ownPawns & ~FileMasks[0]) >>> 9;
+            long pawnAttacks = pawnLeftAttacks | pawnRightAttacks;
+
+            if ((pawnAttacks & opponentPiecesNoKing & promotionRank) != 0) {
+                return true;
+            }
+            if ((pawnAttacks & opponentPiecesNoKing & ~promotionRank) != 0) {
+                return true;
+            }
+
+            int epTarget = getEnPassantTargetIndex();
+            if (epTarget != -1) {
+                int epFile = epTarget & 7;
+                int dir = sideToMoveWhite ? -8 : +8;
+                int pawnRowFrom = epTarget + dir;
+                if (pawnRowFrom >= 0 && pawnRowFrom < 64) {
+                    int leftFrom = epFile > 0 ? pawnRowFrom - 1 : -1;
+                    int rightFrom = epFile < 7 ? pawnRowFrom + 1 : -1;
+                    long pawnMask = ownPawns;
+                    if (leftFrom >= 0 && (pawnMask & (1L << leftFrom)) != 0) {
+                        return true;
+                    }
+                    if (rightFrom >= 0 && (pawnMask & (1L << rightFrom)) != 0) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        long knights = ownKnights;
+        while (knights != 0) {
+            int from = Long.numberOfTrailingZeros(knights);
+            knights &= knights - 1;
+            long attacks = KnightHelper.knightMoveTable[from] & opponentPiecesNoKing;
+            if (attacks != 0) {
+                return true;
+            }
+        }
+
+        long bishops = ownBishops;
+        while (bishops != 0) {
+            int from = Long.numberOfTrailingZeros(bishops);
+            bishops &= bishops - 1;
+            long attacks = bishopHelper.calculateMovesUsingBishopMagic(from, allPieces) & opponentPiecesNoKing;
+            if (attacks != 0) {
+                return true;
+            }
+        }
+
+        long rooks = ownRooks;
+        while (rooks != 0) {
+            int from = Long.numberOfTrailingZeros(rooks);
+            rooks &= rooks - 1;
+            long attacks = rookHelper.calculateMovesUsingRookMagic(from, allPieces) & opponentPiecesNoKing;
+            if (attacks != 0) {
+                return true;
+            }
+        }
+
+        long queens = ownQueens;
+        while (queens != 0) {
+            int from = Long.numberOfTrailingZeros(queens);
+            queens &= queens - 1;
+            long attacks = (bishopHelper.calculateMovesUsingBishopMagic(from, allPieces)
+                    | rookHelper.calculateMovesUsingRookMagic(from, allPieces)) & opponentPiecesNoKing;
+            if (attacks != 0) {
+                return true;
+            }
+        }
+
+        if (ownKing != 0) {
+            int from = Long.numberOfTrailingZeros(ownKing);
+            long kingAttacks = KING_ATTACKS[from] & opponentPiecesNoKing;
+            if (kingAttacks != 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private void recomputeWhiteAttackMap() {
         whiteAttackMap = generateAttackBitboard(true);
         whiteAttackDirty = false;

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -116,6 +116,15 @@ public class Engine {
         }
     }
 
+    public boolean hasAnyCaptureOrPromotion() {
+        synchronized (boardLock) {
+            if (gameState.isTerminal()) {
+                return false;
+            }
+            return bitBoard.hasAnyCaptureOrPromotion();
+        }
+    }
+
     public void performMove(int move) {
         long notifyHash; // sentinel: only notify if we actually set it
 


### PR DESCRIPTION
## Summary
- skip quiescence search when the root position has no immediate tactics
- estimate the maximum tactical swing per node to tighten delta pruning in quiescence search
- add a helper to detect capture and promotion moves without allocating

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITest_QuiescenceAndTerminalInvariants test

------
https://chatgpt.com/codex/tasks/task_e_68e584fa9f9c832aa5b9a5e2eed92b50