### PR TITLE
Make move bucket order follow tuning snapshot

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -137,6 +137,7 @@ public class AI {
     private final Heuristics globalHeuristics;
 
     private final MoveOrderingParameters.Snapshot moveOrderingParameters;
+    private final MoveBucket[] moveBucketOrder;
     private final double moveOrderingHistoryScale;
     private final int moveOrderingHistoryDecayDivisor;
     private final SearchPruningParameters.Snapshot searchPruningParameters;
@@ -287,6 +288,7 @@ public class AI {
         log.info("### SearchThreads = {}, LazySmpThreads = {}", searchThreads, lazySmpThreads);
 
         this.moveOrderingParameters = MoveOrderingParameters.snapshot();
+        this.moveBucketOrder = buildMoveBucketOrder(this.moveOrderingParameters);
         this.moveOrderingHistoryScale = Math.max(0.0, moveOrderingParameters.historyScale());
         this.moveOrderingHistoryDecayDivisor = Math.max(1, moveOrderingParameters.historyDecayDivisor());
         this.searchPruningParameters = SearchPruningParameters.snapshot();
@@ -2774,14 +2776,9 @@ public class AI {
         }
 
         int outIndex = 0;
-        outIndex = writeBucket(ttBucket, moveBuffer, orderedBuffer, outIndex);
-        outIndex = writeBucket(promotionBucket, moveBuffer, orderedBuffer, outIndex);
-        outIndex = writeBucket(captureGoodBucket, moveBuffer, orderedBuffer, outIndex);
-        outIndex = writeBucket(captureEqualBucket, moveBuffer, orderedBuffer, outIndex);
-        outIndex = writeBucket(killer0Bucket, moveBuffer, orderedBuffer, outIndex);
-        outIndex = writeBucket(killer1Bucket, moveBuffer, orderedBuffer, outIndex);
-        outIndex = writeBucket(quietBucket, moveBuffer, orderedBuffer, outIndex);
-        outIndex = writeBucket(captureBadBucket, moveBuffer, orderedBuffer, outIndex);
+        for (MoveBucket bucket : moveBucketOrder) {
+            outIndex = writeBucket(bucketIndexes[bucket.ordinal()], moveBuffer, orderedBuffer, outIndex);
+        }
 
         MoveContainerUtils.overwriteFromBuffer(moves, orderedBuffer, size);
         return moves;
@@ -3069,6 +3066,28 @@ public class AI {
         } finally {
             releaseWriteLock(stamp);
         }
+    }
+
+    private static MoveBucket[] buildMoveBucketOrder(MoveOrderingParameters.Snapshot parameters) {
+        MoveBucket[] order = MoveBucket.values().clone();
+        Arrays.sort(order, Comparator
+                .comparingInt((MoveBucket bucket) -> resolveCategoryWeight(bucket, parameters))
+                .reversed()
+                .thenComparingInt(MoveBucket::ordinal));
+        return order;
+    }
+
+    private static int resolveCategoryWeight(MoveBucket bucket, MoveOrderingParameters.Snapshot parameters) {
+        return switch (bucket) {
+            case TT -> parameters.categoryTt();
+            case PROMOTION -> parameters.categoryPromotion();
+            case CAPTURE_GOOD -> parameters.categoryCaptureGood();
+            case CAPTURE_EQUAL -> parameters.categoryCaptureEqual();
+            case KILLER0 -> parameters.categoryKiller0();
+            case KILLER1 -> parameters.categoryKiller1();
+            case QUIET -> parameters.categoryQuiet();
+            case CAPTURE_BAD -> parameters.categoryCaptureBad();
+        };
     }
 
     private static void insertByScore(IntArrayList bucket, int moveIndex, int[] scoreBuffer, int[] moveBuffer) {

--- a/src/test/java/julius/game/chessengine/ai/AITest_MoveOrderingBuckets.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_MoveOrderingBuckets.java
@@ -1,0 +1,130 @@
+package julius.game.chessengine.ai;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import julius.game.chessengine.board.Move;
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.tuning.AiTuning;
+import julius.game.chessengine.tuning.Tuning;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import testsupport.TestLoggingExtension;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(TestLoggingExtension.class)
+class AITest_MoveOrderingBuckets {
+
+    private static final String MOVE_ORDERING_FEN = "4k3/8/8/8/4B3/3r4/8/4K3 w - - 0 1";
+
+    @Test
+    @DisplayName("Move bucket priority follows category weights from the snapshot")
+    void moveBucketPriorityFollowsSnapshotCategories() throws Exception {
+        Engine baselineEngine = new Engine();
+        baselineEngine.importBoardFromFen(MOVE_ORDERING_FEN);
+
+        AiTuning tuning = AiTuning.builder()
+                .searchThreads(1)
+                .lazySmpThreads(1)
+                .hashSizeMb(16)
+                .build();
+
+        AI baselineAi = new AI(baselineEngine, tuning);
+
+        IntArrayList legalMoves = baselineEngine.getAllLegalMoves();
+        assertFalse(legalMoves.isEmpty(), "Position should expose moves to order");
+
+        int captureMove = findFirst(legalMoves, MoveHelper::isCapture);
+        if (captureMove == -1) {
+            fail("Expected at least one capture move");
+        }
+
+        assertTrue(baselineEngine.see(captureMove) > 0, "Capture must be SEE-positive to land in the good bucket");
+
+        int quietMove = findFirst(legalMoves, m -> !MoveHelper.isCapture(m) && !MoveHelper.isPawnPromotionMove(m));
+        if (quietMove == -1) {
+            fail("Expected at least one quiet move");
+        }
+
+        IntArrayList baselineOrdered = new IntArrayList(legalMoves);
+        baselineAi.sortMovesByEfficiency(baselineOrdered, 0, baselineEngine.getBoardStateHash(), -1, baselineEngine);
+
+        int baselineCaptureIndex = indexOf(baselineOrdered, captureMove);
+        int baselineQuietIndex = indexOf(baselineOrdered, quietMove);
+
+        assertTrue(baselineCaptureIndex >= 0, "Capture must be present after ordering");
+        assertTrue(baselineQuietIndex >= 0, "Quiet move must be present after ordering");
+        assertTrue(baselineCaptureIndex < baselineQuietIndex,
+                () -> "Default ordering should prioritise capture bucket before quiet: "
+                        + describeMoveOrder(baselineOrdered));
+
+        Field quietField = Tuning.class.getDeclaredField("moveOrderingCategoryQuiet");
+        Field captureGoodField = Tuning.class.getDeclaredField("moveOrderingCategoryCaptureGood");
+
+        quietField.setAccessible(true);
+        captureGoodField.setAccessible(true);
+
+        int originalQuiet = quietField.getInt(null);
+        int originalCaptureGood = captureGoodField.getInt(null);
+
+        try {
+            quietField.setInt(null, originalCaptureGood + 100);
+            captureGoodField.setInt(null, originalQuiet);
+
+            Engine adjustedEngine = new Engine();
+            adjustedEngine.importBoardFromFen(MOVE_ORDERING_FEN);
+
+            AI adjustedAi = new AI(adjustedEngine, tuning);
+
+            IntArrayList adjustedOrdered = adjustedEngine.getAllLegalMoves();
+            adjustedAi.sortMovesByEfficiency(adjustedOrdered, 0, adjustedEngine.getBoardStateHash(), -1, adjustedEngine);
+
+            int adjustedCaptureIndex = indexOf(adjustedOrdered, captureMove);
+            int adjustedQuietIndex = indexOf(adjustedOrdered, quietMove);
+
+            assertTrue(adjustedCaptureIndex >= 0, "Capture must be present after adjusted ordering");
+            assertTrue(adjustedQuietIndex >= 0, "Quiet move must be present after adjusted ordering");
+
+            assertTrue(adjustedQuietIndex < adjustedCaptureIndex,
+                    () -> "Quiet bucket should outrank capture bucket after tweaking categories: "
+                            + describeMoveOrder(adjustedOrdered));
+        } finally {
+            quietField.setInt(null, originalQuiet);
+            captureGoodField.setInt(null, originalCaptureGood);
+        }
+    }
+
+    private static int indexOf(IntArrayList moves, int target) {
+        for (int i = 0; i < moves.size(); i++) {
+            if (moves.getInt(i) == target) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int findFirst(IntArrayList moves, java.util.function.IntPredicate predicate) {
+        for (int i = 0; i < moves.size(); i++) {
+            int move = moves.getInt(i);
+            if (predicate.test(move)) {
+                return move;
+            }
+        }
+        return -1;
+    }
+
+    private static String describeMoveOrder(IntArrayList moves) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < moves.size(); i++) {
+            if (i > 0) {
+                builder.append(", ");
+            }
+            builder.append(Move.convertIntToMove(moves.getInt(i)));
+        }
+        return builder.toString();
+    }
+}
+


### PR DESCRIPTION
## Summary
- derive a move bucket ordering from the move-ordering tuning snapshot during AI construction
- iterate through buckets using the computed order so category weights drive move priority
- add a unit test that overrides snapshot category weights to confirm the move order responds

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITest_MoveOrderingBuckets test

------
https://chatgpt.com/codex/tasks/task_e_68eab18e3c1c832ab50285c30d868caf