### PR TITLE
Improve quiet move ordering heuristics

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -182,8 +182,17 @@ public class AI {
     private static final double[] HISTORY_BUCKET_NORMALIZED = new double[HISTORY_BUCKETS];
     private static final int[][][] LMR_REDUCTION_TABLE =
             new int[LMR_MAX_DEPTH + 1][LMR_MAX_MOVES][HISTORY_BUCKETS];
+    private static final int[] QUIET_CENTRALITY_BONUS = new int[64];
 
     static {
+        for (int square = 0; square < QUIET_CENTRALITY_BONUS.length; square++) {
+            int file = square & 7;
+            int rank = square >>> 3;
+            int centrality = 14
+                    - (Math.abs(file - 3) + Math.abs(file - 4)
+                    + Math.abs(rank - 3) + Math.abs(rank - 4));
+            QUIET_CENTRALITY_BONUS[square] = Math.max(0, centrality);
+        }
         if (HISTORY_BUCKETS < 1) {
             throw new IllegalStateException("History bucket count must be positive");
         }
@@ -2471,11 +2480,19 @@ public class AI {
 
         final int depthIndex = Math.max(0, Math.min(currentDepth, killerMoves.length - 1));
 
-        // Category encoding (higher is earlier):
-        // 7: TT move, 6: promotions, 5: good captures, 4: equal captures,
-        // 3: killer[0], 2: killer[1], 1: quiets (history), 0: bad captures
-        final int CAT_TT = 7, CAT_PROMO = 6, CAT_CAP_GOOD = 5, CAT_CAP_EQUAL = 4,
-                CAT_KILLER0 = 3, CAT_KILLER1 = 2, CAT_QUIET = 1, CAT_CAP_BAD = 0;
+        // Category encoding (higher is earlier). Additional buckets allow quiet moves
+        // with strong history/centrality support and refutation (counter) moves to be
+        // surfaced ahead of generic quiet play without sacrificing killer heuristics.
+        final int CAT_TT = 9;
+        final int CAT_PROMO = 8;
+        final int CAT_CAP_GOOD = 7;
+        final int CAT_CAP_EQUAL = 6;
+        final int CAT_KILLER0 = 5;
+        final int CAT_COUNTER = 4;
+        final int CAT_KILLER1 = 3;
+        final int CAT_QUIET_STRONG = 2;
+        final int CAT_QUIET = 1;
+        final int CAT_CAP_BAD = 0;
 
         final int promotionBonus = moveOrderingParameters.promotionBonus();
         final int killer0Bonus = moveOrderingParameters.killer0Bonus();
@@ -2484,6 +2501,9 @@ public class AI {
         final int captureMvvMultiplier = moveOrderingParameters.captureMvvMultiplier();
         final int captureSeeMultiplier = moveOrderingParameters.captureSeeMultiplier();
         final int promotionSeeMultiplier = moveOrderingParameters.promotionSeeMultiplier();
+        final int quietCentralityMultiplier = moveOrderingParameters.quietCentralityMultiplier();
+        final int quietHistoryThreshold = moveOrderingParameters.quietHistoryThreshold();
+        final int maxQuietCentralitySwing = Math.abs(quietCentralityMultiplier) * 12;
 
         // Hash move (TT)
         TranspositionTableEntry ttEntry = transpositionTable.get(boardHash);
@@ -2546,15 +2566,35 @@ public class AI {
             } else if (moveInt == k0) {
                 category = CAT_KILLER0;
                 score = killerMoveScore + killer0Bonus;
+            } else if (moveInt == cm) {
+                final int from = moveInt & 0x3F;
+                final int to = (moveInt >>> 6) & 0x3F;
+                int historyScore = historyTable[from][to];
+                int centralityDelta = QUIET_CENTRALITY_BONUS[to] - QUIET_CENTRALITY_BONUS[from];
+                int centralityBoost = centralityDelta * quietCentralityMultiplier;
+                if (centralityBoost > maxQuietCentralitySwing) centralityBoost = maxQuietCentralitySwing;
+                if (centralityBoost < -maxQuietCentralitySwing) centralityBoost = -maxQuietCentralitySwing;
+                score = historyScore + centralityBoost + counterMoveBonus;
+                if (score < 0) score = 0;
+                category = CAT_COUNTER;
             } else if (moveInt == k1) {
                 category = CAT_KILLER1;
                 score = killerMoveScore + killer1Bonus;
             } else {
                 final int from = moveInt & 0x3F;
                 final int to = (moveInt >>> 6) & 0x3F;
-                category = CAT_QUIET;
-                score = historyTable[from][to];
-                if (moveInt == cm) score += counterMoveBonus;
+                int historyScore = historyTable[from][to];
+                int centralityDelta = QUIET_CENTRALITY_BONUS[to] - QUIET_CENTRALITY_BONUS[from];
+                int centralityBoost = centralityDelta * quietCentralityMultiplier;
+                if (centralityBoost > maxQuietCentralitySwing) centralityBoost = maxQuietCentralitySwing;
+                if (centralityBoost < -maxQuietCentralitySwing) centralityBoost = -maxQuietCentralitySwing;
+                score = historyScore + centralityBoost;
+                if (score < 0) score = 0;
+                if (score >= quietHistoryThreshold) {
+                    category = CAT_QUIET_STRONG;
+                } else {
+                    category = CAT_QUIET;
+                }
             }
 
             moveBuffer[i] = moveInt;

--- a/src/main/java/julius/game/chessengine/tuning/MoveOrderingParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/MoveOrderingParameters.java
@@ -25,7 +25,9 @@ public final class MoveOrderingParameters {
                 Tuning.moveOrderingCounterMoveBonus(),
                 Tuning.moveOrderingCaptureMvvMultiplier(),
                 Tuning.moveOrderingCaptureSeeMultiplier(),
-                Tuning.moveOrderingPromotionSeeMultiplier()
+                Tuning.moveOrderingPromotionSeeMultiplier(),
+                Tuning.moveOrderingQuietCentralityMultiplier(),
+                Tuning.moveOrderingQuietHistoryThreshold()
         );
     }
 
@@ -43,6 +45,8 @@ public final class MoveOrderingParameters {
         defaults.put(ParamId.MOVE_ORDERING_CAPTURE_MVV_MULTIPLIER.key(), ParamId.MOVE_ORDERING_CAPTURE_MVV_MULTIPLIER.defaultValue());
         defaults.put(ParamId.MOVE_ORDERING_CAPTURE_SEE_MULTIPLIER.key(), ParamId.MOVE_ORDERING_CAPTURE_SEE_MULTIPLIER.defaultValue());
         defaults.put(ParamId.MOVE_ORDERING_PROMOTION_SEE_MULTIPLIER.key(), ParamId.MOVE_ORDERING_PROMOTION_SEE_MULTIPLIER.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_QUIET_CENTRALITY_MULTIPLIER.key(), ParamId.MOVE_ORDERING_QUIET_CENTRALITY_MULTIPLIER.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_QUIET_HISTORY_THRESHOLD.key(), ParamId.MOVE_ORDERING_QUIET_HISTORY_THRESHOLD.defaultValue());
         return Collections.unmodifiableMap(defaults);
     }
 
@@ -54,7 +58,9 @@ public final class MoveOrderingParameters {
             int counterMoveBonus,
             int captureMvvMultiplier,
             int captureSeeMultiplier,
-            int promotionSeeMultiplier
+            int promotionSeeMultiplier,
+            int quietCentralityMultiplier,
+            int quietHistoryThreshold
     ) {
         public Map<String, Integer> asMap() {
             Map<String, Integer> values = new LinkedHashMap<>();
@@ -66,6 +72,8 @@ public final class MoveOrderingParameters {
             values.put("moveOrdering.captureMvvMultiplier", captureMvvMultiplier);
             values.put("moveOrdering.captureSeeMultiplier", captureSeeMultiplier);
             values.put("moveOrdering.promotionSeeMultiplier", promotionSeeMultiplier);
+            values.put("moveOrdering.quietCentralityMultiplier", quietCentralityMultiplier);
+            values.put("moveOrdering.quietHistoryThreshold", quietHistoryThreshold);
             return Collections.unmodifiableMap(values);
         }
     }

--- a/src/main/java/julius/game/chessengine/tuning/ParamId.java
+++ b/src/main/java/julius/game/chessengine/tuning/ParamId.java
@@ -79,7 +79,9 @@ public enum ParamId {
     MOVE_ORDERING_COUNTER_MOVE_BONUS("moveOrdering.counterMoveBonus", 400),
     MOVE_ORDERING_CAPTURE_MVV_MULTIPLIER("moveOrdering.captureMvvMultiplier", 16),
     MOVE_ORDERING_CAPTURE_SEE_MULTIPLIER("moveOrdering.captureSeeMultiplier", 32),
-    MOVE_ORDERING_PROMOTION_SEE_MULTIPLIER("moveOrdering.promotionSeeMultiplier", 16);
+    MOVE_ORDERING_PROMOTION_SEE_MULTIPLIER("moveOrdering.promotionSeeMultiplier", 16),
+    MOVE_ORDERING_QUIET_CENTRALITY_MULTIPLIER("moveOrdering.quietCentralityMultiplier", 24),
+    MOVE_ORDERING_QUIET_HISTORY_THRESHOLD("moveOrdering.quietHistoryThreshold", 3200);
 
     private final String key;
     private final double defaultValue;

--- a/src/main/java/julius/game/chessengine/tuning/Tuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/Tuning.java
@@ -93,6 +93,8 @@ public final class Tuning {
     private static int moveOrderingCaptureMvvMultiplier;
     private static int moveOrderingCaptureSeeMultiplier;
     private static int moveOrderingPromotionSeeMultiplier;
+    private static int moveOrderingQuietCentralityMultiplier;
+    private static int moveOrderingQuietHistoryThreshold;
 
     static {
         refresh();
@@ -409,6 +411,14 @@ public final class Tuning {
         return moveOrderingPromotionSeeMultiplier;
     }
 
+    public static int moveOrderingQuietCentralityMultiplier() {
+        return moveOrderingQuietCentralityMultiplier;
+    }
+
+    public static int moveOrderingQuietHistoryThreshold() {
+        return moveOrderingQuietHistoryThreshold;
+    }
+
     /**
      * Reloads all cached tuning values from the current {@link ParameterRegistry} snapshot.
      * Callers should invoke this once after applying a new parameter set (e.g. via hot reload).
@@ -490,6 +500,8 @@ public final class Tuning {
             moveOrderingCaptureMvvMultiplier = loadInt(ParamId.MOVE_ORDERING_CAPTURE_MVV_MULTIPLIER);
             moveOrderingCaptureSeeMultiplier = loadInt(ParamId.MOVE_ORDERING_CAPTURE_SEE_MULTIPLIER);
             moveOrderingPromotionSeeMultiplier = loadInt(ParamId.MOVE_ORDERING_PROMOTION_SEE_MULTIPLIER);
+            moveOrderingQuietCentralityMultiplier = loadInt(ParamId.MOVE_ORDERING_QUIET_CENTRALITY_MULTIPLIER);
+            moveOrderingQuietHistoryThreshold = loadInt(ParamId.MOVE_ORDERING_QUIET_HISTORY_THRESHOLD);
         }
     }
 

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -87,3 +87,5 @@ population:
       moveordering.capturemvvmultiplier: 20
       moveordering.captureseemultiplier: 40
       moveordering.promotionseemultiplier: 20
+      moveordering.quietcentralitymultiplier: 32
+      moveordering.quiethistorythreshold: 3600


### PR DESCRIPTION
## Summary
- add centrality-aware quiet move prioritisation and dedicated counter-move bucket in the search move ordering
- expose new tuning parameters for quiet move centrality weighting and history threshold, including seed tuning defaults

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITest_PruningAndReductions test

------
https://chatgpt.com/codex/tasks/task_e_68e590410910832abaefe650229953d5