### PR TITLE
Fix tablebase evaluation orientation in AI tablebase hit handling

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1927,9 +1927,11 @@ public class AI {
             return Optional.empty();
         }
 
-        // Stable evaluation: use pure WDL sign (no DTZ/DTM scaling noise)
-        double eval = Score.tablebaseToEvaluation(result, engine.whitesTurn(),
+        // Stable evaluation: compute from White's perspective first and convert to the
+        // side-to-move orientation expected by the caller.
+        double whitePerspective = Score.tablebaseToEvaluation(result, engine.whitesTurn(),
                 engine.getGameState().getHalfmoveClock());
+        double eval = isWhite ? whitePerspective : -whitePerspective;
 
         // Determine best move via TB guidance (if available)
         int bestMove = determineTablebaseBestMove(engine, result, isWhite);

--- a/src/test/java/julius/game/chessengine/tablebase/AiTablebaseIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/AiTablebaseIntegrationTest.java
@@ -5,6 +5,7 @@ import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.syzygy.SyzygyProbeResult;
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
+import julius.game.chessengine.syzygy.TestSyzygySupport;
 import julius.game.chessengine.syzygy.SyzygyWdl;
 import julius.game.chessengine.syzygy.TablebaseResult;
 import julius.game.chessengine.utils.Score;
@@ -15,6 +16,7 @@ import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -48,6 +50,35 @@ class AiTablebaseIntegrationTest {
             assertThat(evaluation).isEqualTo(expectedEval);
 
             verify(service, atLeastOnce()).probe(any(BitBoard.class));
+        }
+    }
+
+    @Test
+    void blackWinningTablebasePositionUsesSideToMovePerspective() {
+        TablebaseTestSupport.assumeSyzygyConfigured();
+
+        SyzygyTablebaseService service = TestSyzygySupport.maybeCreateServiceFromConfiguration()
+                .orElseThrow(() -> new IllegalStateException("Syzygy service not configured"));
+
+        try (TablebaseTestSupport.TablebaseServiceRestorer restorer = TablebaseTestSupport.overrideScoreTablebase(service)) {
+            Engine engine = new Engine();
+            engine.importBoardFromFen("6k1/8/8/8/8/8/5r2/6K1 b - - 0 1");
+            engine.getGameState().refreshScore(engine.getBitBoard());
+
+            AI ai = new AI(engine, service);
+
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            double evaluation = ai.evaluateBoard(engine, false, deadline);
+
+            TablebaseResult tablebaseResult = engine.getGameState().getLastTablebaseResult()
+                    .orElseThrow(() -> new AssertionError("Expected tablebase result"));
+
+            double whitePerspective = Score.tablebaseToEvaluation(tablebaseResult, engine.whitesTurn(),
+                    engine.getGameState().getHalfmoveClock());
+
+            assertThat(whitePerspective).isLessThan(0.0);
+            assertThat(evaluation).isGreaterThan(0.0);
+            assertThat(evaluation).isCloseTo(-whitePerspective, within(1e-6));
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure tablebase hit evaluations are converted from the white-perspective score to the side-to-move orientation
- add a regression test that probes a black-to-move Syzygy win and verifies the evaluation sign for both perspectives

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" test *(fails: `UciSyzygyFlowTest` expects a configured Syzygy tablebase path in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ef71cc5928832a8d4a805f1a384206