### PR TITLE
Handle opponent-first cutechess score summaries

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# Makes the scripts directory importable as a Python package for tests.

--- a/scripts/cutechess_tuning_loop.py
+++ b/scripts/cutechess_tuning_loop.py
@@ -163,22 +163,46 @@ def maybe_build_jar(project_root: Path, mvn: str, extra_args: Sequence[str]) -> 
         raise RuntimeError("Maven package command failed")
 
 
-def parse_score(stdout: str, engine_name: str, opponent_name: str, opponent_elo: float, duration_s: float, command: Sequence[str], stderr: str) -> MatchResult:
-    last_match = None
+def parse_score(
+    stdout: str,
+    engine_name: str,
+    opponent_name: str,
+    opponent_elo: float,
+    duration_s: float,
+    command: Sequence[str],
+    stderr: str,
+) -> MatchResult:
+    engine_first = None
+    opponent_first = None
+
     for line in stdout.splitlines():
         match = SCORE_PATTERN.search(line)
         if not match:
             continue
         first = match.group("first").strip()
         second = match.group("second").strip()
+
         if first == engine_name and second == opponent_name:
-            last_match = match
-    if last_match is None:
-        raise ValueError("Unable to locate cutechess score summary for the configured engine")
-    wins = int(last_match.group("wins"))
-    losses = int(last_match.group("losses"))
-    draws = int(last_match.group("draws"))
-    score = float(last_match.group("score"))
+            engine_first = match
+        elif first == opponent_name and second == engine_name:
+            opponent_first = match
+
+    if engine_first is not None:
+        wins = int(engine_first.group("wins"))
+        losses = int(engine_first.group("losses"))
+        draws = int(engine_first.group("draws"))
+    elif opponent_first is not None:
+        wins = int(opponent_first.group("losses"))
+        losses = int(opponent_first.group("wins"))
+        draws = int(opponent_first.group("draws"))
+    else:
+        raise ValueError(
+            "Unable to locate cutechess score summary for the configured engine "
+            f"({engine_name} vs {opponent_name})."
+        )
+
+    total_games = wins + losses + draws
+    score = 0.0 if total_games == 0 else (wins + 0.5 * draws) / total_games
     return MatchResult(
         engine_name=engine_name,
         opponent_name=opponent_name,

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+
+for path in (PROJECT_ROOT, SCRIPTS_DIR):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))

--- a/scripts/tests/test_cutechess_parsing.py
+++ b/scripts/tests/test_cutechess_parsing.py
@@ -1,0 +1,63 @@
+import math
+
+import pytest
+
+from scripts.cutechess_tuning_loop import MatchResult, parse_score
+
+
+def _parse(stdout: str, engine_name: str = "YourJava", opponent_name: str = "SF2000") -> MatchResult:
+    return parse_score(
+        stdout=stdout,
+        engine_name=engine_name,
+        opponent_name=opponent_name,
+        opponent_elo=2000.0,
+        duration_s=12.34,
+        command=["cutechess-cli"],
+        stderr="",
+    )
+
+
+def test_parse_score_engine_first_orientation():
+    stdout = """
+    Started game 1 of 4 (YourJava vs SF2000)
+    Finished game 1 (YourJava vs SF2000): 1-0 {White mates}
+    Score of YourJava vs SF2000: 1 - 0 - 0  [1.000] 1
+    Finished game 2 (SF2000 vs YourJava): 1-0 {White mates}
+    Score of YourJava vs SF2000: 1 - 1 - 0  [0.500] 2
+    Finished game 3 (YourJava vs SF2000): 1/2-1/2 {Draw}
+    Score of YourJava vs SF2000: 1 - 1 - 1  [0.500] 3
+    Finished game 4 (SF2000 vs YourJava): 0-1 {Black mates}
+    Score of YourJava vs SF2000: 2 - 1 - 1  [0.625] 4
+    """.strip()
+
+    result = _parse(stdout)
+
+    assert result.wins == 2
+    assert result.losses == 1
+    assert result.draws == 1
+    assert math.isclose(result.points_fraction, 0.625)
+
+
+def test_parse_score_opponent_first_orientation():
+    stdout = """
+    Started game 1 of 10 (SF2000 vs YourJava)
+    Started game 2 of 10 (YourJava vs SF2000)
+    Finished game 2 (YourJava vs SF2000): 0-1 {Black mates}
+    Score of SF2000 vs YourJava: 1 - 0 - 0  [1.000] 1
+    Finished game 1 (SF2000 vs YourJava): 1-0 {White mates}
+    Score of SF2000 vs YourJava: 2 - 0 - 0  [1.000] 2
+    Finished game 10 (YourJava vs SF2000): 1-0 {White mates}
+    Score of SF2000 vs YourJava: 8 - 2 - 0  [0.800] 10
+    """.strip()
+
+    result = _parse(stdout)
+
+    assert result.wins == 2
+    assert result.losses == 8
+    assert result.draws == 0
+    assert math.isclose(result.points_fraction, 0.2)
+
+
+def test_parse_score_missing_summary_raises():
+    with pytest.raises(ValueError):
+        _parse("Started game 1 (YourJava vs SF2000)")


### PR DESCRIPTION
## Summary
- update cutechess score parsing to recognize either engine/opponent order in the match summary
- compute the stored score from the parsed win/draw counts and improve the error message when no summary is found
- add package/init hooks and pytest coverage for both summary orientations

## Testing
- pytest scripts/tests

------
https://chatgpt.com/codex/tasks/task_e_68ea5b67554c832ab05893d25cb55149