### PR TITLE
Keep tablebase child evaluation white oriented

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1927,11 +1927,11 @@ public class AI {
             return Optional.empty();
         }
 
-        // Stable evaluation: compute from White's perspective first and convert to the
-        // side-to-move orientation expected by the caller.
+        // Stable evaluation: compute from White's perspective and keep the white-oriented
+        // value so all callers reason about tablebase scores consistently.
         double whitePerspective = Score.tablebaseToEvaluation(result, engine.whitesTurn(),
                 engine.getGameState().getHalfmoveClock());
-        double eval = isWhite ? whitePerspective : -whitePerspective;
+        double eval = whitePerspective;
 
         // Determine best move via TB guidance (if available)
         int bestMove = determineTablebaseBestMove(engine, result, isWhite);
@@ -1957,7 +1957,7 @@ public class AI {
             }
         }
 
-        double bestScore = Double.NEGATIVE_INFINITY;
+        double bestScore = parentIsWhite ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
         int bestMove = -1;
         for (int i = 0; i < legal.size(); i++) {
             int move = legal.getInt(i);
@@ -1971,7 +1971,8 @@ public class AI {
             if (Double.isNaN(candidate)) {
                 continue;
             }
-            if (candidate > bestScore) {
+            boolean better = parentIsWhite ? candidate > bestScore : candidate < bestScore;
+            if (better) {
                 bestScore = candidate;
                 bestMove = move;
             }
@@ -2044,7 +2045,7 @@ public class AI {
         }
         double whitePerspective = Score.tablebaseToEvaluation(childResult, simulatorEngine.whitesTurn(),
                 simulatorEngine.getGameState().getHalfmoveClock());
-        return parentIsWhite ? whitePerspective : -whitePerspective;
+        return whitePerspective;
     }
 
     private boolean isExactWdl(TablebaseResult result) {

--- a/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
@@ -110,6 +110,90 @@ class AISyzygyIntegrationTest {
     }
 
     @Test
+    void resolveTablebaseHitReturnsWhitePerspectiveForBlackCaller() throws Exception {
+        Engine engine = new Engine();
+        String fen = "6k1/8/8/8/8/8/5Q2/6K1 b - - 0 1";
+        engine.importBoardFromFen(fen);
+
+        SyzygyProbeResult probe = new SyzygyProbeResult(SyzygyWdl.LOSS, OptionalInt.of(3), OptionalInt.empty(), Optional.empty());
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(Map.of(fen, probe));
+
+        try (AutoCloseable restorer = overrideScoreTablebase(service)) {
+            AI ai = new AI(engine, service);
+            Engine simulation = engine.createSimulation();
+
+            Method resolver = AI.class.getDeclaredMethod("resolveTablebaseHit", Engine.class, boolean.class);
+            resolver.setAccessible(true);
+
+            Object raw = resolver.invoke(ai, simulation, false);
+            assertThat(raw).isInstanceOf(Optional.class);
+
+            Optional<?> hitOptional = (Optional<?>) raw;
+            assertThat(hitOptional).isPresent();
+
+            Object hit = hitOptional.orElseThrow();
+            Method scoreAccessor = hit.getClass().getDeclaredMethod("score");
+            scoreAccessor.setAccessible(true);
+            double score = (double) scoreAccessor.invoke(hit);
+
+            double expected = Score.tablebaseToEvaluation(TablebaseResult.from(probe), simulation.whitesTurn(),
+                    simulation.getGameState().getHalfmoveClock());
+
+            assertThat(simulation.whitesTurn()).isFalse();
+            assertThat(score).isEqualTo(expected);
+            assertThat(score).isPositive();
+
+            ai.shutdown();
+        }
+    }
+
+    @Test
+    void evaluateTablebaseChildReturnsWhitePerspectiveForBlackParent() throws Exception {
+        Engine engine = new Engine();
+        String fen = "6k1/8/8/8/8/8/5Q2/6K1 b - - 0 1";
+        engine.importBoardFromFen(fen);
+
+        IntArrayList legalMoves = engine.getAllLegalMoves();
+        assertThat(legalMoves.size()).isGreaterThan(0);
+
+        int targetMove = legalMoves.getInt(0);
+        engine.performMove(targetMove);
+        String childFen = FEN.translateBoardToFEN(engine.getBitBoard(), engine.getGameState()).getRenderBoard();
+        engine.undoLastMove();
+
+        Map<String, SyzygyProbeResult> responses = new HashMap<>();
+        responses.put(fen, new SyzygyProbeResult(SyzygyWdl.LOSS, OptionalInt.of(5), OptionalInt.empty(), Optional.empty()));
+        SyzygyProbeResult childProbe = new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(7), OptionalInt.empty(), Optional.empty());
+        responses.put(childFen, childProbe);
+
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(responses);
+
+        try (AutoCloseable restorer = overrideScoreTablebase(service)) {
+            AI ai = new AI(engine, service);
+            Engine simulation = engine.createSimulation();
+
+            simulation.performMove(targetMove);
+
+            try {
+                Method evaluator = AI.class.getDeclaredMethod("evaluateTablebaseChild", Engine.class, boolean.class);
+                evaluator.setAccessible(true);
+
+                double eval = (double) evaluator.invoke(ai, simulation, false);
+
+                TablebaseResult expectedResult = TablebaseResult.from(childProbe);
+                double expected = Score.tablebaseToEvaluation(expectedResult, simulation.whitesTurn(),
+                        simulation.getGameState().getHalfmoveClock());
+
+                assertThat(simulation.whitesTurn()).isTrue();
+                assertThat(eval).isEqualTo(expected);
+            } finally {
+                simulation.undoLastMove();
+                ai.shutdown();
+            }
+        }
+    }
+
+    @Test
     void tablebaseTieBreakKeepsUnprobedIncumbentWhenCandidateLoses() throws Exception {
         Engine engine = new Engine();
         String fen = "6k1/8/8/8/8/8/5Q2/6K1 w - - 0 1";


### PR DESCRIPTION
## Summary
- ensure tablebase child evaluations remain white-oriented while choosing the best move
- add a regression test confirming evaluateTablebaseChild reports white perspective for black callers

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AISyzygyIntegrationTest test

------
https://chatgpt.com/codex/tasks/task_e_68efe13fee54832a84f06e5ee5bf61e0