### PR TITLE
Add futility pruning controls and expose search tuning parameters

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -11,6 +11,7 @@ import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.tuning.AiTuning;
 import julius.game.chessengine.tuning.MoveOrderingParameters;
+import julius.game.chessengine.tuning.SearchParameters;
 import julius.game.chessengine.utils.Score;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
@@ -141,6 +142,7 @@ public class AI {
     private final Heuristics globalHeuristics;
 
     private final MoveOrderingParameters.Snapshot moveOrderingParameters;
+    private final SearchParameters.Snapshot searchParameters;
 
     /**
      * Per-thread heuristic state used during move ordering. The tables are
@@ -298,6 +300,7 @@ public class AI {
         log.info("### SearchThreads = {}, LazySmpThreads = {}", searchThreads, lazySmpThreads);
 
         this.moveOrderingParameters = MoveOrderingParameters.snapshot();
+        this.searchParameters = SearchParameters.snapshot();
         this.globalHeuristics = new Heuristics(maxDepth);
         this.threadHeuristics = ThreadLocal.withInitial(() -> new Heuristics(maxDepth));
 
@@ -1883,6 +1886,32 @@ public class AI {
             if (alpha >= beta) return entry.score;
         }
 
+        int iidReduction = searchParameters.iidReduceDepth();
+        if (iidReduction > 0 && depth > iidReduction && !inCheck) {
+            boolean needIid = entry == null || entry.bestMove == -1 || entry.depth < depth;
+            if (needIid) {
+                double iidScore = alphaBeta(simulatorEngine, depth - iidReduction, alpha, beta,
+                        isWhite, deadline, prevMove, plyFromRoot, extStreak);
+                if (iidScore == EXIT_FLAG) {
+                    return EXIT_FLAG;
+                }
+                entry = transpositionTable.get(boardHash);
+                if (entry != null && entry.depth >= depth) {
+                    if (entry.nodeType == NodeType.EXACT) {
+                        return entry.score;
+                    }
+                    if (entry.nodeType == NodeType.LOWERBOUND && entry.score > alpha) {
+                        alpha = entry.score;
+                    } else if (entry.nodeType == NodeType.UPPERBOUND && entry.score < beta) {
+                        beta = entry.score;
+                    }
+                    if (alpha >= beta) {
+                        return entry.score;
+                    }
+                }
+            }
+        }
+
         // -------- Safer Null-move pruning (same as before, but use depthHere) --------
         IntArrayList moves = simulatorEngine.getAllLegalMoves();
         int mobility = moves.size();
@@ -2084,6 +2113,25 @@ public class AI {
         final Heuristics heuristics = threadHeuristics.get();
         final int[][] historyTable = heuristics.history;
 
+        final int futilityMarginDepth1 = searchParameters.futilityMarginDepth1();
+        final int futilityMarginDepth2 = searchParameters.futilityMarginDepth2();
+        final int lmpBase = searchParameters.lateMovePruningBase();
+        final int lmpPerDepth = searchParameters.lateMovePruningPerDepth();
+        final int hmpMinIndex = searchParameters.historyPruneMinIndex();
+        final int hmpHistoryMax = searchParameters.historyPruneMax();
+        final int lmrProtectPlyMax = searchParameters.lmrProtectPlyMax();
+        final int lmrProtectIndexMax = searchParameters.lmrProtectIndexMax();
+        final int lmrCapGoodQuiet = searchParameters.lmrCapGoodQuiet();
+
+        final int lmpThreshold = lmpBase + depth * lmpPerDepth;
+
+        final boolean futilityCandidateNode = !inCheckAtNode
+                && depth <= 2
+                && (futilityMarginDepth1 > 0 || futilityMarginDepth2 > 0);
+        final double staticEvalAtNode = futilityCandidateNode
+                ? evaluateStaticPosition(simulatorEngine.getGameState(), boardHash, true, plyFromRoot)
+                : Double.NaN;
+
         IntArrayList orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove, simulatorEngine);
         final Map<Integer, Integer> seeCache = seeCacheThreadLocal.get();
         seeCache.clear();
@@ -2100,7 +2148,26 @@ public class AI {
             boolean isCapture = MoveHelper.isCapture(move);
             boolean isPromotion = MoveHelper.isPawnPromotionMove(move);
             boolean isQuiet = !isCapture && !isPromotion;
+            boolean isTactical = isCapture || isPromotion;
             int historyScore = historyTable[from][to];
+
+            if (!inCheckAtNode
+                    && isQuiet
+                    && hmpMinIndex >= 0
+                    && index >= hmpMinIndex
+                    && historyScore <= hmpHistoryMax) {
+                continue;
+            }
+
+            if (futilityCandidateNode && isQuiet && plyFromRoot > 0) {
+                int margin = depth == 1 ? futilityMarginDepth1 : futilityMarginDepth2;
+                if (margin > 0 && !Double.isNaN(staticEvalAtNode)) {
+                    double futilityBound = staticEvalAtNode + margin;
+                    if (futilityBound <= alpha) {
+                        continue;
+                    }
+                }
+            }
 
             int seeGain = 0;
             boolean seeEvaluated = false;
@@ -2136,8 +2203,6 @@ public class AI {
             boolean affectsKingFilePawns = touchesKingFile && (movingPieceBits == 1 || capturedPieceBits == 1);
             int pawnsOnFileBefore = (enemyKingSquare >= 0 && affectsKingFilePawns) ? countPawnsOnFile(boardBefore, kingFileMask) : 0;
 
-            boolean isTactical = isCapture || isPromotion;
-            int lmpThreshold = 8 + depth * 2;
             if (!inCheckAtNode && !isTactical && depth <= 3 && index > lmpThreshold) {
                 simulatorEngine.performMove(move);
                 boolean givesCheckTmp = isSideInCheck(simulatorEngine, false);
@@ -2177,9 +2242,9 @@ public class AI {
                         && !opensKingFile
                         && !seeWinsMaterial
                         && nextDepth >= 2
-                        && index >= 3;
+                        && index > lmrProtectIndexMax;
 
-                if (plyFromRoot <= 1) {
+                if (plyFromRoot <= lmrProtectPlyMax) {
                     canReduce = false;
                 }
 
@@ -2189,6 +2254,9 @@ public class AI {
                 int reduction = 0;
                 if (canReduce) {
                     reduction = lmrReduction(nextDepth, index, historyScore);
+                    if (!isTactical && historyScore > 0 && lmrCapGoodQuiet > 0) {
+                        reduction = Math.min(reduction, lmrCapGoodQuiet);
+                    }
                     if (reduction <= 0) canReduce = false;
                 }
 
@@ -2269,6 +2337,29 @@ public class AI {
         final Heuristics heuristics = threadHeuristics.get();
         final int[][] historyTable = heuristics.history;
 
+        final int futilityMarginDepth1 = searchParameters.futilityMarginDepth1();
+        final int futilityMarginDepth2 = searchParameters.futilityMarginDepth2();
+        final int lmpBase = searchParameters.lateMovePruningBase();
+        final int lmpPerDepth = searchParameters.lateMovePruningPerDepth();
+        final int hmpMinIndex = searchParameters.historyPruneMinIndex();
+        final int hmpHistoryMax = searchParameters.historyPruneMax();
+        final int lmrProtectPlyMax = searchParameters.lmrProtectPlyMax();
+        final int lmrProtectIndexMax = searchParameters.lmrProtectIndexMax();
+        final int lmrCapGoodQuiet = searchParameters.lmrCapGoodQuiet();
+
+        final int lmpThreshold = lmpBase + depth * lmpPerDepth;
+
+        final boolean futilityCandidateNode = !inCheckAtNode
+                && depth <= 2
+                && (futilityMarginDepth1 > 0 || futilityMarginDepth2 > 0);
+        final double staticEvalForWhiteAtNode;
+        if (futilityCandidateNode) {
+            double staticEvalBlack = evaluateStaticPosition(simulatorEngine.getGameState(), boardHash, false, plyFromRoot);
+            staticEvalForWhiteAtNode = -staticEvalBlack;
+        } else {
+            staticEvalForWhiteAtNode = Double.NaN;
+        }
+
         IntArrayList orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove, simulatorEngine);
         final Map<Integer, Integer> seeCache = seeCacheThreadLocal.get();
         seeCache.clear();
@@ -2286,7 +2377,26 @@ public class AI {
             boolean isCapture = MoveHelper.isCapture(move);
             boolean isPromotion = MoveHelper.isPawnPromotionMove(move);
             boolean isQuiet = !isCapture && !isPromotion;
+            boolean isTactical = isCapture || isPromotion;
             int historyScore = historyTable[from][to];
+
+            if (!inCheckAtNode
+                    && isQuiet
+                    && hmpMinIndex >= 0
+                    && index >= hmpMinIndex
+                    && historyScore <= hmpHistoryMax) {
+                continue;
+            }
+
+            if (futilityCandidateNode && isQuiet && plyFromRoot > 0) {
+                int margin = depth == 1 ? futilityMarginDepth1 : futilityMarginDepth2;
+                if (margin > 0 && !Double.isNaN(staticEvalForWhiteAtNode)) {
+                    double futilityBound = staticEvalForWhiteAtNode - margin;
+                    if (futilityBound >= beta) {
+                        continue;
+                    }
+                }
+            }
 
             int seeGain = 0;
             boolean seeEvaluated = false;
@@ -2321,7 +2431,15 @@ public class AI {
             boolean affectsKingFilePawns = touchesKingFile && (movingPieceBits == 1 || capturedPieceBits == 1);
             int pawnsOnFileBefore = (enemyKingSquare >= 0 && affectsKingFilePawns) ? countPawnsOnFile(boardBefore, kingFileMask) : 0;
 
-            boolean isTactical = isCapture || isPromotion;
+            if (!inCheckAtNode && !isTactical && depth <= 3 && index > lmpThreshold) {
+                simulatorEngine.performMove(move);
+                boolean givesCheckTmp = isSideInCheck(simulatorEngine, true);
+                boolean attacksQueenTmp = attacksOpponentQueenNow(simulatorEngine, false);
+                simulatorEngine.undoLastMove();
+                if (!givesCheckTmp && !attacksQueenTmp) {
+                    continue;
+                }
+            }
 
             simulatorEngine.performMove(move);
             long newBoardHash = simulatorEngine.getBoardStateHash();
@@ -2354,9 +2472,9 @@ public class AI {
                         && !opensKingFile
                         && !seeWinsMaterial
                         && nextDepth >= 2
-                        && index >= 3;
+                        && index > lmrProtectIndexMax;
 
-                if (plyFromRoot <= 1) {
+                if (plyFromRoot <= lmrProtectPlyMax) {
                     canReduce = false;
                 }
 
@@ -2366,6 +2484,9 @@ public class AI {
                 int reduction = 0;
                 if (canReduce) {
                     reduction = lmrReduction(nextDepth, index, historyScore);
+                    if (!isTactical && historyScore > 0 && lmrCapGoodQuiet > 0) {
+                        reduction = Math.min(reduction, lmrCapGoodQuiet);
+                    }
                     if (reduction <= 0) canReduce = false;
                 }
 

--- a/src/main/java/julius/game/chessengine/tuning/ParamId.java
+++ b/src/main/java/julius/game/chessengine/tuning/ParamId.java
@@ -80,7 +80,18 @@ public enum ParamId {
     MOVE_ORDERING_CAPTURE_MVV_MULTIPLIER("moveOrdering.captureMvvMultiplier", 16),
     MOVE_ORDERING_CAPTURE_SEE_MULTIPLIER("moveOrdering.captureSeeMultiplier", 32),
     MOVE_ORDERING_PROMOTION_SEE_MULTIPLIER("moveOrdering.promotionSeeMultiplier", 16),
-    MOVE_ORDERING_CASTLING_BONUS("moveOrdering.castlingBonus", 2000);
+    MOVE_ORDERING_CASTLING_BONUS("moveOrdering.castlingBonus", 2000),
+
+    SEARCH_FUTILITY_MARGIN_DEPTH1("search.futilityMarginDepth1", 0),
+    SEARCH_FUTILITY_MARGIN_DEPTH2("search.futilityMarginDepth2", 0),
+    SEARCH_LMP_BASE("search.lmpBase", 8),
+    SEARCH_LMP_PER_DEPTH("search.lmpPerDepth", 2),
+    SEARCH_HMP_MIN_INDEX("search.hmpMinIndex", 256),
+    SEARCH_HMP_HISTORY_MAX("search.hmpHistoryMax", 0),
+    SEARCH_IID_REDUCE_DEPTH("search.iidReduceDepth", 0),
+    SEARCH_LMR_PROTECT_PLY_MAX("search.lmrProtectPlyMax", 1),
+    SEARCH_LMR_PROTECT_INDEX_MAX("search.lmrProtectIndexMax", 2),
+    SEARCH_LMR_CAP_GOOD_QUIET("search.lmrCapGoodQuiet", 0);
 
     private final String key;
     private final double defaultValue;

--- a/src/main/java/julius/game/chessengine/tuning/SearchParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/SearchParameters.java
@@ -1,0 +1,58 @@
+package julius.game.chessengine.tuning;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Snapshot of search-related numeric tuning parameters. Values are captured once per search so
+ * hot-reload updates do not interfere with in-flight iterations.
+ */
+public final class SearchParameters {
+
+    private SearchParameters() {
+    }
+
+    public static Snapshot snapshot() {
+        return new Snapshot(
+                Tuning.searchFutilityMarginDepth1(),
+                Tuning.searchFutilityMarginDepth2(),
+                Tuning.searchLateMovePruningBase(),
+                Tuning.searchLateMovePruningPerDepth(),
+                Tuning.searchHistoryPruneMinIndex(),
+                Tuning.searchHistoryPruneMax(),
+                Tuning.searchIidReduceDepth(),
+                Tuning.searchLmrProtectPlyMax(),
+                Tuning.searchLmrProtectIndexMax(),
+                Tuning.searchLmrCapGoodQuiet()
+        );
+    }
+
+    public record Snapshot(
+            int futilityMarginDepth1,
+            int futilityMarginDepth2,
+            int lateMovePruningBase,
+            int lateMovePruningPerDepth,
+            int historyPruneMinIndex,
+            int historyPruneMax,
+            int iidReduceDepth,
+            int lmrProtectPlyMax,
+            int lmrProtectIndexMax,
+            int lmrCapGoodQuiet
+    ) {
+        public Map<String, Integer> asMap() {
+            Map<String, Integer> values = new LinkedHashMap<>();
+            values.put("search.futilityMarginDepth1", futilityMarginDepth1);
+            values.put("search.futilityMarginDepth2", futilityMarginDepth2);
+            values.put("search.lmpBase", lateMovePruningBase);
+            values.put("search.lmpPerDepth", lateMovePruningPerDepth);
+            values.put("search.hmpMinIndex", historyPruneMinIndex);
+            values.put("search.hmpHistoryMax", historyPruneMax);
+            values.put("search.iidReduceDepth", iidReduceDepth);
+            values.put("search.lmrProtectPlyMax", lmrProtectPlyMax);
+            values.put("search.lmrProtectIndexMax", lmrProtectIndexMax);
+            values.put("search.lmrCapGoodQuiet", lmrCapGoodQuiet);
+            return Collections.unmodifiableMap(values);
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/Tuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/Tuning.java
@@ -95,6 +95,17 @@ public final class Tuning {
     private static int moveOrderingPromotionSeeMultiplier;
     private static int moveOrderingCastlingBonus;
 
+    private static int searchFutilityMarginDepth1;
+    private static int searchFutilityMarginDepth2;
+    private static int searchLateMovePruningBase;
+    private static int searchLateMovePruningPerDepth;
+    private static int searchHistoryPruneMinIndex;
+    private static int searchHistoryPruneMax;
+    private static int searchIidReduceDepth;
+    private static int searchLmrProtectPlyMax;
+    private static int searchLmrProtectIndexMax;
+    private static int searchLmrCapGoodQuiet;
+
     static {
         refresh();
     }
@@ -414,6 +425,46 @@ public final class Tuning {
         return moveOrderingCastlingBonus;
     }
 
+    public static int searchFutilityMarginDepth1() {
+        return searchFutilityMarginDepth1;
+    }
+
+    public static int searchFutilityMarginDepth2() {
+        return searchFutilityMarginDepth2;
+    }
+
+    public static int searchLateMovePruningBase() {
+        return searchLateMovePruningBase;
+    }
+
+    public static int searchLateMovePruningPerDepth() {
+        return searchLateMovePruningPerDepth;
+    }
+
+    public static int searchHistoryPruneMinIndex() {
+        return searchHistoryPruneMinIndex;
+    }
+
+    public static int searchHistoryPruneMax() {
+        return searchHistoryPruneMax;
+    }
+
+    public static int searchIidReduceDepth() {
+        return searchIidReduceDepth;
+    }
+
+    public static int searchLmrProtectPlyMax() {
+        return searchLmrProtectPlyMax;
+    }
+
+    public static int searchLmrProtectIndexMax() {
+        return searchLmrProtectIndexMax;
+    }
+
+    public static int searchLmrCapGoodQuiet() {
+        return searchLmrCapGoodQuiet;
+    }
+
     /**
      * Reloads all cached tuning values from the current {@link ParameterRegistry} snapshot.
      * Callers should invoke this once after applying a new parameter set (e.g. via hot reload).
@@ -496,6 +547,17 @@ public final class Tuning {
             moveOrderingCaptureSeeMultiplier = loadInt(ParamId.MOVE_ORDERING_CAPTURE_SEE_MULTIPLIER);
             moveOrderingPromotionSeeMultiplier = loadInt(ParamId.MOVE_ORDERING_PROMOTION_SEE_MULTIPLIER);
             moveOrderingCastlingBonus = loadInt(ParamId.MOVE_ORDERING_CASTLING_BONUS);
+
+            searchFutilityMarginDepth1 = loadInt(ParamId.SEARCH_FUTILITY_MARGIN_DEPTH1);
+            searchFutilityMarginDepth2 = loadInt(ParamId.SEARCH_FUTILITY_MARGIN_DEPTH2);
+            searchLateMovePruningBase = loadInt(ParamId.SEARCH_LMP_BASE);
+            searchLateMovePruningPerDepth = loadInt(ParamId.SEARCH_LMP_PER_DEPTH);
+            searchHistoryPruneMinIndex = loadInt(ParamId.SEARCH_HMP_MIN_INDEX);
+            searchHistoryPruneMax = loadInt(ParamId.SEARCH_HMP_HISTORY_MAX);
+            searchIidReduceDepth = loadInt(ParamId.SEARCH_IID_REDUCE_DEPTH);
+            searchLmrProtectPlyMax = loadInt(ParamId.SEARCH_LMR_PROTECT_PLY_MAX);
+            searchLmrProtectIndexMax = loadInt(ParamId.SEARCH_LMR_PROTECT_INDEX_MAX);
+            searchLmrCapGoodQuiet = loadInt(ParamId.SEARCH_LMR_CAP_GOOD_QUIET);
         }
     }
 

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -88,3 +88,13 @@ population:
       moveordering.captureseemultiplier: 40
       moveordering.promotionseemultiplier: 20
       moveordering.castlingbonus: 2000
+      search.futilitymargindepth1: 0
+      search.futilitymargindepth2: 0
+      search.lmpbase: 8
+      search.lmpperdepth: 2
+      search.hmpminindex: 256
+      search.hmphistorymax: 0
+      search.iidreducedepth: 0
+      search.lmrprotectplymax: 1
+      search.lmrprotectindexmax: 2
+      search.lmrcapgoodquiet: 0


### PR DESCRIPTION
## Summary
- add a search parameter snapshot that feeds futility pruning, history pruning, IID, and LMR guards inside AI.java
- expose the new search tuning keys through the tuning registry and seed defaults so they can be adjusted via seed-tunings.yaml

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68e6527ccc84832aa8103ff65c505789