### PR TITLE
Fix tablebase child evaluation perspective

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1936,6 +1936,8 @@ public class AI {
             }
         }
 
+        boolean parentIsWhite = simulatorEngine.whitesTurn();
+
         double bestScore = Double.NEGATIVE_INFINITY;
         int bestMove = -1;
         for (int i = 0; i < legal.size(); i++) {
@@ -1943,7 +1945,7 @@ public class AI {
             simulatorEngine.performMove(move);
             double candidate;
             try {
-                candidate = evaluateTablebaseChild(simulatorEngine);
+                candidate = evaluateTablebaseChild(simulatorEngine, parentIsWhite);
             } finally {
                 simulatorEngine.undoLastMove();
             }
@@ -2008,7 +2010,7 @@ public class AI {
         moves.set(index, first);
     }
 
-    private double evaluateTablebaseChild(Engine simulatorEngine) {
+    private double evaluateTablebaseChild(Engine simulatorEngine, boolean parentIsWhite) {
         TablebaseResult childResult = simulatorEngine.getGameState().getLastTablebaseResult().orElse(null);
         if (tablebaseService != null) {
             BitBoard snapshot = new BitBoard(simulatorEngine.getBitBoard());
@@ -2022,9 +2024,7 @@ public class AI {
             return Double.NaN;
         }
         double whitePerspective = Score.tablebaseToEvaluation(childResult, simulatorEngine.whitesTurn());
-        boolean childIsWhite = simulatorEngine.whitesTurn();
-        double childSearchPerspective = childIsWhite ? whitePerspective : -whitePerspective;
-        return childSearchPerspective;
+        return parentIsWhite ? whitePerspective : -whitePerspective;
     }
 
     private boolean isExactWdl(TablebaseResult result) {


### PR DESCRIPTION
## Summary
- ensure Syzygy child evaluations are scored from the parent mover's perspective so winning moves stay preferred

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AISyzygyIntegrationTest#determineTablebaseBestMovePicksWinningChild test

------
https://chatgpt.com/codex/tasks/task_e_68ee343c52d0832a984c06612820340c