### PR TITLE
Improve tablebase scoring for cursed wins and blessed losses

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -945,7 +945,8 @@ public class AI {
         Long2DoubleOpenHashMap cache = staticEvalCache.get();
         Optional<TablebaseResult> tablebase = gameState.getLastTablebaseResult();
         if (tablebase.isPresent() && isExactWdl(tablebase.get())) {
-            double exact = Score.tablebaseToEvaluation(tablebase.get(), whiteToMove);
+            double exact = Score.tablebaseToEvaluation(tablebase.get(), whiteToMove,
+                    gameState.getHalfmoveClock());
             cache.put(boardHash, exact);
             return exact;
         }
@@ -1927,7 +1928,8 @@ public class AI {
         }
 
         // Stable evaluation: use pure WDL sign (no DTZ/DTM scaling noise)
-        double eval = Score.tablebaseToEvaluation(result, engine.whitesTurn());
+        double eval = Score.tablebaseToEvaluation(result, engine.whitesTurn(),
+                engine.getGameState().getHalfmoveClock());
 
         // Determine best move via TB guidance (if available)
         int bestMove = determineTablebaseBestMove(engine, result, isWhite);
@@ -2038,7 +2040,8 @@ public class AI {
         if (childResult == null || !isExactWdl(childResult)) {
             return Double.NaN;
         }
-        double whitePerspective = Score.tablebaseToEvaluation(childResult, simulatorEngine.whitesTurn());
+        double whitePerspective = Score.tablebaseToEvaluation(childResult, simulatorEngine.whitesTurn(),
+                simulatorEngine.getGameState().getHalfmoveClock());
         return parentIsWhite ? whitePerspective : -whitePerspective;
     }
 
@@ -3205,7 +3208,8 @@ public class AI {
         boolean whiteToMove = context != null && context.isWhiteToMove();
         Optional<TablebaseResult> tablebase = gameState.getLastTablebaseResult();
         if (tablebase.isPresent() && isExactWdl(tablebase.get())) {
-            double whitePerspective = Score.tablebaseToEvaluation(tablebase.get(), whiteToMove);
+            double whitePerspective = Score.tablebaseToEvaluation(tablebase.get(), whiteToMove,
+                    gameState.getHalfmoveClock());
             return isWhitesTurn ? whitePerspective : -whitePerspective;
         }
         if (gameState.isDrawForUIOrEval()) { // <-- include insufficient material for eval/UI

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -6,6 +6,7 @@ import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.evaluation.*;
 import julius.game.chessengine.syzygy.SyzygyProbeResult;
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
+import julius.game.chessengine.syzygy.SyzygyWdl;
 import julius.game.chessengine.syzygy.TablebaseResult;
 import julius.game.chessengine.tuning.EngineTuningBootstrap;
 import julius.game.chessengine.tuning.MoveOrderingParameters;
@@ -35,6 +36,12 @@ public class Score {
     public static final int CHECKMATE = 100000;
     public static final int CHECK = 50;
     public static final int DRAW = 0;
+
+    private static final int UNSPECIFIED_HALFMOVE_CLOCK = -1;
+    private static final int FIFTY_MOVE_LIMIT = 100; // measured in plies
+    private static final int FIFTY_SENSITIVE_MIN_CP = 75;
+    private static final int FIFTY_SENSITIVE_MAX_CP = CHECKMATE / 8;
+    private static final int FIFTY_SENSITIVE_UNKNOWN_CP = 200;
 
     @JsonIgnore
     private final EvaluationWeights weights;
@@ -343,7 +350,8 @@ public class Score {
         }
         TablebaseResult resolved = TablebaseResult.from(probe.get());
         this.tablebaseResult = resolved;
-        this.tablebaseCentipawn = computeTablebaseCentipawn(resolved, bitBoard.isWhitesTurn());
+        this.tablebaseCentipawn = computeTablebaseCentipawn(resolved, bitBoard.isWhitesTurn(),
+                context.getHalfmoveClock());
         this.tablebaseBypassesEvaluation = true;
         return true;
     }
@@ -355,25 +363,88 @@ public class Score {
     }
 
     public static int tablebaseToCentipawn(TablebaseResult result, boolean whiteToMove) {
-        if (result == null) return DRAW;
+        return tablebaseToCentipawn(result, whiteToMove, UNSPECIFIED_HALFMOVE_CLOCK);
+    }
 
-        int wdl = result.wdl().score();
-        if (wdl == 0) {
-            return DRAW; // theoretical draw
+    public static int tablebaseToCentipawn(TablebaseResult result, boolean whiteToMove, int halfmoveClock) {
+        if (result == null) {
+            return DRAW;
         }
 
-        // Determine side perspective
-        int sign = whiteToMove ? Integer.signum(wdl) : -Integer.signum(wdl);
+        SyzygyWdl wdl = result.wdl();
+        int wdlScore = wdl.score();
+        if (wdlScore == 0 || wdlScore == Integer.MIN_VALUE) {
+            return DRAW;
+        }
 
-        // We treat every WDL win/loss as a "mate-like" evaluation to keep stability.
-        // DTZ/DTM is only for ordering, not for score magnitude.
-        return sign * (CHECKMATE - 1);
+        int magnitude;
+        if (wdl == SyzygyWdl.CURSED_WIN || wdl == SyzygyWdl.BLESSED_LOSS) {
+            magnitude = evaluateFiftyMoveSensitiveMagnitude(result, halfmoveClock);
+            if (magnitude == DRAW) {
+                return DRAW;
+            }
+        } else if (wdl == SyzygyWdl.WIN || wdl == SyzygyWdl.LOSS) {
+            magnitude = CHECKMATE - 1;
+        } else {
+            magnitude = CHECKMATE - 1;
+        }
+
+        int sign = whiteToMove ? Integer.signum(wdlScore) : -Integer.signum(wdlScore);
+        return sign * magnitude;
     }
+
     public static double tablebaseToEvaluation(TablebaseResult result, boolean whiteToMove) {
-        return tablebaseToCentipawn(result, whiteToMove) / 100.0;
+        return tablebaseToEvaluation(result, whiteToMove, UNSPECIFIED_HALFMOVE_CLOCK);
     }
 
-    private int computeTablebaseCentipawn(TablebaseResult result, boolean whiteToMove) {
-        return tablebaseToCentipawn(result, whiteToMove);
+    public static double tablebaseToEvaluation(TablebaseResult result, boolean whiteToMove, int halfmoveClock) {
+        return tablebaseToCentipawn(result, whiteToMove, halfmoveClock) / 100.0;
+    }
+
+    private int computeTablebaseCentipawn(TablebaseResult result, boolean whiteToMove, int halfmoveClock) {
+        return tablebaseToCentipawn(result, whiteToMove, halfmoveClock);
+    }
+
+    private static int evaluateFiftyMoveSensitiveMagnitude(TablebaseResult result, int halfmoveClock) {
+        int budget = remainingFiftyMoveBudget(halfmoveClock);
+        if (budget <= 0) {
+            return DRAW;
+        }
+
+        OptionalInt dtzOpt = result.dtz();
+        if (dtzOpt.isEmpty()) {
+            return FIFTY_SENSITIVE_UNKNOWN_CP;
+        }
+
+        int dtz = dtzOpt.getAsInt();
+        if (dtz <= 0) {
+            return FIFTY_SENSITIVE_MAX_CP;
+        }
+
+        if (dtz >= budget) {
+            return FIFTY_SENSITIVE_MIN_CP;
+        }
+
+        int slack = Math.max(0, budget - dtz);
+        double slackRatio = budget == 0 ? 0.0 : (double) slack / budget;
+
+        double dtmFactor = 0.0;
+        OptionalInt dtmOpt = result.dtm();
+        if (dtmOpt.isPresent()) {
+            int dtm = Math.max(1, dtmOpt.getAsInt());
+            dtmFactor = Math.min(1.0, 6.0 / dtm);
+        }
+
+        double blend = Math.max(slackRatio, dtmFactor);
+        int span = FIFTY_SENSITIVE_MAX_CP - FIFTY_SENSITIVE_MIN_CP;
+        int scaled = FIFTY_SENSITIVE_MIN_CP + (int) Math.round(span * blend);
+        return Math.max(FIFTY_SENSITIVE_MIN_CP, Math.min(FIFTY_SENSITIVE_MAX_CP, scaled));
+    }
+
+    private static int remainingFiftyMoveBudget(int halfmoveClock) {
+        if (halfmoveClock < 0) {
+            return FIFTY_MOVE_LIMIT;
+        }
+        return Math.max(0, FIFTY_MOVE_LIMIT - halfmoveClock);
     }
 }

--- a/src/test/java/julius/game/chessengine/tablebase/ScoreTablebaseIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/ScoreTablebaseIntegrationTest.java
@@ -74,6 +74,37 @@ class ScoreTablebaseIntegrationTest {
     }
 
     @Test
+    void cursedWinEvaluationShrinksAsFiftyMoveClockExpires() {
+        TablebaseResult earlyReset = new TablebaseResult(
+                SyzygyWdl.CURSED_WIN, OptionalInt.of(4), OptionalInt.empty(), Optional.empty());
+        TablebaseResult desperate = new TablebaseResult(
+                SyzygyWdl.CURSED_WIN, OptionalInt.of(60), OptionalInt.empty(), Optional.empty());
+
+        int generousClockScore = Score.tablebaseToCentipawn(earlyReset, true, 10);
+        int expiringClockScore = Score.tablebaseToCentipawn(desperate, true, 90);
+        int claimedDrawScore = Score.tablebaseToCentipawn(desperate, true, 100);
+
+        assertThat(generousClockScore).isPositive();
+        assertThat(expiringClockScore).isPositive();
+        assertThat(generousClockScore).isGreaterThan(expiringClockScore);
+        assertThat(claimedDrawScore).isZero();
+    }
+
+    @Test
+    void blessedLossMirrorsCursedWinMagnitude() {
+        TablebaseResult cursed = new TablebaseResult(
+                SyzygyWdl.CURSED_WIN, OptionalInt.of(8), OptionalInt.of(40), Optional.empty());
+        TablebaseResult blessed = new TablebaseResult(
+                SyzygyWdl.BLESSED_LOSS, OptionalInt.of(8), OptionalInt.of(40), Optional.empty());
+
+        int whitePerspective = Score.tablebaseToCentipawn(cursed, true, 0);
+        int mirrored = Score.tablebaseToCentipawn(blessed, true, 0);
+
+        assertThat(whitePerspective).isGreaterThan(0);
+        assertThat(mirrored).isEqualTo(-whitePerspective);
+    }
+
+    @Test
     void scoreProbesWhenBoardWithinServiceLimit() {
         String fen = "6k1/8/8/8/8/8/PPP5/6K1 w - - 0 1";
         BitBoard board = FEN.translateFENtoBitBoard(fen);


### PR DESCRIPTION
## Summary
- add fifty-move-aware scaling for cursed wins and blessed losses in the tablebase evaluation logic
- propagate halfmove clock information through AI tablebase evaluation calls so alpha-beta sees the refined scores
- extend the tablebase score integration tests to cover cursed/blessed heuristics

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=ScoreTablebaseIntegrationTest test

------
https://chatgpt.com/codex/tasks/task_e_68eec7eff014832a8e7cbb5d5098f2d5