### PR TITLE
Fix Syzygy evaluation orientation

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -9,6 +9,7 @@ import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.engine.GameStateEnum;
+import julius.game.chessengine.evaluation.EvaluationContext;
 import julius.game.chessengine.syzygy.SyzygyProbeResult;
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
 import julius.game.chessengine.syzygy.SyzygyWdl;
@@ -921,11 +922,11 @@ public class AI {
         staticEvalCache.get().clear();
     }
 
-    private double resolveScoreDifference(GameState gameState, long boardHash) {
+    private double resolveScoreDifference(GameState gameState, long boardHash, boolean whiteToMove) {
         Long2DoubleOpenHashMap cache = staticEvalCache.get();
         Optional<TablebaseResult> tablebase = gameState.getLastTablebaseResult();
         if (tablebase.isPresent() && isExactWdl(tablebase.get())) {
-            double exact = Score.tablebaseToEvaluation(tablebase.get());
+            double exact = Score.tablebaseToEvaluation(tablebase.get(), whiteToMove);
             cache.put(boardHash, exact);
             return exact;
         }
@@ -1893,13 +1894,13 @@ public class AI {
         if (!isExactWdl(result)) {
             return Optional.empty();
         }
-        double whitePerspective = Score.tablebaseToEvaluation(result);
+        double whitePerspective = Score.tablebaseToEvaluation(result, simulatorEngine.whitesTurn());
         double searchScore = isWhite ? whitePerspective : -whitePerspective;
-        int bestMove = determineTablebaseBestMove(simulatorEngine, isWhite);
+        int bestMove = determineTablebaseBestMove(simulatorEngine);
         return Optional.of(new TablebaseHit(searchScore, bestMove, result));
     }
 
-    private int determineTablebaseBestMove(Engine simulatorEngine, boolean isWhite) {
+    private int determineTablebaseBestMove(Engine simulatorEngine) {
         IntArrayList legal = simulatorEngine.getAllLegalMoves();
         if (legal.isEmpty()) {
             return -1;
@@ -1911,7 +1912,7 @@ public class AI {
             simulatorEngine.performMove(move);
             double candidate;
             try {
-                candidate = evaluateTablebaseChild(simulatorEngine, isWhite);
+                candidate = evaluateTablebaseChild(simulatorEngine);
             } finally {
                 simulatorEngine.undoLastMove();
             }
@@ -1926,7 +1927,7 @@ public class AI {
         return bestMove;
     }
 
-    private double evaluateTablebaseChild(Engine simulatorEngine, boolean parentIsWhite) {
+    private double evaluateTablebaseChild(Engine simulatorEngine) {
         TablebaseResult childResult = simulatorEngine.getGameState().getLastTablebaseResult().orElse(null);
         if ((childResult == null || !isExactWdl(childResult)) && tablebaseService != null) {
             Optional<SyzygyProbeResult> probe = tablebaseService.probe(simulatorEngine.getBitBoard());
@@ -1940,8 +1941,8 @@ public class AI {
         if (childResult == null || !isExactWdl(childResult)) {
             return Double.NaN;
         }
-        double whitePerspective = Score.tablebaseToEvaluation(childResult);
-        boolean childIsWhite = !parentIsWhite;
+        double whitePerspective = Score.tablebaseToEvaluation(childResult, simulatorEngine.whitesTurn());
+        boolean childIsWhite = simulatorEngine.whitesTurn();
         double childSearchPerspective = childIsWhite ? whitePerspective : -whitePerspective;
         return -childSearchPerspective;
     }
@@ -2243,7 +2244,8 @@ public class AI {
                 || (baseRemainingDepth == 2 && pruning.fpMarginDepth2() > 0));
         double staticEvalWhite = Double.NaN;
         if (futilityPossible) {
-            staticEvalWhite = resolveScoreDifference(simulatorEngine.getGameState(), boardHash);
+            staticEvalWhite = resolveScoreDifference(simulatorEngine.getGameState(), boardHash,
+                    simulatorEngine.whitesTurn());
             if (!Double.isFinite(staticEvalWhite)) {
                 futilityPossible = false;
             }
@@ -2513,7 +2515,8 @@ public class AI {
                 || (baseRemainingDepth == 2 && pruning.fpMarginDepth2() > 0));
         double staticEvalWhite = Double.NaN;
         if (futilityPossible) {
-            staticEvalWhite = resolveScoreDifference(simulatorEngine.getGameState(), boardHash);
+            staticEvalWhite = resolveScoreDifference(simulatorEngine.getGameState(), boardHash,
+                    simulatorEngine.whitesTurn());
             if (!Double.isFinite(staticEvalWhite)) {
                 futilityPossible = false;
             }
@@ -2903,7 +2906,8 @@ public class AI {
 
         // Treat both terminal draws and insufficient-material as draw for evaluation
         if (simulatorEngine.getGameState().isDrawForUIOrEval()) {
-            double scoreDiff = resolveScoreDifference(simulatorEngine.getGameState(), boardStateHash);
+            double scoreDiff = resolveScoreDifference(simulatorEngine.getGameState(), boardStateHash,
+                    simulatorEngine.whitesTurn());
             if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
                 return DRAW - drawBias;
             } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {
@@ -3063,14 +3067,16 @@ public class AI {
         if (gameState.isInStateCheckMate()) {
             return -(CHECKMATE - depthOrPly);
         }
+        EvaluationContext context = gameState.getScore().getEvaluationContext();
+        boolean whiteToMove = context != null && context.isWhiteToMove();
         Optional<TablebaseResult> tablebase = gameState.getLastTablebaseResult();
         if (tablebase.isPresent() && isExactWdl(tablebase.get())) {
-            double whitePerspective = Score.tablebaseToEvaluation(tablebase.get());
+            double whitePerspective = Score.tablebaseToEvaluation(tablebase.get(), whiteToMove);
             return isWhitesTurn ? whitePerspective : -whitePerspective;
         }
         if (gameState.isDrawForUIOrEval()) { // <-- include insufficient material for eval/UI
             if (log.isDebugEnabled()) log.debug("DRAW");
-            double scoreDiff = resolveScoreDifference(gameState, boardHash);
+            double scoreDiff = resolveScoreDifference(gameState, boardHash, whiteToMove);
             if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
                 return DRAW - drawBias;
             } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {
@@ -3078,7 +3084,7 @@ public class AI {
             }
             return DRAW;
         }
-        double scoreDifference = resolveScoreDifference(gameState, boardHash);
+        double scoreDifference = resolveScoreDifference(gameState, boardHash, whiteToMove);
         return isWhitesTurn ? scoreDifference : -scoreDifference;
     }
 

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -355,7 +355,7 @@ public class Score {
         }
         TablebaseResult resolved = TablebaseResult.from(probe.get());
         this.tablebaseResult = resolved;
-        this.tablebaseCentipawn = computeTablebaseCentipawn(resolved);
+        this.tablebaseCentipawn = computeTablebaseCentipawn(resolved, bitBoard.isWhitesTurn());
         this.tablebaseBypassesEvaluation = true;
         return true;
     }
@@ -366,16 +366,19 @@ public class Score {
         this.tablebaseBypassesEvaluation = false;
     }
 
-    public static double tablebaseToEvaluation(TablebaseResult result) {
-        return tablebaseToCentipawn(result) / 100.0;
+    public static double tablebaseToEvaluation(TablebaseResult result, boolean whiteToMove) {
+        return tablebaseToCentipawn(result, whiteToMove) / 100.0;
     }
 
-    public static int tablebaseToCentipawn(TablebaseResult result) {
+    public static int tablebaseToCentipawn(TablebaseResult result, boolean whiteToMove) {
         int wdlScore = result.wdl().score();
         if (wdlScore == 0) {
             return DRAW;
         }
         int sign = Integer.signum(wdlScore);
+        if (!whiteToMove) {
+            sign = -sign;
+        }
         int distance = result.dtm().isPresent()
                 ? Math.abs(result.dtm().getAsInt())
                 : result.dtz().isPresent() ? Math.abs(result.dtz().getAsInt()) : 0;
@@ -383,7 +386,7 @@ public class Score {
         return sign * (CHECKMATE - scaledPenalty);
     }
 
-    private int computeTablebaseCentipawn(TablebaseResult result) {
-        return tablebaseToCentipawn(result);
+    private int computeTablebaseCentipawn(TablebaseResult result, boolean whiteToMove) {
+        return tablebaseToCentipawn(result, whiteToMove);
     }
 }

--- a/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
@@ -43,7 +43,7 @@ class AISyzygyIntegrationTest {
                     Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
                     simulation.whitesTurn(), Long.MAX_VALUE, -1, 0, 0);
 
-            double expected = Score.tablebaseToEvaluation(TablebaseResult.from(probe));
+            double expected = Score.tablebaseToEvaluation(TablebaseResult.from(probe), true);
             assertThat(score).isEqualTo(expected);
 
             ai.shutdown();
@@ -64,7 +64,8 @@ class AISyzygyIntegrationTest {
             int move = legalMoves.getInt(i);
             engine.performMove(move);
             String childFen = FEN.translateBoardToFEN(engine.getBitBoard(), engine.getGameState()).getRenderBoard();
-            SyzygyWdl childResult = childFen.contains("5QK1") ? SyzygyWdl.LOSS : SyzygyWdl.DRAW;
+            boolean forcedWin = childFen.contains("5QK1") || childFen.contains("4Q1K1");
+            SyzygyWdl childResult = forcedWin ? SyzygyWdl.LOSS : SyzygyWdl.DRAW;
             responses.put(childFen, new SyzygyProbeResult(childResult, OptionalInt.of(1), OptionalInt.empty()));
             engine.undoLastMove();
         }
@@ -75,10 +76,10 @@ class AISyzygyIntegrationTest {
             AI ai = new AI(engine, service);
             Engine simulation = engine.createSimulation();
 
-            Method determine = AI.class.getDeclaredMethod("determineTablebaseBestMove", Engine.class, boolean.class);
+            Method determine = AI.class.getDeclaredMethod("determineTablebaseBestMove", Engine.class);
             determine.setAccessible(true);
 
-            int bestMove = (int) determine.invoke(ai, simulation, simulation.whitesTurn());
+            int bestMove = (int) determine.invoke(ai, simulation);
 
             Set<String> winningChildren = responses.entrySet().stream()
                     .filter(entry -> !entry.getKey().equals(fen))

--- a/src/test/java/julius/game/chessengine/tablebase/AiTablebaseIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/AiTablebaseIntegrationTest.java
@@ -42,7 +42,7 @@ class AiTablebaseIntegrationTest {
             double evaluation = ai.evaluateBoard(engine, true, deadline);
 
             TablebaseResult expected = TablebaseResult.from(probe);
-            double expectedEval = Score.tablebaseToEvaluation(expected);
+            double expectedEval = Score.tablebaseToEvaluation(expected, true);
 
             assertThat(engine.getGameState().getLastTablebaseResult()).contains(expected);
             assertThat(evaluation).isEqualTo(expectedEval);

--- a/src/test/java/julius/game/chessengine/tablebase/ScoreTablebaseIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/ScoreTablebaseIntegrationTest.java
@@ -33,7 +33,7 @@ class ScoreTablebaseIntegrationTest {
 
         BitBoard board = FEN.translateFENtoBitBoard("8/8/8/8/8/8/5K2/6k1 w - - 0 1");
         TablebaseResult expected = TablebaseResult.from(probe);
-        int expectedCentipawn = Score.tablebaseToCentipawn(expected);
+        int expectedCentipawn = Score.tablebaseToCentipawn(expected, true);
 
         try (TablebaseTestSupport.TablebaseServiceRestorer restorer = TablebaseTestSupport.overrideScoreTablebase(service)) {
             Score score = new Score();
@@ -59,6 +59,18 @@ class ScoreTablebaseIntegrationTest {
         }
 
         assertThat(service.getProbedFens()).isEmpty();
+    }
+
+    @Test
+    void tablebaseCentipawnRespectsSideToMove() {
+        TablebaseResult win = new TablebaseResult(SyzygyWdl.WIN, OptionalInt.of(1), OptionalInt.empty());
+        TablebaseResult loss = new TablebaseResult(SyzygyWdl.LOSS, OptionalInt.of(1), OptionalInt.empty());
+
+        assertThat(Score.tablebaseToCentipawn(win, true)).isGreaterThan(0);
+        assertThat(Score.tablebaseToCentipawn(win, false)).isLessThan(0);
+
+        assertThat(Score.tablebaseToCentipawn(loss, true)).isLessThan(0);
+        assertThat(Score.tablebaseToCentipawn(loss, false)).isGreaterThan(0);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- adjust Score's tablebase conversion helpers to account for the side to move and cache oriented centipawn values
- propagate the side-to-move flag through AI tablebase probing, best-move selection, and evaluation flows
- update Syzygy-related tests to use the new APIs and add coverage for sign handling

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=ScoreTablebaseIntegrationTest,AISyzygyIntegrationTest,AiTablebaseIntegrationTest test

------
https://chatgpt.com/codex/tasks/task_e_68ee024d9808832ab10cbf3828814b7a