### PR TITLE
Add regression test for Syzygy win detection

### DIFF
--- a/src/test/java/julius/game/chessengine/tablebase/SyzygyWinRegressionTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/SyzygyWinRegressionTest.java
@@ -1,0 +1,54 @@
+package julius.game.chessengine.tablebase;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.syzygy.SyzygyProbeResult;
+import julius.game.chessengine.syzygy.SyzygyTablebaseService;
+import julius.game.chessengine.syzygy.SyzygyWdl;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SyzygyWinRegressionTest {
+
+    private static final String KNIGHT_BISHOP_VS_KING_PAWN_FEN = "3k4/4p3/8/2K5/8/3BN3/8/8 w - - 0 1";
+
+    @Test
+    void whiteWinsKnightBishopVsKingPawnAccordingToSyzygy() {
+        TablebaseTestSupport.assumeSyzygyConfigured();
+
+        String directories = resolveSyzygyDirectories();
+        SyzygyTablebaseService service = new SyzygyTablebaseService(directories, 7, 16384);
+
+        BitBoard board = FEN.translateFENtoBitBoard(KNIGHT_BISHOP_VS_KING_PAWN_FEN);
+        Optional<SyzygyProbeResult> result = service.probe(board);
+
+        assertThat(result)
+                .describedAs("Expected Syzygy to provide a result for %s", KNIGHT_BISHOP_VS_KING_PAWN_FEN)
+                .isPresent();
+        assertThat(result.get().wdl()).isEqualTo(SyzygyWdl.WIN);
+    }
+
+    private static String resolveSyzygyDirectories() {
+        String directories = firstNonEmpty(
+                System.getProperty("chessengine.syzygy.paths"),
+                System.getProperty("chessengine.syzygy.path"),
+                System.getenv("CHESSENGINE_SYZYGY_PATH"),
+                System.getenv("SYZYGY_PATH"));
+        if (directories == null) {
+            throw new IllegalStateException("Syzygy directory configuration missing despite assumption");
+        }
+        return directories;
+    }
+
+    private static String firstNonEmpty(String... values) {
+        for (String value : values) {
+            if (value != null && !value.trim().isEmpty()) {
+                return value;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add a tablebase-backed regression test that verifies the Syzygy probe marks the FEN `3k4/4p3/8/2K5/8/3BN3/8/8 w - - 0 1` as a white win
- automatically resolve the configured Syzygy directory from system properties or environment variables so the test reuses existing tablebase settings

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=SyzygyWinRegressionTest test

------
https://chatgpt.com/codex/tasks/task_e_68eb882daf90832a8cf018d5edc8c99d