### PR TITLE
Refine syzygy recommended move integration

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -219,6 +219,10 @@ public class AI {
     private record TablebaseHit(double score, int bestMove, TablebaseResult result) {
     }
 
+    private record TablebaseContinuation(int move, double evaluation, TablebaseResult result,
+                                         boolean zeroingMove) {
+    }
+
     private record TablebaseInfo(int dtz, int dtm, int whiteWdlSign) {
         boolean hasDtz() { return dtz >= 0; }
     }
@@ -1948,39 +1952,183 @@ public class AI {
             return -1;
         }
 
+        int suggestedMove = -1;
+        TablebaseContinuation bestContinuation = null;
+
         if (parentResult != null) {
             Optional<SyzygyMove> suggestion = parentResult.recommendedMove();
             if (suggestion.isPresent()) {
-                int resolved = findSuggestedMove(legal, suggestion.get());
-                if (resolved != -1) {
-                    log.info(Move.convertIntToMove(resolved).toString());
-                    return resolved;
+                suggestedMove = findSuggestedMove(legal, suggestion.get());
+                if (suggestedMove != -1) {
+                    Optional<TablebaseContinuation> continuation = evaluateTablebaseContinuation(simulatorEngine, suggestedMove);
+                    if (continuation.isPresent()) {
+                        TablebaseContinuation candidate = continuation.get();
+                        if (isContinuationConsistent(parentResult, candidate)) {
+                            return candidate.move();
+                        }
+                        bestContinuation = candidate;
+                    }
                 }
             }
         }
 
-
-        double bestScore = parentIsWhite ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
-        int bestMove = -1;
         for (int i = 0; i < legal.size(); i++) {
             int move = legal.getInt(i);
-            simulatorEngine.performMove(move);
-            double candidate;
-            try {
-                candidate = evaluateTablebaseChild(simulatorEngine, parentIsWhite);
-            } finally {
-                simulatorEngine.undoLastMove();
-            }
-            if (Double.isNaN(candidate)) {
+            if (move == suggestedMove) {
                 continue;
             }
-            boolean better = parentIsWhite ? candidate > bestScore : candidate < bestScore;
-            if (better) {
-                bestScore = candidate;
-                bestMove = move;
+            Optional<TablebaseContinuation> continuation = evaluateTablebaseContinuation(simulatorEngine, move);
+            if (continuation.isEmpty()) {
+                continue;
+            }
+            TablebaseContinuation candidate = continuation.get();
+            if (bestContinuation == null
+                    || isContinuationBetter(parentIsWhite, candidate, bestContinuation, parentResult)) {
+                bestContinuation = candidate;
             }
         }
-        return bestMove;
+        return bestContinuation != null ? bestContinuation.move() : -1;
+    }
+
+    private Optional<TablebaseContinuation> evaluateTablebaseContinuation(Engine simulatorEngine, int move) {
+        boolean zeroing = MoveHelper.isCapture(move) || MoveHelper.derivePieceTypeBits(move) == 1;
+        simulatorEngine.performMove(move);
+        try {
+            Optional<TablebaseResult> childResult = resolveExactTablebaseResult(simulatorEngine);
+            if (childResult.isEmpty()) {
+                return Optional.empty();
+            }
+            TablebaseResult result = childResult.get();
+            double evaluation = Score.tablebaseToEvaluation(result, simulatorEngine.whitesTurn(),
+                    simulatorEngine.getGameState().getHalfmoveClock());
+            return Optional.of(new TablebaseContinuation(move, evaluation, result, zeroing));
+        } finally {
+            simulatorEngine.undoLastMove();
+        }
+    }
+
+    private Optional<TablebaseResult> resolveExactTablebaseResult(Engine engine) {
+        TablebaseResult result = engine.getGameState().getLastTablebaseResult().orElse(null);
+        if (tablebaseService != null) {
+            BitBoard snapshot = new BitBoard(engine.getBitBoard());
+            Optional<SyzygyProbeResult> probe = tablebaseService.probe(snapshot);
+            if (probe.isPresent()) {
+                result = TablebaseResult.from(probe.get());
+                engine.getGameState().setLastTablebaseResult(result);
+            }
+        }
+        if (!isExactWdl(result)) {
+            return Optional.empty();
+        }
+        return Optional.of(result);
+    }
+
+    private boolean isContinuationConsistent(TablebaseResult parentResult, TablebaseContinuation continuation) {
+        if (parentResult == null || continuation == null) {
+            return false;
+        }
+        int parentSign = Integer.signum(parentResult.wdl().score());
+        int childSign = Integer.signum(continuation.result().wdl().score());
+        if (parentSign == 0) {
+            return childSign == 0;
+        }
+        return parentSign == -childSign;
+    }
+
+    private boolean isContinuationBetter(boolean parentIsWhite,
+                                         TablebaseContinuation candidate,
+                                         TablebaseContinuation incumbent,
+                                         TablebaseResult parentResult) {
+        if (incumbent == null) {
+            return true;
+        }
+        if (candidate == null) {
+            return false;
+        }
+
+        double candidateEval = candidate.evaluation();
+        double incumbentEval = incumbent.evaluation();
+        if (!Double.isFinite(candidateEval)) {
+            return false;
+        }
+        if (!Double.isFinite(incumbentEval)) {
+            return true;
+        }
+
+        double diff = candidateEval - incumbentEval;
+        if (Math.abs(diff) > TB_TIE_EPSILON) {
+            return parentIsWhite ? diff > 0 : diff < 0;
+        }
+
+        int outcome = parentResult != null ? Integer.signum(parentResult.wdl().score()) : 0;
+        return switch (outcome) {
+            case 1 -> preferWinningContinuation(candidate, incumbent);
+            case -1 -> preferDefensiveContinuation(candidate, incumbent);
+            case 0 -> preferDrawingContinuation(candidate, incumbent);
+            default -> false;
+        };
+    }
+
+    private boolean preferWinningContinuation(TablebaseContinuation candidate, TablebaseContinuation incumbent) {
+        int candidateDtz = normaliseDistance(candidate.result().dtz(), Integer.MAX_VALUE);
+        int incumbentDtz = normaliseDistance(incumbent.result().dtz(), Integer.MAX_VALUE);
+        if (candidateDtz != incumbentDtz) {
+            return candidateDtz < incumbentDtz;
+        }
+
+        int candidateDtm = normaliseDistance(candidate.result().dtm(), Integer.MAX_VALUE);
+        int incumbentDtm = normaliseDistance(incumbent.result().dtm(), Integer.MAX_VALUE);
+        if (candidateDtm != incumbentDtm) {
+            return candidateDtm < incumbentDtm;
+        }
+
+        if (candidate.zeroingMove() != incumbent.zeroingMove()) {
+            return candidate.zeroingMove();
+        }
+        return false;
+    }
+
+    private boolean preferDefensiveContinuation(TablebaseContinuation candidate, TablebaseContinuation incumbent) {
+        int candidateDtz = normaliseDistance(candidate.result().dtz(), Integer.MIN_VALUE);
+        int incumbentDtz = normaliseDistance(incumbent.result().dtz(), Integer.MIN_VALUE);
+        if (candidateDtz != incumbentDtz) {
+            return candidateDtz > incumbentDtz;
+        }
+
+        int candidateDtm = normaliseDistance(candidate.result().dtm(), Integer.MIN_VALUE);
+        int incumbentDtm = normaliseDistance(incumbent.result().dtm(), Integer.MIN_VALUE);
+        if (candidateDtm != incumbentDtm) {
+            return candidateDtm > incumbentDtm;
+        }
+
+        if (candidate.zeroingMove() != incumbent.zeroingMove()) {
+            return !candidate.zeroingMove();
+        }
+        return false;
+    }
+
+    private boolean preferDrawingContinuation(TablebaseContinuation candidate, TablebaseContinuation incumbent) {
+        int candidateDtz = normaliseDistance(candidate.result().dtz(), Integer.MAX_VALUE);
+        int incumbentDtz = normaliseDistance(incumbent.result().dtz(), Integer.MAX_VALUE);
+        if (candidateDtz != incumbentDtz) {
+            return candidateDtz < incumbentDtz;
+        }
+        if (candidate.zeroingMove() != incumbent.zeroingMove()) {
+            return candidate.zeroingMove();
+        }
+        int candidateDtm = normaliseDistance(candidate.result().dtm(), Integer.MAX_VALUE);
+        int incumbentDtm = normaliseDistance(incumbent.result().dtm(), Integer.MAX_VALUE);
+        if (candidateDtm != incumbentDtm) {
+            return candidateDtm < incumbentDtm;
+        }
+        return false;
+    }
+
+    private int normaliseDistance(OptionalInt value, int fallback) {
+        if (value == null || value.isEmpty()) {
+            return fallback;
+        }
+        return Math.abs(value.getAsInt());
     }
 
     private int findSuggestedMove(IntArrayList legal, SyzygyMove suggestion) {
@@ -2035,19 +2183,11 @@ public class AI {
     }
 
     private double evaluateTablebaseChild(Engine simulatorEngine, boolean parentIsWhite) {
-        TablebaseResult childResult = simulatorEngine.getGameState().getLastTablebaseResult().orElse(null);
-        if (tablebaseService != null) {
-            BitBoard snapshot = new BitBoard(simulatorEngine.getBitBoard());
-            Optional<SyzygyProbeResult> probe = tablebaseService.probe(snapshot);
-            if (probe.isPresent()) {
-                childResult = TablebaseResult.from(probe.get());
-                simulatorEngine.getGameState().setLastTablebaseResult(childResult);
-            }
-        }
-        if (childResult == null || !isExactWdl(childResult)) {
+        Optional<TablebaseResult> childResult = resolveExactTablebaseResult(simulatorEngine);
+        if (childResult.isEmpty()) {
             return Double.NaN;
         }
-        double whitePerspective = Score.tablebaseToEvaluation(childResult, simulatorEngine.whitesTurn(),
+        double whitePerspective = Score.tablebaseToEvaluation(childResult.get(), simulatorEngine.whitesTurn(),
                 simulatorEngine.getGameState().getHalfmoveClock());
         return whitePerspective;
     }

--- a/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AISyzygyIntegrationTest.java
@@ -5,6 +5,7 @@ import julius.game.chessengine.board.FEN;
 import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.tuning.EngineTuningBootstrap;
+import julius.game.chessengine.syzygy.SyzygyMove;
 import julius.game.chessengine.syzygy.SyzygyProbeResult;
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
 import julius.game.chessengine.syzygy.SyzygyWdl;
@@ -104,6 +105,111 @@ class AISyzygyIntegrationTest {
             assertThat(winningChildren)
                     .describedAs("tablebase best move should correspond to a child scored as a forced win")
                     .contains(bestChildFen);
+
+            ai.shutdown();
+        }
+    }
+
+    @Test
+    void determineTablebaseBestMoveHonoursConsistentRecommendation() throws Exception {
+        Engine engine = new Engine();
+        String fen = "6k1/8/8/8/8/8/5Q2/6K1 w - - 0 1";
+        engine.importBoardFromFen(fen);
+
+        IntArrayList legalMoves = engine.getAllLegalMoves();
+        Map<String, SyzygyProbeResult> responses = new HashMap<>();
+
+        int recommendedMove = -1;
+        for (int i = 0; i < legalMoves.size(); i++) {
+            int move = legalMoves.getInt(i);
+            engine.performMove(move);
+            String childFen = FEN.translateBoardToFEN(engine.getBitBoard(), engine.getGameState()).getRenderBoard();
+            boolean forcedWin = childFen.contains("5QK1") || childFen.contains("4Q1K1");
+            SyzygyWdl childResult = forcedWin ? SyzygyWdl.LOSS : SyzygyWdl.DRAW;
+            responses.put(childFen, new SyzygyProbeResult(childResult, OptionalInt.of(1), OptionalInt.empty(), Optional.empty()));
+            if (forcedWin && recommendedMove == -1) {
+                recommendedMove = move;
+            }
+            engine.undoLastMove();
+        }
+
+        assertThat(recommendedMove)
+                .describedAs("expected at least one forced win move to exist")
+                .isNotEqualTo(-1);
+
+        SyzygyMove recommendation = toSyzygyMove(recommendedMove);
+        responses.put(fen, new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(5), OptionalInt.of(9), Optional.of(recommendation)));
+
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(responses);
+
+        try (AutoCloseable restorer = overrideScoreTablebase(service)) {
+            AI ai = new AI(engine, service);
+            Engine simulation = engine.createSimulation();
+
+            Method determine = AI.class.getDeclaredMethod("determineTablebaseBestMove", Engine.class, TablebaseResult.class,
+                    boolean.class);
+            determine.setAccessible(true);
+
+            TablebaseResult parentResult = TablebaseResult.from(responses.get(fen));
+            int bestMove = (int) determine.invoke(ai, simulation, parentResult, simulation.whitesTurn());
+
+            assertThat(bestMove).isEqualTo(recommendedMove);
+
+            ai.shutdown();
+        }
+    }
+
+    @Test
+    void determineTablebaseBestMoveSkipsInconsistentRecommendation() throws Exception {
+        Engine engine = new Engine();
+        String fen = "6k1/8/8/8/8/8/5Q2/6K1 w - - 0 1";
+        engine.importBoardFromFen(fen);
+
+        IntArrayList legalMoves = engine.getAllLegalMoves();
+        Map<String, SyzygyProbeResult> responses = new HashMap<>();
+
+        int winningMove = -1;
+        int drawingMove = -1;
+        for (int i = 0; i < legalMoves.size(); i++) {
+            int move = legalMoves.getInt(i);
+            engine.performMove(move);
+            String childFen = FEN.translateBoardToFEN(engine.getBitBoard(), engine.getGameState()).getRenderBoard();
+            boolean forcedWin = childFen.contains("5QK1") || childFen.contains("4Q1K1");
+            SyzygyWdl childResult = forcedWin ? SyzygyWdl.LOSS : SyzygyWdl.DRAW;
+            responses.put(childFen, new SyzygyProbeResult(childResult, OptionalInt.of(1), OptionalInt.empty(), Optional.empty()));
+            if (forcedWin && winningMove == -1) {
+                winningMove = move;
+            }
+            if (!forcedWin && drawingMove == -1) {
+                drawingMove = move;
+            }
+            engine.undoLastMove();
+        }
+
+        assertThat(winningMove)
+                .describedAs("expected a winning continuation")
+                .isNotEqualTo(-1);
+        assertThat(drawingMove)
+                .describedAs("expected a non-winning continuation to use as a bogus recommendation")
+                .isNotEqualTo(-1);
+
+        SyzygyMove recommendation = toSyzygyMove(drawingMove);
+        responses.put(fen, new SyzygyProbeResult(SyzygyWdl.WIN, OptionalInt.of(5), OptionalInt.of(9), Optional.of(recommendation)));
+
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(responses);
+
+        try (AutoCloseable restorer = overrideScoreTablebase(service)) {
+            AI ai = new AI(engine, service);
+            Engine simulation = engine.createSimulation();
+
+            Method determine = AI.class.getDeclaredMethod("determineTablebaseBestMove", Engine.class, TablebaseResult.class,
+                    boolean.class);
+            determine.setAccessible(true);
+
+            TablebaseResult parentResult = TablebaseResult.from(responses.get(fen));
+            int bestMove = (int) determine.invoke(ai, simulation, parentResult, simulation.whitesTurn());
+
+            assertThat(bestMove).isEqualTo(winningMove);
 
             ai.shutdown();
         }
@@ -269,5 +375,11 @@ class AISyzygyIntegrationTest {
                 Score.setTablebaseService(previous);
             }
         };
+    }
+
+    private SyzygyMove toSyzygyMove(int move) {
+        return new SyzygyMove(MoveHelper.deriveFromIndex(move),
+                MoveHelper.deriveToIndex(move),
+                MoveHelper.derivePromotionPieceTypeBits(move));
     }
 }


### PR DESCRIPTION
## Summary
- add a tablebase continuation record and helper utilities to vet and rank Syzygy recommendations during evaluation
- prioritise consistent recommended moves, apply dtz/dtm based tie-breaks, and reuse tablebase probes when picking the best move
- extend AISyzygyIntegrationTest with coverage for consistent and inconsistent recommendations plus helper conversion to SyzygyMove

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AISyzygyIntegrationTest test

------
https://chatgpt.com/codex/tasks/task_e_68f039c46084832a9b70f993efc2d997