### PR TITLE
Allow outbound loop to resume when games finish

### DIFF
--- a/src/main/resources/py/lichess_bot.py
+++ b/src/main/resources/py/lichess_bot.py
@@ -1048,7 +1048,12 @@ def outbound_challenge_loop(stop_event: threading.Event,
                 for _ in range(period):
                     if stop_event.is_set():
                         return
+                    if active_counter.get() == 0:
+                        print("[outbound] no active games detected; resuming outbound scans")
+                        break
                     time.sleep(1)
+                else:
+                    continue
                 continue
 
             print("[outbound] scanning for targets...")


### PR DESCRIPTION
## Summary
- teach the outbound challenge loop to re-check the active game counter while it sleeps
- resume scanning immediately after the last game ends instead of waiting for the full idle period

## Testing
- not run (python change only)


------
https://chatgpt.com/codex/tasks/task_e_68e60be42c78832aac2b89b397762b45