### PR TITLE
Fix Syzygy DTZ decoding for 50-move edge cases

### DIFF
--- a/src/main/java/julius/game/chessengine/syzygy/Tables.java
+++ b/src/main/java/julius/game/chessengine/syzygy/Tables.java
@@ -81,18 +81,28 @@ final class Tables {
                 board.getHalfmoveClock(), epSquare, whiteToMove);
         OptionalInt dtz = OptionalInt.empty();
         Optional<SyzygyMove> recommendedMove = Optional.empty();
-        if (SyzygyConstants.winDrawLoss(dtzRaw) == wdlValue) {
+        if (dtzRaw != SyzygyConstants.TB_RESULT_FAILED) {
+            SyzygyWdl dtzWdl = toWdl(SyzygyConstants.winDrawLoss(dtzRaw));
+            if (dtzWdl != SyzygyWdl.UNKNOWN && dtzWdl != wdl) {
+                log.debug("Syzygy DTZ probe adjusted WDL from {} to {} (wdlValue={}, dtzRaw={})", wdl, dtzWdl, wdlValue, dtzRaw);
+                wdl = dtzWdl;
+            }
+
             int distance = SyzygyConstants.distanceToZero(dtzRaw);
             dtz = OptionalInt.of(distance);
             recommendedMove = decodeRecommendedMove(dtzRaw);
         } else {
-            log.debug("Syzygy DTZ probe mismatch (wdlValue={}, dtzRaw={})", wdlValue, dtzRaw);
+            log.debug("Syzygy DTZ probe failed (dtzRaw=TB_RESULT_FAILED) for board {}", board);
         }
 
         return Optional.of(new SyzygyProbeResult(wdl, dtz, OptionalInt.empty(), recommendedMove));
     }
 
     private Optional<SyzygyMove> decodeRecommendedMove(int dtzRaw) {
+        if (dtzRaw == SyzygyConstants.TB_RESULT_FAILED) {
+            return Optional.empty();
+        }
+
         int fromSquare = SyzygyConstants.fromSquare(dtzRaw);
         int toSquare = SyzygyConstants.toSquare(dtzRaw);
         if (fromSquare <= 0 || toSquare <= 0) {

--- a/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyConstants.java
+++ b/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyConstants.java
@@ -39,6 +39,7 @@ public final class SyzygyConstants {
     /*
      * Masks and Shifts that allow us to store more information in the DTZ result
      */
+    public static final int TB_RESULT_FAILED = 0xFFFFFFFF;
     public static final int TB_RESULT_WDL_MASK = 0x0000000F;
     public static final int TB_RESULT_TO_MASK = 0x000003F0;
     public static final int TB_RESULT_FROM_MASK = 0x0000FC00;
@@ -87,7 +88,11 @@ public final class SyzygyConstants {
      * @return the number of moves needed to reach the optimal transition (where the 50 move rule would be reset).
      */
     public static int distanceToZero(int result) {
-        return (result & SyzygyConstants.TB_RESULT_DTZ_MASK) >> SyzygyConstants.TB_RESULT_DTZ_SHIFT;
+        int encoded = (result & SyzygyConstants.TB_RESULT_DTZ_MASK) >>> SyzygyConstants.TB_RESULT_DTZ_SHIFT;
+        if ((encoded & 0x800) != 0) {
+            return encoded - 0x1000;
+        }
+        return encoded;
     }
 
     /**

--- a/src/test/java/julius/game/chessengine/syzygy/SyzygyConstantsTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/SyzygyConstantsTest.java
@@ -1,0 +1,34 @@
+package julius.game.chessengine.syzygy;
+
+import julius.game.chessengine.syzygy.bridge.SyzygyConstants;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SyzygyConstantsTest {
+
+    @Test
+    void distanceToZeroDecodesPositiveValues() {
+        int encoded = encodeDtz(5) | SyzygyConstants.TB_WIN;
+        assertThat(SyzygyConstants.distanceToZero(encoded)).isEqualTo(5);
+    }
+
+    @Test
+    void distanceToZeroSignExtendsNegativeValues() {
+        int encoded = encodeDtz(-1) | SyzygyConstants.TB_WIN;
+        assertThat(SyzygyConstants.distanceToZero(encoded)).isEqualTo(-1);
+
+        int deeper = encodeDtz(-33) | SyzygyConstants.TB_CURSED_WIN;
+        assertThat(SyzygyConstants.distanceToZero(deeper)).isEqualTo(-33);
+    }
+
+    @Test
+    void winDrawLossMatchesEncodedValue() {
+        int encoded = encodeDtz(0) | SyzygyConstants.TB_CURSED_WIN;
+        assertThat(SyzygyConstants.winDrawLoss(encoded)).isEqualTo(SyzygyConstants.TB_CURSED_WIN);
+    }
+
+    private static int encodeDtz(int dtz) {
+        return (dtz & 0xFFF) << SyzygyConstants.TB_RESULT_DTZ_SHIFT;
+    }
+}


### PR DESCRIPTION
## Summary
- sign-extend Syzygy DTZ distances and expose the native failure sentinel
- trust DTZ probe WDL results, logging adjustments and ignoring failed move hints
- cover the decoding helpers with a focused SyzygyConstantsTest regression suite

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=SyzygyConstantsTest test


------
https://chatgpt.com/codex/tasks/task_e_68eebef6a150832aae1189cb36f54ef4