### PR TITLE
Handle Syzygy checkmate/stalemate DTZ sentinels

### DIFF
--- a/src/main/java/julius/game/chessengine/syzygy/Tables.java
+++ b/src/main/java/julius/game/chessengine/syzygy/Tables.java
@@ -81,7 +81,15 @@ final class Tables {
                 board.getHalfmoveClock(), epSquare, whiteToMove);
         OptionalInt dtz = OptionalInt.empty();
         Optional<SyzygyMove> recommendedMove = Optional.empty();
-        if (dtzRaw != SyzygyConstants.TB_RESULT_FAILED) {
+        if (dtzRaw == SyzygyConstants.TB_RESULT_FAILED) {
+            log.debug("Syzygy DTZ probe failed for board {}", board);
+        } else if (dtzRaw == SyzygyConstants.TB_RESULT_CHECKMATE) {
+            log.debug("Syzygy DTZ probe reports checkmate (wdl={}, board={})", wdl, board);
+            // Keep the WDL returned by the dedicated probe and avoid decoding
+            // placeholder move/DTZ values. A checkmated side has no legal moves.
+        } else if (dtzRaw == SyzygyConstants.TB_RESULT_STALEMATE) {
+            log.debug("Syzygy DTZ probe reports stalemate (board={})", board);
+        } else {
             int dtzWdlValue = SyzygyConstants.winDrawLoss(dtzRaw);
             SyzygyWdl dtzWdl = toWdl(dtzWdlValue);
             if (dtzWdl == SyzygyWdl.UNKNOWN) {
@@ -104,8 +112,6 @@ final class Tables {
                 dtz = OptionalInt.of(distance);
                 recommendedMove = decodeRecommendedMove(dtzRaw);
             }
-        } else {
-            log.debug("Syzygy DTZ probe failed for board {}", board);
         }
 
         return Optional.of(new SyzygyProbeResult(wdl, dtz, OptionalInt.empty(), recommendedMove));

--- a/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyConstants.java
+++ b/src/main/java/julius/game/chessengine/syzygy/bridge/SyzygyConstants.java
@@ -51,6 +51,11 @@ public final class SyzygyConstants {
     public static final int TB_RESULT_DTZ_SHIFT = 20;
 
     public static final int TB_RESULT_FAILED = 0xFFFFFFFF;
+    // Special DTZ result markers returned by tb_probe_root when the side to move
+    // has no legal moves. They reuse the raw WDL constants without setting any
+    // move or distance bits, so consumers must treat them as sentinels.
+    public static final int TB_RESULT_STALEMATE = TB_DRAW;
+    public static final int TB_RESULT_CHECKMATE = TB_WIN;
 
     /**
      * return the 'from square' part of the move.

--- a/src/test/java/julius/game/chessengine/syzygy/TablesTest.java
+++ b/src/test/java/julius/game/chessengine/syzygy/TablesTest.java
@@ -88,6 +88,68 @@ class TablesTest {
         }
     }
 
+    @Test
+    void shouldTreatCheckmateSentinelAsLossWithoutRecommendation() throws Exception {
+        BitBoard board = FEN.translateFENtoBitBoard("7k/7p/8/8/8/8/7K/7Q b - - 0 1");
+        Tables tables = instantiateTables();
+
+        long white = board.getWhitePieces();
+        long black = board.getBlackPieces();
+        long kings = board.getWhiteKing() | board.getBlackKing();
+        long queens = board.getWhiteQueens() | board.getBlackQueens();
+        long rooks = board.getWhiteRooks() | board.getBlackRooks();
+        long bishops = board.getWhiteBishops() | board.getBlackBishops();
+        long knights = board.getWhiteKnights() | board.getBlackKnights();
+        long pawns = board.getWhitePawns() | board.getBlackPawns();
+        int halfmoveClock = board.getHalfmoveClock();
+        boolean whiteToMove = board.isWhitesTurn();
+
+        try (MockedStatic<SyzygyBridge> bridge = Mockito.mockStatic(SyzygyBridge.class)) {
+            bridge.when(() -> SyzygyBridge.probeSyzygyWDL(white, black, kings, queens, rooks, bishops, knights, pawns, 0,
+                    whiteToMove)).thenReturn(SyzygyConstants.TB_LOSS);
+            bridge.when(() -> SyzygyBridge.probeSyzygyDTZ(white, black, kings, queens, rooks, bishops, knights, pawns,
+                    halfmoveClock, 0, whiteToMove)).thenReturn(SyzygyConstants.TB_RESULT_CHECKMATE);
+
+            Optional<SyzygyProbeResult> result = tables.probe(board);
+            assertThat(result).isPresent();
+            SyzygyProbeResult probeResult = result.get();
+            assertThat(probeResult.wdl()).isEqualTo(SyzygyWdl.LOSS);
+            assertThat(probeResult.dtz()).isEmpty();
+            assertThat(probeResult.recommendedMove()).isEmpty();
+        }
+    }
+
+    @Test
+    void shouldTreatStalemateSentinelAsDrawWithoutRecommendation() throws Exception {
+        BitBoard board = FEN.translateFENtoBitBoard("7k/5Q2/7K/8/8/8/8/8 b - - 0 1");
+        Tables tables = instantiateTables();
+
+        long white = board.getWhitePieces();
+        long black = board.getBlackPieces();
+        long kings = board.getWhiteKing() | board.getBlackKing();
+        long queens = board.getWhiteQueens() | board.getBlackQueens();
+        long rooks = board.getWhiteRooks() | board.getBlackRooks();
+        long bishops = board.getWhiteBishops() | board.getBlackBishops();
+        long knights = board.getWhiteKnights() | board.getBlackKnights();
+        long pawns = board.getWhitePawns() | board.getBlackPawns();
+        int halfmoveClock = board.getHalfmoveClock();
+        boolean whiteToMove = board.isWhitesTurn();
+
+        try (MockedStatic<SyzygyBridge> bridge = Mockito.mockStatic(SyzygyBridge.class)) {
+            bridge.when(() -> SyzygyBridge.probeSyzygyWDL(white, black, kings, queens, rooks, bishops, knights, pawns, 0,
+                    whiteToMove)).thenReturn(SyzygyConstants.TB_DRAW);
+            bridge.when(() -> SyzygyBridge.probeSyzygyDTZ(white, black, kings, queens, rooks, bishops, knights, pawns,
+                    halfmoveClock, 0, whiteToMove)).thenReturn(SyzygyConstants.TB_RESULT_STALEMATE);
+
+            Optional<SyzygyProbeResult> result = tables.probe(board);
+            assertThat(result).isPresent();
+            SyzygyProbeResult probeResult = result.get();
+            assertThat(probeResult.wdl()).isEqualTo(SyzygyWdl.DRAW);
+            assertThat(probeResult.dtz()).isEmpty();
+            assertThat(probeResult.recommendedMove()).isEmpty();
+        }
+    }
+
     private static Tables instantiateTables() throws Exception {
         Constructor<Tables> constructor = Tables.class.getDeclaredConstructor(String.class, int.class, int.class);
         constructor.setAccessible(true);


### PR DESCRIPTION
## Summary
- treat Syzygy DTZ checkmate and stalemate sentinels as terminal positions so the cached WDL result is preserved
- expose explicit constants for these sentinel values and skip decoding placeholder DTZ/move data
- cover the regression with new tablebase unit tests for both checkmate and stalemate responses

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=TablesTest test

------
https://chatgpt.com/codex/tasks/task_e_68f009be31e8832a95c4a6f29ba48e8f