### PR TITLE
Improve Syzygy tablebase configuration and native loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,16 @@ whenever six or fewer pieces remain on the board. Follow these steps to get the 
    them to a local directory (e.g. `C:\tb\syzygy`).
 2. Point the engine at the directory via the `chessengine.syzygy.path` system property (use
    `chessengine.syzygy.paths` when you want to provide several locations separated by the platform
-   path separator).
+   path separator). The engine expands directories that merely group tablebases (for example a
+   parent folder containing `3-4-5-wdl/`, `3-4-5-dtz/`, etc.) so you only have to point at the
+   root once.
    * UCI: `setoption name SyzygyPath value C:\tb\syzygy`
    * CLI: `java -Dchessengine.syzygy.path=C:\tb\syzygy -jar target/chess-engine-<version>-uci.jar`
    * Spring Boot: update `application.yaml` (see the example in this repository) or export the
      `CHESSENGINE_SYZYGY_PATH` environment variable.
+   * Native override: when you do not bundle `JSyzygy` inside the application JAR, set the
+     `chessengine.syzygy.nativeLibrary` system property (or `CHESSENGINE_SYZYGY_NATIVE` environment
+     variable) to the full path of the native library (`JSyzygy.dll`, `libJSyzygy.so`, ...).
 3. Restart the engine so the service warms up the table metadata. When a probe succeeds the console
    starts emitting `info string tablebase ...` lines (including `dtz` updates), and the search score
    snaps to the exact WDL converted from the tablebase answer.

--- a/src/main/java/julius/game/chessengine/syzygy/SyzygyPathResolver.java
+++ b/src/main/java/julius/game/chessengine/syzygy/SyzygyPathResolver.java
@@ -1,0 +1,139 @@
+package julius.game.chessengine.syzygy;
+
+import lombok.extern.log4j.Log4j2;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Log4j2
+final class SyzygyPathResolver {
+
+    private static final String TABLEBASE_TOKEN = ".rtb";
+    private static final int DIRECTORY_SCAN_DEPTH = 2;
+
+    private SyzygyPathResolver() {
+    }
+
+    static Optional<String> sanitize(String directories) {
+        if (directories == null) {
+            return Optional.empty();
+        }
+        List<String> tokens = splitDirectories(directories);
+        if (tokens.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Set<Path> resolved = new LinkedHashSet<>();
+        for (String token : tokens) {
+            Path candidate = toPath(token);
+            if (candidate == null) {
+                continue;
+            }
+            if (!Files.exists(candidate)) {
+                log.warn("Ignoring non-existent Syzygy directory: {}", candidate);
+                continue;
+            }
+            if (Files.isRegularFile(candidate)) {
+                Path parent = candidate.getParent();
+                if (parent != null) {
+                    appendResolved(resolved, parent);
+                } else {
+                    log.warn("Syzygy file {} does not have a parent directory; skipping.", candidate);
+                }
+                continue;
+            }
+            if (!Files.isDirectory(candidate)) {
+                log.warn("Ignoring Syzygy path that is neither file nor directory: {}", candidate);
+                continue;
+            }
+            appendResolved(resolved, candidate);
+        }
+
+        if (resolved.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(resolved.stream()
+                .map(path -> path.toAbsolutePath().normalize().toString())
+                .collect(Collectors.joining(File.pathSeparator)));
+    }
+
+    private static void appendResolved(Set<Path> sink, Path base) {
+        List<Path> discovered = resolveProbeDirectories(base);
+        for (Path path : discovered) {
+            sink.add(path);
+        }
+    }
+
+    private static List<Path> resolveProbeDirectories(Path base) {
+        Path normalised = base.toAbsolutePath().normalize();
+        List<Path> discovered = new ArrayList<>();
+        if (containsTablebaseFiles(normalised)) {
+            discovered.add(normalised);
+        }
+        try (Stream<Path> stream = Files.walk(normalised, DIRECTORY_SCAN_DEPTH)) {
+            discovered.addAll(stream
+                    .filter(path -> !path.equals(normalised))
+                    .filter(Files::isDirectory)
+                    .filter(SyzygyPathResolver::containsTablebaseFiles)
+                    .map(Path::toAbsolutePath)
+                    .map(Path::normalize)
+                    .sorted(Comparator.comparing(Path::toString))
+                    .collect(Collectors.toList()));
+        } catch (IOException ex) {
+            log.warn("Failed to inspect potential Syzygy directory {}", normalised, ex);
+        }
+
+        if (discovered.isEmpty()) {
+            log.warn("Ignoring Syzygy directory {} because no tablebase files were found", normalised);
+        }
+
+        return discovered;
+    }
+
+    private static boolean containsTablebaseFiles(Path directory) {
+        try (Stream<Path> stream = Files.list(directory)) {
+            return stream.anyMatch(path -> Files.isRegularFile(path) && looksLikeTablebaseFile(path.getFileName().toString()));
+        } catch (IOException ex) {
+            log.warn("Failed to inspect Syzygy directory {}", directory, ex);
+            return false;
+        }
+    }
+
+    private static boolean looksLikeTablebaseFile(String filename) {
+        String lower = filename.toLowerCase(Locale.ROOT);
+        return lower.contains(TABLEBASE_TOKEN);
+    }
+
+    private static List<String> splitDirectories(String directories) {
+        String separator = File.pathSeparator;
+        String regex = Pattern.quote(separator);
+        return Arrays.stream(directories.split(regex))
+                .map(String::trim)
+                .filter(token -> !token.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    private static Path toPath(String candidate) {
+        try {
+            return Path.of(candidate);
+        } catch (InvalidPathException ex) {
+            log.warn("Ignoring invalid Syzygy directory path: {}", candidate, ex);
+            return null;
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/syzygy/Tables.java
+++ b/src/main/java/julius/game/chessengine/syzygy/Tables.java
@@ -5,11 +5,6 @@ import julius.game.chessengine.syzygy.bridge.SyzygyBridge;
 import julius.game.chessengine.syzygy.bridge.SyzygyConstants;
 import lombok.extern.log4j.Log4j2;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -35,7 +30,7 @@ final class Tables {
             log.warn("Syzygy native library is not loaded; tablebases will remain disabled.");
             return Optional.empty();
         }
-        Optional<String> sanitized = sanitizeDirectories(directories);
+        Optional<String> sanitized = SyzygyPathResolver.sanitize(directories);
         if (sanitized.isEmpty()) {
             log.warn("No valid Syzygy directories configured. Provided value: '{}'", directories);
             return Optional.empty();
@@ -94,32 +89,6 @@ final class Tables {
 
         return Optional.of(new SyzygyProbeResult(wdl, dtz, OptionalInt.empty()));
     }
-
-    private static Optional<String> sanitizeDirectories(String directories) {
-        if (directories == null) {
-            return Optional.empty();
-        }
-        String separator = File.pathSeparator;
-        String[] raw = directories.split(separator);
-        List<String> valid = new ArrayList<>();
-        for (String candidate : raw) {
-            String trimmed = candidate == null ? "" : candidate.trim();
-            if (trimmed.isEmpty()) {
-                continue;
-            }
-            Path path = Path.of(trimmed);
-            if (Files.isDirectory(path)) {
-                valid.add(path.toAbsolutePath().toString());
-            } else {
-                log.warn("Ignoring non-existent Syzygy directory: {}", trimmed);
-            }
-        }
-        if (valid.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(String.join(separator, valid));
-    }
-
     private static SyzygyWdl toWdl(int wdlValue) {
         return switch (wdlValue) {
             case SyzygyConstants.TB_LOSS -> SyzygyWdl.LOSS;

--- a/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyBridge.java
+++ b/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyBridge.java
@@ -32,6 +32,8 @@ public final class SyzygyBridge {
 
     private static final Logger LOG = LogManager.getLogger();
     private static final String LIBRARY_NAME = "JSyzygy";
+    private static final String LIBRARY_OVERRIDE_PROPERTY = "chessengine.syzygy.nativeLibrary";
+    private static final String LIBRARY_OVERRIDE_ENV = "CHESSENGINE_SYZYGY_NATIVE";
     private static boolean libLoaded = false;
     private static int tbLargest = 0;
 
@@ -53,6 +55,19 @@ public final class SyzygyBridge {
         if (libLoaded) {
             return;
         }
+        String override = firstNonEmpty(System.getProperty(LIBRARY_OVERRIDE_PROPERTY),
+                System.getenv(LIBRARY_OVERRIDE_ENV));
+        if (override != null && !override.isBlank()) {
+            Path overridePath = toPath(override.trim());
+            if (overridePath != null && Files.isRegularFile(overridePath)) {
+                System.load(overridePath.toAbsolutePath().toString());
+                libLoaded = true;
+                LOG.info("Loaded {} from override path {}", LIBRARY_NAME, overridePath);
+                return;
+            }
+            LOG.warn("Configured Syzygy native library override '{}' was not found or is not a file.", override);
+        }
+
         Platform platform = detectPlatform();
         if (platform == null) {
             LOG.warn("Unsupported platform. os.name={} os.arch={}",
@@ -83,12 +98,33 @@ public final class SyzygyBridge {
         libLoaded = true;
     }
 
+    private static Path toPath(String candidate) {
+        try {
+            return Paths.get(candidate);
+        } catch (RuntimeException ex) {
+            LOG.warn("Invalid path configured for Syzygy native library: {}", candidate, ex);
+            return null;
+        }
+    }
+
     private static Platform detectPlatform() {
         String osName = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
         String arch = System.getProperty("os.arch", "").toLowerCase(Locale.ROOT);
         for (Platform platform : Platform.values()) {
             if (platform.matches(osName, arch)) {
                 return platform;
+            }
+        }
+        return null;
+    }
+
+    private static String firstNonEmpty(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value != null && !value.trim().isEmpty()) {
+                return value;
             }
         }
         return null;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,5 +6,6 @@ server:
 # chessengine:
 #   syzygy:
 #     path: "C:/tb/syzygy"      # Directory with .rtbw/.rtbz files; accepts the platform path separator for multiples
+#     nativeLibrary: "C:/native/JSyzygy.dll"  # Optional: absolute path to the JNI library when it is not bundled
 #     maxPieces: 6              # Highest piece-count to load (6 uses ~150 GB on disk)
 #     cacheSize: 65536          # Entries to keep in the in-memory probe cache

--- a/src/test/java/julius/game/chessengine/syzygy/SyzygyPathResolverTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/SyzygyPathResolverTest.java
@@ -1,0 +1,66 @@
+package julius.game.chessengine.syzygy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SyzygyPathResolverTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void returnsEmptyWhenNoDirectoriesAreValid() {
+        assertThat(SyzygyPathResolver.sanitize(null)).isEmpty();
+        assertThat(SyzygyPathResolver.sanitize("   ")).isEmpty();
+        assertThat(SyzygyPathResolver.sanitize("non-existent" + File.pathSeparator + "also-missing")).isEmpty();
+    }
+
+    @Test
+    void discoversNestedTablebaseDirectories() throws IOException {
+        Path root = Files.createDirectory(tempDir.resolve("syzygy"));
+        Path wdl = Files.createDirectories(root.resolve("3-4-5-wdl"));
+        Files.createFile(wdl.resolve("KRRvK.rtbw"));
+        Path dtz = Files.createDirectories(root.resolve("3-4-5-dtz"));
+        Files.createFile(dtz.resolve("KRRvK.rtbz"));
+
+        Optional<String> sanitized = SyzygyPathResolver.sanitize(root.toString());
+
+        assertThat(sanitized).isPresent();
+        List<String> directories = splitPaths(sanitized.get());
+        assertThat(directories)
+                .containsExactlyInAnyOrder(wdl.toAbsolutePath().toString(), dtz.toAbsolutePath().toString());
+        assertThat(directories).doesNotContain(root.toAbsolutePath().toString());
+    }
+
+    @Test
+    void keepsExplicitDirectoriesAndAvoidsDuplicates() throws IOException {
+        Path base = Files.createDirectory(tempDir.resolve("syzygy"));
+        Path wdl = Files.createDirectories(base.resolve("3-4-5-wdl"));
+        Files.createFile(wdl.resolve("table.rtbw"));
+        Path dtz = Files.createDirectories(base.resolve("3-4-5-dtz"));
+        Files.createFile(dtz.resolve("table.rtbz"));
+
+        String configured = wdl + File.pathSeparator + base;
+        Optional<String> sanitized = SyzygyPathResolver.sanitize(configured);
+
+        assertThat(sanitized).isPresent();
+        List<String> directories = splitPaths(sanitized.get());
+        assertThat(directories)
+                .containsExactlyInAnyOrder(wdl.toAbsolutePath().toString(), dtz.toAbsolutePath().toString());
+    }
+
+    private static List<String> splitPaths(String directories) {
+        return Arrays.asList(directories.split(Pattern.quote(File.pathSeparator)));
+    }
+}


### PR DESCRIPTION
## Summary
- add a Syzygy path resolver that expands configured directories and filters invalid entries before loading tablebases
- allow overriding the JSyzygy native library via system property or environment variable and document the configuration options
- cover the resolver with focused unit tests and extend the Spring Boot/sample documentation for the new settings

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=SyzygyPathResolverTest test

------
https://chatgpt.com/codex/tasks/task_e_68ebad186d30832ab9b5ead76a26b89f