### PR TITLE
Align tablebase evaluations with white perspective

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1927,11 +1927,10 @@ public class AI {
             return Optional.empty();
         }
 
-        // Stable evaluation: compute from White's perspective first and convert to the
-        // side-to-move orientation expected by the caller.
-        double whitePerspective = Score.tablebaseToEvaluation(result, engine.whitesTurn(),
+        // Stable evaluation: compute from White's perspective so the result aligns with
+        // the engine-wide score convention.
+        double eval = Score.tablebaseToEvaluation(result, engine.whitesTurn(),
                 engine.getGameState().getHalfmoveClock());
-        double eval = isWhite ? whitePerspective : -whitePerspective;
 
         // Determine best move via TB guidance (if available)
         int bestMove = determineTablebaseBestMove(engine, result, isWhite);
@@ -1957,21 +1956,21 @@ public class AI {
             }
         }
 
-        double bestScore = Double.NEGATIVE_INFINITY;
+        double bestScore = parentIsWhite ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
         int bestMove = -1;
         for (int i = 0; i < legal.size(); i++) {
             int move = legal.getInt(i);
             simulatorEngine.performMove(move);
             double candidate;
             try {
-                candidate = evaluateTablebaseChild(simulatorEngine, parentIsWhite);
+                candidate = evaluateTablebaseChild(simulatorEngine);
             } finally {
                 simulatorEngine.undoLastMove();
             }
             if (Double.isNaN(candidate)) {
                 continue;
             }
-            if (candidate > bestScore) {
+            if (bestMove == -1 || isBetterScore(parentIsWhite, candidate, bestScore)) {
                 bestScore = candidate;
                 bestMove = move;
             }
@@ -2029,7 +2028,7 @@ public class AI {
         moves.set(index, first);
     }
 
-    private double evaluateTablebaseChild(Engine simulatorEngine, boolean parentIsWhite) {
+    private double evaluateTablebaseChild(Engine simulatorEngine) {
         TablebaseResult childResult = simulatorEngine.getGameState().getLastTablebaseResult().orElse(null);
         if (tablebaseService != null) {
             BitBoard snapshot = new BitBoard(simulatorEngine.getBitBoard());
@@ -2042,9 +2041,8 @@ public class AI {
         if (childResult == null || !isExactWdl(childResult)) {
             return Double.NaN;
         }
-        double whitePerspective = Score.tablebaseToEvaluation(childResult, simulatorEngine.whitesTurn(),
+        return Score.tablebaseToEvaluation(childResult, simulatorEngine.whitesTurn(),
                 simulatorEngine.getGameState().getHalfmoveClock());
-        return parentIsWhite ? whitePerspective : -whitePerspective;
     }
 
     private boolean isExactWdl(TablebaseResult result) {

--- a/src/test/java/julius/game/chessengine/tablebase/AiTablebaseWinningMoveSelectionTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/AiTablebaseWinningMoveSelectionTest.java
@@ -83,5 +83,68 @@ class AiTablebaseWinningMoveSelectionTest {
             assertThat(best.getScore()).isGreaterThan(0);
         }
     }
+
+    @Test
+    void tablebaseWinningMovePreferredForBlackWithNegativeScore() {
+        SyzygyTablebaseService service = mock(SyzygyTablebaseService.class);
+        when(service.getEffectiveMaxPieces()).thenReturn(6);
+
+        long d4Mask = 1L << MoveHelper.convertStringToIndex("d4");
+        long d5Mask = 1L << MoveHelper.convertStringToIndex("d5");
+        long h6Mask = 1L << MoveHelper.convertStringToIndex("h6");
+        long h7Mask = 1L << MoveHelper.convertStringToIndex("h7");
+
+        SyzygyProbeResult parentWin = new SyzygyProbeResult(
+                SyzygyWdl.WIN,
+                OptionalInt.of(1),
+                OptionalInt.empty(),
+                Optional.empty());
+        SyzygyProbeResult winningChild = new SyzygyProbeResult(
+                SyzygyWdl.LOSS,
+                OptionalInt.of(1),
+                OptionalInt.empty(),
+                Optional.empty());
+        SyzygyProbeResult drawingChild = new SyzygyProbeResult(
+                SyzygyWdl.DRAW,
+                OptionalInt.empty(),
+                OptionalInt.empty(),
+                Optional.empty());
+
+        when(service.probe(any(BitBoard.class))).thenAnswer(invocation -> {
+            BitBoard board = invocation.getArgument(0);
+            long blackPawns = board.getBlackPawns();
+            long blackKing = board.getBlackKing();
+            if ((blackPawns & d5Mask) != 0 && (blackKing & h7Mask) != 0 && !board.isWhitesTurn()) {
+                return Optional.of(parentWin);
+            }
+            if ((blackPawns & d4Mask) != 0 && (blackKing & h7Mask) != 0 && board.isWhitesTurn()) {
+                return Optional.of(winningChild);
+            }
+            if ((blackKing & h6Mask) != 0) {
+                return Optional.of(drawingChild);
+            }
+            return Optional.of(drawingChild);
+        });
+
+        try (TablebaseTestSupport.TablebaseServiceRestorer ignored = TablebaseTestSupport.overrideScoreTablebase(service)) {
+            Engine engine = new Engine();
+            engine.importBoardFromFen("8/7k/8/3p4/2K5/8/B7/8 b - - 0 1");
+            engine.getGameState().refreshScore(engine.getBitBoard());
+
+            AI ai = new AI(engine, service);
+            ai.setMaxDepth(1);
+
+            MoveAndScore best = ai.searchBestMoveBlocking(TimeUnit.MILLISECONDS.toMillis(50));
+
+            assertThat(best).as("tablebase best move should be available").isNotNull();
+
+            int moveInt = best.getMove();
+            String from = MoveHelper.convertIndexToString(MoveHelper.deriveFromIndex(moveInt));
+            String to = MoveHelper.convertIndexToString(MoveHelper.deriveToIndex(moveInt));
+
+            assertThat(from + to).isEqualTo("d5d4");
+            assertThat(best.getScore()).isLessThan(0);
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
- return white-perspective scores from tablebase probes and reuse the side-aware comparator when ranking moves
- simplify tablebase child evaluation to the engine-wide convention and update the helper selection logic
- add a regression test that covers a black-to-move win and verifies the negative evaluation is preserved

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AiTablebaseWinningMoveSelectionTest test

------
https://chatgpt.com/codex/tasks/task_e_68efd9f1f9d8832a9f47da66aa8e6acb