### PR TITLE
Improve Syzygy tablebase integration and tests

### DIFF
--- a/src/main/java/julius/game/chessengine/syzygy/FathomTablebaseClient.java
+++ b/src/main/java/julius/game/chessengine/syzygy/FathomTablebaseClient.java
@@ -27,4 +27,9 @@ final class FathomTablebaseClient implements TablebaseClient {
             return Optional.empty();
         }
     }
+
+    @Override
+    public int supportedMaxPieces() {
+        return tables.effectiveMaxPieces();
+    }
 }

--- a/src/main/java/julius/game/chessengine/syzygy/SyzygyTablebaseService.java
+++ b/src/main/java/julius/game/chessengine/syzygy/SyzygyTablebaseService.java
@@ -18,6 +18,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Log4j2
 public class SyzygyTablebaseService {
 
+    private static final int DEFAULT_MAX_PIECES = 6;
+
     private final ConcurrentMap<SyzygyCacheKey, Optional<SyzygyProbeResult>> cache = new ConcurrentHashMap<>();
     private final ConcurrentLinkedQueue<SyzygyCacheKey> evictionOrder = new ConcurrentLinkedQueue<>();
     private final AtomicInteger entryCount = new AtomicInteger();
@@ -25,21 +27,24 @@ public class SyzygyTablebaseService {
     private volatile TablebaseClient client;
     private volatile String configuredDirectories;
     private volatile int configuredMaxPieces;
+    private volatile int effectiveMaxPieces;
 
     public SyzygyTablebaseService(
             @Value("${chessengine.syzygy.paths:${chessengine.syzygy.path:}}") String directories,
-            @Value("${chessengine.syzygy.maxPieces:7}") int maxPieces,
+            @Value("${chessengine.syzygy.maxPieces:6}") int maxPieces,
             @Value("${chessengine.syzygy.cacheSize:65536}") int cacheSize) {
         this(resolveClient(directories, maxPieces), cacheSize);
         this.configuredDirectories = directories == null ? "" : directories;
         this.configuredMaxPieces = Math.max(1, maxPieces);
+        this.effectiveMaxPieces = resolveEffectiveMaxPieces(this.client, this.configuredMaxPieces);
     }
 
     SyzygyTablebaseService(TablebaseClient client, int cacheSize) {
         this.maxEntries = Math.max(1024, cacheSize);
         this.client = client;
         this.configuredDirectories = "";
-        this.configuredMaxPieces = 7;
+        this.configuredMaxPieces = DEFAULT_MAX_PIECES;
+        this.effectiveMaxPieces = resolveEffectiveMaxPieces(client, this.configuredMaxPieces);
         log.info("Syzygy tablebase cache initialised with capacity {} entries", this.maxEntries);
     }
 
@@ -71,14 +76,15 @@ public class SyzygyTablebaseService {
         this.client = resolveClient(sanitized, maxPieces);
         this.configuredDirectories = sanitized;
         this.configuredMaxPieces = Math.max(1, maxPieces);
+        this.effectiveMaxPieces = resolveEffectiveMaxPieces(this.client, this.configuredMaxPieces);
         cache.clear();
         evictionOrder.clear();
         entryCount.set(0);
         if (client instanceof NoopClient) {
             log.info("Syzygy tablebase probing disabled (directories='{}').", sanitized);
         } else {
-            log.info("Syzygy tablebase probing configured (directories='{}', maxPieces={}).",
-                    sanitized, this.configuredMaxPieces);
+            log.info("Syzygy tablebase probing configured (directories='{}', maxPieces={}, effectiveMaxPieces={}).",
+                    sanitized, this.configuredMaxPieces, this.effectiveMaxPieces);
         }
     }
 
@@ -92,8 +98,24 @@ public class SyzygyTablebaseService {
         return configuredMaxPieces;
     }
 
+    public int getEffectiveMaxPieces() {
+        return effectiveMaxPieces;
+    }
+
     public String getConfiguredDirectories() {
         return configuredDirectories;
+    }
+
+    private static int resolveEffectiveMaxPieces(TablebaseClient client, int configuredMaxPieces) {
+        int normalized = Math.max(1, configuredMaxPieces);
+        if (client == null) {
+            return normalized;
+        }
+        int supported = client.supportedMaxPieces();
+        if (supported <= 0) {
+            return normalized;
+        }
+        return Math.min(normalized, supported);
     }
 
     private void cacheAndEvict(SyzygyCacheKey key, Optional<SyzygyProbeResult> result) {
@@ -132,6 +154,11 @@ public class SyzygyTablebaseService {
         @Override
         public Optional<SyzygyProbeResult> probe(BitBoard board) {
             return Optional.empty();
+        }
+
+        @Override
+        public int supportedMaxPieces() {
+            return 0;
         }
     }
 }

--- a/src/main/java/julius/game/chessengine/syzygy/TablebaseClient.java
+++ b/src/main/java/julius/game/chessengine/syzygy/TablebaseClient.java
@@ -8,4 +8,11 @@ interface TablebaseClient {
 
     Optional<SyzygyProbeResult> probe(BitBoard board);
 
+    /**
+     * Largest number of pieces the client can probe. Return {@code 0} when the limit is
+     * unknown so callers can fall back to their configured maximums.
+     */
+    default int supportedMaxPieces() {
+        return 0;
+    }
 }

--- a/src/main/java/julius/game/chessengine/syzygy/Tables.java
+++ b/src/main/java/julius/game/chessengine/syzygy/Tables.java
@@ -51,7 +51,7 @@ final class Tables {
             return Optional.empty();
         }
         int pieceCount = Long.bitCount(board.getAllPieces());
-        int limit = Math.min(maxPieces, supportedPieces);
+        int limit = effectiveMaxPieces();
         if (pieceCount > limit) {
             log.debug("Skipping Syzygy probe: {} pieces exceeds configured limit {} (paths={})",
                     pieceCount, limit, configuredPaths);
@@ -89,6 +89,18 @@ final class Tables {
 
         return Optional.of(new SyzygyProbeResult(wdl, dtz, OptionalInt.empty()));
     }
+
+    int effectiveMaxPieces() {
+        if (supportedPieces <= 0) {
+            return Math.max(1, maxPieces);
+        }
+        return Math.min(Math.max(1, maxPieces), supportedPieces);
+    }
+
+    int supportedPieces() {
+        return supportedPieces;
+    }
+
     private static SyzygyWdl toWdl(int wdlValue) {
         return switch (wdlValue) {
             case SyzygyConstants.TB_LOSS -> SyzygyWdl.LOSS;

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -37,7 +37,8 @@ public class Score {
     private static volatile ScoreFactory GLOBAL_FACTORY = bitBoard -> new Score(bitBoard, EvaluationWeights.identity());
     private static volatile SyzygyTablebaseService TABLEBASE_SERVICE;
 
-    private static final int TABLEBASE_PIECE_LIMIT = 6;
+    private static final int DEFAULT_TABLEBASE_PIECE_LIMIT = 6;
+    private static volatile int tablebasePieceLimit = DEFAULT_TABLEBASE_PIECE_LIMIT;
 
     static {
         EngineTuningBootstrap.ensureDefaultTuning();
@@ -157,8 +158,23 @@ public class Score {
         GLOBAL_FACTORY = Objects.requireNonNull(factory, "factory");
     }
 
-    public static void setTablebaseService(SyzygyTablebaseService service) {
-        TABLEBASE_SERVICE = Objects.requireNonNull(service, "service");
+    public static synchronized void setTablebaseService(SyzygyTablebaseService service) {
+        Objects.requireNonNull(service, "service");
+        TABLEBASE_SERVICE = service;
+        tablebasePieceLimit = normalizePieceLimit(service.getEffectiveMaxPieces());
+    }
+
+    public static synchronized void clearTablebaseService() {
+        TABLEBASE_SERVICE = null;
+        tablebasePieceLimit = DEFAULT_TABLEBASE_PIECE_LIMIT;
+    }
+
+    public static synchronized SyzygyTablebaseService getTablebaseService() {
+        return TABLEBASE_SERVICE;
+    }
+
+    private static int normalizePieceLimit(int limit) {
+        return limit > 0 ? limit : DEFAULT_TABLEBASE_PIECE_LIMIT;
     }
 
     public void refresh(BitBoard bitBoard, GameStateEnum state) {
@@ -326,8 +342,9 @@ public class Score {
             clearTablebaseState();
             return false;
         }
+        int limit = tablebasePieceLimit;
         long occupancy = context.getAllPieces();
-        if (Long.bitCount(occupancy) > TABLEBASE_PIECE_LIMIT) {
+        if (Long.bitCount(occupancy) > limit) {
             clearTablebaseState();
             return false;
         }

--- a/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
@@ -1,0 +1,116 @@
+package julius.game.chessengine.ai;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.syzygy.SyzygyProbeResult;
+import julius.game.chessengine.syzygy.SyzygyTablebaseService;
+import julius.game.chessengine.syzygy.SyzygyWdl;
+import julius.game.chessengine.syzygy.TablebaseResult;
+import julius.game.chessengine.syzygy.TestSyzygyTablebaseService;
+import julius.game.chessengine.utils.Score;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AISyzygyIntegrationTest {
+
+    @Test
+    void alphaBetaReturnsExactScoreFromTablebase() throws Exception {
+        Engine engine = new Engine();
+        String fen = "6k1/8/8/8/8/8/5Q2/6K1 w - - 0 1";
+        engine.importBoardFromFen(fen);
+
+        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(3), OptionalInt.empty());
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(Map.of(fen, probe));
+
+        try (AutoCloseable restorer = overrideScoreTablebase(service)) {
+            AI ai = new AI(engine, service);
+            Engine simulation = engine.createSimulation();
+
+            Method alphaBeta = AI.class.getDeclaredMethod("alphaBeta", Engine.class, int.class, double.class,
+                    double.class, boolean.class, long.class, int.class, int.class, int.class);
+            alphaBeta.setAccessible(true);
+
+            double score = (double) alphaBeta.invoke(ai, simulation, 1,
+                    Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
+                    simulation.whitesTurn(), Long.MAX_VALUE, -1, 0, 0);
+
+            double expected = Score.tablebaseToEvaluation(TablebaseResult.from(probe));
+            assertThat(score).isEqualTo(expected);
+
+            ai.shutdown();
+        }
+    }
+
+    @Test
+    void determineTablebaseBestMovePicksWinningChild() throws Exception {
+        Engine engine = new Engine();
+        String fen = "6k1/8/8/8/8/8/5Q2/6K1 w - - 0 1";
+        engine.importBoardFromFen(fen);
+
+        IntArrayList legalMoves = engine.getAllLegalMoves();
+        Map<String, SyzygyProbeResult> responses = new HashMap<>();
+        responses.put(fen, new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(5), OptionalInt.empty()));
+
+        for (int i = 0; i < legalMoves.size(); i++) {
+            int move = legalMoves.getInt(i);
+            engine.performMove(move);
+            String childFen = FEN.translateBoardToFEN(engine.getBitBoard(), engine.getGameState()).getRenderBoard();
+            SyzygyWdl childResult = childFen.contains("5QK1") ? SyzygyWdl.LOSS : SyzygyWdl.DRAW;
+            responses.put(childFen, new SyzygyProbeResult(childResult, OptionalInt.of(1), OptionalInt.empty()));
+            engine.undoLastMove();
+        }
+
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(responses);
+
+        try (AutoCloseable restorer = overrideScoreTablebase(service)) {
+            AI ai = new AI(engine, service);
+            Engine simulation = engine.createSimulation();
+
+            Method determine = AI.class.getDeclaredMethod("determineTablebaseBestMove", Engine.class, boolean.class);
+            determine.setAccessible(true);
+
+            int bestMove = (int) determine.invoke(ai, simulation, simulation.whitesTurn());
+
+            Set<String> winningChildren = responses.entrySet().stream()
+                    .filter(entry -> !entry.getKey().equals(fen))
+                    .filter(entry -> entry.getValue().wdl() == SyzygyWdl.LOSS)
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toSet());
+
+            assertThat(winningChildren)
+                    .describedAs("expected at least one tablebase child to be marked as winning")
+                    .isNotEmpty();
+
+            Engine verifier = engine.createSimulation();
+            verifier.performMove(bestMove);
+            String bestChildFen = FEN.translateBoardToFEN(verifier.getBitBoard(), verifier.getGameState()).getRenderBoard();
+
+            assertThat(winningChildren)
+                    .describedAs("tablebase best move should correspond to a child scored as a forced win")
+                    .contains(bestChildFen);
+
+            ai.shutdown();
+        }
+    }
+
+    private AutoCloseable overrideScoreTablebase(TestSyzygyTablebaseService service) {
+        SyzygyTablebaseService previous = Score.getTablebaseService();
+        Score.setTablebaseService(service);
+        return () -> {
+            if (previous == null) {
+                Score.clearTablebaseService();
+            } else {
+                Score.setTablebaseService(previous);
+            }
+        };
+    }
+}

--- a/src/test/java/julius/game/chessengine/syzygy/SyzygyTablebaseServiceTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/SyzygyTablebaseServiceTest.java
@@ -127,6 +127,26 @@ class SyzygyTablebaseServiceTest {
         assertThat(entryCount.get()).isEqualTo(1);
     }
 
+    @Test
+    void exposesEffectiveMaxPiecesFromClient() {
+        TablebaseClient limitedClient = new TablebaseClient() {
+            @Override
+            public Optional<SyzygyProbeResult> probe(BitBoard board) {
+                return Optional.empty();
+            }
+
+            @Override
+            public int supportedMaxPieces() {
+                return 5;
+            }
+        };
+
+        SyzygyTablebaseService service = new SyzygyTablebaseService(limitedClient, 16);
+
+        assertThat(service.getConfiguredMaxPieces()).isEqualTo(6);
+        assertThat(service.getEffectiveMaxPieces()).isEqualTo(5);
+    }
+
     @SuppressWarnings("unchecked")
     private static AtomicInteger extractEntryCount(SyzygyTablebaseService service) throws Exception {
         Field field = SyzygyTablebaseService.class.getDeclaredField("entryCount");

--- a/src/test/java/julius/game/chessengine/syzygy/TestSyzygySupport.java
+++ b/src/test/java/julius/game/chessengine/syzygy/TestSyzygySupport.java
@@ -38,7 +38,7 @@ public final class TestSyzygySupport {
         if (directories.isEmpty()) {
             return Optional.empty();
         }
-        int maxPieces = parsePositiveInt(System.getProperty(MAX_PIECES_PROPERTY), 7);
+        int maxPieces = parsePositiveInt(System.getProperty(MAX_PIECES_PROPERTY), 6);
         int cacheSize = parsePositiveInt(System.getProperty(CACHE_SIZE_PROPERTY), 65_536);
 
         SyzygyTablebaseService service = new SyzygyTablebaseService(directories.get(), maxPieces, cacheSize);

--- a/src/test/java/julius/game/chessengine/syzygy/TestSyzygyTablebaseService.java
+++ b/src/test/java/julius/game/chessengine/syzygy/TestSyzygyTablebaseService.java
@@ -28,7 +28,11 @@ public final class TestSyzygyTablebaseService extends SyzygyTablebaseService {
     }
 
     public static TestSyzygyTablebaseService fromResponses(Map<String, SyzygyProbeResult> responses) {
-        return new TestSyzygyTablebaseService(new TestClient(responses), 16);
+        return fromResponses(responses, 6);
+    }
+
+    public static TestSyzygyTablebaseService fromResponses(Map<String, SyzygyProbeResult> responses, int maxPieces) {
+        return new TestSyzygyTablebaseService(new TestClient(responses, maxPieces), 16);
     }
 
     public List<String> getProbedFens() {
@@ -39,9 +43,11 @@ public final class TestSyzygyTablebaseService extends SyzygyTablebaseService {
 
         private final Map<String, SyzygyProbeResult> responses;
         private final CopyOnWriteArrayList<String> probedFens = new CopyOnWriteArrayList<>();
+        private final int maxPieces;
 
-        private TestClient(Map<String, SyzygyProbeResult> responses) {
+        private TestClient(Map<String, SyzygyProbeResult> responses, int maxPieces) {
             this.responses = responses;
+            this.maxPieces = maxPieces;
         }
 
         @Override
@@ -49,6 +55,11 @@ public final class TestSyzygyTablebaseService extends SyzygyTablebaseService {
             String fen = toFen(board);
             probedFens.add(fen);
             return Optional.ofNullable(responses.get(fen));
+        }
+
+        @Override
+        public int supportedMaxPieces() {
+            return maxPieces;
         }
 
         private List<String> snapshot() {

--- a/src/test/java/julius/game/chessengine/tablebase/ScoreTablebaseIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/ScoreTablebaseIntegrationTest.java
@@ -7,9 +7,11 @@ import julius.game.chessengine.syzygy.SyzygyProbeResult;
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
 import julius.game.chessengine.syzygy.SyzygyWdl;
 import julius.game.chessengine.syzygy.TablebaseResult;
+import julius.game.chessengine.syzygy.TestSyzygyTablebaseService;
 import julius.game.chessengine.utils.Score;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -44,5 +46,33 @@ class ScoreTablebaseIntegrationTest {
             assertThat(score.getBlendedScore()).isEqualTo(expectedCentipawn);
             assertThat(score.getScoreDifference()).isEqualTo(expectedCentipawn / 100.0);
         }
+    }
+
+    @Test
+    void scoreSkipsProbeWhenBoardExceedsServiceLimit() {
+        BitBoard board = FEN.translateFENtoBitBoard("6k1/8/8/8/8/8/PPPP4/6K1 w - - 0 1");
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(Map.of(), 5);
+
+        try (TablebaseTestSupport.TablebaseServiceRestorer restorer = TablebaseTestSupport.overrideScoreTablebase(service)) {
+            Score score = new Score();
+            score.refresh(board, GameStateEnum.PLAY);
+        }
+
+        assertThat(service.getProbedFens()).isEmpty();
+    }
+
+    @Test
+    void scoreProbesWhenBoardWithinServiceLimit() {
+        String fen = "6k1/8/8/8/8/8/PPP5/6K1 w - - 0 1";
+        BitBoard board = FEN.translateFENtoBitBoard(fen);
+        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.DRAW, OptionalInt.of(0), OptionalInt.empty());
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(Map.of(fen, probe), 6);
+
+        try (TablebaseTestSupport.TablebaseServiceRestorer restorer = TablebaseTestSupport.overrideScoreTablebase(service)) {
+            Score score = new Score();
+            score.refresh(board, GameStateEnum.PLAY);
+        }
+
+        assertThat(service.getProbedFens()).containsExactly(fen);
     }
 }

--- a/src/test/java/julius/game/chessengine/tablebase/TablebaseTestSupport.java
+++ b/src/test/java/julius/game/chessengine/tablebase/TablebaseTestSupport.java
@@ -5,8 +5,6 @@ import julius.game.chessengine.syzygy.TestSyzygySupport;
 import julius.game.chessengine.utils.Score;
 import org.junit.jupiter.api.Assumptions;
 
-import java.lang.reflect.Field;
-
 final class TablebaseTestSupport {
 
     private TablebaseTestSupport() {
@@ -26,25 +24,17 @@ final class TablebaseTestSupport {
         if (service == null) {
             throw new IllegalArgumentException("service");
         }
-        try {
-            Field field = Score.class.getDeclaredField("TABLEBASE_SERVICE");
-            field.setAccessible(true);
-            SyzygyTablebaseService previous = (SyzygyTablebaseService) field.get(null);
-            Score.setTablebaseService(service);
-            return new TablebaseServiceRestorer(field, previous);
-        } catch (ReflectiveOperationException ex) {
-            throw new IllegalStateException("Unable to override Score tablebase service", ex);
-        }
+        SyzygyTablebaseService previous = Score.getTablebaseService();
+        Score.setTablebaseService(service);
+        return new TablebaseServiceRestorer(previous);
     }
 
     static final class TablebaseServiceRestorer implements AutoCloseable {
 
-        private final Field field;
         private final SyzygyTablebaseService previous;
         private boolean closed;
 
-        private TablebaseServiceRestorer(Field field, SyzygyTablebaseService previous) {
-            this.field = field;
+        private TablebaseServiceRestorer(SyzygyTablebaseService previous) {
             this.previous = previous;
         }
 
@@ -53,18 +43,12 @@ final class TablebaseTestSupport {
             if (closed) {
                 return;
             }
-            try {
-                if (previous == null) {
-                    field.setAccessible(true);
-                    field.set(null, null);
-                } else {
-                    Score.setTablebaseService(previous);
-                }
-            } catch (ReflectiveOperationException ex) {
-                throw new IllegalStateException("Unable to restore Score tablebase service", ex);
-            } finally {
-                closed = true;
+            if (previous == null) {
+                Score.clearTablebaseService();
+            } else {
+                Score.setTablebaseService(previous);
             }
+            closed = true;
         }
     }
 }

--- a/src/test/java/julius/game/chessengine/tablebase/UciSyzygyOptionIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/UciSyzygyOptionIntegrationTest.java
@@ -18,9 +18,7 @@ class UciSyzygyOptionIntegrationTest {
     void setoptionPropagatesSyzygyPathToService() throws Exception {
         List<String> output = new ArrayList<>();
 
-        Field scoreField = Score.class.getDeclaredField("TABLEBASE_SERVICE");
-        scoreField.setAccessible(true);
-        SyzygyTablebaseService originalScoreService = (SyzygyTablebaseService) scoreField.get(null);
+        SyzygyTablebaseService originalScoreService = Score.getTablebaseService();
 
         UciHandler handler = new UciHandler(output::add, () -> true);
 
@@ -35,7 +33,11 @@ class UciSyzygyOptionIntegrationTest {
             verify(mockService).configure("/var/syzygy");
         } finally {
             serviceField.set(handler, originalHandlerService);
-            scoreField.set(null, originalScoreService);
+            if (originalScoreService == null) {
+                Score.clearTablebaseService();
+            } else {
+                Score.setTablebaseService(originalScoreService);
+            }
         }
     }
 }

--- a/src/test/java/julius/game/chessengine/uci/UciSyzygyFlowTest.java
+++ b/src/test/java/julius/game/chessengine/uci/UciSyzygyFlowTest.java
@@ -113,25 +113,17 @@ class UciSyzygyFlowTest {
         if (service == null) {
             throw new IllegalArgumentException("service");
         }
-        try {
-            java.lang.reflect.Field field = Score.class.getDeclaredField("TABLEBASE_SERVICE");
-            field.setAccessible(true);
-            SyzygyTablebaseService previous = (SyzygyTablebaseService) field.get(null);
-            Score.setTablebaseService(service);
-            return new ScoreTablebaseRestorer(field, previous);
-        } catch (ReflectiveOperationException ex) {
-            throw new IllegalStateException("Unable to override Score tablebase service", ex);
-        }
+        SyzygyTablebaseService previous = Score.getTablebaseService();
+        Score.setTablebaseService(service);
+        return new ScoreTablebaseRestorer(previous);
     }
 
     private static final class ScoreTablebaseRestorer implements AutoCloseable {
 
-        private final java.lang.reflect.Field field;
         private final SyzygyTablebaseService previous;
         private boolean closed;
 
-        private ScoreTablebaseRestorer(java.lang.reflect.Field field, SyzygyTablebaseService previous) {
-            this.field = field;
+        private ScoreTablebaseRestorer(SyzygyTablebaseService previous) {
             this.previous = previous;
         }
 
@@ -140,18 +132,12 @@ class UciSyzygyFlowTest {
             if (closed) {
                 return;
             }
-            try {
-                if (previous == null) {
-                    field.setAccessible(true);
-                    field.set(null, null);
-                } else {
-                    Score.setTablebaseService(previous);
-                }
-            } catch (ReflectiveOperationException ex) {
-                throw new IllegalStateException("Unable to restore Score tablebase service", ex);
-            } finally {
-                closed = true;
+            if (previous == null) {
+                Score.clearTablebaseService();
+            } else {
+                Score.setTablebaseService(previous);
             }
+            closed = true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Respect Syzygy client-supported piece limits and default to six-piece tables when configuring the service and table wrappers.
- Expose the active tablebase service through `Score` while keeping the evaluation guarded by the effective piece count.
- Refresh Syzygy-focused tests and add AI tablebase integration coverage that exercises alpha-beta and move selection with mocked probes.

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=SyzygyTablebaseServiceTest,ScoreTablebaseIntegrationTest,AISyzygyIntegrationTest,UciSyzygyFlowTest,UciSyzygyOptionIntegrationTest test

------
https://chatgpt.com/codex/tasks/task_e_68ed457b5784832aa3e0d62f731454fa