### PR TITLE
Fix inclusive DTZ budget handling for Syzygy cursed wins

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -421,7 +421,10 @@ public class Score {
             return FIFTY_SENSITIVE_MAX_CP;
         }
 
-        if (dtz >= budget) {
+        // DTZ values equal to the remaining budget are still convertible because the side to move
+        // can reset the half-move clock on the final permissible ply. Treat only strictly larger
+        // distances as failures so cursed wins that require a last-gasp capture stay attractive.
+        if (dtz > budget) {
             return FIFTY_SENSITIVE_MIN_CP;
         }
 

--- a/src/test/java/julius/game/chessengine/tablebase/ScoreTablebaseIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/ScoreTablebaseIntegrationTest.java
@@ -91,6 +91,23 @@ class ScoreTablebaseIntegrationTest {
     }
 
     @Test
+    void cursedWinEvaluationTreatsExactBudgetAsConvertible() {
+        TablebaseResult mustMoveNow = new TablebaseResult(
+                SyzygyWdl.CURSED_WIN, OptionalInt.of(1), OptionalInt.of(1), Optional.empty());
+        TablebaseResult outOfTime = new TablebaseResult(
+                SyzygyWdl.CURSED_WIN, OptionalInt.of(2), OptionalInt.of(1), Optional.empty());
+
+        int halfmoveClock = 99; // budget = 1 ply remaining; inclusive per fifty-move rule.
+
+        int inclusiveBudgetScore = Score.tablebaseToCentipawn(mustMoveNow, true, halfmoveClock);
+        int exhaustedBudgetScore = Score.tablebaseToCentipawn(outOfTime, true, halfmoveClock);
+
+        assertThat(inclusiveBudgetScore).isGreaterThan(Score.DRAW);
+        assertThat(exhaustedBudgetScore).isPositive();
+        assertThat(inclusiveBudgetScore).isGreaterThan(exhaustedBudgetScore);
+    }
+
+    @Test
     void blessedLossMirrorsCursedWinMagnitude() {
         TablebaseResult cursed = new TablebaseResult(
                 SyzygyWdl.CURSED_WIN, OptionalInt.of(8), OptionalInt.of(40), Optional.empty());


### PR DESCRIPTION
## Summary
- treat equal DTZ values as still convertible in `Score.evaluateFiftyMoveSensitiveMagnitude` and document the inclusive budget
- add a regression around the fifty-move boundary to ensure cursed wins stay positive until the budget is exceeded

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=ScoreTablebaseIntegrationTest test

------
https://chatgpt.com/codex/tasks/task_e_68ef72f1f850832ab6c8dd4b14b73030