### PR TITLE
Guard Syzygy tie-break preference when tablebase data is missing

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -3432,15 +3432,10 @@ public class AI {
             if (candidateSign > 0 && candidateInfo.hasDtz()) {
                 return true;
             }
-            if (candidateSign < 0 && candidateInfo.hasDtz()) {
-                return true;
-            }
             if (candidateSign > 0 && candidateZeroing != bestZeroing) {
                 return candidateZeroing;
             }
-            if (candidateSign < 0 && candidateZeroing != bestZeroing) {
-                return !candidateZeroing;
-            }
+            return false;
         }
 
         if (candidateInfo == null) {

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -172,5 +172,5 @@ population:
       search.ttCaptureWeight: 4.0
       search.qsMaxDeltaPawn: 8.8
       search.drawBias: 0.3
-      search.preferFastMate: 0.0
-      search.tbTieBreak: 0.0
+      search.preferFastMate: 1.0
+      search.tbTieBreak: 1.0

--- a/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
@@ -2,7 +2,9 @@ package julius.game.chessengine.ai;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.tuning.EngineTuningBootstrap;
 import julius.game.chessengine.syzygy.SyzygyProbeResult;
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
 import julius.game.chessengine.syzygy.SyzygyWdl;
@@ -11,6 +13,7 @@ import julius.game.chessengine.syzygy.TestSyzygyTablebaseService;
 import julius.game.chessengine.utils.Score;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
@@ -77,11 +80,12 @@ class AISyzygyIntegrationTest {
             AI ai = new AI(engine, service);
             Engine simulation = engine.createSimulation();
 
-            Method determine = AI.class.getDeclaredMethod("determineTablebaseBestMove", Engine.class, TablebaseResult.class);
+            Method determine = AI.class.getDeclaredMethod("determineTablebaseBestMove", Engine.class, TablebaseResult.class,
+                    boolean.class);
             determine.setAccessible(true);
 
             TablebaseResult parentResult = TablebaseResult.from(responses.get(fen));
-            int bestMove = (int) determine.invoke(ai, simulation, parentResult);
+            int bestMove = (int) determine.invoke(ai, simulation, parentResult, simulation.whitesTurn());
 
             Set<String> winningChildren = responses.entrySet().stream()
                     .filter(entry -> !entry.getKey().equals(fen))
@@ -100,6 +104,72 @@ class AISyzygyIntegrationTest {
             assertThat(winningChildren)
                     .describedAs("tablebase best move should correspond to a child scored as a forced win")
                     .contains(bestChildFen);
+
+            ai.shutdown();
+        }
+    }
+
+    @Test
+    void tablebaseTieBreakKeepsUnprobedIncumbentWhenCandidateLoses() throws Exception {
+        Engine engine = new Engine();
+        String fen = "6k1/8/8/8/8/8/5Q2/6K1 w - - 0 1";
+        engine.importBoardFromFen(fen);
+
+        IntArrayList legalMoves = engine.getAllLegalMoves();
+        assertThat(legalMoves.size()).isGreaterThan(1);
+
+        int incumbentMove = legalMoves.getInt(0);
+        int losingMove = legalMoves.getInt(1);
+
+        Map<String, SyzygyProbeResult> responses = new HashMap<>();
+        engine.performMove(losingMove);
+        String losingFen = FEN.translateBoardToFEN(engine.getBitBoard(), engine.getGameState()).getRenderBoard();
+        engine.undoLastMove();
+        responses.put(losingFen, new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(7), OptionalInt.empty(), Optional.empty()));
+
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(responses);
+
+        try (AutoCloseable restorer = overrideScoreTablebase(service)) {
+            AI ai = new AI(engine, service);
+            Engine simulation = engine.createSimulation();
+
+            Method prefer = AI.class.getDeclaredMethod("preferCandidateByTablebase", Engine.class, int.class, double.class,
+                    boolean.class, int.class, boolean.class);
+            prefer.setAccessible(true);
+
+            double incumbentEval = -0.25;
+            double losingEval = -0.25;
+            boolean losingZeroing = MoveHelper.isCapture(losingMove)
+                    || MoveHelper.derivePieceTypeBits(losingMove) == 1;
+            boolean incumbentZeroing = MoveHelper.isCapture(incumbentMove)
+                    || MoveHelper.derivePieceTypeBits(incumbentMove) == 1;
+
+            boolean preferLosing = (boolean) prefer.invoke(ai, simulation, losingMove, losingEval, losingZeroing,
+                    incumbentMove, incumbentZeroing);
+
+            assertThat(preferLosing).isFalse();
+
+            ai.shutdown();
+        }
+    }
+
+    @Test
+    void defaultTuningEnablesFastMateAndTablebaseTieBreak() throws Exception {
+        EngineTuningBootstrap.reloadDefaults();
+
+        Engine engine = new Engine();
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(Map.of());
+
+        try (AutoCloseable restorer = overrideScoreTablebase(service)) {
+            AI ai = new AI(engine, service);
+
+            Field preferFastMateField = AI.class.getDeclaredField("preferFastMate");
+            preferFastMateField.setAccessible(true);
+            Field tbTieBreakField = AI.class.getDeclaredField("tbTieBreak");
+            tbTieBreakField.setAccessible(true);
+
+            assertThat(preferFastMateField.getBoolean(ai)).isTrue();
+            assertThat(tbTieBreakField.getBoolean(ai)).isTrue();
 
             ai.shutdown();
         }


### PR DESCRIPTION
## Summary
- prevent tablebase tie-breaks from preferring losing candidates when the incumbent move lacks a probe result
- enable the default tuning flags for fast mates and tablebase tie-breaks in the seed configuration
- extend the Syzygy integration tests to cover the new tie-break behaviour and verify the tuning flags are loaded

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AISyzygyIntegrationTest test

------
https://chatgpt.com/codex/tasks/task_e_68efce6522f4832a8a3e5936781aa3c8