### PR TITLE
Enable Syzygy tablebases during diagnostic AI tests

### DIFF
--- a/src/test/java/julius/game/chessengine/ai/AITest_MateThreatDiagnostics.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_MateThreatDiagnostics.java
@@ -7,6 +7,7 @@ import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.tuning.AiTuning;
 import julius.game.chessengine.utils.Score;
+import julius.game.chessengine.syzygy.TestSyzygySupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.TestInstance;
@@ -142,7 +143,8 @@ class AITest_MateThreatDiagnostics {
         private final List<DepthTrace> depthTraces = Collections.synchronizedList(new ArrayList<>());
 
         DiagnosticAI(Engine engine, AiTuning tuning) {
-            super(engine, tuning);
+            super(engine, tuning, TestSyzygySupport.maybeCreateServiceFromConfiguration()
+                    .orElse(null));
             try {
                 sortMovesMethod = AI.class.getDeclaredMethod("sortMovesByEfficiency", IntArrayList.class,
                         int.class, long.class, int.class, Engine.class);

--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -7,6 +7,7 @@ import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.tuning.AiTuning;
 import julius.game.chessengine.utils.Score;
+import julius.game.chessengine.syzygy.TestSyzygySupport;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -506,7 +507,8 @@ public class BestMoveSearchTest {
         private volatile int targetDepth;
 
         DiagnosticAI(Engine engine, AiTuning tuning) {
-            super(engine, tuning);
+            super(engine, tuning, TestSyzygySupport.maybeCreateServiceFromConfiguration()
+                    .orElse(null));
             try {
                 sortMovesMethod = AI.class.getDeclaredMethod("sortMovesByEfficiency", IntArrayList.class,
                         int.class, long.class, int.class, Engine.class);

--- a/src/test/java/julius/game/chessengine/syzygy/TestSyzygySupport.java
+++ b/src/test/java/julius/game/chessengine/syzygy/TestSyzygySupport.java
@@ -1,0 +1,86 @@
+package julius.game.chessengine.syzygy;
+
+import java.util.Optional;
+
+/**
+ * Shared Syzygy configuration helpers for integration-style tests. The helpers probe the
+ * JVM/system properties used by the production engine so tests can opt in to the real native
+ * tablebases when the caller supplies the relevant directories.
+ */
+public final class TestSyzygySupport {
+
+    private static final String PATH_PROPERTY = "chessengine.syzygy.paths";
+    private static final String ALT_PATH_PROPERTY = "chessengine.syzygy.path";
+    private static final String PATH_ENV = "CHESSENGINE_SYZYGY_PATH";
+    private static final String ALT_PATH_ENV = "SYZYGY_PATH";
+    private static final String MAX_PIECES_PROPERTY = "chessengine.syzygy.maxPieces";
+    private static final String CACHE_SIZE_PROPERTY = "chessengine.syzygy.cacheSize";
+
+    private TestSyzygySupport() {
+    }
+
+    public static boolean isSyzygyConfigured() {
+        return isNonEmpty(System.getProperty(PATH_PROPERTY))
+                || isNonEmpty(System.getProperty(ALT_PATH_PROPERTY))
+                || isNonEmpty(System.getenv(PATH_ENV))
+                || isNonEmpty(System.getenv(ALT_PATH_ENV));
+    }
+
+    public static Optional<String> resolveConfiguredDirectories() {
+        if (!isSyzygyConfigured()) {
+            return Optional.empty();
+        }
+        return Optional.of(resolveDirectories());
+    }
+
+    public static Optional<SyzygyTablebaseService> maybeCreateServiceFromConfiguration() {
+        Optional<String> directories = resolveConfiguredDirectories();
+        if (directories.isEmpty()) {
+            return Optional.empty();
+        }
+        int maxPieces = parsePositiveInt(System.getProperty(MAX_PIECES_PROPERTY), 7);
+        int cacheSize = parsePositiveInt(System.getProperty(CACHE_SIZE_PROPERTY), 65_536);
+
+        SyzygyTablebaseService service = new SyzygyTablebaseService(directories.get(), maxPieces, cacheSize);
+        service.ensureReady();
+        return Optional.of(service);
+    }
+
+    private static String resolveDirectories() {
+        String directories = firstNonEmpty(
+                System.getProperty(PATH_PROPERTY),
+                System.getProperty(ALT_PATH_PROPERTY),
+                System.getenv(PATH_ENV),
+                System.getenv(ALT_PATH_ENV)
+        );
+        if (directories == null) {
+            throw new IllegalStateException("Syzygy directory configuration missing despite opt-in");
+        }
+        return directories;
+    }
+
+    private static int parsePositiveInt(String value, int defaultValue) {
+        if (!isNonEmpty(value)) {
+            return defaultValue;
+        }
+        try {
+            int parsed = Integer.parseInt(value.trim());
+            return parsed > 0 ? parsed : defaultValue;
+        } catch (NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+
+    private static String firstNonEmpty(String... values) {
+        for (String value : values) {
+            if (isNonEmpty(value)) {
+                return value.trim();
+            }
+        }
+        return null;
+    }
+
+    private static boolean isNonEmpty(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/src/test/java/julius/game/chessengine/tablebase/SyzygyWinRegressionTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/SyzygyWinRegressionTest.java
@@ -4,6 +4,7 @@ import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.FEN;
 import julius.game.chessengine.syzygy.SyzygyProbeResult;
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
+import julius.game.chessengine.syzygy.TestSyzygySupport;
 import julius.game.chessengine.syzygy.SyzygyWdl;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +20,8 @@ class SyzygyWinRegressionTest {
     void whiteWinsKnightBishopVsKingPawnAccordingToSyzygy() {
         TablebaseTestSupport.assumeSyzygyConfigured();
 
-        String directories = resolveSyzygyDirectories();
+        String directories = TestSyzygySupport.resolveConfiguredDirectories()
+                .orElseThrow(() -> new IllegalStateException("Syzygy directory configuration missing despite assumption"));
         SyzygyTablebaseService service = new SyzygyTablebaseService(directories, 7, 16384);
 
         BitBoard board = FEN.translateFENtoBitBoard(KNIGHT_BISHOP_VS_KING_PAWN_FEN);
@@ -31,24 +33,4 @@ class SyzygyWinRegressionTest {
         assertThat(result.get().wdl()).isEqualTo(SyzygyWdl.WIN);
     }
 
-    private static String resolveSyzygyDirectories() {
-        String directories = firstNonEmpty(
-                System.getProperty("chessengine.syzygy.paths"),
-                System.getProperty("chessengine.syzygy.path"),
-                System.getenv("CHESSENGINE_SYZYGY_PATH"),
-                System.getenv("SYZYGY_PATH"));
-        if (directories == null) {
-            throw new IllegalStateException("Syzygy directory configuration missing despite assumption");
-        }
-        return directories;
-    }
-
-    private static String firstNonEmpty(String... values) {
-        for (String value : values) {
-            if (value != null && !value.trim().isEmpty()) {
-                return value;
-            }
-        }
-        return null;
-    }
 }

--- a/src/test/java/julius/game/chessengine/tablebase/TablebaseTestSupport.java
+++ b/src/test/java/julius/game/chessengine/tablebase/TablebaseTestSupport.java
@@ -1,6 +1,7 @@
 package julius.game.chessengine.tablebase;
 
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
+import julius.game.chessengine.syzygy.TestSyzygySupport;
 import julius.game.chessengine.utils.Score;
 import org.junit.jupiter.api.Assumptions;
 
@@ -8,29 +9,17 @@ import java.lang.reflect.Field;
 
 final class TablebaseTestSupport {
 
-    private static final String PROPERTY = "chessengine.syzygy.paths";
-    private static final String ALT_PROPERTY = "chessengine.syzygy.path";
-    private static final String ENV = "CHESSENGINE_SYZYGY_PATH";
-    private static final String ALT_ENV = "SYZYGY_PATH";
-
     private TablebaseTestSupport() {
     }
 
     static void assumeSyzygyConfigured() {
-        Assumptions.assumeTrue(isSyzygyConfigured(), () ->
-                "Syzygy directory not configured. Set '" + PROPERTY + "' or '" + ALT_PROPERTY +
-                        "' (or the matching env vars) to run tablebase-backed tests.");
+        Assumptions.assumeTrue(TestSyzygySupport.isSyzygyConfigured(), () ->
+                "Syzygy directory not configured. Set 'chessengine.syzygy.paths' or 'chessengine.syzygy.path' "
+                        + "(or the matching env vars) to run tablebase-backed tests.");
     }
 
     static boolean isSyzygyConfigured() {
-        return isNonEmpty(System.getProperty(PROPERTY))
-                || isNonEmpty(System.getProperty(ALT_PROPERTY))
-                || isNonEmpty(System.getenv(ENV))
-                || isNonEmpty(System.getenv(ALT_ENV));
-    }
-
-    private static boolean isNonEmpty(String value) {
-        return value != null && !value.trim().isEmpty();
+        return TestSyzygySupport.isSyzygyConfigured();
     }
 
     static TablebaseServiceRestorer overrideScoreTablebase(SyzygyTablebaseService service) {


### PR DESCRIPTION
## Summary
- allow the diagnostic AI helpers in tests to attach a Syzygy tablebase service when the JVM/configure properties are present
- share a reusable Syzygy test support helper so tablebase-aware tests reuse the same configuration lookup logic

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=SyzygyWinRegressionTest test

------
https://chatgpt.com/codex/tasks/task_e_68ebe30f0640832a91bbd2dc4ddcae75