### PR TITLE
Handle fifty-move sensitive Syzygy outcomes

### DIFF
--- a/src/main/java/julius/game/chessengine/syzygy/Tables.java
+++ b/src/main/java/julius/game/chessengine/syzygy/Tables.java
@@ -81,12 +81,31 @@ final class Tables {
                 board.getHalfmoveClock(), epSquare, whiteToMove);
         OptionalInt dtz = OptionalInt.empty();
         Optional<SyzygyMove> recommendedMove = Optional.empty();
-        if (SyzygyConstants.winDrawLoss(dtzRaw) == wdlValue) {
-            int distance = SyzygyConstants.distanceToZero(dtzRaw);
-            dtz = OptionalInt.of(distance);
-            recommendedMove = decodeRecommendedMove(dtzRaw);
+        if (dtzRaw != SyzygyConstants.TB_RESULT_FAILED) {
+            int dtzWdlValue = SyzygyConstants.winDrawLoss(dtzRaw);
+            SyzygyWdl dtzWdl = toWdl(dtzWdlValue);
+            if (dtzWdl == SyzygyWdl.UNKNOWN) {
+                log.debug("Syzygy DTZ probe returned unknown WDL slice (dtzRaw={})", dtzRaw);
+            } else {
+                if (wdl != dtzWdl) {
+                    if (wdl == SyzygyWdl.WIN && dtzWdl == SyzygyWdl.DRAW) {
+                        wdl = SyzygyWdl.CURSED_WIN;
+                    } else if (wdl == SyzygyWdl.LOSS && dtzWdl == SyzygyWdl.DRAW) {
+                        wdl = SyzygyWdl.BLESSED_LOSS;
+                    } else if ((wdl == SyzygyWdl.CURSED_WIN || wdl == SyzygyWdl.BLESSED_LOSS)
+                            && dtzWdl == SyzygyWdl.DRAW) {
+                        // Keep the existing 50-move aware classification.
+                    } else {
+                        log.debug("Syzygy DTZ probe mismatch (wdlValue={}, dtzRaw={})", wdlValue, dtzRaw);
+                        wdl = dtzWdl;
+                    }
+                }
+                int distance = SyzygyConstants.distanceToZero(dtzRaw);
+                dtz = OptionalInt.of(distance);
+                recommendedMove = decodeRecommendedMove(dtzRaw);
+            }
         } else {
-            log.debug("Syzygy DTZ probe mismatch (wdlValue={}, dtzRaw={})", wdlValue, dtzRaw);
+            log.debug("Syzygy DTZ probe failed for board {}", board);
         }
 
         return Optional.of(new SyzygyProbeResult(wdl, dtz, OptionalInt.empty(), recommendedMove));

--- a/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyConstants.java
+++ b/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyConstants.java
@@ -50,6 +50,8 @@ public final class SyzygyConstants {
     public static final int TB_RESULT_PROMOTES_SHIFT = 16;
     public static final int TB_RESULT_DTZ_SHIFT = 20;
 
+    public static final int TB_RESULT_FAILED = 0xFFFFFFFF;
+
     /**
      * return the 'from square' part of the move.
      *
@@ -87,7 +89,13 @@ public final class SyzygyConstants {
      * @return the number of moves needed to reach the optimal transition (where the 50 move rule would be reset).
      */
     public static int distanceToZero(int result) {
-        return (result & SyzygyConstants.TB_RESULT_DTZ_MASK) >> SyzygyConstants.TB_RESULT_DTZ_SHIFT;
+        int raw = (result & SyzygyConstants.TB_RESULT_DTZ_MASK) >>> SyzygyConstants.TB_RESULT_DTZ_SHIFT;
+        // DTZ is stored as a signed 12-bit value. Sign-extend to 32 bits so
+        // callers observe negative distances when the tablebase encodes them.
+        if ((raw & 0x800) != 0) {
+            raw -= 0x1000;
+        }
+        return raw;
     }
 
     /**
@@ -97,6 +105,9 @@ public final class SyzygyConstants {
      * @return 1 .. 5 for loss, blessed loss, draw, cursed win and win.
      */
     public static int winDrawLoss(int result) {
+        if (result == TB_RESULT_FAILED) {
+            return TB_RESULT_FAILED;
+        }
         return (result & SyzygyConstants.TB_RESULT_WDL_MASK) >> SyzygyConstants.TB_RESULT_WDL_SHIFT;
     }
 }

--- a/src/test/java/julius/game/chessengine/syzygy/SyzygyConstantsTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/SyzygyConstantsTest.java
@@ -1,0 +1,29 @@
+package julius.game.chessengine.syzygy;
+
+import julius.game.chessengine.syzygy.bridge.SyzygyConstants;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SyzygyConstantsTest {
+
+    @Test
+    void winDrawLossExtractsEncodedValue() {
+        int encodedWin = SyzygyConstants.TB_WIN << SyzygyConstants.TB_RESULT_WDL_SHIFT;
+        int encodedCursed = SyzygyConstants.TB_CURSED_WIN << SyzygyConstants.TB_RESULT_WDL_SHIFT;
+
+        assertThat(SyzygyConstants.winDrawLoss(encodedWin)).isEqualTo(SyzygyConstants.TB_WIN);
+        assertThat(SyzygyConstants.winDrawLoss(encodedCursed)).isEqualTo(SyzygyConstants.TB_CURSED_WIN);
+        assertThat(SyzygyConstants.winDrawLoss(SyzygyConstants.TB_RESULT_FAILED))
+                .isEqualTo(SyzygyConstants.TB_RESULT_FAILED);
+    }
+
+    @Test
+    void distanceToZeroSignExtends() {
+        int positive = 7 << SyzygyConstants.TB_RESULT_DTZ_SHIFT;
+        int negative = 0xFFB << SyzygyConstants.TB_RESULT_DTZ_SHIFT; // -5 encoded in 12-bit two's complement
+
+        assertThat(SyzygyConstants.distanceToZero(positive)).isEqualTo(7);
+        assertThat(SyzygyConstants.distanceToZero(negative)).isEqualTo(-5);
+    }
+}


### PR DESCRIPTION
## Summary
- classify Syzygy DTZ results that disagree with WDL probes as cursed or blessed outcomes so fifty-move edge cases stay accurate
- expose the native failure code and sign-extend DTZ values when decoding tablebase responses
- add a focused unit test that locks down the helper logic for extracting WDL and DTZ slices

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=SyzygyConstantsTest test

------
https://chatgpt.com/codex/tasks/task_e_68eebef6a150832aae1189cb36f54ef4