### PR TITLE
Precompute pawn attacker lookups

### DIFF
--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -876,17 +876,9 @@ public class BitBoard {
      * Bitboard of pawns (for the given side) that attack 'sq'.
      */
     private long pawnAttackersToSquare(int sq, boolean whiteSide, long whitePawnsBB, long blackPawnsBB) {
-        int file = sq & 7;
-        long res = 0L;
-        if (whiteSide) {
-            if (file != 7 && sq >= 7) res |= (1L << (sq - 7));  // from ... -> to = +7
-            if (file != 0 && sq >= 9) res |= (1L << (sq - 9));  // from ... -> to = +9
-            return res & whitePawnsBB;
-        } else {
-            if (file != 0 && sq <= 56) res |= (1L << (sq + 7));  // from ... -> to = -7
-            if (file != 7 && sq <= 54) res |= (1L << (sq + 9));  // from ... -> to = -9
-            return res & blackPawnsBB;
-        }
+        int colorIndex = whiteSide ? 0 : 1;
+        long pawnBitboard = whiteSide ? whitePawnsBB : blackPawnsBB;
+        return PawnMoveTables.PAWN_ATTACKERS[colorIndex][sq] & pawnBitboard;
     }
 
     /**

--- a/src/main/java/julius/game/chessengine/helper/PawnMoveTables.java
+++ b/src/main/java/julius/game/chessengine/helper/PawnMoveTables.java
@@ -4,12 +4,15 @@ package julius.game.chessengine.helper;
  * Precomputed pawn move tables for quick lookup of pawn pushes and attacks.
  * PAWN_ATTACKS[color][square] gives bitboard of attack targets for a pawn of the
  * given color on the given square. PAWN_PUSHES[color][square] gives the square
- * one step forward. These tables are initialised once at class load time.
+ * one step forward. PAWN_ATTACKERS[color][square] gives the bitboard of source
+ * squares of pawns of the given color that attack the square. These tables are
+ * initialised once at class load time.
  */
 public class PawnMoveTables {
 
     public static final long[][] PAWN_ATTACKS = new long[2][64];
     public static final long[][] PAWN_PUSHES = new long[2][64];
+    public static final long[][] PAWN_ATTACKERS = new long[2][64];
 
     static {
         for (int square = 0; square < 64; square++) {
@@ -47,6 +50,20 @@ public class PawnMoveTables {
             PAWN_PUSHES[1][square] = blackPush;
             PAWN_ATTACKS[0][square] = whiteAttacks;
             PAWN_ATTACKS[1][square] = blackAttacks;
+
+            long attacks = whiteAttacks;
+            while (attacks != 0) {
+                int target = Long.numberOfTrailingZeros(attacks);
+                PAWN_ATTACKERS[0][target] |= 1L << square;
+                attacks &= attacks - 1;
+            }
+
+            attacks = blackAttacks;
+            while (attacks != 0) {
+                int target = Long.numberOfTrailingZeros(attacks);
+                PAWN_ATTACKERS[1][target] |= 1L << square;
+                attacks &= attacks - 1;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- precompute pawn attacker bitboards in `PawnMoveTables`, including attacker reverse mappings
- use the cached attacker tables in `BitBoard` to remove per-call pawn attack shifts

## Testing
- `mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" test` *(fails in existing AI regression suites such as `MateInThreeToSevenTest` and `AIMateDistanceNormalizationTest`)*

------
https://chatgpt.com/codex/tasks/task_e_68ee7515182c832a8da0081ad2aa7103