### PR TITLE
Reuse BitBoard recalc scratch buffers

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -127,6 +127,7 @@ Agents should compute `S, L, R, TT` via the heuristics above and substitute into
   - **Per-depth leaderboards** of the most expensive moves, including alpha/beta windows and evaluation sources.
   Use these logs to spot missing beta cut-offs, ineffective move ordering, or null-move pruning gaps before adjusting pruning heuristics.
 * `BitBoard` now caches per-piece attack contributions incrementally. When touching move application code, call the existing helpers (`markRecalc`, `updateAttackCachesAfterChange`, etc.) so both the caches and the aggregated maps stay in sync without forcing full recomputation.
+* `BitBoard`'s legality/attack cache invalidation now reuses `whiteRecalcScratch` / `blackRecalcScratch`. Clear them with `Arrays.fill(..., false)` before reuse instead of allocating new boolean arrays, and let `updateAttackCachesAfterChange` mark any additional entries that need recalculation.
 * `ActivityModule` precomputes bishop/rook watcher tables so slider updates can skip full-board scans. Pass `-Dchessengine.activity.linearScanFallback=true` to restore the legacy scan when debugging or if the watcher tables need to be bypassed.
 * Move ordering now uses per-thread bucketed buffers (TT → promotions → SEE-sorted captures → killers → quiet → bad captures) instead of a global `Arrays.sort`. Buckets reuse IntArrayList storage, tie-break on the move id to remain deterministic, and cut the `BestMoveSearchTest` runtime on the reference container from ~3m36s to ~3m14s.
 

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -61,6 +61,8 @@ public class BitBoard {
     private final PieceBitboards attackScratchBlack = new PieceBitboards();
     private final PieceBitboards seeWhiteScratch = new PieceBitboards();
     private final PieceBitboards seeBlackScratch = new PieceBitboards();
+    private final boolean[] whiteRecalcScratch = new boolean[7];
+    private final boolean[] blackRecalcScratch = new boolean[7];
 
     // Reuse gain stack in SEE (allocation-free)
     private final int[] seeGain = new int[32];
@@ -2162,8 +2164,10 @@ public class BitBoard {
         long fromMask = 1L << fromIndex;
         long toMask = 1L << toIndex;
 
-        boolean[] whiteRecalc = new boolean[7];
-        boolean[] blackRecalc = new boolean[7];
+        Arrays.fill(whiteRecalcScratch, false);
+        Arrays.fill(blackRecalcScratch, false);
+        boolean[] whiteRecalc = whiteRecalcScratch;
+        boolean[] blackRecalc = blackRecalcScratch;
         markRecalc(isWhite, pieceBits, whiteRecalc, blackRecalc);
         if (promoBits != 0) {
             markRecalc(isWhite, promoBits, whiteRecalc, blackRecalc);
@@ -2602,8 +2606,10 @@ public class BitBoard {
         long fromMask = 1L << fromIndex;
         long toMask = 1L << toIndex;
 
-        boolean[] whiteRecalc = new boolean[7];
-        boolean[] blackRecalc = new boolean[7];
+        Arrays.fill(whiteRecalcScratch, false);
+        Arrays.fill(blackRecalcScratch, false);
+        boolean[] whiteRecalc = whiteRecalcScratch;
+        boolean[] blackRecalc = blackRecalcScratch;
         markRecalc(isWhite, pieceTypeBits, whiteRecalc, blackRecalc);
         if (promotionPieceTypeBits != 0) {
             markRecalc(isWhite, promotionPieceTypeBits, whiteRecalc, blackRecalc);


### PR DESCRIPTION
## Summary
- add reusable boolean scratch buffers for BitBoard attack cache invalidation and clear them before each move to avoid per-call allocations
- document the new BitBoard scratch buffer reuse expectations in Agents.md so future changes continue to rely on the shared arrays

## Testing
- `mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=BitBoardTest test`
- `mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITest*,AITest_* test` *(fails: existing SEE expectations in AITest_PruningAndReductions)*

------
https://chatgpt.com/codex/tasks/task_e_68ea85e521c8832a86c23ca4200fd556