### PR TITLE
Refactor Syzygy tablebase probing to use bitboards

### DIFF
--- a/src/main/java/julius/game/chessengine/syzygy/FathomTablebaseClient.java
+++ b/src/main/java/julius/game/chessengine/syzygy/FathomTablebaseClient.java
@@ -1,7 +1,6 @@
 package julius.game.chessengine.syzygy;
 
 import julius.game.chessengine.board.BitBoard;
-import julius.game.chessengine.board.FEN;
 import lombok.extern.log4j.Log4j2;
 
 import java.util.Optional;
@@ -20,12 +19,11 @@ final class FathomTablebaseClient implements TablebaseClient {
     }
 
     @Override
-    public Optional<SyzygyProbeResult> probe(String fen) {
+    public Optional<SyzygyProbeResult> probe(BitBoard board) {
         try {
-            BitBoard board = FEN.translateFENtoBitBoard(fen);
             return tables.probe(board);
         } catch (RuntimeException ex) {
-            log.warn("Failed to translate FEN '{}' for Syzygy probe", fen, ex);
+            log.warn("Failed to probe Syzygy tables for board {}", board, ex);
             return Optional.empty();
         }
     }

--- a/src/main/java/julius/game/chessengine/syzygy/SyzygyTablebaseService.java
+++ b/src/main/java/julius/game/chessengine/syzygy/SyzygyTablebaseService.java
@@ -1,11 +1,8 @@
 package julius.game.chessengine.syzygy;
 
 import julius.game.chessengine.board.BitBoard;
-import julius.game.chessengine.board.MoveHelper;
-import julius.game.chessengine.utils.Color;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -14,8 +11,8 @@ import java.util.concurrent.ConcurrentMap;
 
 /**
  * Thread-safe Syzygy probe cache. Consumers can feed {@link BitBoard} states and receive
- * cached tablebase answers. The service translates the engine specific representation into
- * the FEN strings expected by standard Syzygy backends.
+ * cached tablebase answers. The service now forwards bitboards directly to the underlying
+ * tablebase client, avoiding intermediate FEN translation overhead.
  */
 @Log4j2
 public class SyzygyTablebaseService {
@@ -57,8 +54,7 @@ public class SyzygyTablebaseService {
         if (cached != null) {
             return cached;
         }
-        String fen = toFen(board);
-        Optional<SyzygyProbeResult> resolved = client.probe(fen)
+        Optional<SyzygyProbeResult> resolved = client.probe(board)
                 .filter(result -> result.wdl() != SyzygyWdl.UNKNOWN || result.dtz().isPresent() || result.dtm().isPresent());
         cacheAndEvict(key, resolved);
         return resolved;
@@ -109,63 +105,6 @@ public class SyzygyTablebaseService {
         }
     }
 
-    private String toFen(BitBoard board) {
-        StringBuilder fen = new StringBuilder();
-        for (int rank = 7; rank >= 0; rank--) {
-            int empty = 0;
-            for (int file = 0; file < 8; file++) {
-                int index = rank * 8 + file;
-                var pieceType = board.getPieceTypeAtIndex(index);
-                if (pieceType == null) {
-                    empty++;
-                    continue;
-                }
-                if (empty > 0) {
-                    fen.append(empty);
-                    empty = 0;
-                }
-                Color color = board.getPieceColorAtIndex(index);
-                char notation = pieceType.getNotation();
-                fen.append(color == Color.WHITE ? notation : Character.toLowerCase(notation));
-            }
-            if (empty > 0) {
-                fen.append(empty);
-            }
-            if (rank > 0) {
-                fen.append('/');
-            }
-        }
-        fen.append(' ');
-        fen.append(board.isWhitesTurn() ? 'w' : 'b');
-        fen.append(' ');
-        fen.append(buildCastlingAvailability(board));
-        fen.append(' ');
-        int enPassant = board.getEnPassantTargetIndex();
-        fen.append(enPassant < 0 ? '-' : MoveHelper.convertIndexToString(enPassant));
-        fen.append(' ');
-        fen.append(Math.max(0, board.getHalfmoveClock()));
-        fen.append(' ');
-        fen.append(Math.max(1, board.getFullmoveNumber()));
-        return fen.toString();
-    }
-
-    private String buildCastlingAvailability(BitBoard board) {
-        StringBuilder castling = new StringBuilder();
-        if (!board.isWhiteKingMoved() && !board.isWhiteRookH1Moved()) {
-            castling.append('K');
-        }
-        if (!board.isWhiteKingMoved() && !board.isWhiteRookA1Moved()) {
-            castling.append('Q');
-        }
-        if (!board.isBlackKingMoved() && !board.isBlackRookH8Moved()) {
-            castling.append('k');
-        }
-        if (!board.isBlackKingMoved() && !board.isBlackRookA8Moved()) {
-            castling.append('q');
-        }
-        return castling.length() == 0 ? "-" : castling.toString();
-    }
-
     private record SyzygyCacheKey(long zobrist, int halfmoveClock, int fullmoveNumber) {
 
         static SyzygyCacheKey from(BitBoard board) {
@@ -175,7 +114,7 @@ public class SyzygyTablebaseService {
 
     private static final class NoopClient implements TablebaseClient {
         @Override
-        public Optional<SyzygyProbeResult> probe(String fen) {
+        public Optional<SyzygyProbeResult> probe(BitBoard board) {
             return Optional.empty();
         }
     }

--- a/src/main/java/julius/game/chessengine/syzygy/TablebaseClient.java
+++ b/src/main/java/julius/game/chessengine/syzygy/TablebaseClient.java
@@ -1,9 +1,11 @@
 package julius.game.chessengine.syzygy;
 
+import julius.game.chessengine.board.BitBoard;
+
 import java.util.Optional;
 
 interface TablebaseClient {
 
-    Optional<SyzygyProbeResult> probe(String fen);
+    Optional<SyzygyProbeResult> probe(BitBoard board);
 
 }

--- a/src/test/java/julius/game/chessengine/syzygy/SyzygyTablebaseServiceTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/SyzygyTablebaseServiceTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SyzygyTablebaseServiceTest {
 
     @Test
-    void translatesBitBoardStateToFen() {
+    void forwardsBitBoardStateToClient() {
         BitBoard board = FEN.translateFENtoBitBoard("8/8/8/8/8/8/8/8 w - - 0 1");
         RecordingClient client = new RecordingClient();
         client.response = Optional.of(SyzygyProbeResult.unavailable());
@@ -20,7 +20,7 @@ class SyzygyTablebaseServiceTest {
         SyzygyTablebaseService service = new SyzygyTablebaseService(client, 16);
         service.probe(board);
 
-        assertThat(client.lastFen).isEqualTo("8/8/8/8/8/8/8/8 w - - 0 1");
+        assertThat(client.lastBoard).isSameAs(board);
     }
 
     @Test
@@ -45,13 +45,13 @@ class SyzygyTablebaseServiceTest {
 
     private static final class RecordingClient implements TablebaseClient {
         Optional<SyzygyProbeResult> response = Optional.empty();
-        String lastFen;
+        BitBoard lastBoard;
         int invocations = 0;
 
         @Override
-        public Optional<SyzygyProbeResult> probe(String fen) {
+        public Optional<SyzygyProbeResult> probe(BitBoard board) {
             invocations++;
-            lastFen = fen;
+            lastBoard = board;
             return response;
         }
     }

--- a/src/test/java/julius/game/chessengine/syzygy/TestSyzygyTablebaseService.java
+++ b/src/test/java/julius/game/chessengine/syzygy/TestSyzygyTablebaseService.java
@@ -1,5 +1,9 @@
 package julius.game.chessengine.syzygy;
 
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.engine.GameState;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -41,13 +45,19 @@ public final class TestSyzygyTablebaseService extends SyzygyTablebaseService {
         }
 
         @Override
-        public Optional<SyzygyProbeResult> probe(String fen) {
+        public Optional<SyzygyProbeResult> probe(BitBoard board) {
+            String fen = toFen(board);
             probedFens.add(fen);
             return Optional.ofNullable(responses.get(fen));
         }
 
         private List<String> snapshot() {
             return List.copyOf(probedFens);
+        }
+
+        private String toFen(BitBoard board) {
+            GameState state = new GameState(new BitBoard(board));
+            return FEN.translateBoardToFEN(board, state).getRenderBoard();
         }
     }
 }


### PR DESCRIPTION
## Summary
- forward `BitBoard` instances directly through the `TablebaseClient` API and cache layer
- adapt the Fathom-backed client and supporting test doubles to consume bitboards while still exposing recorded probe states for assertions
- refresh the Syzygy tablebase service tests to exercise the new probe contract

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=SyzygyTablebaseServiceTest,UciSyzygyFlowTest test

------
https://chatgpt.com/codex/tasks/task_e_68ebe84910bc832aa374a32f8c355538