### PR TITLE
Optimize move bucket sorting and add ordering test

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1,6 +1,8 @@
 package julius.game.chessengine.ai;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.ints.IntComparator;
 import it.unimi.dsi.fastutil.longs.Long2DoubleOpenHashMap;
 import julius.game.chessengine.ai.time.TimeManager;
 import julius.game.chessengine.board.BitBoard;
@@ -2971,7 +2973,30 @@ public class AI {
                 s = maxScore;
             }
             scoreBuffer[i] = s;
-            insertByScore(targetBucket, i, scoreBuffer, moveBuffer);
+            targetBucket.add(i);
+        }
+
+        IntComparator bucketComparator = new IntComparator() {
+            @Override
+            public int compare(int a, int b) {
+                int scoreCompare = Integer.compare(scoreBuffer[b], scoreBuffer[a]);
+                if (scoreCompare != 0) {
+                    return scoreCompare;
+                }
+                return Integer.compare(moveBuffer[b], moveBuffer[a]);
+            }
+
+            @Override
+            public int compare(Integer a, Integer b) {
+                return compare(a.intValue(), b.intValue());
+            }
+        };
+
+        for (IntArrayList bucket : bucketIndexes) {
+            int bucketSize = bucket.size();
+            if (bucketSize > 1) {
+                IntArrays.quickSort(bucket.elements(), 0, bucketSize, bucketComparator);
+            }
         }
 
         int outIndex = 0;
@@ -3479,27 +3504,6 @@ public class AI {
             case CAPTURE_BAD -> parameters.categoryCaptureBad();
         };
     }
-
-    private static void insertByScore(IntArrayList bucket, int moveIndex, int[] scoreBuffer, int[] moveBuffer) {
-        int score = scoreBuffer[moveIndex];
-        int move = moveBuffer[moveIndex];
-        int insertPosition = bucket.size();
-        while (insertPosition > 0) {
-            int existingIndex = bucket.getInt(insertPosition - 1);
-            int existingScore = scoreBuffer[existingIndex];
-            if (score > existingScore) {
-                insertPosition--;
-                continue;
-            }
-            if (score == existingScore && move > moveBuffer[existingIndex]) {
-                insertPosition--;
-                continue;
-            }
-            break;
-        }
-        bucket.add(insertPosition, moveIndex);
-    }
-
     private static int writeBucket(IntArrayList bucket, int[] sourceMoves, int[] target, int startIndex) {
         for (int i = 0, size = bucket.size(); i < size; i++) {
             target[startIndex++] = sourceMoves[bucket.getInt(i)];

--- a/src/test/java/julius/game/chessengine/ai/AITest_MoveOrderingBuckets.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_MoveOrderingBuckets.java
@@ -97,6 +97,71 @@ class AITest_MoveOrderingBuckets {
         }
     }
 
+    @Test
+    @DisplayName("Buckets are sorted by score (desc) with move tie-breaks and feed writeBucket as-is")
+    void bucketsMaintainScoreAndMoveOrdering() throws Exception {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+
+        AiTuning tuning = AiTuning.builder()
+                .searchThreads(1)
+                .lazySmpThreads(1)
+                .hashSizeMb(16)
+                .build();
+
+        AI ai = new AI(engine, tuning);
+
+        IntArrayList ordered = engine.getAllLegalMoves();
+        assertFalse(ordered.isEmpty(), "Position should expose moves to order");
+
+        ai.sortMovesByEfficiency(ordered, 0, engine.getBoardStateHash(), -1, engine);
+
+        Field sortBuffersField = AI.class.getDeclaredField("sortBuffers");
+        sortBuffersField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        ThreadLocal<SortBuffers> sortBuffers = (ThreadLocal<SortBuffers>) sortBuffersField.get(ai);
+        SortBuffers buffers = sortBuffers.get();
+
+        Field moveBucketOrderField = AI.class.getDeclaredField("moveBucketOrder");
+        moveBucketOrderField.setAccessible(true);
+        Object[] bucketOrder = (Object[]) moveBucketOrderField.get(ai);
+
+        IntArrayList reconstructed = new IntArrayList(ordered.size());
+        boolean validated = false;
+
+        for (Object bucketObj : bucketOrder) {
+            Enum<?> bucketEnum = (Enum<?>) bucketObj;
+            IntArrayList bucket = buffers.bucketIndexes[bucketEnum.ordinal()];
+            if (bucket.size() > 1) {
+                validated = true;
+                for (int i = 1; i < bucket.size(); i++) {
+                    int previousIndex = bucket.getInt(i - 1);
+                    int currentIndex = bucket.getInt(i);
+                    int previousScore = buffers.scoreBuffer[previousIndex];
+                    int currentScore = buffers.scoreBuffer[currentIndex];
+                    assertTrue(previousScore >= currentScore,
+                            () -> "Scores should be non-increasing within a bucket" +
+                                    " (prev=" + previousScore + ", curr=" + currentScore + ")");
+                    if (previousScore == currentScore) {
+                        int previousMove = buffers.moveBuffer[previousIndex];
+                        int currentMove = buffers.moveBuffer[currentIndex];
+                        assertTrue(previousMove >= currentMove,
+                                () -> "Moves should tie-break by descending id" +
+                                        " (prev=" + Move.convertIntToMove(previousMove) +
+                                        ", curr=" + Move.convertIntToMove(currentMove) + ")");
+                    }
+                }
+            }
+            for (int i = 0; i < bucket.size(); i++) {
+                reconstructed.add(buffers.moveBuffer[bucket.getInt(i)]);
+            }
+        }
+
+        assertTrue(validated, "Expected at least one bucket to contain multiple moves for ordering checks");
+        assertArrayEquals(ordered.toIntArray(), reconstructed.toIntArray(),
+                "writeBucket should consume the pre-sorted buckets without reordering");
+    }
+
     private static int indexOf(IntArrayList moves, int target) {
         for (int i = 0; i < moves.size(); i++) {
             if (moves.getInt(i) == target) {


### PR DESCRIPTION
## Summary
- replace per-move bucket insertion with a single quicksort per bucket keyed by score and move id
- add a regression test that inspects bucket buffers to verify ordering and writeBucket integration

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITest_MoveOrderingBuckets test

------
https://chatgpt.com/codex/tasks/task_e_68ee5faa5670832abb9b8817b6eb07bf