### PR TITLE
Add native access flag to engine launchers

### DIFF
--- a/src/main/resources/py/ProfileEngine.py
+++ b/src/main/resources/py/ProfileEngine.py
@@ -190,6 +190,7 @@ def build_java_cmd(jar: Path, jfr_file: Path, jfr_duration: str,
         "-Xms{}".format(java_xms),
         "-Xmx{}".format(java_xmx),
         gc_flag(java_gc),
+        "--enable-native-access=ALL-UNNAMED",
         "-XX:ActiveProcessorCount={}".format(apc),
     ]
 

--- a/src/main/resources/py/lichess_bot.py
+++ b/src/main/resources/py/lichess_bot.py
@@ -221,6 +221,7 @@ def build_engine_cmd() -> List[str]:
         f"-Xms{JAVA_XMS}",
         f"-Xmx{JAVA_XMX}",
         gc_flag(JAVA_GC),
+        "--enable-native-access=ALL-UNNAMED",
         "-XX:+AlwaysPreTouch",
         # harmless even if JFR off; keeps stacks deep when you enable it
         "-XX:FlightRecorderOptions=stackdepth=256",


### PR DESCRIPTION
## Summary
- ensure the lichess bot launcher enables native access for the JVM
- add the same native access flag to the profiling helper so Syzygy loads without warnings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68edf576afb0832aac61e5a650abbdc2