### PR TITLE
Fix Windows build issues in Syzygy native layer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
         <!-- Boot uses this to set the compiler release -->
         <java.version>25</java.version>
         <lombok.version>1.18.42</lombok.version>
+        <!-- Default preview flag for Surefire's argLine; CLI -DargLine overrides when provided -->
+        <argLine>--enable-preview</argLine>
     </properties>
 
     <dependencies>

--- a/src/main/native/tbcore.c
+++ b/src/main/native/tbcore.c
@@ -35,6 +35,9 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/mman.h>
@@ -73,12 +76,16 @@ static LOCK_T TB_MUTEX;
 
 #ifdef TB_CUSTOM_BSWAP32
 #define internal_bswap32(x) TB_CUSTOM_BSWAP32(x)
+#elif defined(_MSC_VER)
+#define internal_bswap32(x) _byteswap_ulong(x)
 #else
 #define internal_bswap32(x) __builtin_bswap32(x)
 #endif
 
 #ifdef TB_CUSTOM_BSWAP64
 #define internal_bswap64(x) TB_CUSTOM_BSWAP64(x)
+#elif defined(_MSC_VER)
+#define internal_bswap64(x) _byteswap_uint64(x)
 #else
 #define internal_bswap64(x) __builtin_bswap64(x)
 #endif
@@ -103,36 +110,26 @@ static uint64_t calc_key_from_pcs(int *pcs, int mirror);
 static void free_wdl_entry(struct TBEntry *entry);
 static void free_dtz_entry(struct TBEntry *entry);
 
+#ifdef _WIN32
+#define TB_MAX_PATH_LEN MAX_PATH
+#else
+#define TB_MAX_PATH_LEN 256
+#endif
+
 static FD open_tb(const char *str, const char *suffix)
 {
-  int i;
   FD fd;
-  size_t remain;
-#ifdef _WIN32
-  const int MAX_LEN = MAX_PATH;
-#else
-  // assume 256
-  const int MAX_LEN = 256;
-#endif
-  remain = MAX_LEN-1; // allow room for null
-  char file[MAX_LEN];
+  char file[TB_MAX_PATH_LEN];
 
-  for (i = 0; i < num_paths; i++) {
-    strncpy(file, paths[i], remain);
-    remain -= strlen(paths[i]);
-    if (remain <=0) break;
-    strncat(file, "/", remain);
-    remain--;
-    if (remain <=0) break;
-    strncat(file, str, remain);
-    remain -= strlen(str);
-    if (remain <=0) break;
-    strncat(file, suffix, remain);
+  for (int i = 0; i < num_paths; i++) {
+    int written = snprintf(file, TB_MAX_PATH_LEN, "%s/%s%s", paths[i], str, suffix);
+    if (written < 0 || written >= TB_MAX_PATH_LEN)
+      continue;
 #ifndef _WIN32
     fd = open(file, O_RDONLY);
 #else
     fd = CreateFile(file, GENERIC_READ, FILE_SHARE_READ, NULL,
-			  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                          OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 #endif
     if (fd != FD_ERR) {
       return fd;

--- a/src/main/native/tbprobe.c
+++ b/src/main/native/tbprobe.c
@@ -25,6 +25,9 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
 
 #include "tbprobe.h"
 
@@ -137,9 +140,27 @@ unsigned TB_LARGEST = 0;
 #else
 static inline unsigned lsb(uint64_t b)
 {
+#if defined(_MSC_VER)
+    if (!b)
+        return 0;
+#if defined(_M_X64) || defined(_M_AMD64) || defined(_M_IA64)
+    unsigned long idx;
+    _BitScanForward64(&idx, b);
+    return (unsigned)idx;
+#else
+    unsigned long idx;
+    unsigned long lower = (unsigned long)(b & 0xFFFFFFFFULL);
+    if (_BitScanForward(&idx, lower))
+        return (unsigned)idx;
+    unsigned long upper = (unsigned long)(b >> 32);
+    _BitScanForward(&idx, upper);
+    return (unsigned)(idx + 32);
+#endif
+#else
     size_t idx;
     __asm__("bsfq %1, %0": "=r"(idx): "rm"(b));
     return idx;
+#endif
 }
 #endif
 #define square(r, f)            (8 * (r) + (f))


### PR DESCRIPTION
## Summary
- use MSVC-compatible byte-swap helpers and path buffer sizing in `tbcore.c`
- add MSVC-safe least-significant-bit computation that avoids inline assembly in `tbprobe.c`

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68eba91621b8832a96e9a51e096ac33a