### PR TITLE
Fix Syzygy tablebase move decoding to honour recommended moves

### DIFF
--- a/src/main/java/julius/game/chessengine/syzygy/Tables.java
+++ b/src/main/java/julius/game/chessengine/syzygy/Tables.java
@@ -92,10 +92,13 @@ final class Tables {
         return Optional.of(new SyzygyProbeResult(wdl, dtz, OptionalInt.empty(), recommendedMove));
     }
 
-    private Optional<SyzygyMove> decodeRecommendedMove(int dtzRaw) {
+    static Optional<SyzygyMove> decodeRecommendedMove(int dtzRaw) {
         int fromSquare = SyzygyConstants.fromSquare(dtzRaw);
         int toSquare = SyzygyConstants.toSquare(dtzRaw);
-        if (fromSquare <= 0 || toSquare <= 0) {
+        if (fromSquare == toSquare) {
+            return Optional.empty();
+        }
+        if (fromSquare < 0 || fromSquare >= 64 || toSquare < 0 || toSquare >= 64) {
             return Optional.empty();
         }
 
@@ -108,7 +111,7 @@ final class Tables {
         };
 
         try {
-            return Optional.of(new SyzygyMove(fromSquare - 1, toSquare - 1, promotionBits));
+            return Optional.of(new SyzygyMove(fromSquare, toSquare, promotionBits));
         } catch (IllegalArgumentException ex) {
             log.debug("Ignoring invalid Syzygy move suggestion (dtzRaw={}, from={}, to={}, promo={})",
                     dtzRaw, fromSquare, toSquare, promotionBits, ex);

--- a/src/test/java/julius/game/chessengine/syzygy/TablesTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/TablesTest.java
@@ -1,0 +1,55 @@
+package julius.game.chessengine.syzygy;
+
+import julius.game.chessengine.syzygy.bridge.SyzygyConstants;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TablesTest {
+
+    @Test
+    void decodeRecommendedMoveUsesZeroBasedIndices() {
+        int raw = buildDtzRaw(
+                SyzygyConstants.TB_WIN,
+                33,
+                41,
+                1,
+                SyzygyConstants.TB_PROMOTES_NONE
+        );
+
+        Optional<SyzygyMove> decoded = Tables.decodeRecommendedMove(raw);
+
+        assertThat(decoded).isPresent();
+        assertThat(decoded.get().fromIndex()).isEqualTo(33);
+        assertThat(decoded.get().toIndex()).isEqualTo(41);
+        assertThat(decoded.get().promotionPieceTypeBits()).isZero();
+    }
+
+    @Test
+    void decodeRecommendedMoveSupportsAFileSquares() {
+        int raw = buildDtzRaw(
+                SyzygyConstants.TB_WIN,
+                0,
+                8,
+                2,
+                SyzygyConstants.TB_PROMOTES_NONE
+        );
+
+        Optional<SyzygyMove> decoded = Tables.decodeRecommendedMove(raw);
+
+        assertThat(decoded).isPresent();
+        assertThat(decoded.get().fromIndex()).isEqualTo(0);
+        assertThat(decoded.get().toIndex()).isEqualTo(8);
+    }
+
+    private static int buildDtzRaw(int wdl, int from, int to, int dtz, int promote) {
+        return (wdl << SyzygyConstants.TB_RESULT_WDL_SHIFT)
+                | (to << SyzygyConstants.TB_RESULT_TO_SHIFT)
+                | (from << SyzygyConstants.TB_RESULT_FROM_SHIFT)
+                | (promote << SyzygyConstants.TB_RESULT_PROMOTES_SHIFT)
+                | (dtz << SyzygyConstants.TB_RESULT_DTZ_SHIFT);
+    }
+}
+


### PR DESCRIPTION
## Summary
- keep Syzygy recommended moves in zero-based board coordinates and guard invalid suggestions
- add unit tests covering the decoder's zero-based mapping and a-file moves

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=TablesTest,AITablebaseRecommendationTest test

------
https://chatgpt.com/codex/tasks/task_e_68ee110f7380832a9f1fd11544bf5af1