### PR TITLE
Fix Syzygy en passant encoding

### DIFF
--- a/src/main/java/julius/game/chessengine/syzygy/Tables.java
+++ b/src/main/java/julius/game/chessengine/syzygy/Tables.java
@@ -66,8 +66,7 @@ final class Tables {
         long bishops = board.getWhiteBishops() | board.getBlackBishops();
         long knights = board.getWhiteKnights() | board.getBlackKnights();
         long pawns = board.getWhitePawns() | board.getBlackPawns();
-        int epIndex = board.getEnPassantTargetIndex();
-        int epSquare = epIndex >= 0 ? epIndex + 1 : 0;
+        int epSquare = encodeEnPassantSquare(board.getEnPassantTargetIndex());
         boolean whiteToMove = board.isWhitesTurn();
 
         int wdlValue = SyzygyBridge.probeSyzygyWDL(white, black, kings, queens, rooks, bishops, knights, pawns, epSquare, whiteToMove);
@@ -109,6 +108,17 @@ final class Tables {
         }
 
         return Optional.of(new SyzygyProbeResult(wdl, dtz, OptionalInt.empty(), recommendedMove));
+    }
+
+    static int encodeEnPassantSquare(int epIndex) {
+        if (epIndex < 0) {
+            return 0;
+        }
+        if (epIndex >= 64) {
+            log.warn("Ignoring invalid en passant index {} beyond board bounds", epIndex);
+            return 0;
+        }
+        return epIndex;
     }
 
     private Optional<SyzygyMove> decodeRecommendedMove(int dtzRaw) {

--- a/src/test/java/julius/game/chessengine/syzygy/TablesTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/TablesTest.java
@@ -1,0 +1,21 @@
+package julius.game.chessengine.syzygy;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TablesTest {
+
+    @Test
+    void encodeEnPassantSquareUsesZeroSentinel() {
+        assertThat(Tables.encodeEnPassantSquare(-1)).isZero();
+        assertThat(Tables.encodeEnPassantSquare(0)).isZero();
+        assertThat(Tables.encodeEnPassantSquare(44)).isEqualTo(44);
+    }
+
+    @Test
+    void encodeEnPassantSquareClampsValuesBeyondBoard() {
+        assertThat(Tables.encodeEnPassantSquare(64)).isZero();
+        assertThat(Tables.encodeEnPassantSquare(Integer.MAX_VALUE)).isZero();
+    }
+}


### PR DESCRIPTION
## Summary
- stop offsetting the en passant square when forwarding positions to the Syzygy bridge
- add a helper that clamps invalid indices and cover it with unit tests

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=TablesTest test

------
https://chatgpt.com/codex/tasks/task_e_68efec2e1a84832ab3e62982c36f77d8