### PR TITLE
Ensure tablebase hits retain white-oriented evaluation

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1927,11 +1927,12 @@ public class AI {
             return Optional.empty();
         }
 
-        // Stable evaluation: compute from White's perspective first and convert to the
-        // side-to-move orientation expected by the caller.
+        // Stable evaluation: compute from White's perspective. The rest of the search
+        // already treats tablebase scores as white-oriented values, regardless of the
+        // side to move at the current node.
         double whitePerspective = Score.tablebaseToEvaluation(result, engine.whitesTurn(),
                 engine.getGameState().getHalfmoveClock());
-        double eval = isWhite ? whitePerspective : -whitePerspective;
+        double eval = whitePerspective;
 
         // Determine best move via TB guidance (if available)
         int bestMove = determineTablebaseBestMove(engine, result, isWhite);

--- a/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
@@ -55,6 +55,38 @@ class AISyzygyIntegrationTest {
     }
 
     @Test
+    void resolveTablebaseHitReturnsWhitePerspectiveWhenBlackToMoveLoses() throws Exception {
+        Engine engine = new Engine();
+        String fen = "6k1/8/8/8/8/8/5Q2/6K1 b - - 0 1";
+        engine.importBoardFromFen(fen);
+
+        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.LOSS, OptionalInt.of(5), OptionalInt.empty(), Optional.empty());
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(Map.of(fen, probe));
+
+        try (AutoCloseable restorer = overrideScoreTablebase(service)) {
+            AI ai = new AI(engine, service);
+            Engine simulation = engine.createSimulation();
+
+            Method resolve = AI.class.getDeclaredMethod("resolveTablebaseHit", Engine.class, boolean.class);
+            resolve.setAccessible(true);
+
+            @SuppressWarnings("unchecked")
+            Optional<Object> hitOpt = (Optional<Object>) resolve.invoke(ai, simulation, false);
+
+            assertThat(hitOpt).isPresent();
+
+            Object hit = hitOpt.get();
+            double score = (double) hit.getClass().getMethod("score").invoke(hit);
+
+            assertThat(score)
+                    .describedAs("tablebase scores should remain white-oriented even when black to move")
+                    .isPositive();
+
+            ai.shutdown();
+        }
+    }
+
+    @Test
     void determineTablebaseBestMovePicksWinningChild() throws Exception {
         Engine engine = new Engine();
         String fen = "6k1/8/8/8/8/8/5Q2/6K1 w - - 0 1";


### PR DESCRIPTION
## Summary
- keep tablebase evaluations in resolveTablebaseHit aligned with the white perspective expected by the search
- add a regression test that forces a losing result for the side to move and verifies the returned score stays positive for white

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AISyzygyIntegrationTest test

------
https://chatgpt.com/codex/tasks/task_e_68efe13fee54832a84f06e5ee5bf61e0