### PR TITLE
Add UCI Syzygy flow tests

### DIFF
--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -46,17 +46,27 @@ public class UciHandler {
     }
 
     public UciHandler(Consumer<String> output, Supplier<Boolean> running) {
-        String syzygyPaths = System.getProperty("chessengine.syzygy.paths", System.getProperty("chessengine.syzygy.path", ""));
-        int syzygyMaxPieces = Integer.getInteger("chessengine.syzygy.maxPieces", 7);
-        int syzygyCacheSize = Integer.getInteger("chessengine.syzygy.cacheSize", 65536);
-        this.tablebaseService = new SyzygyTablebaseService(syzygyPaths, syzygyMaxPieces, syzygyCacheSize);
-        Score.setTablebaseService(tablebaseService);
+        this(createTablebaseService(), new Engine(), null, output, running);
+    }
 
-        this.engine = new Engine();
-        this.ai = new AI(engine, tablebaseService);
+    UciHandler(SyzygyTablebaseService tablebaseService, Engine engine, AI ai,
+            Consumer<String> output, Supplier<Boolean> running) {
+        this.tablebaseService = Objects.requireNonNull(tablebaseService, "tablebaseService");
+        Score.setTablebaseService(this.tablebaseService);
+
+        this.engine = Objects.requireNonNull(engine, "engine");
+        this.ai = ai == null ? new AI(this.engine, this.tablebaseService) : ai;
         this.output = Objects.requireNonNull(output, "output");
         this.running = Objects.requireNonNull(running, "running");
         registerOptions();
+    }
+
+    private static SyzygyTablebaseService createTablebaseService() {
+        String syzygyPaths = System.getProperty("chessengine.syzygy.paths",
+                System.getProperty("chessengine.syzygy.path", ""));
+        int syzygyMaxPieces = Integer.getInteger("chessengine.syzygy.maxPieces", 7);
+        int syzygyCacheSize = Integer.getInteger("chessengine.syzygy.cacheSize", 65536);
+        return new SyzygyTablebaseService(syzygyPaths, syzygyMaxPieces, syzygyCacheSize);
     }
 
     /**

--- a/src/test/java/julius/game/chessengine/syzygy/TestSyzygyTablebaseService.java
+++ b/src/test/java/julius/game/chessengine/syzygy/TestSyzygyTablebaseService.java
@@ -1,0 +1,53 @@
+package julius.game.chessengine.syzygy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Test-only extension exposing helpers to create {@link SyzygyTablebaseService}
+ * instances backed by deterministic tablebase clients.
+ */
+public final class TestSyzygyTablebaseService extends SyzygyTablebaseService {
+
+    private final TestClient testClient;
+
+    public TestSyzygyTablebaseService(TablebaseClient client, int cacheSize) {
+        super(client, cacheSize);
+        this.testClient = client instanceof TestClient ? (TestClient) client : null;
+    }
+
+    private TestSyzygyTablebaseService(TestClient client, int cacheSize) {
+        super(client, cacheSize);
+        this.testClient = client;
+    }
+
+    public static TestSyzygyTablebaseService fromResponses(Map<String, SyzygyProbeResult> responses) {
+        return new TestSyzygyTablebaseService(new TestClient(responses), 16);
+    }
+
+    public List<String> getProbedFens() {
+        return testClient == null ? List.of() : testClient.snapshot();
+    }
+
+    private static final class TestClient implements TablebaseClient {
+
+        private final Map<String, SyzygyProbeResult> responses;
+        private final CopyOnWriteArrayList<String> probedFens = new CopyOnWriteArrayList<>();
+
+        private TestClient(Map<String, SyzygyProbeResult> responses) {
+            this.responses = responses;
+        }
+
+        @Override
+        public Optional<SyzygyProbeResult> probe(String fen) {
+            probedFens.add(fen);
+            return Optional.ofNullable(responses.get(fen));
+        }
+
+        private List<String> snapshot() {
+            return List.copyOf(probedFens);
+        }
+    }
+}

--- a/src/test/java/julius/game/chessengine/uci/UciSyzygyFlowTest.java
+++ b/src/test/java/julius/game/chessengine/uci/UciSyzygyFlowTest.java
@@ -1,0 +1,157 @@
+package julius.game.chessengine.uci;
+
+import julius.game.chessengine.ai.AI;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.syzygy.SyzygyProbeResult;
+import julius.game.chessengine.syzygy.SyzygyTablebaseService;
+import julius.game.chessengine.syzygy.SyzygyWdl;
+import julius.game.chessengine.syzygy.TestSyzygyTablebaseService;
+import julius.game.chessengine.syzygy.TablebaseResult;
+import julius.game.chessengine.utils.Score;
+import org.junit.jupiter.api.Test;
+import testsupport.DeterministicAiHelper;
+
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UciSyzygyFlowTest {
+
+    @Test
+    void blackSyzygyWinIsBroadcast() throws Exception {
+        String fen = "8/8/8/8/8/1kb1n3/8/2K5 b - - 31 16";
+        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(5), OptionalInt.empty());
+
+        ScenarioResult result = runSyzygyScenario(fen, probe);
+
+        assertThat(result.tablebaseResult().wdl()).isEqualTo(SyzygyWdl.WIN);
+        assertThat(result.tablebaseResult().dtz()).hasValue(5);
+        assertThat(result.outputLines()).anyMatch(line -> line.startsWith("bestmove"));
+        assertThat(result.probedFens()).contains(fen);
+    }
+
+    @Test
+    void whiteSyzygyWinIsBroadcast() throws Exception {
+        String fen = "3k4/p6p/8/8/8/4N3/5B2/3K4 w - - 0 1";
+        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(7), OptionalInt.empty());
+
+        ScenarioResult result = runSyzygyScenario(fen, probe);
+
+        assertThat(result.tablebaseResult().wdl()).isEqualTo(SyzygyWdl.WIN);
+        assertThat(result.tablebaseResult().dtz()).hasValue(7);
+        assertThat(result.outputLines()).anyMatch(line -> line.startsWith("bestmove"));
+        assertThat(result.probedFens()).contains(fen);
+    }
+
+    private ScenarioResult runSyzygyScenario(String fen, SyzygyProbeResult probe) throws Exception {
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(Map.of(fen, probe));
+
+        try (ScoreTablebaseRestorer restorer = overrideScoreTablebase(service)) {
+            Engine engine = new Engine();
+            AI ai = new AI(engine, service);
+
+            try (AutoCloseable single = DeterministicAiHelper.withSingleThread(ai);
+                 AutoCloseable limit = DeterministicAiHelper.withShortTimeLimit(ai, 50)) {
+                RecordingOutput output = new RecordingOutput();
+                UciHandler handler = new UciHandler(service, engine, ai, output, () -> true);
+
+                // Prime the engine so the board hash matches what the tablebase client expects.
+                engine.importBoardFromFen(fen);
+
+                assertThat(handler.handle("uci")).isTrue();
+                assertThat(handler.handle("isready")).isTrue();
+                assertThat(handler.handle("position fen " + fen)).isTrue();
+                engine.getGameState().refreshScore(engine.getBitBoard());
+                assertThat(handler.handle("go movetime 100"))
+                        .withFailMessage(() -> String.join("\n", output.snapshot()))
+                        .isTrue();
+
+                waitForBestMove(output);
+                handler.stop();
+
+                TablebaseResult result = engine.getLastTablebaseResult()
+                        .orElseThrow(() -> new IllegalStateException("Expected tablebase result"));
+                return new ScenarioResult(result, output.snapshot(), service.getProbedFens());
+            }
+        }
+    }
+
+    private void waitForBestMove(RecordingOutput output) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (System.nanoTime() < deadline) {
+            if (output.snapshot().stream().anyMatch(line -> line.startsWith("bestmove"))) {
+                return;
+            }
+            Thread.sleep(20);
+        }
+        throw new AssertionError("Timed out waiting for bestmove.\nOutput:\n" + String.join("\n", output.snapshot()));
+    }
+
+    private static final class RecordingOutput implements Consumer<String> {
+
+        private final CopyOnWriteArrayList<String> lines = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void accept(String line) {
+            lines.add(line);
+        }
+
+        List<String> snapshot() {
+            return List.copyOf(lines);
+        }
+    }
+
+    private record ScenarioResult(TablebaseResult tablebaseResult, List<String> outputLines, List<String> probedFens) {
+    }
+
+    private ScoreTablebaseRestorer overrideScoreTablebase(TestSyzygyTablebaseService service) {
+        if (service == null) {
+            throw new IllegalArgumentException("service");
+        }
+        try {
+            java.lang.reflect.Field field = Score.class.getDeclaredField("TABLEBASE_SERVICE");
+            field.setAccessible(true);
+            SyzygyTablebaseService previous = (SyzygyTablebaseService) field.get(null);
+            Score.setTablebaseService(service);
+            return new ScoreTablebaseRestorer(field, previous);
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException("Unable to override Score tablebase service", ex);
+        }
+    }
+
+    private static final class ScoreTablebaseRestorer implements AutoCloseable {
+
+        private final java.lang.reflect.Field field;
+        private final SyzygyTablebaseService previous;
+        private boolean closed;
+
+        private ScoreTablebaseRestorer(java.lang.reflect.Field field, SyzygyTablebaseService previous) {
+            this.field = field;
+            this.previous = previous;
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            try {
+                if (previous == null) {
+                    field.setAccessible(true);
+                    field.set(null, null);
+                } else {
+                    Score.setTablebaseService(previous);
+                }
+            } catch (ReflectiveOperationException ex) {
+                throw new IllegalStateException("Unable to restore Score tablebase service", ex);
+            } finally {
+                closed = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow tests to inject custom engines and tablebase services into `UciHandler`
- add a test-only Syzygy tablebase service wrapper for deterministic probing
- cover Syzygy win scenarios for both sides via new UCI integration tests

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=UciSyzygyFlowTest test

------
https://chatgpt.com/codex/tasks/task_e_68ebc48e60c8832aae7712e8592caf57