### PR TITLE
Expose move ordering category knobs for tuning

### DIFF
--- a/scripts/auto_tuning_loop.py
+++ b/scripts/auto_tuning_loop.py
@@ -794,6 +794,46 @@ PARAM_MUTATION_HINTS: Dict[str, Dict[str, object]] = {
         "soft_min": -100.0,
         "soft_max": 0.0,
     },
+    "moveordering.category.tt": {
+        "step": 1.0,
+        "soft_min": 6.0,
+        "soft_max": 8.0,
+    },
+    "moveordering.category.promotion": {
+        "step": 1.0,
+        "soft_min": 5.0,
+        "soft_max": 7.0,
+    },
+    "moveordering.category.capturegood": {
+        "step": 1.0,
+        "soft_min": 4.0,
+        "soft_max": 6.0,
+    },
+    "moveordering.category.captureequal": {
+        "step": 1.0,
+        "soft_min": 3.0,
+        "soft_max": 5.0,
+    },
+    "moveordering.category.killer0": {
+        "step": 1.0,
+        "soft_min": 2.0,
+        "soft_max": 4.0,
+    },
+    "moveordering.category.killer1": {
+        "step": 1.0,
+        "soft_min": 1.0,
+        "soft_max": 3.0,
+    },
+    "moveordering.category.quiet": {
+        "step": 1.0,
+        "soft_min": 0.0,
+        "soft_max": 2.0,
+    },
+    "moveordering.category.capturebad": {
+        "step": 1.0,
+        "soft_min": -1.0,
+        "soft_max": 1.0,
+    },
     "moveordering.killermovescore": {
         "step": 400.0,
         "soft_min": 2000.0,

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2652,11 +2652,16 @@ public class AI {
 
         final int depthIndex = Math.max(0, Math.min(currentDepth, killerMoves.length - 1));
 
-        // Category encoding (higher is earlier):
-        // 7: TT move, 6: promotions, 5: good captures, 4: equal captures,
-        // 3: killer[0], 2: killer[1], 1: quiets (history), 0: bad captures
-        final int CAT_TT = 7, CAT_PROMO = 6, CAT_CAP_GOOD = 5, CAT_CAP_EQUAL = 4,
-                CAT_KILLER0 = 3, CAT_KILLER1 = 2, CAT_QUIET = 1, CAT_CAP_BAD = 0;
+        // Category encoding (higher is earlier). Ties are resolved via the score field in
+        // the packed sort key so categories remain a stable first-level bucket.
+        final int categoryTt = moveOrderingParameters.categoryTt();
+        final int categoryPromotion = moveOrderingParameters.categoryPromotion();
+        final int categoryCaptureGood = moveOrderingParameters.categoryCaptureGood();
+        final int categoryCaptureEqual = moveOrderingParameters.categoryCaptureEqual();
+        final int categoryKiller0 = moveOrderingParameters.categoryKiller0();
+        final int categoryKiller1 = moveOrderingParameters.categoryKiller1();
+        final int categoryQuiet = moveOrderingParameters.categoryQuiet();
+        final int categoryCaptureBad = moveOrderingParameters.categoryCaptureBad();
 
         final int promotionBonus = moveOrderingParameters.promotionBonus();
         final int killer0Bonus = moveOrderingParameters.killer0Bonus();
@@ -2705,10 +2710,10 @@ public class AI {
             int score;
 
             if (moveInt == ttMove) {
-                category = CAT_TT;
+                category = categoryTt;
                 score = maxScore; // max within bucket
             } else if (isPromotion) {
-                category = CAT_PROMO;
+                category = categoryPromotion;
                 int base = calculateMvvLvaScore(moveInt);
                 int seeBonus = 0;
                 if (hasSee) {
@@ -2721,11 +2726,11 @@ public class AI {
             } else if (isCapture) {
                 final int mvvLva = calculateMvvLvaScore(moveInt);
                 if (seeValue > 0) {
-                    category = CAT_CAP_GOOD;
+                    category = categoryCaptureGood;
                 } else if (seeValue == 0) {
-                    category = CAT_CAP_EQUAL;
+                    category = categoryCaptureEqual;
                 } else {
-                    category = CAT_CAP_BAD;
+                    category = categoryCaptureBad;
                 }
                 int cappedSee = captureSeeClamp > 0
                         ? Math.max(-captureSeeClamp, Math.min(captureSeeClamp, seeValue))
@@ -2733,15 +2738,15 @@ public class AI {
                 score = (mvvLva * captureMvvMultiplier) + (cappedSee * captureSeeMultiplier);
                 if (score < 0) score = 0;
             } else if (moveInt == k0) {
-                category = CAT_KILLER0;
+                category = categoryKiller0;
                 score = killerMoveScore + killer0Bonus;
             } else if (moveInt == k1) {
-                category = CAT_KILLER1;
+                category = categoryKiller1;
                 score = killerMoveScore + killer1Bonus;
             } else {
                 final int from = moveInt & 0x3F;
                 final int to = (moveInt >>> 6) & 0x3F;
-                category = CAT_QUIET;
+                category = categoryQuiet;
                 score = historyTable[from][to];
                 if (moveInt == cm) score += counterMoveBonus;
                 if (MoveHelper.isCastlingMove(moveInt)) {

--- a/src/main/java/julius/game/chessengine/tuning/MoveOrderingParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/MoveOrderingParameters.java
@@ -18,6 +18,14 @@ public final class MoveOrderingParameters {
 
     public static Snapshot snapshot() {
         return new Snapshot(
+                Tuning.moveOrderingCategoryTt(),
+                Tuning.moveOrderingCategoryPromotion(),
+                Tuning.moveOrderingCategoryCaptureGood(),
+                Tuning.moveOrderingCategoryCaptureEqual(),
+                Tuning.moveOrderingCategoryKiller0(),
+                Tuning.moveOrderingCategoryKiller1(),
+                Tuning.moveOrderingCategoryQuiet(),
+                Tuning.moveOrderingCategoryCaptureBad(),
                 Tuning.moveOrderingKillerMoveScore(),
                 Tuning.moveOrderingPromotionBonus(),
                 Tuning.moveOrderingKiller0Bonus(),
@@ -49,6 +57,14 @@ public final class MoveOrderingParameters {
 
     public static Map<String, Double> defaults() {
         Map<String, Double> defaults = new LinkedHashMap<>();
+        defaults.put(ParamId.MOVE_ORDERING_CATEGORY_TT.key(), ParamId.MOVE_ORDERING_CATEGORY_TT.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_CATEGORY_PROMOTION.key(), ParamId.MOVE_ORDERING_CATEGORY_PROMOTION.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_CATEGORY_CAPTURE_GOOD.key(), ParamId.MOVE_ORDERING_CATEGORY_CAPTURE_GOOD.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_CATEGORY_CAPTURE_EQUAL.key(), ParamId.MOVE_ORDERING_CATEGORY_CAPTURE_EQUAL.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_CATEGORY_KILLER0.key(), ParamId.MOVE_ORDERING_CATEGORY_KILLER0.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_CATEGORY_KILLER1.key(), ParamId.MOVE_ORDERING_CATEGORY_KILLER1.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_CATEGORY_QUIET.key(), ParamId.MOVE_ORDERING_CATEGORY_QUIET.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_CATEGORY_CAPTURE_BAD.key(), ParamId.MOVE_ORDERING_CATEGORY_CAPTURE_BAD.defaultValue());
         defaults.put(ParamId.MOVE_ORDERING_KILLER_MOVE_SCORE.key(), ParamId.MOVE_ORDERING_KILLER_MOVE_SCORE.defaultValue());
         defaults.put(ParamId.MOVE_ORDERING_PROMOTION_BONUS.key(), ParamId.MOVE_ORDERING_PROMOTION_BONUS.defaultValue());
         defaults.put(ParamId.MOVE_ORDERING_KILLER0_BONUS.key(), ParamId.MOVE_ORDERING_KILLER0_BONUS.defaultValue());
@@ -67,6 +83,14 @@ public final class MoveOrderingParameters {
     }
 
     public record Snapshot(
+            int categoryTt,
+            int categoryPromotion,
+            int categoryCaptureGood,
+            int categoryCaptureEqual,
+            int categoryKiller0,
+            int categoryKiller1,
+            int categoryQuiet,
+            int categoryCaptureBad,
             int killerMoveScore,
             int promotionBonus,
             int killer0Bonus,
@@ -84,6 +108,14 @@ public final class MoveOrderingParameters {
     ) {
         public Map<String, Number> asMap() {
             Map<String, Number> values = new LinkedHashMap<>();
+            values.put("moveOrdering.category.tt", categoryTt);
+            values.put("moveOrdering.category.promotion", categoryPromotion);
+            values.put("moveOrdering.category.captureGood", categoryCaptureGood);
+            values.put("moveOrdering.category.captureEqual", categoryCaptureEqual);
+            values.put("moveOrdering.category.killer0", categoryKiller0);
+            values.put("moveOrdering.category.killer1", categoryKiller1);
+            values.put("moveOrdering.category.quiet", categoryQuiet);
+            values.put("moveOrdering.category.captureBad", categoryCaptureBad);
             values.put("moveOrdering.killerMoveScore", killerMoveScore);
             values.put("moveOrdering.promotionBonus", promotionBonus);
             values.put("moveOrdering.killer0Bonus", killer0Bonus);

--- a/src/main/java/julius/game/chessengine/tuning/ParamId.java
+++ b/src/main/java/julius/game/chessengine/tuning/ParamId.java
@@ -72,6 +72,15 @@ public enum ParamId {
 
     EVALUATION_BLEND_SCALE("evaluation.blendScale", 256, 1.0, 1024.0),
 
+    MOVE_ORDERING_CATEGORY_TT("moveOrdering.category.tt", 7, 6.0, 8.0),
+    MOVE_ORDERING_CATEGORY_PROMOTION("moveOrdering.category.promotion", 6, 5.0, 7.0),
+    MOVE_ORDERING_CATEGORY_CAPTURE_GOOD("moveOrdering.category.captureGood", 5, 4.0, 6.0),
+    MOVE_ORDERING_CATEGORY_CAPTURE_EQUAL("moveOrdering.category.captureEqual", 4, 3.0, 5.0),
+    MOVE_ORDERING_CATEGORY_KILLER0("moveOrdering.category.killer0", 3, 2.0, 4.0),
+    MOVE_ORDERING_CATEGORY_KILLER1("moveOrdering.category.killer1", 2, 1.0, 3.0),
+    MOVE_ORDERING_CATEGORY_QUIET("moveOrdering.category.quiet", 1, 0.0, 2.0),
+    MOVE_ORDERING_CATEGORY_CAPTURE_BAD("moveOrdering.category.captureBad", 0, -1.0, 1.0),
+
     MOVE_ORDERING_KILLER_MOVE_SCORE("moveOrdering.killerMoveScore", 10_000),
     MOVE_ORDERING_PROMOTION_BONUS("moveOrdering.promotionBonus", 900),
     MOVE_ORDERING_KILLER0_BONUS("moveOrdering.killer0Bonus", 50),

--- a/src/main/java/julius/game/chessengine/tuning/Tuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/Tuning.java
@@ -85,6 +85,14 @@ public final class Tuning {
 
     private static int evaluationBlendScale;
 
+    private static int moveOrderingCategoryTt;
+    private static int moveOrderingCategoryPromotion;
+    private static int moveOrderingCategoryCaptureGood;
+    private static int moveOrderingCategoryCaptureEqual;
+    private static int moveOrderingCategoryKiller0;
+    private static int moveOrderingCategoryKiller1;
+    private static int moveOrderingCategoryQuiet;
+    private static int moveOrderingCategoryCaptureBad;
     private static int moveOrderingKillerMoveScore;
     private static int moveOrderingPromotionBonus;
     private static int moveOrderingKiller0Bonus;
@@ -453,6 +461,38 @@ public final class Tuning {
 
     public static int evaluationBlendScale() {
         return evaluationBlendScale;
+    }
+
+    public static int moveOrderingCategoryTt() {
+        return moveOrderingCategoryTt;
+    }
+
+    public static int moveOrderingCategoryPromotion() {
+        return moveOrderingCategoryPromotion;
+    }
+
+    public static int moveOrderingCategoryCaptureGood() {
+        return moveOrderingCategoryCaptureGood;
+    }
+
+    public static int moveOrderingCategoryCaptureEqual() {
+        return moveOrderingCategoryCaptureEqual;
+    }
+
+    public static int moveOrderingCategoryKiller0() {
+        return moveOrderingCategoryKiller0;
+    }
+
+    public static int moveOrderingCategoryKiller1() {
+        return moveOrderingCategoryKiller1;
+    }
+
+    public static int moveOrderingCategoryQuiet() {
+        return moveOrderingCategoryQuiet;
+    }
+
+    public static int moveOrderingCategoryCaptureBad() {
+        return moveOrderingCategoryCaptureBad;
     }
 
     public static int moveOrderingKillerMoveScore() {
@@ -868,6 +908,14 @@ public final class Tuning {
 
             evaluationBlendScale = loadInt(ParamId.EVALUATION_BLEND_SCALE);
 
+            moveOrderingCategoryTt = loadInt(ParamId.MOVE_ORDERING_CATEGORY_TT);
+            moveOrderingCategoryPromotion = loadInt(ParamId.MOVE_ORDERING_CATEGORY_PROMOTION);
+            moveOrderingCategoryCaptureGood = loadInt(ParamId.MOVE_ORDERING_CATEGORY_CAPTURE_GOOD);
+            moveOrderingCategoryCaptureEqual = loadInt(ParamId.MOVE_ORDERING_CATEGORY_CAPTURE_EQUAL);
+            moveOrderingCategoryKiller0 = loadInt(ParamId.MOVE_ORDERING_CATEGORY_KILLER0);
+            moveOrderingCategoryKiller1 = loadInt(ParamId.MOVE_ORDERING_CATEGORY_KILLER1);
+            moveOrderingCategoryQuiet = loadInt(ParamId.MOVE_ORDERING_CATEGORY_QUIET);
+            moveOrderingCategoryCaptureBad = loadInt(ParamId.MOVE_ORDERING_CATEGORY_CAPTURE_BAD);
             moveOrderingKillerMoveScore = loadInt(ParamId.MOVE_ORDERING_KILLER_MOVE_SCORE);
             moveOrderingPromotionBonus = loadInt(ParamId.MOVE_ORDERING_PROMOTION_BONUS);
             moveOrderingKiller0Bonus = loadInt(ParamId.MOVE_ORDERING_KILLER0_BONUS);

--- a/src/main/resources/tuning/search-1-lazy-10.yaml
+++ b/src/main/resources/tuning/search-1-lazy-10.yaml
@@ -79,6 +79,14 @@ population:
       kingsafety.attackweightbishop: 11
       kingsafety.attackweightrook: 14
       kingsafety.attackweightqueen: 26
+      moveordering.category.tt: 7
+      moveordering.category.promotion: 6
+      moveordering.category.capturegood: 5
+      moveordering.category.captureequal: 4
+      moveordering.category.killer0: 3
+      moveordering.category.killer1: 2
+      moveordering.category.quiet: 1
+      moveordering.category.capturebad: 0
       moveordering.killermovescore: 11568
       moveordering.promotionbonus: 957
       moveordering.killer0bonus: 59

--- a/src/main/resources/tuning/seed-population.yaml
+++ b/src/main/resources/tuning/seed-population.yaml
@@ -79,6 +79,14 @@ population:
       kingsafety.attackweightbishop: 12
       kingsafety.attackweightrook: 16
       kingsafety.attackweightqueen: 22
+      moveordering.category.tt: 7
+      moveordering.category.promotion: 6
+      moveordering.category.capturegood: 5
+      moveordering.category.captureequal: 4
+      moveordering.category.killer0: 3
+      moveordering.category.killer1: 2
+      moveordering.category.quiet: 1
+      moveordering.category.capturebad: 0
       moveordering.killermovescore: 8000
       moveordering.promotionbonus: 900
       moveordering.killer0bonus: 60

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -79,6 +79,14 @@ population:
       kingsafety.attackweightbishop: 12
       kingsafety.attackweightrook: 14
       kingsafety.attackweightqueen: 26
+      moveordering.category.tt: 7
+      moveordering.category.promotion: 6
+      moveordering.category.capturegood: 5
+      moveordering.category.captureequal: 4
+      moveordering.category.killer0: 3
+      moveordering.category.killer1: 2
+      moveordering.category.quiet: 1
+      moveordering.category.capturebad: 0
       moveordering.killermovescore: 9910
       moveordering.promotionbonus: 965
       moveordering.killer0bonus: 59


### PR DESCRIPTION
## Summary
- add move ordering category ParamIds with sensible defaults and bounds, wiring them through Tuning and MoveOrderingParameters
- consume the snapshot-provided category values in AI move ordering so tuned weights drive sorting
- seed the new parameters in tuning YAMLs and expose mutation hints for the auto tuning loop

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e81b5e25bc832aa0b3b96fd2cd4a6f