### PR TITLE
Add SEE margin overload and adjust pruning

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2109,7 +2109,7 @@ public class AI {
             // SEE pruning for losing captures/quiets (keep checks/promotions)
             boolean seePruneCandidate = (!inCheckAtNode && isCapture && !isPromotion) || isQuiet;
             if (seePruneCandidate) {
-                seeGain = seeCache.computeIfAbsent(move, simulatorEngine::see);
+                seeGain = simulatorEngine.see(move, 0);
                 seeEvaluated = true;
                 boolean nearRoot = plyFromRoot <= SEE_PRUNE_NEAR_ROOT_PLY;
                 boolean allowSeePrune = seeGain < 0 && !nearRoot;
@@ -2294,7 +2294,7 @@ public class AI {
 
             boolean seePruneCandidate = (!inCheckAtNode && isCapture && !isPromotion) || isQuiet;
             if (seePruneCandidate) {
-                seeGain = seeCache.computeIfAbsent(move, simulatorEngine::see);
+                seeGain = simulatorEngine.see(move, 0);
                 seeEvaluated = true;
                 boolean nearRoot = plyFromRoot <= SEE_PRUNE_NEAR_ROOT_PLY;
                 boolean allowSeePrune = seeGain < 0 && !nearRoot;
@@ -2722,7 +2722,7 @@ public class AI {
             // SEE pruning: drop clearly losing captures (keep promotions).
             // Optionally keep losing captures that give check (aggressive but sometimes good).
             if (!inCheck && isCapture && !isPromotion) {
-                int see = simulatorEngine.see(m);
+                int see = simulatorEngine.see(m, 0);
                 if (see < 0) {
                     // Cheap “gives check?” probe; only spend the make/undo if node didn't turn terminal.
                     if (!simulatorEngine.getGameState().isTerminal()) {

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -64,6 +64,7 @@ public class BitBoard {
 
     // Reuse gain stack in SEE (allocation-free)
     private final int[] seeGain = new int[32];
+    private static final int SEE_MARGIN_DISABLED = Integer.MIN_VALUE;
 
     private static final int MAX_PSEUDO_LEGAL_MOVES = 218;
 
@@ -615,6 +616,10 @@ public class BitBoard {
      * Positive => winning capture; Negative => losing capture.
      */
     public int see(int move) {
+        return see(move, SEE_MARGIN_DISABLED);
+    }
+
+    public int see(int move, int margin) {
         // Only meaningful for captures/promotions (we keep 0 for non-captures).
         boolean isCapture = MoveHelper.isCapture(move);
         int promoBits = MoveHelper.derivePromotionPieceTypeBits(move);
@@ -668,7 +673,12 @@ public class BitBoard {
         if (promoBits != 0) {
             capVal += Score.getPieceValue(promoBits) - Score.getPieceValue(1); // promotion delta (to piece - pawn)
         }
-        gain[0] = capVal;
+        boolean thresholded = margin != SEE_MARGIN_DISABLED;
+        int initialGain = capVal;
+        if (thresholded) {
+            initialGain -= margin;
+        }
+        gain[0] = initialGain;
 
         // Track current occupant of 'to' (side/piece) – initially the mover after first capture
         int victimValue = Score.getPieceValue(placedBits);
@@ -799,13 +809,17 @@ public class BitBoard {
             toPieceBits = attBits;
             toPieceWhite = sideWhite;
             sideWhite = !sideWhite;
+
+            if (thresholded && Math.max(-gain[d - 1], gain[d]) <= 0) {
+                break;
+            }
         }
 
         // Resolve swaps back (fail-soft)
         for (int i = d - 1; i >= 0; i--) {
             gain[i] = -Math.max(-gain[i], gain[i + 1]);
         }
-        return gain[0];
+        return thresholded ? gain[0] + margin : gain[0];
     }
 
     private boolean isKingCaptureLegal(boolean kingIsWhite, int kingFrom, int target,

--- a/src/main/java/julius/game/chessengine/engine/Engine.java
+++ b/src/main/java/julius/game/chessengine/engine/Engine.java
@@ -100,6 +100,12 @@ public class Engine {
         }
     }
 
+    public int see(int move, int margin) {
+        synchronized (boardLock) {
+            return bitBoard.see(move, margin);
+        }
+    }
+
     public IntArrayList getAllLegalMoves() {
         synchronized (boardLock) {
             long boardHash = getBoardStateHash();

--- a/src/test/java/julius/game/chessengine/ai/AITest_PruningAndReductions.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_PruningAndReductions.java
@@ -5,6 +5,7 @@ import julius.game.chessengine.board.Move;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.tuning.AiTuning;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.DisplayName;
@@ -85,6 +86,44 @@ class AITest_PruningAndReductions {
                             + "0 is ideal; 1 is allowed for a probe. Found: " + sim.losingCapturePerformed
                             + " | moves: " + movesPerformed);
         }
+    }
+
+    @Test
+    @DisplayName("SEE exact evaluation matches material swing on a winning capture")
+    void seeReturnsExactGainForWinningCapture() {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("6k1/3b4/8/8/8/8/8/3QK3 w - - 0 1");
+
+        int from = MoveHelper.convertStringToIndex("d1");
+        int to = MoveHelper.convertStringToIndex("d7");
+        PieceType captured = engine.getBitBoard().getPieceTypeAtIndex(to);
+
+        int move = MoveHelper.createMoveInt(from, to, PieceType.QUEEN, true,
+                true, false, false, null, captured, false, false,
+                engine.getBitBoard().getLastMoveDoubleStepPawnIndex());
+
+        assertEquals(3, engine.see(move), "Winning capture should yield bishop material gain");
+        assertEquals(3, engine.see(move, 0), "Thresholded SEE should report the same winning score when above the margin");
+        assertEquals(3, engine.see(move, 2), "Margin larger than zero must keep the exact gain when the capture wins");
+    }
+
+    @Test
+    @DisplayName("SEE margin pruning flags a clearly losing queen capture")
+    void seeMarginDetectsLosingCapture() {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("3rk3/3b4/8/8/8/8/8/3QK3 w - - 0 1");
+
+        int from = MoveHelper.convertStringToIndex("d1");
+        int to = MoveHelper.convertStringToIndex("d7");
+        PieceType captured = engine.getBitBoard().getPieceTypeAtIndex(to);
+
+        int move = MoveHelper.createMoveInt(from, to, PieceType.QUEEN, true,
+                true, false, false, null, captured, false, false,
+                engine.getBitBoard().getLastMoveDoubleStepPawnIndex());
+
+        assertEquals(-6, engine.see(move), "Full SEE should recognize the losing exchange");
+        assertTrue(engine.see(move, 0) < 0, "Thresholded SEE should report losing capture as negative");
+        assertTrue(engine.see(move, 2) <= 2, "SEE with positive margin must not exceed the threshold when the trade loses");
     }
 
     @Test
@@ -187,6 +226,12 @@ class AITest_PruningAndReductions {
         public int see(int move) {
             if (move == losingCapture) return -200; // clearly losing
             return super.see(move);
+        }
+
+        @Override
+        public int see(int move, int margin) {
+            if (move == losingCapture) return -200;
+            return super.see(move, margin);
         }
 
         @Override


### PR DESCRIPTION
## Summary
- add a margin-aware SEE overload in BitBoard and expose it via Engine
- switch SEE-based pruning to the thresholded overload while keeping full values for ordering
- extend pruning tests to cover the new SEE margin behaviour and ensure the test double honours it

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITest*,AITest_* test

------
https://chatgpt.com/codex/tasks/task_e_68e62fbe78b0832a8a994b5a7e9138ff