### PR TITLE
Fix Syzygy DTZ parsing from tablebase results

### DIFF
--- a/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyConstants.java
+++ b/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyConstants.java
@@ -89,13 +89,7 @@ public final class SyzygyConstants {
      * @return the number of moves needed to reach the optimal transition (where the 50 move rule would be reset).
      */
     public static int distanceToZero(int result) {
-        int raw = (result & SyzygyConstants.TB_RESULT_DTZ_MASK) >>> SyzygyConstants.TB_RESULT_DTZ_SHIFT;
-        // DTZ is stored as a signed 12-bit value. Sign-extend to 32 bits so
-        // callers observe negative distances when the tablebase encodes them.
-        if ((raw & 0x800) != 0) {
-            raw -= 0x1000;
-        }
-        return raw;
+        return (result & SyzygyConstants.TB_RESULT_DTZ_MASK) >>> SyzygyConstants.TB_RESULT_DTZ_SHIFT;
     }
 
     /**

--- a/src/test/java/julius/game/chessengine/syzygy/SyzygyConstantsTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/SyzygyConstantsTest.java
@@ -19,11 +19,11 @@ class SyzygyConstantsTest {
     }
 
     @Test
-    void distanceToZeroSignExtends() {
-        int positive = 7 << SyzygyConstants.TB_RESULT_DTZ_SHIFT;
-        int negative = 0xFFB << SyzygyConstants.TB_RESULT_DTZ_SHIFT; // -5 encoded in 12-bit two's complement
+    void distanceToZeroTreatsValuesAsUnsigned() {
+        int small = 7 << SyzygyConstants.TB_RESULT_DTZ_SHIFT;
+        int large = 0xFFB << SyzygyConstants.TB_RESULT_DTZ_SHIFT; // 4091 encoded in 12-bit storage
 
-        assertThat(SyzygyConstants.distanceToZero(positive)).isEqualTo(7);
-        assertThat(SyzygyConstants.distanceToZero(negative)).isEqualTo(-5);
+        assertThat(SyzygyConstants.distanceToZero(small)).isEqualTo(7);
+        assertThat(SyzygyConstants.distanceToZero(large)).isEqualTo(0xFFB);
     }
 }


### PR DESCRIPTION
## Summary
- treat the Syzygy DTZ component as an unsigned 12-bit field when decoding results
- extend the SyzygyConstants tests to cover large DTZ payloads

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=SyzygyConstantsTest test

------
https://chatgpt.com/codex/tasks/task_e_68f009be31e8832a95c4a6f29ba48e8f