### PR TITLE
Preserve cached Syzygy result when follow-up probes fail

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -56,6 +56,8 @@ public class Score {
     private Integer tablebaseCentipawn;
     @JsonIgnore
     private boolean tablebaseBypassesEvaluation;
+    @JsonIgnore
+    private long tablebaseResultBoardHash = Long.MIN_VALUE;
 
     public Score() {
         this(EvaluationWeights.identity());
@@ -345,7 +347,7 @@ public class Score {
         }
         Optional<SyzygyProbeResult> probe = service.probe(bitBoard);
         if (probe.isEmpty()) {
-            clearTablebaseState();
+            tablebaseBypassesEvaluation = false;
             return false;
         }
         TablebaseResult resolved = TablebaseResult.from(probe.get());
@@ -353,6 +355,7 @@ public class Score {
         this.tablebaseCentipawn = computeTablebaseCentipawn(resolved, bitBoard.isWhitesTurn(),
                 context.getHalfmoveClock());
         this.tablebaseBypassesEvaluation = true;
+        this.tablebaseResultBoardHash = bitBoard.getBoardStateHash();
         return true;
     }
 
@@ -360,6 +363,7 @@ public class Score {
         this.tablebaseResult = null;
         this.tablebaseCentipawn = null;
         this.tablebaseBypassesEvaluation = false;
+        this.tablebaseResultBoardHash = Long.MIN_VALUE;
     }
 
     public static int tablebaseToCentipawn(TablebaseResult result, boolean whiteToMove) {


### PR DESCRIPTION
## Summary
- keep the last Syzygy tablebase result when subsequent probes return empty so the engine can still surface cached information after applying a move
- record the hash of the board that produced the cached result while forcing the evaluation pipeline to run when new probes miss

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest="UciSyzygyFlowTest" test
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest="TablesTest" test

------
https://chatgpt.com/codex/tasks/task_e_68f009be31e8832a95c4a6f29ba48e8f