### PR TITLE
Prevent opponent Elo regression in tuning loop

### DIFF
--- a/scripts/cutechess_tuning_loop.py
+++ b/scripts/cutechess_tuning_loop.py
@@ -447,14 +447,24 @@ def run_match(args: argparse.Namespace, tuning_path: Path) -> MatchResult:
 def adapt_opponent_elo(args: argparse.Namespace, result: MatchResult, *, context: str) -> None:
     """Update the opponent Elo to the rounded-up implied rating from the last match."""
 
-    next_elo = int(math.ceil(result.implied_rating))
-    if next_elo != args.opponent_elo:
+    implied_next_elo = int(math.ceil(result.implied_rating))
+    floor_attr = "_opponent_elo_floor"
+    current_floor = getattr(args, floor_attr, args.opponent_elo)
+
+    if implied_next_elo > current_floor:
+        current_floor = implied_next_elo
         print(
-            f"[adapt-elo] {context}: setting opponent Elo from {args.opponent_elo} to {next_elo}"
+            f"[adapt-elo] {context}: setting opponent Elo from {args.opponent_elo} to {current_floor}"
+        )
+    elif implied_next_elo < current_floor:
+        print(
+            f"[adapt-elo] {context}: implied opponent Elo {implied_next_elo} below floor {current_floor}, keeping {current_floor}"
         )
     else:
-        print(f"[adapt-elo] {context}: opponent Elo remains at {next_elo}")
-    args.opponent_elo = next_elo
+        print(f"[adapt-elo] {context}: opponent Elo remains at {current_floor}")
+
+    setattr(args, floor_attr, current_floor)
+    args.opponent_elo = current_floor
 
 
 def accept_match_candidate(

--- a/scripts/tests/test_adapt_opponent_elo.py
+++ b/scripts/tests/test_adapt_opponent_elo.py
@@ -1,0 +1,43 @@
+import argparse
+import math
+
+from cutechess_tuning_loop import MatchResult, adapt_opponent_elo
+
+
+def make_result(opponent_elo: int, *, wins: int, losses: int, draws: int) -> MatchResult:
+    total = wins + losses + draws
+    score = (wins + 0.5 * draws) / total if total else 0.0
+    return MatchResult(
+        engine_name="YourJava",
+        opponent_name="SF",
+        wins=wins,
+        losses=losses,
+        draws=draws,
+        score=score,
+        opponent_elo=opponent_elo,
+        duration_s=10.0,
+        stdout="",
+        stderr="",
+        command=(),
+    )
+
+
+def test_adapt_opponent_elo_never_decreases(capsys):
+    args = argparse.Namespace(opponent_elo=2000)
+    winning_result = make_result(args.opponent_elo, wins=6, losses=0, draws=0)
+
+    expected_floor = int(math.ceil(winning_result.implied_rating))
+    adapt_opponent_elo(args, winning_result, context="baseline")
+    first_capture = capsys.readouterr().out
+
+    assert args.opponent_elo == expected_floor
+    assert getattr(args, "_opponent_elo_floor") == expected_floor
+    assert f"{expected_floor}" in first_capture
+
+    losing_result = make_result(args.opponent_elo, wins=0, losses=6, draws=0)
+    adapt_opponent_elo(args, losing_result, context="regression")
+    second_capture = capsys.readouterr().out
+
+    assert args.opponent_elo == expected_floor
+    assert getattr(args, "_opponent_elo_floor") == expected_floor
+    assert f"keeping {expected_floor}" in second_capture


### PR DESCRIPTION
## Summary
- prevent the cutechess tuning loop from decreasing the opponent Elo once it has been raised
- record the highest opponent Elo seen and reuse it across subsequent adjustments
- add a regression test covering the Elo floor behaviour

## Testing
- pytest scripts/tests/test_adapt_opponent_elo.py

------
https://chatgpt.com/codex/tasks/task_e_68ea9c732be4832aa95fb8cab32fe71c