### PR TITLE
Fix native Syzygy build on Windows

### DIFF
--- a/src/main/native/tbcore.c
+++ b/src/main/native/tbcore.c
@@ -109,13 +109,13 @@ static FD open_tb(const char *str, const char *suffix)
   FD fd;
   size_t remain;
 #ifdef _WIN32
-  const int MAX_LEN = MAX_PATH;
+#define TB_PATH_MAX_LEN MAX_PATH
 #else
   // assume 256
-  const int MAX_LEN = 256;
+#define TB_PATH_MAX_LEN 256
 #endif
-  remain = MAX_LEN-1; // allow room for null
-  char file[MAX_LEN];
+  remain = TB_PATH_MAX_LEN-1; // allow room for null
+  char file[TB_PATH_MAX_LEN];
 
   for (i = 0; i < num_paths; i++) {
     strncpy(file, paths[i], remain);
@@ -138,6 +138,7 @@ static FD open_tb(const char *str, const char *suffix)
       return fd;
     }
   }
+#undef TB_PATH_MAX_LEN
   return FD_ERR;
 }
 

--- a/src/main/native/tbprobe.c
+++ b/src/main/native/tbprobe.c
@@ -134,12 +134,24 @@ unsigned TB_LARGEST = 0;
 #define board(s)                ((uint64_t)1 << (s))
 #ifdef TB_CUSTOM_LSB
 #define lsb(b) TB_CUSTOM_LSB(b)
+#elif defined(_MSC_VER)
+#include <intrin.h>
+static inline unsigned lsb(uint64_t b)
+{
+    unsigned long idx;
+    _BitScanForward64(&idx, b);
+    return (unsigned)idx;
+}
 #else
 static inline unsigned lsb(uint64_t b)
 {
+#if defined(__GNUC__) || defined(__clang__)
+    return (unsigned)__builtin_ctzll(b);
+#else
     size_t idx;
     __asm__("bsfq %1, %0": "=r"(idx): "rm"(b));
     return idx;
+#endif
 }
 #endif
 #define square(r, f)            (8 * (r) + (f))


### PR DESCRIPTION
## Summary
- replace function-local const array length with preprocessor macros so MSVC treats the buffer size as a compile-time constant
- add MSVC-friendly least-significant-bit helper using _BitScanForward64 and fall back to compiler intrinsics when available

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68eba91621b8832a96e9a51e096ac33a