### PR TITLE
Handle Syzygy recommended moves at root

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -10,6 +10,7 @@ import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.evaluation.EvaluationContext;
+import julius.game.chessengine.syzygy.SyzygyMove;
 import julius.game.chessengine.syzygy.SyzygyProbeResult;
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
 import julius.game.chessengine.syzygy.SyzygyWdl;
@@ -1827,6 +1828,16 @@ public class AI {
         IntArrayList sortedMoves = sortMovesByEfficiency(simulatorEngine.getAllLegalMoves(), depth,
                 simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
         maybeRotateRootMoves(sortedMoves, rng);
+        promoteTablebaseMove(sortedMoves, simulatorEngine);
+
+        Optional<TablebaseHit> rootTablebase = resolveTablebaseHit(simulatorEngine, isWhitesTurn);
+        if (rootTablebase.isPresent()) {
+            TablebaseHit hit = rootTablebase.get();
+            int candidateMove = hit.bestMove();
+            if (candidateMove >= 0 && MoveContainerUtils.contains(sortedMoves, candidateMove)) {
+                return RootSearchResult.completed(createCandidate(candidateMove, hit.score()));
+            }
+        }
 
         for (int idx = 0; idx < sortedMoves.size(); idx++) {
             int moveInt = sortedMoves.getInt(idx);
@@ -1896,15 +1907,26 @@ public class AI {
         }
         double whitePerspective = Score.tablebaseToEvaluation(result, simulatorEngine.whitesTurn());
         double searchScore = isWhite ? whitePerspective : -whitePerspective;
-        int bestMove = determineTablebaseBestMove(simulatorEngine);
+        int bestMove = determineTablebaseBestMove(simulatorEngine, result);
         return Optional.of(new TablebaseHit(searchScore, bestMove, result));
     }
 
-    private int determineTablebaseBestMove(Engine simulatorEngine) {
+    private int determineTablebaseBestMove(Engine simulatorEngine, TablebaseResult parentResult) {
         IntArrayList legal = simulatorEngine.getAllLegalMoves();
         if (legal.isEmpty()) {
             return -1;
         }
+
+        if (parentResult != null) {
+            Optional<SyzygyMove> suggestion = parentResult.recommendedMove();
+            if (suggestion.isPresent()) {
+                int resolved = findSuggestedMove(legal, suggestion.get());
+                if (resolved != -1) {
+                    return resolved;
+                }
+            }
+        }
+
         double bestScore = Double.NEGATIVE_INFINITY;
         int bestMove = -1;
         for (int i = 0; i < legal.size(); i++) {
@@ -1925,6 +1947,56 @@ public class AI {
             }
         }
         return bestMove;
+    }
+
+    private int findSuggestedMove(IntArrayList legal, SyzygyMove suggestion) {
+        int fromIndex = suggestion.fromIndex();
+        int toIndex = suggestion.toIndex();
+        int promotionBits = suggestion.promotionPieceTypeBits();
+        for (int i = 0; i < legal.size(); i++) {
+            int move = legal.getInt(i);
+            if (MoveHelper.deriveFromIndex(move) != fromIndex) {
+                continue;
+            }
+            if (MoveHelper.deriveToIndex(move) != toIndex) {
+                continue;
+            }
+            int movePromotion = MoveHelper.derivePromotionPieceTypeBits(move);
+            if (promotionBits == 0) {
+                if (movePromotion != 0) {
+                    continue;
+                }
+            } else if (movePromotion != promotionBits) {
+                continue;
+            }
+            return move;
+        }
+        return -1;
+    }
+
+    private void promoteTablebaseMove(IntArrayList moves, Engine engine) {
+        if (moves == null || moves.isEmpty()) {
+            return;
+        }
+        TablebaseResult result = engine.getGameState().getLastTablebaseResult().orElse(null);
+        if (result == null) {
+            return;
+        }
+        Optional<SyzygyMove> suggestion = result.recommendedMove();
+        if (suggestion.isEmpty()) {
+            return;
+        }
+        int matchedMove = findSuggestedMove(moves, suggestion.get());
+        if (matchedMove == -1) {
+            return;
+        }
+        int index = moves.indexOf(matchedMove);
+        if (index <= 0) {
+            return;
+        }
+        int first = moves.getInt(0);
+        moves.set(0, matchedMove);
+        moves.set(index, first);
     }
 
     private double evaluateTablebaseChild(Engine simulatorEngine) {

--- a/src/main/java/julius/game/chessengine/syzygy/SyzygyMove.java
+++ b/src/main/java/julius/game/chessengine/syzygy/SyzygyMove.java
@@ -1,0 +1,25 @@
+package julius.game.chessengine.syzygy;
+
+/**
+ * Normalised representation of a move suggested by the Syzygy tablebases.
+ * The indices follow the engine's 0-based square encoding ({@code a1 = 0}).
+ */
+public record SyzygyMove(int fromIndex, int toIndex, int promotionPieceTypeBits) {
+
+    public SyzygyMove {
+        if (fromIndex < 0 || fromIndex >= 64) {
+            throw new IllegalArgumentException("fromIndex out of bounds: " + fromIndex);
+        }
+        if (toIndex < 0 || toIndex >= 64) {
+            throw new IllegalArgumentException("toIndex out of bounds: " + toIndex);
+        }
+        if (promotionPieceTypeBits < 0 || promotionPieceTypeBits > 7) {
+            throw new IllegalArgumentException("Invalid promotion piece bits: " + promotionPieceTypeBits);
+        }
+    }
+
+    public boolean isPromotion() {
+        return promotionPieceTypeBits != 0;
+    }
+}
+

--- a/src/main/java/julius/game/chessengine/syzygy/SyzygyProbeResult.java
+++ b/src/main/java/julius/game/chessengine/syzygy/SyzygyProbeResult.java
@@ -1,20 +1,22 @@
 package julius.game.chessengine.syzygy;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalInt;
 
 /**
  * Immutable payload returned by the {@link SyzygyTablebaseService}.
  */
-public record SyzygyProbeResult(SyzygyWdl wdl, OptionalInt dtz, OptionalInt dtm) {
+public record SyzygyProbeResult(SyzygyWdl wdl, OptionalInt dtz, OptionalInt dtm, Optional<SyzygyMove> recommendedMove) {
 
     public SyzygyProbeResult {
         Objects.requireNonNull(wdl, "wdl");
         dtz = dtz == null ? OptionalInt.empty() : dtz;
         dtm = dtm == null ? OptionalInt.empty() : dtm;
+        recommendedMove = recommendedMove == null ? Optional.empty() : recommendedMove;
     }
 
     public static SyzygyProbeResult unavailable() {
-        return new SyzygyProbeResult(SyzygyWdl.UNKNOWN, OptionalInt.empty(), OptionalInt.empty());
+        return new SyzygyProbeResult(SyzygyWdl.UNKNOWN, OptionalInt.empty(), OptionalInt.empty(), Optional.empty());
     }
 }

--- a/src/main/java/julius/game/chessengine/syzygy/TablebaseResult.java
+++ b/src/main/java/julius/game/chessengine/syzygy/TablebaseResult.java
@@ -1,6 +1,7 @@
 package julius.game.chessengine.syzygy;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalInt;
 
 /**
@@ -8,17 +9,18 @@ import java.util.OptionalInt;
  * The record exposes the WDL and optional DTZ/DTM distances so higher layers
  * can surface them without re-interpreting the raw service payload.
  */
-public record TablebaseResult(SyzygyWdl wdl, OptionalInt dtz, OptionalInt dtm) {
+public record TablebaseResult(SyzygyWdl wdl, OptionalInt dtz, OptionalInt dtm, Optional<SyzygyMove> recommendedMove) {
 
     public TablebaseResult {
         Objects.requireNonNull(wdl, "wdl");
         dtz = dtz == null ? OptionalInt.empty() : dtz;
         dtm = dtm == null ? OptionalInt.empty() : dtm;
+        recommendedMove = recommendedMove == null ? Optional.empty() : recommendedMove;
     }
 
     public static TablebaseResult from(SyzygyProbeResult result) {
         Objects.requireNonNull(result, "result");
-        return new TablebaseResult(result.wdl(), result.dtz(), result.dtm());
+        return new TablebaseResult(result.wdl(), result.dtz(), result.dtm(), result.recommendedMove());
     }
 
     public boolean isWin() {

--- a/src/main/java/julius/game/chessengine/syzygy/Tables.java
+++ b/src/main/java/julius/game/chessengine/syzygy/Tables.java
@@ -80,14 +80,40 @@ final class Tables {
         int dtzRaw = SyzygyBridge.probeSyzygyDTZ(white, black, kings, queens, rooks, bishops, knights, pawns,
                 board.getHalfmoveClock(), epSquare, whiteToMove);
         OptionalInt dtz = OptionalInt.empty();
+        Optional<SyzygyMove> recommendedMove = Optional.empty();
         if (SyzygyConstants.winDrawLoss(dtzRaw) == wdlValue) {
             int distance = SyzygyConstants.distanceToZero(dtzRaw);
             dtz = OptionalInt.of(distance);
+            recommendedMove = decodeRecommendedMove(dtzRaw);
         } else {
             log.debug("Syzygy DTZ probe mismatch (wdlValue={}, dtzRaw={})", wdlValue, dtzRaw);
         }
 
-        return Optional.of(new SyzygyProbeResult(wdl, dtz, OptionalInt.empty()));
+        return Optional.of(new SyzygyProbeResult(wdl, dtz, OptionalInt.empty(), recommendedMove));
+    }
+
+    private Optional<SyzygyMove> decodeRecommendedMove(int dtzRaw) {
+        int fromSquare = SyzygyConstants.fromSquare(dtzRaw);
+        int toSquare = SyzygyConstants.toSquare(dtzRaw);
+        if (fromSquare <= 0 || toSquare <= 0) {
+            return Optional.empty();
+        }
+
+        int promotionBits = switch (SyzygyConstants.promoteInto(dtzRaw)) {
+            case SyzygyConstants.TB_PROMOTES_QUEEN -> 5;
+            case SyzygyConstants.TB_PROMOTES_ROOK -> 4;
+            case SyzygyConstants.TB_PROMOTES_BISHOP -> 3;
+            case SyzygyConstants.TB_PROMOTES_KNIGHT -> 2;
+            default -> 0;
+        };
+
+        try {
+            return Optional.of(new SyzygyMove(fromSquare - 1, toSquare - 1, promotionBits));
+        } catch (IllegalArgumentException ex) {
+            log.debug("Ignoring invalid Syzygy move suggestion (dtzRaw={}, from={}, to={}, promo={})",
+                    dtzRaw, fromSquare, toSquare, promotionBits, ex);
+            return Optional.empty();
+        }
     }
 
     int effectiveMaxPieces() {

--- a/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,7 +29,7 @@ class AISyzygyIntegrationTest {
         String fen = "6k1/8/8/8/8/8/5Q2/6K1 w - - 0 1";
         engine.importBoardFromFen(fen);
 
-        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(3), OptionalInt.empty());
+        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(3), OptionalInt.empty(), Optional.empty());
         TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(Map.of(fen, probe));
 
         try (AutoCloseable restorer = overrideScoreTablebase(service)) {
@@ -58,7 +59,7 @@ class AISyzygyIntegrationTest {
 
         IntArrayList legalMoves = engine.getAllLegalMoves();
         Map<String, SyzygyProbeResult> responses = new HashMap<>();
-        responses.put(fen, new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(5), OptionalInt.empty()));
+        responses.put(fen, new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(5), OptionalInt.empty(), Optional.empty()));
 
         for (int i = 0; i < legalMoves.size(); i++) {
             int move = legalMoves.getInt(i);
@@ -66,7 +67,7 @@ class AISyzygyIntegrationTest {
             String childFen = FEN.translateBoardToFEN(engine.getBitBoard(), engine.getGameState()).getRenderBoard();
             boolean forcedWin = childFen.contains("5QK1") || childFen.contains("4Q1K1");
             SyzygyWdl childResult = forcedWin ? SyzygyWdl.LOSS : SyzygyWdl.DRAW;
-            responses.put(childFen, new SyzygyProbeResult(childResult, OptionalInt.of(1), OptionalInt.empty()));
+            responses.put(childFen, new SyzygyProbeResult(childResult, OptionalInt.of(1), OptionalInt.empty(), Optional.empty()));
             engine.undoLastMove();
         }
 
@@ -76,10 +77,11 @@ class AISyzygyIntegrationTest {
             AI ai = new AI(engine, service);
             Engine simulation = engine.createSimulation();
 
-            Method determine = AI.class.getDeclaredMethod("determineTablebaseBestMove", Engine.class);
+            Method determine = AI.class.getDeclaredMethod("determineTablebaseBestMove", Engine.class, TablebaseResult.class);
             determine.setAccessible(true);
 
-            int bestMove = (int) determine.invoke(ai, simulation);
+            TablebaseResult parentResult = TablebaseResult.from(responses.get(fen));
+            int bestMove = (int) determine.invoke(ai, simulation, parentResult);
 
             Set<String> winningChildren = responses.entrySet().stream()
                     .filter(entry -> !entry.getKey().equals(fen))

--- a/src/test/java/julius/game/chessengine/ai/AITablebaseRecommendationTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AITablebaseRecommendationTest.java
@@ -1,0 +1,65 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.syzygy.SyzygyMove;
+import julius.game.chessengine.syzygy.SyzygyWdl;
+import julius.game.chessengine.syzygy.TablebaseResult;
+import julius.game.chessengine.tuning.AiTuning;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AITablebaseRecommendationTest {
+
+    @Test
+    void prioritisesRecommendedSyzygyMoveWhenScoresAreTied() {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("8/8/3k4/1P6/3P4/6K1/8/7B w - - 1 57");
+
+        int fromIndex = MoveHelper.convertStringToIndex("b5");
+        int toIndex = MoveHelper.convertStringToIndex("b6");
+        TablebaseResult recommendation = new TablebaseResult(
+                SyzygyWdl.WIN,
+                OptionalInt.of(1),
+                OptionalInt.empty(),
+                Optional.of(new SyzygyMove(fromIndex, toIndex, 0))
+        );
+        engine.getGameState().setLastTablebaseResult(recommendation);
+
+        AiTuning tuning = AiTuning.builder()
+                .searchThreads(1)
+                .lazySmpThreads(1)
+                .hashSizeMb(16)
+                .maxDepth(6)
+                .timeLimitMillis(200)
+                .build();
+
+        AI ai = new AI(engine, tuning, null);
+        Engine simulation = engine.createSimulation();
+        int direct = invokeDetermineTablebaseBestMove(ai, simulation, recommendation);
+        assertThat(MoveHelper.convertIndexToString(MoveHelper.deriveFromIndex(direct))).isEqualTo("b5");
+        assertThat(MoveHelper.convertIndexToString(MoveHelper.deriveToIndex(direct))).isEqualTo("b6");
+
+        MoveAndScore best = ai.searchBestMoveBlocking(100);
+        ai.shutdown();
+
+        assertThat(best).as("tablebase recommendation should be respected").isNotNull();
+        assertThat(MoveHelper.convertIndexToString(MoveHelper.deriveFromIndex(best.getMove()))).isEqualTo("b5");
+        assertThat(MoveHelper.convertIndexToString(MoveHelper.deriveToIndex(best.getMove()))).isEqualTo("b6");
+    }
+
+    private int invokeDetermineTablebaseBestMove(AI ai, Engine simulation, TablebaseResult result) {
+        try {
+            var method = AI.class.getDeclaredMethod("determineTablebaseBestMove", Engine.class, TablebaseResult.class);
+            method.setAccessible(true);
+            return (int) method.invoke(ai, simulation, result);
+        } catch (ReflectiveOperationException ex) {
+            throw new AssertionError("Failed to invoke determineTablebaseBestMove", ex);
+        }
+    }
+}
+

--- a/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
@@ -16,6 +16,12 @@ import java.util.stream.Stream;
 public final class BestMoveFixtures {
 
     private static final List<BestMoveTestCase> CASES = List.of(
+
+            new BestMoveTestCase(
+                    "8/8/3k4/1P6/3P4/6K1/8/7B w - - 1 57",
+                    List.of("b6"),
+                    7
+            ),
             new BestMoveTestCase(
                     "8/8/8/8/8/1kb1n3/8/2K5 b - - 31 16",
                     List.of("Be1", "Bb4", "Ba5", "Kc4")

--- a/src/test/java/julius/game/chessengine/syzygy/SyzygyTablebaseServiceTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/SyzygyTablebaseServiceTest.java
@@ -34,7 +34,7 @@ class SyzygyTablebaseServiceTest {
     void cachesProbesUsingZobristAndClocks() {
         BitBoard board = FEN.translateFENtoBitBoard("8/8/8/8/8/8/8/8 w - - 0 1");
         RecordingClient client = new RecordingClient();
-        client.response = Optional.of(new SyzygyProbeResult(SyzygyWdl.DRAW, OptionalInt.of(0), OptionalInt.empty()));
+        client.response = Optional.of(new SyzygyProbeResult(SyzygyWdl.DRAW, OptionalInt.of(0), OptionalInt.empty(), Optional.empty()));
 
         SyzygyTablebaseService service = new SyzygyTablebaseService(client, 16);
         Optional<SyzygyProbeResult> first = service.probe(board);

--- a/src/test/java/julius/game/chessengine/tablebase/AiTablebaseIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/AiTablebaseIntegrationTest.java
@@ -27,7 +27,7 @@ class AiTablebaseIntegrationTest {
     void aiEvaluationReflectsTablebaseResult() {
         TablebaseTestSupport.assumeSyzygyConfigured();
 
-        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.LOSS, OptionalInt.of(2), OptionalInt.of(6));
+        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.LOSS, OptionalInt.of(2), OptionalInt.of(6), Optional.empty());
         SyzygyTablebaseService service = mock(SyzygyTablebaseService.class);
         when(service.probe(any(BitBoard.class))).thenReturn(Optional.of(probe));
 

--- a/src/test/java/julius/game/chessengine/tablebase/ScoreTablebaseIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/ScoreTablebaseIntegrationTest.java
@@ -27,7 +27,7 @@ class ScoreTablebaseIntegrationTest {
     void scoreUsesExactTablebaseProbeWhenAvailable() {
         TablebaseTestSupport.assumeSyzygyConfigured();
 
-        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(3), OptionalInt.of(7));
+        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(3), OptionalInt.of(7), Optional.empty());
         SyzygyTablebaseService service = mock(SyzygyTablebaseService.class);
         when(service.probe(any(BitBoard.class))).thenReturn(Optional.of(probe));
 
@@ -63,8 +63,8 @@ class ScoreTablebaseIntegrationTest {
 
     @Test
     void tablebaseCentipawnRespectsSideToMove() {
-        TablebaseResult win = new TablebaseResult(SyzygyWdl.WIN, OptionalInt.of(1), OptionalInt.empty());
-        TablebaseResult loss = new TablebaseResult(SyzygyWdl.LOSS, OptionalInt.of(1), OptionalInt.empty());
+        TablebaseResult win = new TablebaseResult(SyzygyWdl.WIN, OptionalInt.of(1), OptionalInt.empty(), Optional.empty());
+        TablebaseResult loss = new TablebaseResult(SyzygyWdl.LOSS, OptionalInt.of(1), OptionalInt.empty(), Optional.empty());
 
         assertThat(Score.tablebaseToCentipawn(win, true)).isGreaterThan(0);
         assertThat(Score.tablebaseToCentipawn(win, false)).isLessThan(0);
@@ -77,7 +77,7 @@ class ScoreTablebaseIntegrationTest {
     void scoreProbesWhenBoardWithinServiceLimit() {
         String fen = "6k1/8/8/8/8/8/PPP5/6K1 w - - 0 1";
         BitBoard board = FEN.translateFENtoBitBoard(fen);
-        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.DRAW, OptionalInt.of(0), OptionalInt.empty());
+        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.DRAW, OptionalInt.of(0), OptionalInt.empty(), Optional.empty());
         TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(Map.of(fen, probe), 6);
 
         try (TablebaseTestSupport.TablebaseServiceRestorer restorer = TablebaseTestSupport.overrideScoreTablebase(service)) {

--- a/src/test/java/julius/game/chessengine/uci/UciSyzygyFlowTest.java
+++ b/src/test/java/julius/game/chessengine/uci/UciSyzygyFlowTest.java
@@ -13,6 +13,7 @@ import testsupport.DeterministicAiHelper;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -25,7 +26,7 @@ class UciSyzygyFlowTest {
     @Test
     void blackSyzygyWinIsBroadcast() throws Exception {
         String fen = "8/8/8/8/8/1kb1n3/8/2K5 b - - 31 16";
-        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(5), OptionalInt.empty());
+        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(5), OptionalInt.empty(), Optional.empty());
 
         ScenarioResult result = runSyzygyScenario(fen, probe);
 
@@ -38,7 +39,7 @@ class UciSyzygyFlowTest {
     @Test
     void whiteSyzygyWinIsBroadcast() throws Exception {
         String fen = "3k4/p6p/8/8/8/4N3/5B2/3K4 w - - 0 1";
-        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(7), OptionalInt.empty());
+        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(7), OptionalInt.empty(), Optional.empty());
 
         ScenarioResult result = runSyzygyScenario(fen, probe);
 


### PR DESCRIPTION
## Summary
- capture the recommended move from Syzygy DTZ probes and expose it via new `SyzygyMove`
- teach the search to prioritise tablebase moves, including a root-level short circuit when an exact hit is available
- update existing Syzygy tests and add a regression test that ensures the engine plays the zeroing move from the 5-man tablebase position

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITablebaseRecommendationTest test

------
https://chatgpt.com/codex/tasks/task_e_68ee07961530832aac93f711d3afa6ce