### PR TITLE
Fix center pawn counting and add coverage

### DIFF
--- a/src/main/java/julius/game/chessengine/helper/PawnHelper.java
+++ b/src/main/java/julius/game/chessengine/helper/PawnHelper.java
@@ -71,11 +71,11 @@ public class PawnHelper {
             0, 0, 0, 0, 0, 0, 0, 0  // R8
     };
 
-    // Method to count pawns in the center (e4, d4, e0, d0 squares)
+    // Method to count pawns in the center (d4, e4, d5, e5 squares)
     public static int countCenterPawns(long pawnsBitboard) {
-        // Bit positions for e4, d4, e0, d0
-        long centerSquares = (1L << bitIndex('e', 4)) | (1L << bitIndex('d', 4))
-                | (1L << bitIndex('e', 0)) | (1L << bitIndex('d', 0));
+        // Bit positions for d4, e4, d5, e5
+        long centerSquares = (1L << bitIndex('d', 4)) | (1L << bitIndex('e', 4))
+                | (1L << bitIndex('d', 5)) | (1L << bitIndex('e', 5));
         return Long.bitCount(pawnsBitboard & centerSquares);
     }
 

--- a/src/test/java/julius/game/chessengine/helper/PawnHelperTest.java
+++ b/src/test/java/julius/game/chessengine/helper/PawnHelperTest.java
@@ -1,0 +1,23 @@
+package julius.game.chessengine.helper;
+
+import org.junit.jupiter.api.Test;
+
+import static julius.game.chessengine.helper.BitHelper.bitIndex;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PawnHelperTest {
+
+    @Test
+    void countCenterPawnsCountsWhitePawnsOnD4AndE4() {
+        long whiteCenterPawns = (1L << bitIndex('d', 4)) | (1L << bitIndex('e', 4));
+
+        assertThat(PawnHelper.countCenterPawns(whiteCenterPawns)).isEqualTo(2);
+    }
+
+    @Test
+    void countCenterPawnsCountsBlackPawnsOnD5AndE5() {
+        long blackCenterPawns = (1L << bitIndex('d', 5)) | (1L << bitIndex('e', 5));
+
+        assertThat(PawnHelper.countCenterPawns(blackCenterPawns)).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
## Summary
- correct the center pawn mask to cover d4/e4/d5/e5
- document the intended center squares in the helper
- add a unit test ensuring both white and black center pawns are counted

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=PawnHelperTest test

------
https://chatgpt.com/codex/tasks/task_e_68e8d51b4894832a979d4d7e2251553a