### PR TITLE
Fix Syzygy recommended move decoding

### DIFF
--- a/src/main/java/julius/game/chessengine/syzygy/Tables.java
+++ b/src/main/java/julius/game/chessengine/syzygy/Tables.java
@@ -112,9 +112,17 @@ final class Tables {
     }
 
     private Optional<SyzygyMove> decodeRecommendedMove(int dtzRaw) {
-        int fromSquare = SyzygyConstants.fromSquare(dtzRaw);
-        int toSquare = SyzygyConstants.toSquare(dtzRaw);
-        if (fromSquare < 0 || toSquare < 0) {
+        int rawFrom = SyzygyConstants.fromSquare(dtzRaw);
+        int rawTo = SyzygyConstants.toSquare(dtzRaw);
+        if (rawFrom <= 0 || rawTo <= 0) {
+            return Optional.empty();
+        }
+
+        int fromSquare = rawFrom - 1;
+        int toSquare = rawTo - 1;
+        if (fromSquare < 0 || fromSquare >= 64 || toSquare < 0 || toSquare >= 64) {
+            log.debug("Ignoring Syzygy move suggestion with out-of-bounds squares (dtzRaw={}, fromRaw={}, toRaw={})",
+                    dtzRaw, rawFrom, rawTo);
             return Optional.empty();
         }
 

--- a/src/test/java/julius/game/chessengine/syzygy/TablesTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/TablesTest.java
@@ -47,7 +47,7 @@ class TablesTest {
     }
 
     @Test
-    void shouldDecodeRecommendedMoveUsingZeroBasedIndices() throws Exception {
+    void shouldDecodeRecommendedMoveByNormalisingOneBasedSquares() throws Exception {
         BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/3pP3/8/8/8/4K3 w - - 0 1");
         Tables tables = instantiateTables();
 
@@ -66,8 +66,8 @@ class TablesTest {
         int to = 17;  // b3
         int dtzValue = 7;
         int dtzRaw = (SyzygyConstants.TB_WIN << SyzygyConstants.TB_RESULT_WDL_SHIFT)
-                | (to << SyzygyConstants.TB_RESULT_TO_SHIFT)
-                | (from << SyzygyConstants.TB_RESULT_FROM_SHIFT)
+                | ((to + 1) << SyzygyConstants.TB_RESULT_TO_SHIFT)
+                | ((from + 1) << SyzygyConstants.TB_RESULT_FROM_SHIFT)
                 | (dtzValue << SyzygyConstants.TB_RESULT_DTZ_SHIFT);
 
         try (MockedStatic<SyzygyBridge> bridge = Mockito.mockStatic(SyzygyBridge.class)) {
@@ -85,6 +85,40 @@ class TablesTest {
             assertThat(move.fromIndex()).isEqualTo(from);
             assertThat(move.toIndex()).isEqualTo(to);
             assertThat(move.promotionPieceTypeBits()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    void shouldIgnoreRecommendedMoveWhenSquaresAreMissing() throws Exception {
+        BitBoard board = FEN.translateFENtoBitBoard("4k3/8/8/3pP3/8/8/8/4K3 w - - 0 1");
+        Tables tables = instantiateTables();
+
+        long white = board.getWhitePieces();
+        long black = board.getBlackPieces();
+        long kings = board.getWhiteKing() | board.getBlackKing();
+        long queens = board.getWhiteQueens() | board.getBlackQueens();
+        long rooks = board.getWhiteRooks() | board.getBlackRooks();
+        long bishops = board.getWhiteBishops() | board.getBlackBishops();
+        long knights = board.getWhiteKnights() | board.getBlackKnights();
+        long pawns = board.getWhitePawns() | board.getBlackPawns();
+        int halfmoveClock = board.getHalfmoveClock();
+        boolean whiteToMove = board.isWhitesTurn();
+
+        int dtzValue = 4;
+        int dtzRaw = (SyzygyConstants.TB_WIN << SyzygyConstants.TB_RESULT_WDL_SHIFT)
+                | (dtzValue << SyzygyConstants.TB_RESULT_DTZ_SHIFT);
+
+        try (MockedStatic<SyzygyBridge> bridge = Mockito.mockStatic(SyzygyBridge.class)) {
+            bridge.when(() -> SyzygyBridge.probeSyzygyWDL(white, black, kings, queens, rooks, bishops, knights, pawns, 0,
+                    whiteToMove)).thenReturn(SyzygyConstants.TB_WIN);
+            bridge.when(() -> SyzygyBridge.probeSyzygyDTZ(white, black, kings, queens, rooks, bishops, knights, pawns,
+                    halfmoveClock, 0, whiteToMove)).thenReturn(dtzRaw);
+
+            Optional<SyzygyProbeResult> result = tables.probe(board);
+            assertThat(result).isPresent();
+            SyzygyProbeResult probeResult = result.get();
+            assertThat(probeResult.dtz()).hasValue(dtzValue);
+            assertThat(probeResult.recommendedMove()).isEmpty();
         }
     }
 


### PR DESCRIPTION
## Summary
- normalise Syzygy DTZ recommended move squares from the JNI bridge to the engine's 0-based indexing
- drop tablebase suggestions when the bridge omits square data and log the discard for diagnostics
- update the Syzygy tables unit tests to cover the 1-based encoding and missing-move sentinel

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=julius.game.chessengine.syzygy.TablesTest test

------
https://chatgpt.com/codex/tasks/task_e_68f009be31e8832a95c4a6f29ba48e8f