### PR TITLE
Refactor heuristics snapshot pooling

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -397,6 +397,7 @@ public class AI {
                 heuristicsLockMetrics.recordOptimisticSnapshot();
                 return optimistic;
             }
+            optimistic.close();
         }
 
         long readStamp = acquireReadLock();
@@ -865,8 +866,9 @@ public class AI {
                 releaseWriteLock(stamp);
             }
         }
-        Heuristics.Snapshot snapshot = captureHeuristicsSnapshot(maxDepth);
-        heuristics.beginIteration(snapshot, maxDepth);
+        try (Heuristics.Snapshot snapshot = captureHeuristicsSnapshot(maxDepth)) {
+            heuristics.beginIteration(snapshot, maxDepth);
+        }
         heuristics.markPrepared(task.getId(), currentDepth);
     }
 
@@ -889,8 +891,9 @@ public class AI {
             } finally {
                 releaseWriteLock(stamp);
             }
-            Heuristics.Snapshot snapshot = captureHeuristicsSnapshot(maxDepth);
-            heuristics.beginIteration(snapshot, maxDepth);
+            try (Heuristics.Snapshot snapshot = captureHeuristicsSnapshot(maxDepth)) {
+                heuristics.beginIteration(snapshot, maxDepth);
+            }
             heuristics.markPrepared(task.getId(), depth);
         }
         return heuristics;
@@ -3629,35 +3632,95 @@ public class AI {
         void beginIteration(Snapshot snapshot, int requiredDepth) {
             resetUpdates();
             ensureCapacity(requiredDepth);
-            int limit = Math.min(requiredDepth, snapshot.killers.length);
-            for (int d = 0; d < limit; d++) {
-                System.arraycopy(snapshot.killers[d], 0, killers[d], 0, NUM_KILLER_MOVES);
-            }
-            for (int d = limit; d < requiredDepth; d++) {
-                Arrays.fill(killers[d], -1);
-            }
-            for (int f = 0; f < BOARD_SQUARES; f++) {
-                System.arraycopy(snapshot.history[f], 0, history[f], 0, BOARD_SQUARES);
-                System.arraycopy(snapshot.counter[f], 0, counter[f], 0, BOARD_SQUARES);
-            }
+            snapshot.copyKillersInto(killers, requiredDepth);
+            snapshot.copyHistoryInto(history);
+            snapshot.copyCounterInto(counter);
         }
 
         Snapshot snapshot(int requiredDepth) {
-            int killerDepth = Math.min(requiredDepth, killers.length);
-            int[][] killerCopy = new int[killerDepth][];
-            for (int d = 0; d < killerDepth; d++) {
-                killerCopy[d] = Arrays.copyOf(killers[d], NUM_KILLER_MOVES);
-            }
-            int[][] historyCopy = new int[BOARD_SQUARES][];
-            int[][] counterCopy = new int[BOARD_SQUARES][];
-            for (int f = 0; f < BOARD_SQUARES; f++) {
-                historyCopy[f] = Arrays.copyOf(history[f], BOARD_SQUARES);
-                counterCopy[f] = Arrays.copyOf(counter[f], BOARD_SQUARES);
-            }
-            return new Snapshot(killerCopy, historyCopy, counterCopy);
+            Snapshot snapshot = Snapshot.borrow();
+            snapshot.populateFrom(this, requiredDepth);
+            return snapshot;
         }
 
-        record Snapshot(int[][] killers, int[][] history, int[][] counter) {
+        private static final class Snapshot implements AutoCloseable {
+            private static final ThreadLocal<Snapshot> POOL =
+                    ThreadLocal.withInitial(Snapshot::new);
+
+            private int[][] killers;
+            private int killerDepth;
+            private final int[][] history;
+            private final int[][] counter;
+            private boolean inUse;
+
+            private Snapshot() {
+                this.killers = new int[0][];
+                this.history = new int[BOARD_SQUARES][BOARD_SQUARES];
+                this.counter = new int[BOARD_SQUARES][BOARD_SQUARES];
+            }
+
+            static Snapshot borrow() {
+                Snapshot snapshot = POOL.get();
+                if (snapshot.inUse) {
+                    snapshot = new Snapshot();
+                }
+                snapshot.inUse = true;
+                snapshot.killerDepth = 0;
+                return snapshot;
+            }
+
+            void populateFrom(Heuristics heuristics, int requiredDepth) {
+                int depth = Math.min(requiredDepth, heuristics.killers.length);
+                ensureKillerCapacity(depth);
+                for (int d = 0; d < depth; d++) {
+                    System.arraycopy(heuristics.killers[d], 0, killers[d], 0, NUM_KILLER_MOVES);
+                }
+                killerDepth = depth;
+                for (int f = 0; f < BOARD_SQUARES; f++) {
+                    System.arraycopy(heuristics.history[f], 0, history[f], 0, BOARD_SQUARES);
+                    System.arraycopy(heuristics.counter[f], 0, counter[f], 0, BOARD_SQUARES);
+                }
+            }
+
+            private void ensureKillerCapacity(int depth) {
+                if (killers.length >= depth) {
+                    return;
+                }
+                int[][] expanded = new int[depth][];
+                System.arraycopy(killers, 0, expanded, 0, killers.length);
+                for (int i = killers.length; i < depth; i++) {
+                    expanded[i] = new int[NUM_KILLER_MOVES];
+                }
+                killers = expanded;
+            }
+
+            void copyKillersInto(int[][] target, int requiredDepth) {
+                int limit = Math.min(requiredDepth, killerDepth);
+                for (int d = 0; d < limit; d++) {
+                    System.arraycopy(killers[d], 0, target[d], 0, NUM_KILLER_MOVES);
+                }
+                for (int d = limit; d < requiredDepth; d++) {
+                    Arrays.fill(target[d], -1);
+                }
+            }
+
+            void copyHistoryInto(int[][] target) {
+                for (int f = 0; f < BOARD_SQUARES; f++) {
+                    System.arraycopy(history[f], 0, target[f], 0, BOARD_SQUARES);
+                }
+            }
+
+            void copyCounterInto(int[][] target) {
+                for (int f = 0; f < BOARD_SQUARES; f++) {
+                    System.arraycopy(counter[f], 0, target[f], 0, BOARD_SQUARES);
+                }
+            }
+
+            @Override
+            public void close() {
+                killerDepth = 0;
+                inUse = false;
+            }
         }
 
         boolean isPreparedFor(long taskId, int depth) {

--- a/src/test/java/julius/game/chessengine/ai/HeuristicsSnapshotPoolingTest.java
+++ b/src/test/java/julius/game/chessengine/ai/HeuristicsSnapshotPoolingTest.java
@@ -1,0 +1,76 @@
+package julius.game.chessengine.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static testsupport.TestUtils.readField;
+
+class HeuristicsSnapshotPoolingTest {
+
+    @Test
+    @DisplayName("Heuristics snapshots reuse pooled buffers and refresh contents")
+    void snapshotReusesBuffersAndCopiesFreshData() throws Exception {
+        Class<?> heuristicsClass = Class.forName("julius.game.chessengine.ai.AI$Heuristics");
+        Constructor<?> constructor = heuristicsClass.getDeclaredConstructor(int.class);
+        constructor.setAccessible(true);
+        Object heuristics = constructor.newInstance(4);
+
+        int[][] killers = (int[][]) readField(heuristics, "killers");
+        int[][] history = (int[][]) readField(heuristics, "history");
+        int[][] counter = (int[][]) readField(heuristics, "counter");
+
+        killers[0][0] = 12345;
+        killers[1][0] = 67890;
+        history[2][3] = 17;
+        counter[4][5] = 222;
+
+        Method snapshotMethod = heuristicsClass.getDeclaredMethod("snapshot", int.class);
+        snapshotMethod.setAccessible(true);
+        Object snapshot1 = snapshotMethod.invoke(heuristics, 4);
+
+        Class<?> snapshotClass = Class.forName("julius.game.chessengine.ai.AI$Heuristics$Snapshot");
+        Field killersField = snapshotClass.getDeclaredField("killers");
+        Field historyField = snapshotClass.getDeclaredField("history");
+        Field counterField = snapshotClass.getDeclaredField("counter");
+        killersField.setAccessible(true);
+        historyField.setAccessible(true);
+        counterField.setAccessible(true);
+
+        int[][] snapshotKillers1 = (int[][]) killersField.get(snapshot1);
+        int[][] snapshotHistory1 = (int[][]) historyField.get(snapshot1);
+        int[][] snapshotCounter1 = (int[][]) counterField.get(snapshot1);
+
+        assertEquals(12345, snapshotKillers1[0][0]);
+        assertEquals(67890, snapshotKillers1[1][0]);
+        assertEquals(17, snapshotHistory1[2][3]);
+        assertEquals(222, snapshotCounter1[4][5]);
+
+        Method closeMethod = snapshotClass.getDeclaredMethod("close");
+        closeMethod.setAccessible(true);
+        closeMethod.invoke(snapshot1);
+
+        killers[0][0] = 9999;
+        killers[1][0] = 1111;
+        history[2][3] = 88;
+        counter[4][5] = 333;
+
+        Object snapshot2 = snapshotMethod.invoke(heuristics, 4);
+        assertSame(snapshot1, snapshot2, "Snapshot instances should be reused after closing");
+
+        int[][] snapshotKillers2 = (int[][]) killersField.get(snapshot2);
+        int[][] snapshotHistory2 = (int[][]) historyField.get(snapshot2);
+        int[][] snapshotCounter2 = (int[][]) counterField.get(snapshot2);
+
+        assertEquals(9999, snapshotKillers2[0][0]);
+        assertEquals(1111, snapshotKillers2[1][0]);
+        assertEquals(88, snapshotHistory2[2][3]);
+        assertEquals(333, snapshotCounter2[4][5]);
+
+        closeMethod.invoke(snapshot2);
+    }
+}


### PR DESCRIPTION
## Summary
- reuse thread-local heuristic snapshot buffers in `AI` to avoid repeated array allocations and close snapshots via try-with-resources
- copy killer, history, and counter heuristics into reusable buffers instead of allocating new arrays for each snapshot capture
- add a reflection-based unit test that verifies snapshots are reused and refreshed between captures

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=HeuristicsSnapshotPoolingTest test

------
https://chatgpt.com/codex/tasks/task_e_68ee847ecf28832a8a36603fb6cf5f42