### PR TITLE
Optimize SEE continuation cutoff

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -805,12 +805,16 @@ public class BitBoard {
             // Push gain and toggle
             d++;
             gain[d] = victimValue - gain[d - 1];
+            int continuation = Math.max(-gain[d - 1], gain[d]);
+            if (continuation < 0) {
+                break;
+            }
             victimValue = Score.getPieceValue(attBits);
             toPieceBits = attBits;
             toPieceWhite = sideWhite;
             sideWhite = !sideWhite;
 
-            if (thresholded && Math.max(-gain[d - 1], gain[d]) <= 0) {
+            if (thresholded && continuation <= 0) {
                 break;
             }
         }

--- a/src/test/java/julius/game/chessengine/board/BitBoardTest.java
+++ b/src/test/java/julius/game/chessengine/board/BitBoardTest.java
@@ -194,6 +194,25 @@ public class BitBoardTest {
     }
 
     @Test
+    void seeKeepsLongCaptureChainOutcomeStable() {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("3r2k1/8/2p1pn2/3b4/4PN2/1B3Q2/8/3R2K1 w - - 0 1");
+
+        BitBoard board = engine.getBitBoard();
+        int from = convertStringToIndex("f4");
+        int to = convertStringToIndex("d5");
+        PieceType captured = board.getPieceTypeAtIndex(to);
+
+        int move = MoveHelper.createMoveInt(from, to, PieceType.KNIGHT, true,
+                true, false, false, null, captured, false, false,
+                board.getLastMoveDoubleStepPawnIndex());
+
+        int see = engine.see(move);
+
+        assertEquals(1, see, "Long capture chains should not change the SEE result");
+    }
+
+    @Test
     public void PERFT() {
         long startTime = System.nanoTime(); // Start timing
 


### PR DESCRIPTION
## Summary
- add an early-exit guard in the SEE swap loop so analysis stops once both sides would decline further exchanges
- cover a long capture chain in `BitBoardTest` to confirm the SEE score remains unchanged after the optimization

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=BitBoardTest test

------
https://chatgpt.com/codex/tasks/task_e_68e6340e7c50832a91c96f6b2c63e40e