### PR TITLE
Refactor heuristics snapshot pooling for reduced allocations

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -172,6 +172,8 @@ public class AI {
      * merged back afterwards.
      */
     private final ThreadLocal<Heuristics> threadHeuristics;
+    private final ThreadLocal<Heuristics.SnapshotPool> heuristicsSnapshotPool =
+            ThreadLocal.withInitial(Heuristics.SnapshotPool::new);
 
     private final StampedLock heuristicsLock = new StampedLock();
     private final LockMetrics heuristicsLockMetrics = new LockMetrics();
@@ -390,21 +392,33 @@ public class AI {
     }
 
     private Heuristics.Snapshot captureHeuristicsSnapshot(int requiredDepth) {
-        long stamp = heuristicsLock.tryOptimisticRead();
-        if (stamp != 0L) {
-            Heuristics.Snapshot optimistic = globalHeuristics.snapshot(requiredDepth);
-            if (heuristicsLock.validate(stamp)) {
-                heuristicsLockMetrics.recordOptimisticSnapshot();
-                return optimistic;
-            }
-        }
-
-        long readStamp = acquireReadLock();
+        Heuristics.SnapshotPool pool = heuristicsSnapshotPool.get();
+        Heuristics.Snapshot snapshot = pool.borrow();
+        boolean success = false;
         try {
-            heuristicsLockMetrics.recordOptimisticFallback();
-            return globalHeuristics.snapshot(requiredDepth);
+            long stamp = heuristicsLock.tryOptimisticRead();
+            if (stamp != 0L) {
+                globalHeuristics.populateSnapshot(snapshot, requiredDepth);
+                if (heuristicsLock.validate(stamp)) {
+                    heuristicsLockMetrics.recordOptimisticSnapshot();
+                    success = true;
+                    return snapshot;
+                }
+            }
+
+            long readStamp = acquireReadLock();
+            try {
+                heuristicsLockMetrics.recordOptimisticFallback();
+                globalHeuristics.populateSnapshot(snapshot, requiredDepth);
+                success = true;
+                return snapshot;
+            } finally {
+                releaseReadLock(readStamp);
+            }
         } finally {
-            releaseReadLock(readStamp);
+            if (!success) {
+                snapshot.close();
+            }
         }
     }
 
@@ -865,8 +879,9 @@ public class AI {
                 releaseWriteLock(stamp);
             }
         }
-        Heuristics.Snapshot snapshot = captureHeuristicsSnapshot(maxDepth);
-        heuristics.beginIteration(snapshot, maxDepth);
+        try (Heuristics.Snapshot snapshot = captureHeuristicsSnapshot(maxDepth)) {
+            heuristics.beginIteration(snapshot, maxDepth);
+        }
         heuristics.markPrepared(task.getId(), currentDepth);
     }
 
@@ -889,8 +904,9 @@ public class AI {
             } finally {
                 releaseWriteLock(stamp);
             }
-            Heuristics.Snapshot snapshot = captureHeuristicsSnapshot(maxDepth);
-            heuristics.beginIteration(snapshot, maxDepth);
+            try (Heuristics.Snapshot snapshot = captureHeuristicsSnapshot(maxDepth)) {
+                heuristics.beginIteration(snapshot, maxDepth);
+            }
             heuristics.markPrepared(task.getId(), depth);
         }
         return heuristics;
@@ -3629,7 +3645,7 @@ public class AI {
         void beginIteration(Snapshot snapshot, int requiredDepth) {
             resetUpdates();
             ensureCapacity(requiredDepth);
-            int limit = Math.min(requiredDepth, snapshot.killers.length);
+            int limit = Math.min(requiredDepth, snapshot.killerDepth());
             for (int d = 0; d < limit; d++) {
                 System.arraycopy(snapshot.killers[d], 0, killers[d], 0, NUM_KILLER_MOVES);
             }
@@ -3642,22 +3658,84 @@ public class AI {
             }
         }
 
-        Snapshot snapshot(int requiredDepth) {
-            int killerDepth = Math.min(requiredDepth, killers.length);
-            int[][] killerCopy = new int[killerDepth][];
-            for (int d = 0; d < killerDepth; d++) {
-                killerCopy[d] = Arrays.copyOf(killers[d], NUM_KILLER_MOVES);
+        void populateSnapshot(Snapshot snapshot, int requiredDepth) {
+            int limit = Math.min(requiredDepth, killers.length);
+            snapshot.ensureKillerCapacity(limit);
+            snapshot.killerDepth = limit;
+            for (int d = 0; d < limit; d++) {
+                System.arraycopy(killers[d], 0, snapshot.killers[d], 0, NUM_KILLER_MOVES);
             }
-            int[][] historyCopy = new int[BOARD_SQUARES][];
-            int[][] counterCopy = new int[BOARD_SQUARES][];
             for (int f = 0; f < BOARD_SQUARES; f++) {
-                historyCopy[f] = Arrays.copyOf(history[f], BOARD_SQUARES);
-                counterCopy[f] = Arrays.copyOf(counter[f], BOARD_SQUARES);
+                System.arraycopy(history[f], 0, snapshot.history[f], 0, BOARD_SQUARES);
+                System.arraycopy(counter[f], 0, snapshot.counter[f], 0, BOARD_SQUARES);
             }
-            return new Snapshot(killerCopy, historyCopy, counterCopy);
         }
 
-        record Snapshot(int[][] killers, int[][] history, int[][] counter) {
+        static final class SnapshotPool {
+            private final ArrayDeque<Snapshot> cache = new ArrayDeque<>();
+
+            Snapshot borrow() {
+                Snapshot snapshot = cache.pollFirst();
+                if (snapshot == null) {
+                    snapshot = new Snapshot(this);
+                }
+                snapshot.markBorrowed();
+                return snapshot;
+            }
+
+            void release(Snapshot snapshot) {
+                snapshot.reset();
+                cache.addFirst(snapshot);
+            }
+        }
+
+        static final class Snapshot implements AutoCloseable {
+            private final SnapshotPool owner;
+            private int[][] killers = new int[0][];
+            private final int[][] history = new int[BOARD_SQUARES][BOARD_SQUARES];
+            private final int[][] counter = new int[BOARD_SQUARES][BOARD_SQUARES];
+            private int killerDepth;
+            private boolean inUse;
+
+            private Snapshot(SnapshotPool owner) {
+                this.owner = owner;
+            }
+
+            void markBorrowed() {
+                if (inUse) {
+                    throw new IllegalStateException("Snapshot already in use");
+                }
+                inUse = true;
+            }
+
+            void ensureKillerCapacity(int depth) {
+                if (killers.length >= depth) {
+                    return;
+                }
+                int[][] expanded = Arrays.copyOf(killers, depth);
+                for (int i = killers.length; i < depth; i++) {
+                    expanded[i] = new int[NUM_KILLER_MOVES];
+                    Arrays.fill(expanded[i], -1);
+                }
+                killers = expanded;
+            }
+
+            void reset() {
+                killerDepth = 0;
+                inUse = false;
+            }
+
+            int killerDepth() {
+                return killerDepth;
+            }
+
+            @Override
+            public void close() {
+                if (!inUse) {
+                    return;
+                }
+                owner.release(this);
+            }
         }
 
         boolean isPreparedFor(long taskId, int depth) {

--- a/src/test/java/julius/game/chessengine/ai/HeuristicsSnapshotPoolTest.java
+++ b/src/test/java/julius/game/chessengine/ai/HeuristicsSnapshotPoolTest.java
@@ -1,0 +1,66 @@
+package julius.game.chessengine.ai;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class HeuristicsSnapshotPoolTest {
+
+    @Test
+    void snapshotReuseAvoidsReallocatingBuffers() throws Exception {
+        Class<?> heuristicsClass = Class.forName("julius.game.chessengine.ai.AI$Heuristics");
+        Constructor<?> heuristicsCtor = heuristicsClass.getDeclaredConstructor(int.class);
+        heuristicsCtor.setAccessible(true);
+        Object heuristics = heuristicsCtor.newInstance(8);
+
+        Class<?> poolClass = Class.forName("julius.game.chessengine.ai.AI$Heuristics$SnapshotPool");
+        Constructor<?> poolCtor = poolClass.getDeclaredConstructor();
+        poolCtor.setAccessible(true);
+        Object pool = poolCtor.newInstance();
+
+        Class<?> snapshotClass = Class.forName("julius.game.chessengine.ai.AI$Heuristics$Snapshot");
+
+        Method borrowMethod = poolClass.getDeclaredMethod("borrow");
+        borrowMethod.setAccessible(true);
+
+        Method populateMethod = heuristicsClass.getDeclaredMethod("populateSnapshot", snapshotClass, int.class);
+        populateMethod.setAccessible(true);
+
+        Method closeMethod = snapshotClass.getDeclaredMethod("close");
+        closeMethod.setAccessible(true);
+
+        Object snapshot1 = borrowMethod.invoke(pool);
+        populateMethod.invoke(heuristics, snapshot1, 8);
+
+        Field killersField = snapshotClass.getDeclaredField("killers");
+        killersField.setAccessible(true);
+        Field historyField = snapshotClass.getDeclaredField("history");
+        historyField.setAccessible(true);
+        Field counterField = snapshotClass.getDeclaredField("counter");
+        counterField.setAccessible(true);
+
+        int[][] killersRef1 = (int[][]) killersField.get(snapshot1);
+        int[][] historyRef1 = (int[][]) historyField.get(snapshot1);
+        int[][] counterRef1 = (int[][]) counterField.get(snapshot1);
+
+        closeMethod.invoke(snapshot1);
+
+        Object snapshot2 = borrowMethod.invoke(pool);
+        populateMethod.invoke(heuristics, snapshot2, 8);
+
+        int[][] killersRef2 = (int[][]) killersField.get(snapshot2);
+        int[][] historyRef2 = (int[][]) historyField.get(snapshot2);
+        int[][] counterRef2 = (int[][]) counterField.get(snapshot2);
+
+        assertSame(killersRef1, killersRef2, "Killers matrix should be reused");
+        assertSame(historyRef1, historyRef2, "History matrix should be reused");
+        assertSame(counterRef1, counterRef2, "Counter matrix should be reused");
+
+        closeMethod.invoke(snapshot2);
+    }
+}
+


### PR DESCRIPTION
## Summary
- reuse heuristics snapshots via a thread-local pool so captures no longer allocate fresh killer/history/counter matrices on every iteration
- update the snapshot lifecycle to populate existing buffers with System.arraycopy and return them with try-with-resources when iteration prep completes
- add a regression test that exercises the snapshot pool via reflection and verifies the killer/history/counter tables are reused across borrows

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" test *(fails on existing AI regressions and long-running BestMoveSearchTest; aborted after confirming new test execution)*

------
https://chatgpt.com/codex/tasks/task_e_68ee847ecf28832a8a36603fb6cf5f42