### PR TITLE
Fix cutechess score parsing when engine listed second

### DIFF
--- a/scripts/cutechess_tuning_loop.py
+++ b/scripts/cutechess_tuning_loop.py
@@ -164,7 +164,7 @@ def maybe_build_jar(project_root: Path, mvn: str, extra_args: Sequence[str]) -> 
 
 
 def parse_score(stdout: str, engine_name: str, opponent_name: str, opponent_elo: float, duration_s: float, command: Sequence[str], stderr: str) -> MatchResult:
-    last_match = None
+    last_match: Optional[tuple[str, "re.Match[str]"]] = None
     for line in stdout.splitlines():
         match = SCORE_PATTERN.search(line)
         if not match:
@@ -172,13 +172,19 @@ def parse_score(stdout: str, engine_name: str, opponent_name: str, opponent_elo:
         first = match.group("first").strip()
         second = match.group("second").strip()
         if first == engine_name and second == opponent_name:
-            last_match = match
+            last_match = ("direct", match)
+        elif first == opponent_name and second == engine_name:
+            last_match = ("swapped", match)
     if last_match is None:
         raise ValueError("Unable to locate cutechess score summary for the configured engine")
-    wins = int(last_match.group("wins"))
-    losses = int(last_match.group("losses"))
-    draws = int(last_match.group("draws"))
-    score = float(last_match.group("score"))
+    orientation, match = last_match
+    wins = int(match.group("wins"))
+    losses = int(match.group("losses"))
+    draws = int(match.group("draws"))
+    score = float(match.group("score"))
+    if orientation == "swapped":
+        wins, losses = losses, wins
+        score = 1.0 - score
     return MatchResult(
         engine_name=engine_name,
         opponent_name=opponent_name,


### PR DESCRIPTION
## Summary
- make the cutechess tuning loop recognise summaries where the opponent is listed first
- flip the wins/losses and score fields when the summary order is reversed so MatchResult reflects the engine being tuned

## Testing
- python -m compileall scripts/cutechess_tuning_loop.py

------
https://chatgpt.com/codex/tasks/task_e_68ea5b67554c832ab05893d25cb55149