### PR TITLE
Refactor magic occupancy masking for sliders

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -858,18 +858,14 @@ public class BitBoard {
      * Bishop-ray attacks from 'sq' with an explicit occupancy.
      */
     private long bishopAttacksFromWithOcc(int sq, long occ) {
-        long mask = bishopHelper.bishopMasks[sq];
-        long occMasked = occ & mask;
-        return bishopHelper.calculateMovesUsingBishopMagic(sq, occMasked);
+        return bishopHelper.calculateMovesUsingBishopMagic(sq, occ);
     }
 
     /**
      * Rook-ray attacks from 'sq' with an explicit occupancy.
      */
     private long rookAttacksFromWithOcc(int sq, long occ) {
-        long mask = rookHelper.rookMasks[sq];
-        long occMasked = occ & mask;
-        return rookHelper.calculateMovesUsingRookMagic(sq, occMasked);
+        return rookHelper.calculateMovesUsingRookMagic(sq, occ);
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove redundant bishop and rook occupancy masking in `BitBoard`
- delegate masking responsibilities to the magic move generators directly

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=MagicTest,BitBoardTest test

------
https://chatgpt.com/codex/tasks/task_e_68ee75236b70832a9fbc0f6d3ab8189d