### PR TITLE
Fix tablebase evaluation perspective for root side

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1926,6 +1926,7 @@ public class AI {
             return -1;
         }
 
+        boolean rootIsWhite = simulatorEngine.whitesTurn();
         if (parentResult != null) {
             Optional<SyzygyMove> suggestion = parentResult.recommendedMove();
             if (suggestion.isPresent()) {
@@ -1943,7 +1944,7 @@ public class AI {
             simulatorEngine.performMove(move);
             double candidate;
             try {
-                candidate = evaluateTablebaseChild(simulatorEngine);
+                candidate = evaluateTablebaseChild(simulatorEngine, rootIsWhite);
             } finally {
                 simulatorEngine.undoLastMove();
             }
@@ -2008,7 +2009,7 @@ public class AI {
         moves.set(index, first);
     }
 
-    private double evaluateTablebaseChild(Engine simulatorEngine) {
+    private double evaluateTablebaseChild(Engine simulatorEngine, boolean rootIsWhite) {
         TablebaseResult childResult = simulatorEngine.getGameState().getLastTablebaseResult().orElse(null);
         if (tablebaseService != null) {
             BitBoard snapshot = new BitBoard(simulatorEngine.getBitBoard());
@@ -2022,9 +2023,7 @@ public class AI {
             return Double.NaN;
         }
         double whitePerspective = Score.tablebaseToEvaluation(childResult, simulatorEngine.whitesTurn());
-        boolean childIsWhite = simulatorEngine.whitesTurn();
-        double childSearchPerspective = childIsWhite ? whitePerspective : -whitePerspective;
-        return childSearchPerspective;
+        return rootIsWhite ? whitePerspective : -whitePerspective;
     }
 
     private boolean isExactWdl(TablebaseResult result) {

--- a/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
@@ -3,6 +3,7 @@ package julius.game.chessengine.ai;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import julius.game.chessengine.board.FEN;
 import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.syzygy.SyzygyProbeResult;
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
 import julius.game.chessengine.syzygy.SyzygyWdl;
@@ -100,6 +101,55 @@ class AISyzygyIntegrationTest {
             assertThat(winningChildren)
                     .describedAs("tablebase best move should correspond to a child scored as a forced win")
                     .contains(bestChildFen);
+
+            ai.shutdown();
+        }
+    }
+
+    @Test
+    void determineTablebaseBestMovePrefersWinningMoveForRootSide() throws Exception {
+        Engine engine = new Engine();
+        String fen = "8/7K/8/8/2kP4/8/8/7B w - - 2 61";
+        engine.importBoardFromFen(fen);
+
+        IntArrayList legalMoves = engine.getAllLegalMoves();
+        Map<String, SyzygyProbeResult> responses = new HashMap<>();
+        responses.put(fen, new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(7), OptionalInt.empty(), Optional.empty()));
+
+        for (int i = 0; i < legalMoves.size(); i++) {
+            int move = legalMoves.getInt(i);
+            int fromIndex = MoveHelper.deriveFromIndex(move);
+            int toIndex = MoveHelper.deriveToIndex(move);
+            String moveKey = MoveHelper.convertIndexToString(fromIndex) + MoveHelper.convertIndexToString(toIndex);
+
+            engine.performMove(move);
+            String childFen = FEN.translateBoardToFEN(engine.getBitBoard(), engine.getGameState()).getRenderBoard();
+
+            boolean winningChild = "d4d5".equals(moveKey);
+            SyzygyWdl childWdl = winningChild ? SyzygyWdl.LOSS : SyzygyWdl.DRAW;
+            responses.put(childFen, new SyzygyProbeResult(childWdl, OptionalInt.of(1), OptionalInt.empty(), Optional.empty()));
+            engine.undoLastMove();
+        }
+
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(responses);
+
+        try (AutoCloseable restorer = overrideScoreTablebase(service)) {
+            AI ai = new AI(engine, service);
+            Engine simulation = engine.createSimulation();
+
+            Method determine = AI.class.getDeclaredMethod("determineTablebaseBestMove", Engine.class, TablebaseResult.class);
+            determine.setAccessible(true);
+
+            TablebaseResult parentResult = TablebaseResult.from(responses.get(fen));
+            int bestMove = (int) determine.invoke(ai, simulation, parentResult);
+
+            int fromIndex = MoveHelper.deriveFromIndex(bestMove);
+            int toIndex = MoveHelper.deriveToIndex(bestMove);
+            String bestMoveKey = MoveHelper.convertIndexToString(fromIndex) + MoveHelper.convertIndexToString(toIndex);
+
+            assertThat(bestMoveKey)
+                    .describedAs("tablebase best move should play the forced winning move for the root side")
+                    .isEqualTo("d4d5");
 
             ai.shutdown();
         }


### PR DESCRIPTION
## Summary
- ensure tablebase best-move selection evaluates child scores from the root side's perspective so wins are preferred even when the side to move flips
- add a regression test covering the 8/7K/8/8/2kP4/8/8/7B w - - 2 61 position to verify the d4d5 tablebase win is chosen

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AISyzygyIntegrationTest test


------
https://chatgpt.com/codex/tasks/task_e_68ee343c52d0832a984c06612820340c