### PR TITLE
Ensure Windows native builds target x64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,4 +243,34 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>windows-x64-cmake</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>cmake-configure</id>
+                                <configuration>
+                                    <arguments combine.children="append">
+                                        <argument>-A</argument>
+                                        <argument>x64</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/scripts/auto_tuning_loop.py
+++ b/scripts/auto_tuning_loop.py
@@ -86,6 +86,21 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import DefaultDict, Dict, List, Optional, Set, Tuple
 
+
+DEFAULT_SYZYGY_NATIVE = r"C:\\Development\\Chess-Engine\\target\\classes\\natives\\win-x86_64\\Release\\JSyzygy.dll"
+DEFAULT_SYZYGY_PATHS = r"E:\\Syzygy"
+
+
+def resolve_syzygy_from_env(env: Optional[Dict[str, str]] = None) -> Tuple[str, str]:
+    source = env if env is not None else os.environ
+    native = source.get("CHESSENGINE_SYZYGY_NATIVE") or DEFAULT_SYZYGY_NATIVE
+    paths = (
+        source.get("CHESSENGINE_SYZYGY_PATHS")
+        or source.get("CHESSENGINE_SYZYGY_PATH")
+        or DEFAULT_SYZYGY_PATHS
+    )
+    return native, paths
+
 # ----------------------------
 # Patterns
 # ----------------------------
@@ -2260,6 +2275,12 @@ def main() -> None:
         "chessengine.uci.info.minIntervalMs": "200",
         "chessengine.uci.info.maxPvLen": "10",
     }
+
+    syzygy_native, syzygy_paths = resolve_syzygy_from_env()
+    if syzygy_native:
+        engine_sysprops["chessengine.syzygy.nativeLibrary"] = syzygy_native
+    if syzygy_paths:
+        engine_sysprops["chessengine.syzygy.paths"] = syzygy_paths
     if args.tuning_file:
         override_path = Path(args.tuning_file)
         if not override_path.is_absolute():

--- a/scripts/cutechess_tuning_loop.py
+++ b/scripts/cutechess_tuning_loop.py
@@ -17,6 +17,21 @@ from pathlib import Path
 from typing import Dict, List, Optional, Sequence
 import re
 
+# Shared Syzygy configuration defaults (override via env/CLI)
+DEFAULT_SYZYGY_NATIVE = r"C:\\Development\\Chess-Engine\\target\\classes\\natives\\win-x86_64\\Release\\JSyzygy.dll"
+DEFAULT_SYZYGY_PATHS = r"E:\\Syzygy"
+
+
+def resolve_syzygy_from_env(env: Optional[Dict[str, str]] = None) -> (str, str):
+    source = env if env is not None else os.environ
+    native = source.get("CHESSENGINE_SYZYGY_NATIVE") or DEFAULT_SYZYGY_NATIVE
+    paths = (
+        source.get("CHESSENGINE_SYZYGY_PATHS")
+        or source.get("CHESSENGINE_SYZYGY_PATH")
+        or DEFAULT_SYZYGY_PATHS
+    )
+    return native, paths
+
 #py .\scripts\cutechess_tuning_loop.py --project-root C:\Development\Chess-Engine --cutechess-cli "C:\Program Files (x86)\Cute Chess\cutechess-cli.exe" --stockfish C:\Development\cutechess\stockfish\stockfish-windows-x86-64-avx2.exe --java java --engine-name Alieknek --opponent-name SF --opponent-elo 1750 --time-control 10+0.1 --concurrency 3 --rounds 10 --pgn-out C:\Development\cutechess\match_tuning.pgn --engine-gc zgc --engine-active-processor-count 24 --engine-tt-mb 1024 --engine-threads 1 --engine-lazy-threads 1 --mut-frac 0.22 --mut-frac-min 0.18 --mut-frac-max 0.28 --temp-start 0.25 --temp-min 0.05 --temp-decay 14 --spectral-base 0.70 --reheat-factor 1.0
 
 try:
@@ -315,6 +330,7 @@ def parse_score(
 
 def derive_java_args(args: argparse.Namespace, tuning_path: Path) -> List[str]:
     flags: List[str] = []
+    syzygy_native, syzygy_paths = resolve_syzygy_from_env()
     if args.engine_xms:
         flags.append(f"-Xms{args.engine_xms}")
     if args.engine_xmx:
@@ -336,6 +352,10 @@ def derive_java_args(args: argparse.Namespace, tuning_path: Path) -> List[str]:
     sysprops = {
         "chessengine.tuning.file": str(tuning_path),
     }
+    if syzygy_native:
+        sysprops.setdefault("chessengine.syzygy.nativeLibrary", syzygy_native)
+    if syzygy_paths:
+        sysprops.setdefault("chessengine.syzygy.paths", syzygy_paths)
     if args.engine_tt_mb:
         sysprops["chessengine.tt.mb"] = str(args.engine_tt_mb)
     if args.engine_threads:

--- a/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyBridge.java
+++ b/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyBridge.java
@@ -211,7 +211,7 @@ public final class SyzygyBridge {
      * @param turn    true if white is to move, false if black is.
      * @return WDL result (see c code)
      */
-    public static int probeSyzygyWDL(long white, long black, long kings, long queens, long rooks, long bishops, long knights, long pawns, int ep, boolean turn) { //NOSONAR
+    public static synchronized int probeSyzygyWDL(long white, long black, long kings, long queens, long rooks, long bishops, long knights, long pawns, int ep, boolean turn) { //NOSONAR
         return probeWDL(white, black, kings, queens, rooks, bishops, knights, pawns, ep, turn);
     }
 
@@ -231,7 +231,7 @@ public final class SyzygyBridge {
      * @param turn    true if white is to move, false if black is.
      * @return DTZ result (see c code)
      */
-    public static int probeSyzygyDTZ(long white, long black, long kings, long queens, long rooks, long bishops, long knights, long pawns, int rule50, int ep, boolean turn) { //NOSONAR
+    public static synchronized int probeSyzygyDTZ(long white, long black, long kings, long queens, long rooks, long bishops, long knights, long pawns, int rule50, int ep, boolean turn) { //NOSONAR
         return probeDTZ(white, black, kings, queens, rooks, bishops, knights, pawns, rule50, ep, turn);
     }
 

--- a/src/main/resources/bat/Start-Lichess-Bot.bat
+++ b/src/main/resources/bat/Start-Lichess-Bot.bat
@@ -13,6 +13,10 @@ rem (Recommended: store LICHESS_TOKEN in your user env, not here)
 rem Workdir where lichess_bot.py lives
 set "WORKDIR=C:\Development\Chess-Engine\src\main\resources\py"
 
+rem Default Syzygy native + tablebase locations (override via env before launching)
+set "CHESSENGINE_SYZYGY_NATIVE=C:\Development\Chess-Engine\target\classes\natives\win-x86_64\Release\JSyzygy.dll"
+set "CHESSENGINE_SYZYGY_PATHS=E:\Syzygy"
+
 rem =========================
 rem   JVM / ENGINE PRESETS
 rem   (tuned for 24 physical cores)
@@ -75,7 +79,7 @@ rem =========================
 rem - ZGC: no need for MaxGCPauseMillis; AlwaysPreTouch stabilizes latency
 rem - Opening book off during games to avoid random disk stalls; enable only if preloaded
 rem - Trim UCI chatter a bit; shorter PV reduces tiny allocs
-set "JAVA_EXTRA_OPTS=-XX:+AlwaysPreTouch -Dchessengine.tt.mb=%CHESSENGINE_TT_MB% -Dchessengine.openingbook.enabled=false -Dchessengine.uci.info.minIntervalMs=200 -Dchessengine.uci.info.maxPvLen=10"
+set "JAVA_EXTRA_OPTS=-XX:+AlwaysPreTouch -Dchessengine.tt.mb=%CHESSENGINE_TT_MB% -Dchessengine.openingbook.enabled=false -Dchessengine.uci.info.minIntervalMs=200 -Dchessengine.uci.info.maxPvLen=10 -Dchessengine.syzygy.nativeLibrary=%CHESSENGINE_SYZYGY_NATIVE% -Dchessengine.syzygy.paths=%CHESSENGINE_SYZYGY_PATHS%"
 
 rem Ponder off is safest on Lichess; MoveOverhead set in Python (120 bullet / 200 blitz+)
 set "BOT_ENABLE_PONDER=0"

--- a/src/main/resources/bat/run-tuning.bat
+++ b/src/main/resources/bat/run-tuning.bat
@@ -4,6 +4,9 @@ setlocal
 REM --- project root ---
 cd /d "C:\Development\Chess-Engine"
 
+set "CHESSENGINE_SYZYGY_NATIVE=C:\Development\Chess-Engine\target\classes\natives\win-x86_64\Release\JSyzygy.dll"
+set "CHESSENGINE_SYZYGY_PATHS=E:\Syzygy"
+
 REM --- newest chess-engine-*-uci.jar ---
 set "JARFILE="
 for /f "usebackq delims=" %%F in (`dir /b /a:-d /o:-d "target\chess-engine-*-uci.jar" 2^>nul`) do (
@@ -36,6 +39,8 @@ REM PropertiesLauncher explicitly. Then -Dloader.main=<FQN> is honored.
 REM ---------------------------------------------------------------------------
 
 java ^
+  "-Dchessengine.syzygy.nativeLibrary=%CHESSENGINE_SYZYGY_NATIVE%" ^
+  "-Dchessengine.syzygy.paths=%CHESSENGINE_SYZYGY_PATHS%" ^
   "-Dloader.main=julius.game.chessengine.tuning.GeneticTuningMain" ^
   -cp "%JARFILE%" ^
   org.springframework.boot.loader.launch.PropertiesLauncher ^

--- a/src/main/resources/py/EngineBattle.py
+++ b/src/main/resources/py/EngineBattle.py
@@ -3,10 +3,38 @@ import os
 import re
 import subprocess
 import time
-from typing import Optional, Dict, Any, Tuple
+from typing import Optional, Dict, Any, Tuple, List
 import shlex
 
 import requests
+
+# Shared Syzygy defaults for all engine JVM launches
+DEFAULT_SYZYGY_NATIVE = r"C:\\Development\\Chess-Engine\\target\\classes\\natives\\win-x86_64\\Release\\JSyzygy.dll"
+DEFAULT_SYZYGY_PATHS = r"E:\\Syzygy"
+
+
+def resolve_syzygy_from_env() -> Tuple[str, str]:
+    native = os.environ.get("CHESSENGINE_SYZYGY_NATIVE") or DEFAULT_SYZYGY_NATIVE
+    paths = (
+        os.environ.get("CHESSENGINE_SYZYGY_PATHS")
+        or os.environ.get("CHESSENGINE_SYZYGY_PATH")
+        or DEFAULT_SYZYGY_PATHS
+    )
+    return native, paths
+
+
+def ensure_syzygy_args(jvm_args: Optional[List[str]]) -> List[str]:
+    args = list(jvm_args) if jvm_args else []
+    native, paths = resolve_syzygy_from_env()
+
+    def has_prefix(prefix: str) -> bool:
+        return any(item.startswith(prefix) for item in args)
+
+    if native and not has_prefix("-Dchessengine.syzygy.nativeLibrary"):
+        args.append(f"-Dchessengine.syzygy.nativeLibrary={native}")
+    if paths and not has_prefix("-Dchessengine.syzygy.paths"):
+        args.append(f"-Dchessengine.syzygy.paths={paths}")
+    return args
 
 #py -3 EngineBattle.py --jar1 "E:\ChessEngines\chess-engine-3.0.4.jar" --jar2 "E:\ChessEngines\chess-engine-3.0.6.jar" --jvm1 "-Xms4g -Xmx8g -XX:+UseG1GC"  --jvm2 "-Xms4g -Xmx8g -XX:+UseG1GC -Dchessengine.searchThreads=8 -Dchessengine.rootParallelLimit=128" --games 100 --engine-time-limit 1000
 
@@ -42,7 +70,7 @@ def start_java_process(jar_path: str, port: int, jvm_args=None) -> subprocess.Po
     """
     if not os.path.isfile(jar_path):
         raise FileNotFoundError(f"JAR not found: {jar_path}")
-    cmd = ['java'] + (jvm_args or []) + ['-jar', jar_path, f'--server.port={port}']
+    cmd = ['java'] + ensure_syzygy_args(jvm_args) + ['-jar', jar_path, f'--server.port={port}']
     with open(os.devnull, 'w') as devnull:
         return subprocess.Popen(cmd, stdout=devnull, stderr=devnull)
 
@@ -590,7 +618,7 @@ def start_java_process(jar_path: str, port: int, jvm_args=None) -> subprocess.Po
     """
     if not os.path.isfile(jar_path):
         raise FileNotFoundError(f"JAR not found: {jar_path}")
-    cmd = ['java'] + (jvm_args or []) + ['-jar', jar_path, f'--server.port={port}']
+    cmd = ['java'] + ensure_syzygy_args(jvm_args) + ['-jar', jar_path, f'--server.port={port}']
     with open(os.devnull, 'w') as devnull:
         return subprocess.Popen(cmd, stdout=devnull, stderr=devnull)
 

--- a/src/main/resources/py/ProfileEngine.py
+++ b/src/main/resources/py/ProfileEngine.py
@@ -14,6 +14,19 @@ import time
 from pathlib import Path
 from typing import Optional, List, Pattern, Match, TextIO
 
+DEFAULT_SYZYGY_NATIVE = r"C:\\Development\\Chess-Engine\\target\\classes\\natives\\win-x86_64\\Release\\JSyzygy.dll"
+DEFAULT_SYZYGY_PATHS = r"E:\\Syzygy"
+
+
+def resolve_syzygy_from_env():
+    native = os.getenv("CHESSENGINE_SYZYGY_NATIVE") or DEFAULT_SYZYGY_NATIVE
+    paths = (
+        os.getenv("CHESSENGINE_SYZYGY_PATHS")
+        or os.getenv("CHESSENGINE_SYZYGY_PATH")
+        or DEFAULT_SYZYGY_PATHS
+    )
+    return native, paths
+
 # ---------------- Utilities ----------------
 
 def ts() -> str:
@@ -149,6 +162,7 @@ def detect_project_root(script_path: Path) -> Path:
 def build_java_cmd(jar: Path, jfr_file: Path, jfr_duration: str,
                    chess_threads: str, lazy_threads: str, root_par_limit: str) -> List[str]:
     # JVM/env defaults (tuned for lower pauses & less thread thrash)
+    syzygy_native, syzygy_paths = resolve_syzygy_from_env()
     java_xms = os.getenv("JAVA_XMS", "8g")
     java_xmx = os.getenv("JAVA_XMX", "8g")
     java_gc  = os.getenv("JAVA_GC",  "zgc")   # default: low-pause ZGC
@@ -179,8 +193,13 @@ def build_java_cmd(jar: Path, jfr_file: Path, jfr_duration: str,
         "-XX:ActiveProcessorCount={}".format(apc),
     ]
 
-    if extra.strip():
-        cmd += [x for x in extra.split() if x.strip()]
+    extra_flags = [x for x in extra.split() if x.strip()]
+    if syzygy_native:
+        extra_flags.append(f"-Dchessengine.syzygy.nativeLibrary={syzygy_native}")
+    if syzygy_paths:
+        extra_flags.append(f"-Dchessengine.syzygy.paths={syzygy_paths}")
+    if extra_flags:
+        cmd += extra_flags
 
     cmd += [
         "-Dchessengine.searchThreads={}".format(chess_threads),

--- a/src/main/resources/py/lichess_bot.py
+++ b/src/main/resources/py/lichess_bot.py
@@ -22,6 +22,25 @@ import asyncio
 import random
 import contextlib
 
+
+DEFAULT_SYZYGY_NATIVE = r"C:\\Development\\Chess-Engine\\target\\classes\\natives\\win-x86_64\\Release\\JSyzygy.dll"
+DEFAULT_SYZYGY_PATHS = r"E:\\Syzygy"
+
+
+def _resolve_syzygy_config():
+    native = os.environ.get("CHESSENGINE_SYZYGY_NATIVE")
+    if not native:
+        native = DEFAULT_SYZYGY_NATIVE
+
+    paths = (
+        os.environ.get("CHESSENGINE_SYZYGY_PATHS")
+        or os.environ.get("CHESSENGINE_SYZYGY_PATH")
+    )
+    if not paths:
+        paths = DEFAULT_SYZYGY_PATHS
+
+    return native, paths
+
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
@@ -222,6 +241,8 @@ def build_engine_cmd() -> List[str]:
 
     TUNING_FILE = os.environ.get("CHESSENGINE_TUNING_FILE", DEFAULT_TUNING_FILE)
 
+    syzygy_native, syzygy_paths = _resolve_syzygy_config()
+
     engine_sysprops = [
         f"-Dchessengine.searchThreads={SEARCH_T}",
         f"-Dchessengine.lazySmpThreads={LAZY_T}",
@@ -233,6 +254,11 @@ def build_engine_cmd() -> List[str]:
         f"-Dchessengine.tuning.file={TUNING_FILE}",
         "-Dlogging.level.root=INFO",
     ]
+
+    if syzygy_native:
+        engine_sysprops.append(f"-Dchessengine.syzygy.nativeLibrary={syzygy_native}")
+    if syzygy_paths:
+        engine_sysprops.append(f"-Dchessengine.syzygy.paths={syzygy_paths}")
 
     return [*java_opts, *engine_sysprops, "-jar", str(jar)]
 

--- a/src/test/java/julius/game/chessengine/syzygy/SyzygyBridgeThreadSafetyTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/SyzygyBridgeThreadSafetyTest.java
@@ -1,0 +1,35 @@
+package julius.game.chessengine.syzygy;
+
+import julius.game.chessengine.syzygy.bridge.SyzygyBridge;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SyzygyBridgeThreadSafetyTest {
+
+    private static final Class<?>[] WDL_SIGNATURE = {
+            long.class, long.class, long.class, long.class, long.class,
+            long.class, long.class, long.class, int.class, boolean.class
+    };
+
+    private static final Class<?>[] DTZ_SIGNATURE = {
+            long.class, long.class, long.class, long.class, long.class,
+            long.class, long.class, long.class, int.class, int.class, boolean.class
+    };
+
+    @Test
+    void probeMethodsAreSynchronized() throws NoSuchMethodException {
+        Method wdl = SyzygyBridge.class.getDeclaredMethod("probeSyzygyWDL", WDL_SIGNATURE);
+        Method dtz = SyzygyBridge.class.getDeclaredMethod("probeSyzygyDTZ", DTZ_SIGNATURE);
+
+        assertThat(Modifier.isSynchronized(wdl.getModifiers()))
+                .as("probeSyzygyWDL must be synchronized to avoid concurrent native access")
+                .isTrue();
+        assertThat(Modifier.isSynchronized(dtz.getModifiers()))
+                .as("probeSyzygyDTZ must be synchronized to avoid concurrent native access")
+                .isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- add a Windows-specific Maven profile that appends `-A x64` to the CMake configure step
- prevent Visual Studio builds from defaulting to 32-bit and producing incompatible JSyzygy.dll binaries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebb29ce10c832a8866f0eb7f5c5058