### PR TITLE
Adjust cutechess tuning acceptance to use implied rating

### DIFF
--- a/scripts/cutechess_tuning_loop.py
+++ b/scripts/cutechess_tuning_loop.py
@@ -467,7 +467,12 @@ def accept_match_candidate(
     min_score_gain: float,
     time_bonus_threshold: float,
 ) -> AcceptanceDecision:
-    elo_delta = candidate.elo_diff - best.elo_diff
+    # Compare candidates using implied rating so that adjustments to the
+    # opponent's Elo (after each match) do not give the baseline an unfair
+    # advantage. The baseline's `elo_diff` is tied to the opponent rating it
+    # originally faced, so once we raise the opponent strength we must compare
+    # the absolute strength estimates instead of the raw Elo deltas.
+    elo_delta = candidate.implied_rating - best.implied_rating
     score_delta = candidate.points_fraction - best.points_fraction
     time_delta = best.avg_time_per_game - candidate.avg_time_per_game
     info: Dict[str, float] = {


### PR DESCRIPTION
## Summary
- compare match candidates using implied rating deltas so the adaptive opponent Elo does not skew acceptance decisions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea9831b3d4832aae8aa9426f9a7322