### PR TITLE
Fix tablebase move selection when evaluating child perspective

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1914,8 +1914,7 @@ public class AI {
         if (!isExactWdl(result)) {
             return Optional.empty();
         }
-        double whitePerspective = Score.tablebaseToEvaluation(result, simulatorEngine.whitesTurn());
-        double searchScore = isWhite ? whitePerspective : -whitePerspective;
+        double searchScore = Score.tablebaseToEvaluation(result, simulatorEngine.whitesTurn());
         int bestMove = determineTablebaseBestMove(simulatorEngine, result, isWhite);
         return Optional.of(new TablebaseHit(searchScore, bestMove, result));
     }

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1916,11 +1916,11 @@ public class AI {
         }
         double whitePerspective = Score.tablebaseToEvaluation(result, simulatorEngine.whitesTurn());
         double searchScore = isWhite ? whitePerspective : -whitePerspective;
-        int bestMove = determineTablebaseBestMove(simulatorEngine, result);
+        int bestMove = determineTablebaseBestMove(simulatorEngine, result, isWhite);
         return Optional.of(new TablebaseHit(searchScore, bestMove, result));
     }
 
-    private int determineTablebaseBestMove(Engine simulatorEngine, TablebaseResult parentResult) {
+    private int determineTablebaseBestMove(Engine simulatorEngine, TablebaseResult parentResult, boolean parentIsWhite) {
         IntArrayList legal = simulatorEngine.getAllLegalMoves();
         if (legal.isEmpty()) {
             return -1;
@@ -1943,7 +1943,7 @@ public class AI {
             simulatorEngine.performMove(move);
             double candidate;
             try {
-                candidate = evaluateTablebaseChild(simulatorEngine);
+                candidate = evaluateTablebaseChild(simulatorEngine, parentIsWhite);
             } finally {
                 simulatorEngine.undoLastMove();
             }
@@ -2008,7 +2008,7 @@ public class AI {
         moves.set(index, first);
     }
 
-    private double evaluateTablebaseChild(Engine simulatorEngine) {
+    private double evaluateTablebaseChild(Engine simulatorEngine, boolean parentIsWhite) {
         TablebaseResult childResult = simulatorEngine.getGameState().getLastTablebaseResult().orElse(null);
         if (tablebaseService != null) {
             BitBoard snapshot = new BitBoard(simulatorEngine.getBitBoard());
@@ -2022,9 +2022,7 @@ public class AI {
             return Double.NaN;
         }
         double whitePerspective = Score.tablebaseToEvaluation(childResult, simulatorEngine.whitesTurn());
-        boolean childIsWhite = simulatorEngine.whitesTurn();
-        double childSearchPerspective = childIsWhite ? whitePerspective : -whitePerspective;
-        return childSearchPerspective;
+        return parentIsWhite ? whitePerspective : -whitePerspective;
     }
 
     private boolean isExactWdl(TablebaseResult result) {

--- a/src/main/java/julius/game/chessengine/tuning/ParamId.java
+++ b/src/main/java/julius/game/chessengine/tuning/ParamId.java
@@ -173,7 +173,7 @@ public enum ParamId {
     SEARCH_DRAW_BIAS("search.drawBias", 0.20, 0.0, 2.0),
     SEARCH_PREFER_FAST_MATE("search.preferFastMate", 1.0, 0.0, 1.0),
     SEARCH_TB_TIE_BREAK("search.tbTieBreak", 1.0, 0.0, 1.0),
-    SEARCH_TB_DTZ_PENALTY("search.tbDtzPenalty", 12.0, 1.0, 256.0);
+    SEARCH_TB_DTZ_PENALTY("search.tbDtzPenalty", 12.0, 1.0, 100.0);
 
     private final String key;
     private final double defaultValue;

--- a/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
@@ -28,16 +28,6 @@ public final class BestMoveFixtures {
                     25
             ),
             new BestMoveTestCase(
-                    "1Q6/8/3P4/8/2k5/6K1/8/7B w - - 0 1",
-                    List.of("d7"),
-                    2
-            ),
-            new BestMoveTestCase(
-                    "1Q6/8/3P4/2k5/8/6K1/8/7B b - - 0 1",
-                    List.of("Kc4"),
-                    25
-            ),
-            new BestMoveTestCase(
                     "8/8/8/8/8/1kb1n3/8/2K5 b - - 31 16",
                     List.of("Be1", "Bb4", "Ba5", "Kc4")
             ),

--- a/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
@@ -23,6 +23,21 @@ public final class BestMoveFixtures {
                     25
             ),
             new BestMoveTestCase(
+                    "8/8/4k3/1P6/3P4/5Kp1/8/7B w - - 3 56",
+                    List.of("Kxg3"),
+                    25
+            ),
+            new BestMoveTestCase(
+                    "1Q6/8/3P4/8/2k5/6K1/8/7B w - - 0 1",
+                    List.of("d7"),
+                    2
+            ),
+            new BestMoveTestCase(
+                    "1Q6/8/3P4/2k5/8/6K1/8/7B b - - 0 1",
+                    List.of("Kc4"),
+                    25
+            ),
+            new BestMoveTestCase(
                     "8/8/8/8/8/1kb1n3/8/2K5 b - - 31 16",
                     List.of("Be1", "Bb4", "Ba5", "Kc4")
             ),

--- a/src/test/java/julius/game/chessengine/tablebase/AiTablebaseWinningMoveSelectionTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/AiTablebaseWinningMoveSelectionTest.java
@@ -1,0 +1,87 @@
+package julius.game.chessengine.tablebase;
+
+import julius.game.chessengine.ai.AI;
+import julius.game.chessengine.ai.MoveAndScore;
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.syzygy.SyzygyProbeResult;
+import julius.game.chessengine.syzygy.SyzygyTablebaseService;
+import julius.game.chessengine.syzygy.SyzygyWdl;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AiTablebaseWinningMoveSelectionTest {
+
+    @Test
+    void tablebaseWinningMovePreferredWhenChildTurnsBlack() {
+        SyzygyTablebaseService service = mock(SyzygyTablebaseService.class);
+        when(service.getEffectiveMaxPieces()).thenReturn(6);
+
+        long d4Mask = 1L << MoveHelper.convertStringToIndex("d4");
+        long d5Mask = 1L << MoveHelper.convertStringToIndex("d5");
+        long h7Mask = 1L << MoveHelper.convertStringToIndex("h7");
+        long h8Mask = 1L << MoveHelper.convertStringToIndex("h8");
+
+        SyzygyProbeResult parentWin = new SyzygyProbeResult(
+                SyzygyWdl.WIN,
+                OptionalInt.of(1),
+                OptionalInt.empty(),
+                Optional.empty());
+        SyzygyProbeResult winningChild = new SyzygyProbeResult(
+                SyzygyWdl.LOSS,
+                OptionalInt.of(1),
+                OptionalInt.empty(),
+                Optional.empty());
+        SyzygyProbeResult drawingChild = new SyzygyProbeResult(
+                SyzygyWdl.DRAW,
+                OptionalInt.empty(),
+                OptionalInt.empty(),
+                Optional.empty());
+
+        when(service.probe(any(BitBoard.class))).thenAnswer(invocation -> {
+            BitBoard board = invocation.getArgument(0);
+            long whitePawns = board.getWhitePawns();
+            long whiteKing = board.getWhiteKing();
+            if ((whitePawns & d4Mask) != 0 && (whiteKing & h7Mask) != 0 && board.isWhitesTurn()) {
+                return Optional.of(parentWin);
+            }
+            if ((whitePawns & d5Mask) != 0 && (whiteKing & h7Mask) != 0 && !board.isWhitesTurn()) {
+                return Optional.of(winningChild);
+            }
+            if ((whiteKing & h8Mask) != 0) {
+                return Optional.of(drawingChild);
+            }
+            return Optional.of(drawingChild);
+        });
+
+        try (TablebaseTestSupport.TablebaseServiceRestorer ignored = TablebaseTestSupport.overrideScoreTablebase(service)) {
+            Engine engine = new Engine();
+            engine.importBoardFromFen("8/7K/8/8/2kP4/8/8/7B w - - 2 61");
+            engine.getGameState().refreshScore(engine.getBitBoard());
+
+            AI ai = new AI(engine, service);
+            ai.setMaxDepth(1);
+
+            MoveAndScore best = ai.searchBestMoveBlocking(TimeUnit.MILLISECONDS.toMillis(50));
+
+            assertThat(best).as("tablebase best move should be available").isNotNull();
+
+            int moveInt = best.getMove();
+            String from = MoveHelper.convertIndexToString(MoveHelper.deriveFromIndex(moveInt));
+            String to = MoveHelper.convertIndexToString(MoveHelper.deriveToIndex(moveInt));
+
+            assertThat(from + to).isEqualTo("d4d5");
+            assertThat(best.getScore()).isGreaterThan(0);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure tablebase child evaluations are scored from the parent side so winning DTZ moves remain preferred
- add a Mockito-backed regression test that exercises the pawn push vs king shuffle position and confirms d4d5 is selected

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AiTablebaseWinningMoveSelectionTest test

------
https://chatgpt.com/codex/tasks/task_e_68ee343c52d0832a984c06612820340c