### PR TITLE
Improve evaluation context invalidation granularity

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -129,6 +129,26 @@ Agents should compute `S, L, R, TT` via the heuristics above and substitute into
 * `BitBoard` now caches per-piece attack contributions incrementally. When touching move application code, call the existing helpers (`markRecalc`, `updateAttackCachesAfterChange`, etc.) so both the caches and the aggregated maps stay in sync without forcing full recomputation.
 * `ActivityModule` precomputes bishop/rook watcher tables so slider updates can skip full-board scans. Pass `-Dchessengine.activity.linearScanFallback=true` to restore the legacy scan when debugging or if the watcher tables need to be bypassed.
 * Move ordering now uses per-thread bucketed buffers (TT → promotions → SEE-sorted captures → killers → quiet → bad captures) instead of a global `Arrays.sort`. Buckets reuse IntArrayList storage, tie-break on the move id to remain deterministic, and cut the `BestMoveSearchTest` runtime on the reference container from ~3m36s to ~3m14s.
+* Performance spot-check: capture `BitBoardTwst` timing with
+  ```bash
+  python - <<'PY'
+  import subprocess, time
+  cmd = [
+      "mvn", "-q",
+      "-Djava.version=21",
+      "-Dmaven.compiler.release=21",
+      "-Dmaven.compiler.enablePreview=true",
+      "-DargLine=--enable-preview",
+      "-Dtest=BitBoardTwst",
+      "-Dsurefire.failIfNoSpecifiedTests=false",
+      "test",
+  ]
+  start = time.perf_counter()
+  subprocess.run(cmd, check=True)
+  print(f"{time.perf_counter() - start:.3f}s")
+  PY
+  ```
+  before and after code changes.
 
 ### AI search & evaluation notes
 * Quiescence delta pruning now compares against the alpha window captured before the stand-pat update. Earlier builds raised `alpha` first, which meant `standPat + Δ < alpha` never triggered and the pruning shortcut was effectively disabled.

--- a/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
@@ -10,6 +10,7 @@ import julius.game.chessengine.helper.RookHelper;
 import julius.game.chessengine.tuning.Tuning;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Objects;
 
 /**
@@ -17,7 +18,7 @@ import java.util.Objects;
  * components.  The module keeps per-piece caches and incrementally updates only the
  * pieces affected by a move so the evaluation pipeline can reuse the tapered score.
  */
-public final class ActivityModule implements EvaluationModule {
+public final class ActivityModule implements EvaluationModule, ContextAwareEvaluationModule {
 
     private static final int WHITE = 0;
     private static final int BLACK = 1;
@@ -237,6 +238,11 @@ public final class ActivityModule implements EvaluationModule {
     @Override
     public void markDirty() {
         dirty = true;
+    }
+
+    @Override
+    public EnumSet<EvaluationContextAspect> getContextAspects() {
+        return EnumSet.of(EvaluationContextAspect.STRUCTURE);
     }
 
     private boolean ensureInitialized(MoveContext moveContext) {

--- a/src/main/java/julius/game/chessengine/evaluation/ContextAwareEvaluationModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ContextAwareEvaluationModule.java
@@ -1,0 +1,15 @@
+package julius.game.chessengine.evaluation;
+
+import java.util.EnumSet;
+
+/**
+ * Optional extension point for {@link EvaluationModule}s that want the evaluation pipeline to
+ * invalidate them selectively when only certain {@link EvaluationContext} features change.
+ */
+public interface ContextAwareEvaluationModule {
+
+    /**
+     * Returns the evaluation context aspects that influence this module's cached state.
+     */
+    EnumSet<EvaluationContextAspect> getContextAspects();
+}

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationContextAspect.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationContextAspect.java
@@ -1,0 +1,20 @@
+package julius.game.chessengine.evaluation;
+
+/**
+ * Identifiers for coarse-grained {@link EvaluationContext} features that evaluation modules rely
+ * on. The evaluation pipeline uses these aspects to invalidate only the modules whose inputs
+ * changed after a context refresh.
+ */
+public enum EvaluationContextAspect {
+
+    /**
+     * Structural board changes such as piece placement, side to move, castling rights, or the
+     * fifty-move metadata.
+     */
+    STRUCTURE,
+
+    /**
+     * Derived attack bitboards for each side.
+     */
+    ATTACK_MAPS
+}

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
@@ -1,10 +1,12 @@
 package julius.game.chessengine.evaluation;
 
+import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.utils.Score;
 import julius.game.chessengine.tuning.Tuning;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -19,13 +21,26 @@ public final class EvaluationPipeline {
     private static final class ModuleState {
         private final EvaluationModule module;
         private final EvaluationWeights.ModuleWeight weight;
+        private final EnumSet<EvaluationContextAspect> contextAspects;
         private int midgameCache;
         private int endgameCache;
 
         private ModuleState(EvaluationModule module, EvaluationWeights.ModuleWeight weight) {
             this.module = module;
             this.weight = weight;
+            this.contextAspects = resolveAspects(module);
             this.module.markDirty();
+        }
+
+        private static EnumSet<EvaluationContextAspect> resolveAspects(EvaluationModule module) {
+            if (module instanceof ContextAwareEvaluationModule aware) {
+                EnumSet<EvaluationContextAspect> aspects = aware.getContextAspects();
+                if (aspects == null || aspects.isEmpty()) {
+                    return EnumSet.allOf(EvaluationContextAspect.class);
+                }
+                return EnumSet.copyOf(aspects);
+            }
+            return EnumSet.allOf(EvaluationContextAspect.class);
         }
     }
 
@@ -35,6 +50,9 @@ public final class EvaluationPipeline {
     private EvaluationContext context;
     private boolean initialized;
     private boolean aggregateDirty = true;
+    private final EnumSet<EvaluationContextAspect> pendingContextChanges =
+            EnumSet.noneOf(EvaluationContextAspect.class);
+    private ContextFingerprint fingerprint;
     private int midgameTotal;
     private int endgameTotal;
 
@@ -58,6 +76,8 @@ public final class EvaluationPipeline {
 
     public void initialize(EvaluationContext context) {
         this.context = Objects.requireNonNull(context, "context");
+        fingerprint = ContextFingerprint.capture(this.context);
+        pendingContextChanges.clear();
         for (ModuleState state : modules) {
             state.module.initialize(context);
             state.module.markDirty();
@@ -72,12 +92,26 @@ public final class EvaluationPipeline {
             initialize(context);
             return;
         }
-        this.context = Objects.requireNonNull(context, "context");
-        markAllDirty();
+        EvaluationContext next = Objects.requireNonNull(context, "context");
+        ContextFingerprint nextFingerprint = ContextFingerprint.capture(next);
+        EnumSet<EvaluationContextAspect> changes =
+                (fingerprint == null)
+                        ? EnumSet.allOf(EvaluationContextAspect.class)
+                        : nextFingerprint.diff(fingerprint);
+        boolean stateChanged = nextFingerprint.stateChanged(fingerprint);
+        this.context = next;
+        if (!changes.isEmpty()) {
+            pendingContextChanges.addAll(changes);
+        }
+        if (stateChanged || !changes.isEmpty()) {
+            aggregateDirty = true;
+        }
+        fingerprint = nextFingerprint;
     }
 
     public void applyMove(MoveContext moveContext) {
         ensureInitialized();
+        pendingContextChanges.clear();
         for (ModuleState state : modules) {
             state.module.applyMove(moveContext);
         }
@@ -86,6 +120,7 @@ public final class EvaluationPipeline {
 
     public void undoMove(MoveContext moveContext) {
         ensureInitialized();
+        pendingContextChanges.clear();
         for (ModuleState state : modules) {
             state.module.undoMove(moveContext);
         }
@@ -128,6 +163,7 @@ public final class EvaluationPipeline {
 
     private void refreshTotals() {
         ensureInitialized();
+        propagatePendingContextChanges();
         if (!aggregateDirty) {
             return;
         }
@@ -156,6 +192,21 @@ public final class EvaluationPipeline {
         }
     }
 
+    private void propagatePendingContextChanges() {
+        if (pendingContextChanges.isEmpty()) {
+            return;
+        }
+        for (ModuleState state : modules) {
+            for (EvaluationContextAspect aspect : pendingContextChanges) {
+                if (state.contextAspects.contains(aspect)) {
+                    state.module.markDirty();
+                    break;
+                }
+            }
+        }
+        pendingContextChanges.clear();
+    }
+
     private void markAllDirty() {
         for (ModuleState state : modules) {
             state.module.markDirty();
@@ -171,6 +222,85 @@ public final class EvaluationPipeline {
             return blendScale;
         }
         return phase;
+    }
+
+    private static final class ContextFingerprint {
+        private static final long STRUCTURE_SEED = 0x9E3779B97F4A7C15L;
+        private static final long ATTACK_SEED = 0x517CC1B727220A95L;
+
+        private final long structureSignature;
+        private final long attackSignature;
+        private final GameStateEnum gameState;
+
+        private ContextFingerprint(long structureSignature, long attackSignature, GameStateEnum gameState) {
+            this.structureSignature = structureSignature;
+            this.attackSignature = attackSignature;
+            this.gameState = gameState;
+        }
+
+        private static ContextFingerprint capture(EvaluationContext context) {
+            if (context == null) {
+                return new ContextFingerprint(0L, 0L, null);
+            }
+            ImmutableBoardView board = context.getBoardView();
+            long structure = STRUCTURE_SEED;
+            if (board != null) {
+                structure = mix(structure, board.isWhitesTurn() ? 1L : 0L);
+                structure = mix(structure, board.getWhitePawns());
+                structure = mix(structure, board.getBlackPawns());
+                structure = mix(structure, board.getWhiteKnights());
+                structure = mix(structure, board.getBlackKnights());
+                structure = mix(structure, board.getWhiteBishops());
+                structure = mix(structure, board.getBlackBishops());
+                structure = mix(structure, board.getWhiteRooks());
+                structure = mix(structure, board.getBlackRooks());
+                structure = mix(structure, board.getWhiteQueens());
+                structure = mix(structure, board.getBlackQueens());
+                structure = mix(structure, board.getWhiteKing());
+                structure = mix(structure, board.getBlackKing());
+                structure = mix(structure, board.getWhitePieces());
+                structure = mix(structure, board.getBlackPieces());
+                structure = mix(structure, board.getAllPieces());
+                structure = mix(structure, board.isWhiteKingMoved() ? 1L : 0L);
+                structure = mix(structure, board.isBlackKingMoved() ? 1L : 0L);
+                structure = mix(structure, board.isWhiteRookA1Moved() ? 1L : 0L);
+                structure = mix(structure, board.isWhiteRookH1Moved() ? 1L : 0L);
+                structure = mix(structure, board.isBlackRookA8Moved() ? 1L : 0L);
+                structure = mix(structure, board.isBlackRookH8Moved() ? 1L : 0L);
+                structure = mix(structure, board.isWhiteKingHasCastled() ? 1L : 0L);
+                structure = mix(structure, board.isBlackKingHasCastled() ? 1L : 0L);
+                structure = mix(structure, board.getLastMoveDoubleStepPawnIndex());
+                structure = mix(structure, board.getHalfmoveClock());
+                structure = mix(structure, board.getFullmoveNumber());
+            }
+            structure = mix(structure, context.getPhase());
+            long attacks = ATTACK_SEED;
+            attacks = mix(attacks, context.getWhiteAttackMap());
+            attacks = mix(attacks, context.getBlackAttackMap());
+            return new ContextFingerprint(structure, attacks, context.getGameState());
+        }
+
+        private EnumSet<EvaluationContextAspect> diff(ContextFingerprint previous) {
+            EnumSet<EvaluationContextAspect> changes = EnumSet.noneOf(EvaluationContextAspect.class);
+            if (previous == null || structureSignature != previous.structureSignature) {
+                changes.add(EvaluationContextAspect.STRUCTURE);
+            }
+            if (previous == null || attackSignature != previous.attackSignature) {
+                changes.add(EvaluationContextAspect.ATTACK_MAPS);
+            }
+            return changes;
+        }
+
+        private boolean stateChanged(ContextFingerprint previous) {
+            return previous == null || !Objects.equals(gameState, previous.gameState);
+        }
+
+        private static long mix(long accumulator, long value) {
+            long x = accumulator ^ value;
+            x ^= Long.rotateLeft(x, 21);
+            x *= 0x9E3779B97F4A7C15L;
+            return x;
+        }
     }
 
     private int computeCheckAdjustment() {

--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -9,6 +9,7 @@ import julius.game.chessengine.helper.RookHelper;
 import julius.game.chessengine.tuning.Tuning;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Objects;
 
 import static julius.game.chessengine.helper.BitHelper.FileMasks;
@@ -21,7 +22,7 @@ import static julius.game.chessengine.helper.PawnMoveTables.PAWN_ATTACKS;
  * map from king-zone squares to aggregated attacker weights together with pawn-shield metadata so
  * the evaluation pipeline can refresh the score incrementally.
  */
-public final class KingSafetyModule implements EvaluationModule {
+public final class KingSafetyModule implements EvaluationModule, ContextAwareEvaluationModule {
 
     private static final int WHITE = 0;
     private static final int BLACK = 1;
@@ -137,6 +138,11 @@ public final class KingSafetyModule implements EvaluationModule {
     @Override
     public void markDirty() {
         dirty = true;
+    }
+
+    @Override
+    public EnumSet<EvaluationContextAspect> getContextAspects() {
+        return EnumSet.of(EvaluationContextAspect.STRUCTURE, EvaluationContextAspect.ATTACK_MAPS);
     }
 
     public KingSafetyView evaluate(BitBoard board) {

--- a/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/MaterialModule.java
@@ -1,6 +1,7 @@
 package julius.game.chessengine.evaluation;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Objects;
 
 import julius.game.chessengine.board.MoveHelper;
@@ -10,7 +11,7 @@ import julius.game.chessengine.tuning.Tuning;
  * Tracks per-side material using incremental updates so the evaluation pipeline can
  * access midgame and endgame material totals without rescanning the board.
  */
-public final class MaterialModule implements EvaluationModule {
+public final class MaterialModule implements EvaluationModule, ContextAwareEvaluationModule {
 
     public static final int DEFAULT_PAWN_VALUE = 100;
     public static final int DEFAULT_KNIGHT_VALUE = 320;
@@ -134,6 +135,11 @@ public final class MaterialModule implements EvaluationModule {
     @Override
     public void markDirty() {
         dirty = true;
+    }
+
+    @Override
+    public EnumSet<EvaluationContextAspect> getContextAspects() {
+        return EnumSet.of(EvaluationContextAspect.STRUCTURE);
     }
 
     private boolean isForwardMove(MoveContext moveContext) {

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -4,6 +4,7 @@ import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.helper.PawnHelper;
 import julius.game.chessengine.tuning.Tuning;
 
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -18,7 +19,7 @@ import static julius.game.chessengine.helper.PawnMoveTables.PAWN_PUSHES;
  * components so the evaluation pipeline and {@link julius.game.chessengine.utils.Score}
  * can blend them consistently.
  */
-public final class PawnStructureModule implements EvaluationModule, MaterialModule.PawnChangeListener {
+public final class PawnStructureModule implements EvaluationModule, MaterialModule.PawnChangeListener, ContextAwareEvaluationModule {
     private static final int WHITE = 0;
     private static final int BLACK = 1;
     private static final long WHITE_ADVANCED_RANKS = RankMasks[3] | RankMasks[4] | RankMasks[5] | RankMasks[6];
@@ -251,6 +252,11 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
     @Override
     public void markDirty() {
         dirty = true;
+    }
+
+    @Override
+    public EnumSet<EvaluationContextAspect> getContextAspects() {
+        return EnumSet.of(EvaluationContextAspect.STRUCTURE, EvaluationContextAspect.ATTACK_MAPS);
     }
 
     @Override

--- a/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
@@ -5,6 +5,7 @@ import julius.game.chessengine.board.ImmutableBoardView;
 import julius.game.chessengine.figures.PieceType;
 import julius.game.chessengine.tuning.Tuning;
 
+import java.util.EnumSet;
 import java.util.Objects;
 
 import static julius.game.chessengine.helper.PawnMoveTables.PAWN_ATTACKS;
@@ -14,7 +15,7 @@ import static julius.game.chessengine.helper.PawnMoveTables.PAWN_ATTACKS;
  * pieces. The module recomputes its contribution when marked dirty rather than maintaining
  * incremental state.
  */
-public final class ThreatModule implements EvaluationModule {
+public final class ThreatModule implements EvaluationModule, ContextAwareEvaluationModule {
 
     private static final int WHITE = 0;
     private static final int BLACK = 1;
@@ -104,6 +105,11 @@ public final class ThreatModule implements EvaluationModule {
     @Override
     public void markDirty() {
         dirty = true;
+    }
+
+    @Override
+    public EnumSet<EvaluationContextAspect> getContextAspects() {
+        return EnumSet.of(EvaluationContextAspect.STRUCTURE, EvaluationContextAspect.ATTACK_MAPS);
     }
 
     private int evaluateSide(ImmutableBoardView board, boolean isWhite, long friendlyAttacks, long enemyAttacks) {


### PR DESCRIPTION
## Summary
- add an evaluation-context fingerprint so the pipeline only dirties modules whose inputs actually changed
- let evaluation modules declare the context aspects they depend on and document the BitBoardTwst timing harness in Agents.md

## Testing
- python - <<'PY' ... (BitBoardTwst timing)
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=EvaluationPipelineTest test

------
https://chatgpt.com/codex/tasks/task_e_68ea46076340832a9f1d20cf518a5e71