### PR TITLE
Fix Syzygy move indexing and add conversion test

### DIFF
--- a/src/main/java/julius/game/chessengine/syzygy/Tables.java
+++ b/src/main/java/julius/game/chessengine/syzygy/Tables.java
@@ -93,9 +93,9 @@ final class Tables {
     }
 
     private Optional<SyzygyMove> decodeRecommendedMove(int dtzRaw) {
-        int fromSquare = SyzygyConstants.fromSquare(dtzRaw);
-        int toSquare = SyzygyConstants.toSquare(dtzRaw);
-        if (fromSquare <= 0 || toSquare <= 0) {
+        int fromIndex = toEngineIndex(SyzygyConstants.fromSquare(dtzRaw));
+        int toIndex = toEngineIndex(SyzygyConstants.toSquare(dtzRaw));
+        if (fromIndex < 0 || toIndex < 0) {
             return Optional.empty();
         }
 
@@ -108,12 +108,31 @@ final class Tables {
         };
 
         try {
-            return Optional.of(new SyzygyMove(fromSquare - 1, toSquare - 1, promotionBits));
+            return Optional.of(new SyzygyMove(fromIndex, toIndex, promotionBits));
         } catch (IllegalArgumentException ex) {
             log.debug("Ignoring invalid Syzygy move suggestion (dtzRaw={}, from={}, to={}, promo={})",
-                    dtzRaw, fromSquare, toSquare, promotionBits, ex);
+                    dtzRaw, fromIndex, toIndex, promotionBits, ex);
             return Optional.empty();
         }
+    }
+
+    /**
+     * Syzygy squares are encoded with {@code a8 = 1} increasing by file then rank.
+     * The engine however uses {@code a1 = 0}. This helper mirrors the rank so the
+     * returned index matches {@link julius.game.chessengine.board.MoveHelper}'s layout.
+     */
+    static int toEngineIndex(int syzygySquare) {
+        if (syzygySquare <= 0) {
+            return -1;
+        }
+        int zeroBased = syzygySquare - 1;
+        int file = zeroBased & 7; // modulo 8
+        int rankFromTop = zeroBased >>> 3; // divide by 8 with a8 == 0
+        int engineRank = 7 - rankFromTop;
+        if (engineRank < 0 || engineRank >= 8) {
+            return -1;
+        }
+        return engineRank * 8 + file;
     }
 
     int effectiveMaxPieces() {

--- a/src/test/java/julius/game/chessengine/syzygy/TablesTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/TablesTest.java
@@ -1,0 +1,25 @@
+package julius.game.chessengine.syzygy;
+
+import julius.game.chessengine.board.MoveHelper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TablesTest {
+
+    @Test
+    void convertsSyzygySquaresToEngineIndices() {
+        assertThat(Tables.toEngineIndex(1)).isEqualTo(MoveHelper.convertStringToIndex("a8"));
+        assertThat(Tables.toEngineIndex(8)).isEqualTo(MoveHelper.convertStringToIndex("h8"));
+        assertThat(Tables.toEngineIndex(26)).isEqualTo(MoveHelper.convertStringToIndex("b5"));
+        assertThat(Tables.toEngineIndex(57)).isEqualTo(MoveHelper.convertStringToIndex("a1"));
+        assertThat(Tables.toEngineIndex(64)).isEqualTo(MoveHelper.convertStringToIndex("h1"));
+    }
+
+    @Test
+    void returnsMinusOneForInvalidSyzygySquares() {
+        assertThat(Tables.toEngineIndex(0)).isEqualTo(-1);
+        assertThat(Tables.toEngineIndex(65)).isEqualTo(-1);
+        assertThat(Tables.toEngineIndex(-4)).isEqualTo(-1);
+    }
+}


### PR DESCRIPTION
## Summary
- mirror Syzygy square indices so recommended moves match the engine's internal layout
- expose a helper for converting Syzygy squares and reuse it when decoding DTZ moves
- add a unit test covering the conversion helper and invalid inputs

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=TablesTest,AITablebaseRecommendationTest test

------
https://chatgpt.com/codex/tasks/task_e_68ee110f7380832a9f1fd11544bf5af1