### PR TITLE
Include halfmove clock in static eval cache keys

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -941,21 +941,28 @@ public class AI {
         staticEvalCache.get().clear();
     }
 
+    private long makeStaticEvalKey(long boardHash, int halfmoveClock) {
+        long clock = Integer.toUnsignedLong(halfmoveClock) & 0xFFFFL;
+        long salt = (clock << 48) ^ (clock << 32) ^ (clock << 16) ^ clock;
+        return boardHash ^ Long.rotateLeft(salt, 17);
+    }
+
     private double resolveScoreDifference(GameState gameState, long boardHash, boolean whiteToMove) {
         Long2DoubleOpenHashMap cache = staticEvalCache.get();
+        int halfmoveClock = gameState.getHalfmoveClock();
+        long cacheKey = makeStaticEvalKey(boardHash, halfmoveClock);
         Optional<TablebaseResult> tablebase = gameState.getLastTablebaseResult();
         if (tablebase.isPresent() && isExactWdl(tablebase.get())) {
-            double exact = Score.tablebaseToEvaluation(tablebase.get(), whiteToMove,
-                    gameState.getHalfmoveClock());
-            cache.put(boardHash, exact);
+            double exact = Score.tablebaseToEvaluation(tablebase.get(), whiteToMove, halfmoveClock);
+            cache.put(cacheKey, exact);
             return exact;
         }
-        double cached = cache.get(boardHash);
+        double cached = cache.get(cacheKey);
         if (!Double.isNaN(cached)) {
             return cached;
         }
         double computed = gameState.getScore().getScoreDifference();
-        cache.put(boardHash, computed);
+        cache.put(cacheKey, computed);
         return computed;
     }
 

--- a/src/test/java/julius/game/chessengine/ai/AIStaticEvalCacheTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AIStaticEvalCacheTest.java
@@ -1,0 +1,58 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.engine.GameState;
+import julius.game.chessengine.syzygy.SyzygyWdl;
+import julius.game.chessengine.syzygy.TablebaseResult;
+import julius.game.chessengine.utils.Score;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AIStaticEvalCacheTest {
+
+    @Test
+    void staticEvalCacheKeysIncludeHalfmoveClockForTablebaseResults() throws Exception {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("8/8/8/8/8/8/8/K6k w - - 0 1");
+
+        AI ai = new AI(engine);
+        Method resolve = AI.class.getDeclaredMethod("resolveScoreDifference", GameState.class, long.class, boolean.class);
+        resolve.setAccessible(true);
+
+        GameState state = engine.getGameState();
+        long boardHash = engine.getBoardStateHash();
+        boolean whiteToMove = engine.whitesTurn();
+
+        TablebaseResult win = new TablebaseResult(SyzygyWdl.WIN, OptionalInt.of(1), OptionalInt.of(1), Optional.empty());
+        state.setHalfmoveClock(0);
+        state.setLastTablebaseResult(win);
+        double expectedWin = Score.tablebaseToEvaluation(win, whiteToMove, 0);
+        double cachedWin = (double) resolve.invoke(ai, state, boardHash, whiteToMove);
+        assertThat(cachedWin).isEqualTo(expectedWin);
+
+        TablebaseResult loss = new TablebaseResult(SyzygyWdl.LOSS, OptionalInt.of(1), OptionalInt.of(1), Optional.empty());
+        state.setHalfmoveClock(99);
+        state.setLastTablebaseResult(loss);
+        double expectedLoss = Score.tablebaseToEvaluation(loss, whiteToMove, 99);
+        double cachedLoss = (double) resolve.invoke(ai, state, boardHash, whiteToMove);
+        assertThat(cachedLoss).isEqualTo(expectedLoss);
+
+        state.setLastTablebaseResult(null);
+
+        state.setHalfmoveClock(0);
+        double replayedWin = (double) resolve.invoke(ai, state, boardHash, whiteToMove);
+        assertThat(replayedWin).isEqualTo(expectedWin);
+
+        state.setHalfmoveClock(99);
+        double replayedLoss = (double) resolve.invoke(ai, state, boardHash, whiteToMove);
+        assertThat(replayedLoss).isEqualTo(expectedLoss);
+
+        ai.shutdown();
+    }
+}
+


### PR DESCRIPTION
## Summary
- mix the game state's halfmove clock into static evaluation cache keys and reuse the helper in the tablebase fast path
- add a helper to centralise cache key construction for future call sites
- cover the regression with a unit test that exercises the cache across two halfmove-clock values for the same FEN

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AIStaticEvalCacheTest test

------
https://chatgpt.com/codex/tasks/task_e_68ef72d19398832aa63886e751bfef40