### PR TITLE
Fix Syzygy bridge indexing and add regression tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Spock on Groovy 4 works with Java 21 -->
         <dependency>
             <groupId>org.spockframework</groupId>

--- a/src/main/java/julius/game/chessengine/syzygy/Tables.java
+++ b/src/main/java/julius/game/chessengine/syzygy/Tables.java
@@ -67,7 +67,7 @@ final class Tables {
         long knights = board.getWhiteKnights() | board.getBlackKnights();
         long pawns = board.getWhitePawns() | board.getBlackPawns();
         int epIndex = board.getEnPassantTargetIndex();
-        int epSquare = epIndex >= 0 ? epIndex + 1 : 0;
+        int epSquare = epIndex >= 0 ? epIndex : 0;
         boolean whiteToMove = board.isWhitesTurn();
 
         int wdlValue = SyzygyBridge.probeSyzygyWDL(white, black, kings, queens, rooks, bishops, knights, pawns, epSquare, whiteToMove);
@@ -114,7 +114,7 @@ final class Tables {
     private Optional<SyzygyMove> decodeRecommendedMove(int dtzRaw) {
         int fromSquare = SyzygyConstants.fromSquare(dtzRaw);
         int toSquare = SyzygyConstants.toSquare(dtzRaw);
-        if (fromSquare <= 0 || toSquare <= 0) {
+        if (fromSquare < 0 || toSquare < 0) {
             return Optional.empty();
         }
 
@@ -127,7 +127,7 @@ final class Tables {
         };
 
         try {
-            return Optional.of(new SyzygyMove(fromSquare - 1, toSquare - 1, promotionBits));
+            return Optional.of(new SyzygyMove(fromSquare, toSquare, promotionBits));
         } catch (IllegalArgumentException ex) {
             log.debug("Ignoring invalid Syzygy move suggestion (dtzRaw={}, from={}, to={}, promo={})",
                     dtzRaw, fromSquare, toSquare, promotionBits, ex);

--- a/src/test/java/julius/game/chessengine/syzygy/TablesTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/TablesTest.java
@@ -1,0 +1,96 @@
+package julius.game.chessengine.syzygy;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.FEN;
+import julius.game.chessengine.syzygy.bridge.SyzygyBridge;
+import julius.game.chessengine.syzygy.bridge.SyzygyConstants;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TablesTest {
+
+    @Test
+    void shouldPassZeroBasedEnPassantSquareToBridge() throws Exception {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/3pP3/8/8/8/4K3 w - d6 0 1");
+        Tables tables = instantiateTables();
+
+        long expectedWhite = board.getWhitePieces();
+        long expectedBlack = board.getBlackPieces();
+        long expectedKings = board.getWhiteKing() | board.getBlackKing();
+        long expectedQueens = board.getWhiteQueens() | board.getBlackQueens();
+        long expectedRooks = board.getWhiteRooks() | board.getBlackRooks();
+        long expectedBishops = board.getWhiteBishops() | board.getBlackBishops();
+        long expectedKnights = board.getWhiteKnights() | board.getBlackKnights();
+        long expectedPawns = board.getWhitePawns() | board.getBlackPawns();
+        int expectedEp = board.getEnPassantTargetIndex();
+
+        try (MockedStatic<SyzygyBridge> bridge = Mockito.mockStatic(SyzygyBridge.class)) {
+            bridge.when(() -> SyzygyBridge.probeSyzygyWDL(expectedWhite, expectedBlack, expectedKings, expectedQueens,
+                    expectedRooks, expectedBishops, expectedKnights, expectedPawns, expectedEp, board.isWhitesTurn()))
+                    .thenReturn(SyzygyConstants.TB_WIN);
+            bridge.when(() -> SyzygyBridge.probeSyzygyDTZ(expectedWhite, expectedBlack, expectedKings, expectedQueens,
+                    expectedRooks, expectedBishops, expectedKnights, expectedPawns, board.getHalfmoveClock(), expectedEp,
+                    board.isWhitesTurn())).thenReturn(SyzygyConstants.TB_RESULT_FAILED);
+
+            Optional<SyzygyProbeResult> result = tables.probe(board);
+            assertThat(result).isPresent();
+
+            bridge.verify(() -> SyzygyBridge.probeSyzygyWDL(expectedWhite, expectedBlack, expectedKings, expectedQueens,
+                    expectedRooks, expectedBishops, expectedKnights, expectedPawns, expectedEp, board.isWhitesTurn()));
+        }
+    }
+
+    @Test
+    void shouldDecodeRecommendedMoveUsingZeroBasedIndices() throws Exception {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/3pP3/8/8/8/4K3 w - - 0 1");
+        Tables tables = instantiateTables();
+
+        long white = board.getWhitePieces();
+        long black = board.getBlackPieces();
+        long kings = board.getWhiteKing() | board.getBlackKing();
+        long queens = board.getWhiteQueens() | board.getBlackQueens();
+        long rooks = board.getWhiteRooks() | board.getBlackRooks();
+        long bishops = board.getWhiteBishops() | board.getBlackBishops();
+        long knights = board.getWhiteKnights() | board.getBlackKnights();
+        long pawns = board.getWhitePawns() | board.getBlackPawns();
+        int halfmoveClock = board.getHalfmoveClock();
+        boolean whiteToMove = board.isWhitesTurn();
+
+        int from = 9; // c2
+        int to = 17;  // b3
+        int dtzValue = 7;
+        int dtzRaw = (SyzygyConstants.TB_WIN << SyzygyConstants.TB_RESULT_WDL_SHIFT)
+                | (to << SyzygyConstants.TB_RESULT_TO_SHIFT)
+                | (from << SyzygyConstants.TB_RESULT_FROM_SHIFT)
+                | (dtzValue << SyzygyConstants.TB_RESULT_DTZ_SHIFT);
+
+        try (MockedStatic<SyzygyBridge> bridge = Mockito.mockStatic(SyzygyBridge.class)) {
+            bridge.when(() -> SyzygyBridge.probeSyzygyWDL(white, black, kings, queens, rooks, bishops, knights, pawns, 0,
+                    whiteToMove)).thenReturn(SyzygyConstants.TB_WIN);
+            bridge.when(() -> SyzygyBridge.probeSyzygyDTZ(white, black, kings, queens, rooks, bishops, knights, pawns,
+                    halfmoveClock, 0, whiteToMove)).thenReturn(dtzRaw);
+
+            Optional<SyzygyProbeResult> result = tables.probe(board);
+            assertThat(result).isPresent();
+            SyzygyProbeResult probeResult = result.get();
+            assertThat(probeResult.dtz()).hasValue(dtzValue);
+            assertThat(probeResult.recommendedMove()).isPresent();
+            SyzygyMove move = probeResult.recommendedMove().orElseThrow();
+            assertThat(move.fromIndex()).isEqualTo(from);
+            assertThat(move.toIndex()).isEqualTo(to);
+            assertThat(move.promotionPieceTypeBits()).isEqualTo(0);
+        }
+    }
+
+    private static Tables instantiateTables() throws Exception {
+        Constructor<Tables> constructor = Tables.class.getDeclaredConstructor(String.class, int.class, int.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance("paths", 6, 6);
+    }
+}


### PR DESCRIPTION
## Summary
- stop offsetting Syzygy en-passant squares so the bridge receives the expected 0-based index
- keep decoded DTZ moves in their native 0-based coordinates when exposing `SyzygyMove`
- add Mockito-inline and new unit tests that verify bridge arguments and move decoding

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=TablesTest test

------
https://chatgpt.com/codex/tasks/task_e_68efec2e1a84832ab3e62982c36f77d8