### PR TITLE
Add abort check to quiet evaluation path

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2626,6 +2626,9 @@ public class AI {
 
         if (!isSideInCheck(simulatorEngine, isWhitesTurn)
                 && !hasImmediateTacticalMoves(simulatorEngine)) {
+            if (abortRequested(deadline)) {
+                return EXIT_FLAG;
+            }
             double quietScore = evaluateStaticPosition(
                     simulatorEngine.getGameState(), boardStateHash, isWhitesTurn, 0
             );


### PR DESCRIPTION
## Summary
- invoke abortRequested before computing a quiet-node evaluation so search exits cleanly
- avoid caching a static score when the search deadline has already expired

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITest_QuiescenceAndTerminalInvariants test

------
https://chatgpt.com/codex/tasks/task_e_68e58ee237f0832ab2fda0aa71fa17d3