### PR TITLE
Serialize Syzygy JNI probes to avoid native crashes

### DIFF
--- a/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyBridge.java
+++ b/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyBridge.java
@@ -211,7 +211,7 @@ public final class SyzygyBridge {
      * @param turn    true if white is to move, false if black is.
      * @return WDL result (see c code)
      */
-    public static int probeSyzygyWDL(long white, long black, long kings, long queens, long rooks, long bishops, long knights, long pawns, int ep, boolean turn) { //NOSONAR
+    public static synchronized int probeSyzygyWDL(long white, long black, long kings, long queens, long rooks, long bishops, long knights, long pawns, int ep, boolean turn) { //NOSONAR
         return probeWDL(white, black, kings, queens, rooks, bishops, knights, pawns, ep, turn);
     }
 
@@ -231,7 +231,7 @@ public final class SyzygyBridge {
      * @param turn    true if white is to move, false if black is.
      * @return DTZ result (see c code)
      */
-    public static int probeSyzygyDTZ(long white, long black, long kings, long queens, long rooks, long bishops, long knights, long pawns, int rule50, int ep, boolean turn) { //NOSONAR
+    public static synchronized int probeSyzygyDTZ(long white, long black, long kings, long queens, long rooks, long bishops, long knights, long pawns, int rule50, int ep, boolean turn) { //NOSONAR
         return probeDTZ(white, black, kings, queens, rooks, bishops, knights, pawns, rule50, ep, turn);
     }
 

--- a/src/test/java/julius/game/chessengine/syzygy/SyzygyBridgeThreadSafetyTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/SyzygyBridgeThreadSafetyTest.java
@@ -1,0 +1,35 @@
+package julius.game.chessengine.syzygy;
+
+import julius.game.chessengine.syzygy.bridge.SyzygyBridge;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SyzygyBridgeThreadSafetyTest {
+
+    private static final Class<?>[] WDL_SIGNATURE = {
+            long.class, long.class, long.class, long.class, long.class,
+            long.class, long.class, long.class, int.class, boolean.class
+    };
+
+    private static final Class<?>[] DTZ_SIGNATURE = {
+            long.class, long.class, long.class, long.class, long.class,
+            long.class, long.class, long.class, int.class, int.class, boolean.class
+    };
+
+    @Test
+    void probeMethodsAreSynchronized() throws NoSuchMethodException {
+        Method wdl = SyzygyBridge.class.getDeclaredMethod("probeSyzygyWDL", WDL_SIGNATURE);
+        Method dtz = SyzygyBridge.class.getDeclaredMethod("probeSyzygyDTZ", DTZ_SIGNATURE);
+
+        assertThat(Modifier.isSynchronized(wdl.getModifiers()))
+                .as("probeSyzygyWDL must be synchronized to avoid concurrent native access")
+                .isTrue();
+        assertThat(Modifier.isSynchronized(dtz.getModifiers()))
+                .as("probeSyzygyDTZ must be synchronized to avoid concurrent native access")
+                .isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- synchronize the SyzygyBridge probe methods so JNI tablebase access happens serially and no longer trips native crashes
- add a regression test that guards the synchronized modifiers on the Syzygy bridge probes

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=SyzygyBridgeThreadSafetyTest test

------
https://chatgpt.com/codex/tasks/task_e_68ebb8f538dc832a9d9d72c08f1c1b68