### PR TITLE
Reduce BitBoard move application allocations

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -127,6 +127,7 @@ Agents should compute `S, L, R, TT` via the heuristics above and substitute into
   - **Per-depth leaderboards** of the most expensive moves, including alpha/beta windows and evaluation sources.
   Use these logs to spot missing beta cut-offs, ineffective move ordering, or null-move pruning gaps before adjusting pruning heuristics.
 * `BitBoard` now caches per-piece attack contributions incrementally. When touching move application code, call the existing helpers (`markRecalc`, `updateAttackCachesAfterChange`, etc.) so both the caches and the aggregated maps stay in sync without forcing full recomputation.
+* `BitBoard` reuses the `whiteRecalcScratch` / `blackRecalcScratch` boolean buffers during move application. Always reset them with `Arrays.fill(..., false)` instead of allocating new arrays so `BitBoardTest` keeps its improved runtime budget.
 * `ActivityModule` precomputes bishop/rook watcher tables so slider updates can skip full-board scans. Pass `-Dchessengine.activity.linearScanFallback=true` to restore the legacy scan when debugging or if the watcher tables need to be bypassed.
 * Move ordering now uses per-thread bucketed buffers (TT → promotions → SEE-sorted captures → killers → quiet → bad captures) instead of a global `Arrays.sort`. Buckets reuse IntArrayList storage, tie-break on the move id to remain deterministic, and cut the `BestMoveSearchTest` runtime on the reference container from ~3m36s to ~3m14s.
 

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -56,6 +56,9 @@ public class BitBoard {
     private boolean blackAttackDirty = true;
     private PieceType[] pieceBoard = new PieceType[64];
 
+    private final boolean[] whiteRecalcScratch = new boolean[7];
+    private final boolean[] blackRecalcScratch = new boolean[7];
+
     private final MoveSnapshot moveSnapshot = new MoveSnapshot();
     private final PieceBitboards attackScratchWhite = new PieceBitboards();
     private final PieceBitboards attackScratchBlack = new PieceBitboards();
@@ -2162,8 +2165,10 @@ public class BitBoard {
         long fromMask = 1L << fromIndex;
         long toMask = 1L << toIndex;
 
-        boolean[] whiteRecalc = new boolean[7];
-        boolean[] blackRecalc = new boolean[7];
+        Arrays.fill(whiteRecalcScratch, false);
+        Arrays.fill(blackRecalcScratch, false);
+        boolean[] whiteRecalc = whiteRecalcScratch;
+        boolean[] blackRecalc = blackRecalcScratch;
         markRecalc(isWhite, pieceBits, whiteRecalc, blackRecalc);
         if (promoBits != 0) {
             markRecalc(isWhite, promoBits, whiteRecalc, blackRecalc);
@@ -2602,8 +2607,10 @@ public class BitBoard {
         long fromMask = 1L << fromIndex;
         long toMask = 1L << toIndex;
 
-        boolean[] whiteRecalc = new boolean[7];
-        boolean[] blackRecalc = new boolean[7];
+        Arrays.fill(whiteRecalcScratch, false);
+        Arrays.fill(blackRecalcScratch, false);
+        boolean[] whiteRecalc = whiteRecalcScratch;
+        boolean[] blackRecalc = blackRecalcScratch;
         markRecalc(isWhite, pieceTypeBits, whiteRecalc, blackRecalc);
         if (promotionPieceTypeBits != 0) {
             markRecalc(isWhite, promotionPieceTypeBits, whiteRecalc, blackRecalc);


### PR DESCRIPTION
## Summary
- reuse BitBoard recalc scratch buffers during move execution to avoid repeated boolean array allocations
- document the BitBoard scratch buffer policy in Agents.md for future contributors

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=BitBoardTest test
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITest test

------
https://chatgpt.com/codex/tasks/task_e_68ea85e521c8832a86c23ca4200fd556