### PR TITLE
Fix cutechess score parsing orientation

### DIFF
--- a/scripts/cutechess_tuning_loop.py
+++ b/scripts/cutechess_tuning_loop.py
@@ -163,8 +163,16 @@ def maybe_build_jar(project_root: Path, mvn: str, extra_args: Sequence[str]) -> 
         raise RuntimeError("Maven package command failed")
 
 
-def parse_score(stdout: str, engine_name: str, opponent_name: str, opponent_elo: float, duration_s: float, command: Sequence[str], stderr: str) -> MatchResult:
-    last_match = None
+def parse_score(
+    stdout: str,
+    engine_name: str,
+    opponent_name: str,
+    opponent_elo: float,
+    duration_s: float,
+    command: Sequence[str],
+    stderr: str,
+) -> MatchResult:
+    last_match: Optional[tuple[re.Match[str], bool]] = None
     for line in stdout.splitlines():
         match = SCORE_PATTERN.search(line)
         if not match:
@@ -172,13 +180,21 @@ def parse_score(stdout: str, engine_name: str, opponent_name: str, opponent_elo:
         first = match.group("first").strip()
         second = match.group("second").strip()
         if first == engine_name and second == opponent_name:
-            last_match = match
+            last_match = (match, True)
+        elif first == opponent_name and second == engine_name:
+            last_match = (match, False)
     if last_match is None:
         raise ValueError("Unable to locate cutechess score summary for the configured engine")
-    wins = int(last_match.group("wins"))
-    losses = int(last_match.group("losses"))
-    draws = int(last_match.group("draws"))
-    score = float(last_match.group("score"))
+    match, is_engine_first = last_match
+    wins = int(match.group("wins"))
+    losses = int(match.group("losses"))
+    draws = int(match.group("draws"))
+    score = float(match.group("score"))
+
+    if not is_engine_first:
+        wins, losses = losses, wins
+        score = 1.0 - score
+
     return MatchResult(
         engine_name=engine_name,
         opponent_name=opponent_name,

--- a/scripts/tests/test_cutechess_tuning_loop_parsing.py
+++ b/scripts/tests/test_cutechess_tuning_loop_parsing.py
@@ -1,0 +1,49 @@
+"""Tests for cutechess_tuning_loop parsing helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# Ensure the scripts directory (parent of this file) is importable.
+SCRIPT_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+
+from cutechess_tuning_loop import MatchResult, parse_score  # type: ignore  # noqa: E402
+
+
+def build_stdout(summary_line: str) -> str:
+    return "\n".join(
+        [
+            "Started game 1 of 10 (SF2000 vs YourJava)",
+            "Finished game 1 (SF2000 vs YourJava): 1-0 {White mates}",
+            summary_line,
+            "Finished match",
+        ]
+    )
+
+
+def test_parse_score_handles_engine_as_first_participant() -> None:
+    stdout = build_stdout("Score of YourJava vs SF2000: 2 - 8 - 0  [0.200] 10")
+    result = parse_score(stdout, "YourJava", "SF2000", 2000.0, 10.0, ("cutechess",), "")
+    assert isinstance(result, MatchResult)
+    assert result.wins == 2
+    assert result.losses == 8
+    assert result.draws == 0
+    assert result.score == pytest.approx(0.2)
+
+
+def test_parse_score_inverts_when_engine_listed_second() -> None:
+    stdout = build_stdout("Score of SF2000 vs YourJava: 8 - 2 - 0  [0.800] 10")
+    result = parse_score(stdout, "YourJava", "SF2000", 2000.0, 10.0, ("cutechess",), "")
+    assert isinstance(result, MatchResult)
+    assert result.wins == 2
+    assert result.losses == 8
+    assert result.draws == 0
+    assert result.score == pytest.approx(0.2)
+


### PR DESCRIPTION
## Summary
- handle cutechess summary lines where the tuned engine is listed second and normalise the win/loss record
- keep reporting logic unchanged for the original orientation while converting the score when necessary
- add regression tests that cover both cutechess summary orientations

## Testing
- python -m pytest scripts/tests/test_cutechess_tuning_loop_parsing.py

------
https://chatgpt.com/codex/tasks/task_e_68ea5b67554c832ab05893d25cb55149