### PR TITLE
Fix static rank lookup in BestMoveSearchTest

### DIFF
--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -436,10 +436,12 @@ public class BestMoveSearchTest {
 
         // Rank is based on static ordering; if desired, you could recompute rank from search ordering
         int rank = -1;
-        if (searchResult == null && chosenEvaluation != null) {
-            // Only meaningful when chosenEvaluation came from the static list
-            rank = evaluations.indexOf(evaluationMap.get(chosenMove)) + 1;
-            if (rank == 0) rank = -1;
+        MoveEvaluation staticChosen = evaluationMap.get(chosenMove);
+        if (staticChosen != null) {
+            int index = evaluations.indexOf(staticChosen);
+            if (index >= 0) {
+                rank = index + 1;
+            }
         }
 
         String pvString = renderPrincipalVariation(whiteToMove, ai.principalVariation());


### PR DESCRIPTION
## Summary
- ensure BestMoveSearchTest determines the static rank using the precomputed evaluation map even when a search result is present
- allow rank to report 1 when the searched move matches the static best move

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=BestMoveSearchTest test

------
https://chatgpt.com/codex/tasks/task_e_68e677935d14832ab9dfd30918860490