### PR TITLE
Add tuning controls for move ordering history heuristics

### DIFF
--- a/scripts/auto_tuning_loop.py
+++ b/scripts/auto_tuning_loop.py
@@ -854,6 +854,16 @@ PARAM_MUTATION_HINTS: Dict[str, Dict[str, object]] = {
         "soft_min": 1048576.0,
         "soft_max": 16777215.0,
     },
+    "moveordering.historyscale": {
+        "step": 0.1,
+        "soft_min": 0.0,
+        "soft_max": 4.0,
+    },
+    "moveordering.historydecaydivisor": {
+        "step": 1.0,
+        "soft_min": 1.0,
+        "soft_max": 16.0,
+    },
 }
 
 # ----------------------------

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -137,6 +137,8 @@ public class AI {
     private final Heuristics globalHeuristics;
 
     private final MoveOrderingParameters.Snapshot moveOrderingParameters;
+    private final double moveOrderingHistoryScale;
+    private final int moveOrderingHistoryDecayDivisor;
     private final SearchPruningParameters.Snapshot searchPruningParameters;
     private final AspirationParameters.Snapshot aspirationParameters;
     private final NullMoveParameters.Snapshot nullMoveParameters;
@@ -274,6 +276,8 @@ public class AI {
         log.info("### SearchThreads = {}, LazySmpThreads = {}", searchThreads, lazySmpThreads);
 
         this.moveOrderingParameters = MoveOrderingParameters.snapshot();
+        this.moveOrderingHistoryScale = Math.max(0.0, moveOrderingParameters.historyScale());
+        this.moveOrderingHistoryDecayDivisor = Math.max(1, moveOrderingParameters.historyDecayDivisor());
         this.searchPruningParameters = SearchPruningParameters.snapshot();
         this.aspirationParameters = AspirationParameters.snapshot();
         this.nullMoveParameters = NullMoveParameters.snapshot();
@@ -804,7 +808,7 @@ public class AI {
                 if (captureTranspositionTable != null) {
                     captureTranspositionTable.advanceAge();
                 }
-                globalHeuristics.decayHistory();
+                globalHeuristics.decayHistory(moveOrderingHistoryDecayDivisor);
             } finally {
                 releaseWriteLock(stamp);
             }
@@ -3048,7 +3052,14 @@ public class AI {
     }
 
     private void incrementHistory(int move, int depth) {
-        threadHeuristics.get().addHistory(move, depth);
+        if (depth <= 0) {
+            return;
+        }
+        long base = (long) depth * (long) depth;
+        double scaled = moveOrderingHistoryScale * base;
+        long deltaLong = Math.max(1L, Math.round(scaled));
+        int delta = deltaLong > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) deltaLong;
+        threadHeuristics.get().addHistory(move, delta);
     }
 
     private void clearHistoryTable() {
@@ -3256,13 +3267,12 @@ public class AI {
             }
         }
 
-        void addHistory(int move, int depth) {
-            if (move == -1 || MoveHelper.isCapture(move)) {
+        void addHistory(int move, int delta) {
+            if (move == -1 || MoveHelper.isCapture(move) || delta <= 0) {
                 return;
             }
             int from = move & 0x3F;
             int to = (move >>> 6) & 0x3F;
-            int delta = depth * depth;
             history[from][to] += delta;
             int idx = (from << 6) | to;
             if (!historyDirty[idx]) {
@@ -3329,10 +3339,13 @@ public class AI {
             row[0] = move;
         }
 
-        void decayHistory() {
+        void decayHistory(int divisor) {
+            if (divisor <= 1) {
+                return;
+            }
             for (int f = 0; f < BOARD_SQUARES; f++) {
                 for (int t = 0; t < BOARD_SQUARES; t++) {
-                    history[f][t] >>= 1;
+                    history[f][t] /= divisor;
                 }
             }
         }

--- a/src/main/java/julius/game/chessengine/tuning/MoveOrderingParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/MoveOrderingParameters.java
@@ -29,12 +29,22 @@ public final class MoveOrderingParameters {
                 Tuning.moveOrderingCastlingBonus(),
                 Tuning.moveOrderingCaptureSeeClamp(),
                 Tuning.moveOrderingPromotionSeeClamp(),
-                Tuning.moveOrderingMaxScore()
+                Tuning.moveOrderingMaxScore(),
+                Tuning.moveOrderingHistoryScale(),
+                Tuning.moveOrderingHistoryDecayDivisor()
         );
     }
 
     public static int killerMoveScore() {
         return Tuning.moveOrderingKillerMoveScore();
+    }
+
+    public static double historyScale() {
+        return Tuning.moveOrderingHistoryScale();
+    }
+
+    public static int historyDecayDivisor() {
+        return Tuning.moveOrderingHistoryDecayDivisor();
     }
 
     public static Map<String, Double> defaults() {
@@ -51,6 +61,8 @@ public final class MoveOrderingParameters {
         defaults.put(ParamId.MOVE_ORDERING_CAPTURE_SEE_CLAMP.key(), ParamId.MOVE_ORDERING_CAPTURE_SEE_CLAMP.defaultValue());
         defaults.put(ParamId.MOVE_ORDERING_PROMOTION_SEE_CLAMP.key(), ParamId.MOVE_ORDERING_PROMOTION_SEE_CLAMP.defaultValue());
         defaults.put(ParamId.MOVE_ORDERING_MAX_SCORE.key(), ParamId.MOVE_ORDERING_MAX_SCORE.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_HISTORY_SCALE.key(), ParamId.MOVE_ORDERING_HISTORY_SCALE.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_HISTORY_DECAY_DIVISOR.key(), ParamId.MOVE_ORDERING_HISTORY_DECAY_DIVISOR.defaultValue());
         return Collections.unmodifiableMap(defaults);
     }
 
@@ -66,10 +78,12 @@ public final class MoveOrderingParameters {
             int castlingBonus,
             int captureSeeClamp,
             int promotionSeeClamp,
-            int maxScore
+            int maxScore,
+            double historyScale,
+            int historyDecayDivisor
     ) {
-        public Map<String, Integer> asMap() {
-            Map<String, Integer> values = new LinkedHashMap<>();
+        public Map<String, Number> asMap() {
+            Map<String, Number> values = new LinkedHashMap<>();
             values.put("moveOrdering.killerMoveScore", killerMoveScore);
             values.put("moveOrdering.promotionBonus", promotionBonus);
             values.put("moveOrdering.killer0Bonus", killer0Bonus);
@@ -82,6 +96,8 @@ public final class MoveOrderingParameters {
             values.put("moveOrdering.captureSeeClamp", captureSeeClamp);
             values.put("moveOrdering.promotionSeeClamp", promotionSeeClamp);
             values.put("moveOrdering.maxScore", maxScore);
+            values.put("moveOrdering.historyScale", historyScale);
+            values.put("moveOrdering.historyDecayDivisor", historyDecayDivisor);
             return Collections.unmodifiableMap(values);
         }
     }

--- a/src/main/java/julius/game/chessengine/tuning/ParamId.java
+++ b/src/main/java/julius/game/chessengine/tuning/ParamId.java
@@ -84,6 +84,8 @@ public enum ParamId {
     MOVE_ORDERING_CAPTURE_SEE_CLAMP("moveOrdering.captureSeeClamp", 2048, 0.0, 32768.0),
     MOVE_ORDERING_PROMOTION_SEE_CLAMP("moveOrdering.promotionSeeClamp", 512, 0.0, 32768.0),
     MOVE_ORDERING_MAX_SCORE("moveOrdering.maxScore", 0x00FFFFFF, 1024.0, 16777215.0),
+    MOVE_ORDERING_HISTORY_SCALE("moveOrdering.historyScale", 1.0, 0.0, null),
+    MOVE_ORDERING_HISTORY_DECAY_DIVISOR("moveOrdering.historyDecayDivisor", 2, 1.0, null),
 
     SEARCH_FP_MARGIN_DEPTH1("search.fpMarginDepth1", 0, 0.0, 4000.0),
     SEARCH_FP_MARGIN_DEPTH2("search.fpMarginDepth2", 0, 0.0, 8000.0),

--- a/src/main/java/julius/game/chessengine/tuning/Tuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/Tuning.java
@@ -97,6 +97,8 @@ public final class Tuning {
     private static int moveOrderingCaptureSeeClamp;
     private static int moveOrderingPromotionSeeClamp;
     private static int moveOrderingMaxScore;
+    private static double moveOrderingHistoryScale;
+    private static int moveOrderingHistoryDecayDivisor;
 
     private static int searchFpMarginDepth1;
     private static int searchFpMarginDepth2;
@@ -501,6 +503,14 @@ public final class Tuning {
         return moveOrderingMaxScore;
     }
 
+    public static double moveOrderingHistoryScale() {
+        return moveOrderingHistoryScale;
+    }
+
+    public static int moveOrderingHistoryDecayDivisor() {
+        return moveOrderingHistoryDecayDivisor;
+    }
+
     public static int searchFpMarginDepth1() {
         return searchFpMarginDepth1;
     }
@@ -870,6 +880,8 @@ public final class Tuning {
             moveOrderingCaptureSeeClamp = loadInt(ParamId.MOVE_ORDERING_CAPTURE_SEE_CLAMP);
             moveOrderingPromotionSeeClamp = loadInt(ParamId.MOVE_ORDERING_PROMOTION_SEE_CLAMP);
             moveOrderingMaxScore = loadInt(ParamId.MOVE_ORDERING_MAX_SCORE);
+            moveOrderingHistoryScale = loadDouble(ParamId.MOVE_ORDERING_HISTORY_SCALE);
+            moveOrderingHistoryDecayDivisor = loadInt(ParamId.MOVE_ORDERING_HISTORY_DECAY_DIVISOR);
 
             searchFpMarginDepth1 = loadInt(ParamId.SEARCH_FP_MARGIN_DEPTH1);
             searchFpMarginDepth2 = loadInt(ParamId.SEARCH_FP_MARGIN_DEPTH2);

--- a/src/main/resources/tuning/seed-population.yaml
+++ b/src/main/resources/tuning/seed-population.yaml
@@ -87,3 +87,5 @@ population:
       moveordering.capturemvvmultiplier: 20
       moveordering.captureseemultiplier: 40
       moveordering.promotionseemultiplier: 20
+      moveordering.historyscale: 1.0
+      moveordering.historydecaydivisor: 2

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -91,6 +91,8 @@ population:
       moveordering.captureseeclamp: 2317
       moveordering.promotionseeclamp: 556
       moveordering.maxscore: 16305521
+      moveordering.historyscale: 1.0
+      moveordering.historydecaydivisor: 2
       search.fpMarginDepth1: 123
       search.fpMarginDepth2: 0
       search.lmpBase: 4


### PR DESCRIPTION
## Summary
- add tuning parameters for move-ordering history scaling and decay and expose them through the tuning registry
- update AI heuristics to use scaled history deltas and the configurable decay divisor during search
- seed default values and tuning hints so the auto-tuner can mutate the new parameters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8193c9f74832a82443183fc22e175