### PR TITLE
Integrate cached tablebase recommendations

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -17,6 +17,7 @@ import julius.game.chessengine.syzygy.SyzygyMove;
 import julius.game.chessengine.syzygy.SyzygyProbeResult;
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
 import julius.game.chessengine.syzygy.SyzygyWdl;
+import julius.game.chessengine.syzygy.TablebaseRecommendation;
 import julius.game.chessengine.syzygy.TablebaseResult;
 import julius.game.chessengine.tuning.AiTuning;
 import julius.game.chessengine.tuning.AspirationParameters;
@@ -1948,6 +1949,19 @@ public class AI {
             return -1;
         }
 
+        Optional<TablebaseRecommendation> cachedRecommendation = simulatorEngine.getGameState()
+                .getLastTablebaseRecommendation();
+        if (cachedRecommendation.isPresent()) {
+            TablebaseRecommendation rec = cachedRecommendation.get();
+            if (rec.matches(simulatorEngine.getBoardStateHash())) {
+                int hintedMove = rec.encodedMove();
+                int index = legal.indexOf(hintedMove);
+                if (index >= 0) {
+                    return hintedMove;
+                }
+            }
+        }
+
         if (parentResult != null) {
             Optional<SyzygyMove> suggestion = parentResult.recommendedMove();
             if (suggestion.isPresent()) {
@@ -2017,11 +2031,18 @@ public class AI {
         if (result == null) {
             return;
         }
-        Optional<SyzygyMove> suggestion = result.recommendedMove();
-        if (suggestion.isEmpty()) {
-            return;
+        OptionalInt encoded = engine.getGameState().getLastTablebaseRecommendedMove();
+        int matchedMove = encoded.isPresent() ? encoded.getAsInt() : -1;
+        if (matchedMove != -1 && moves.indexOf(matchedMove) < 0) {
+            matchedMove = -1;
         }
-        int matchedMove = findSuggestedMove(moves, suggestion.get());
+        if (matchedMove == -1) {
+            Optional<SyzygyMove> suggestion = result.recommendedMove();
+            if (suggestion.isEmpty()) {
+                return;
+            }
+            matchedMove = findSuggestedMove(moves, suggestion.get());
+        }
         if (matchedMove == -1) {
             return;
         }

--- a/src/main/java/julius/game/chessengine/board/BitBoard.java
+++ b/src/main/java/julius/game/chessengine/board/BitBoard.java
@@ -2477,6 +2477,10 @@ public class BitBoard {
         return whitesTurn ? !whiteKingMoved : !blackKingMoved;
     }
 
+    public int getCastlingStateBits() {
+        return packCastlingState();
+    }
+
     private void markRookAsMoved(int rookIndex) {
         if (rookIndex == 0) {
             whiteRookA1Moved = true;

--- a/src/main/java/julius/game/chessengine/engine/GameState.java
+++ b/src/main/java/julius/game/chessengine/engine/GameState.java
@@ -5,6 +5,7 @@ import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import julius.game.chessengine.board.BitBoard;
 import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.syzygy.TablebaseRecommendation;
 import julius.game.chessengine.syzygy.TablebaseResult;
 import julius.game.chessengine.utils.Score;
 import lombok.Data;
@@ -27,6 +28,7 @@ public class GameState {
     private boolean drawByInsufficientMaterial;
 
     private TablebaseResult lastTablebaseResult;
+    private TablebaseRecommendation lastTablebaseRecommendation;
 
     @Getter
     private int halfmoveClock = 0;          // resets on pawn move or capture
@@ -57,6 +59,7 @@ public class GameState {
         this.halfmoveStack.addAll(other.halfmoveStack);
         this.fullmoveStack.addAll(other.fullmoveStack);
         this.lastTablebaseResult = other.lastTablebaseResult;
+        this.lastTablebaseRecommendation = other.lastTablebaseRecommendation;
     }
 
     public void refreshScore(BitBoard bitBoard) {
@@ -232,6 +235,19 @@ public class GameState {
         this.lastTablebaseResult = score != null
                 ? score.getTablebaseResult().orElse(null)
                 : null;
+        this.lastTablebaseRecommendation = score != null
+                ? score.getTablebaseRecommendation().orElse(null)
+                : null;
+    }
+
+    public java.util.Optional<TablebaseRecommendation> getLastTablebaseRecommendation() {
+        return java.util.Optional.ofNullable(lastTablebaseRecommendation);
+    }
+
+    public java.util.OptionalInt getLastTablebaseRecommendedMove() {
+        return lastTablebaseRecommendation != null
+                ? java.util.OptionalInt.of(lastTablebaseRecommendation.encodedMove())
+                : java.util.OptionalInt.empty();
     }
 
     @Override

--- a/src/main/java/julius/game/chessengine/syzygy/TablebaseRecommendation.java
+++ b/src/main/java/julius/game/chessengine/syzygy/TablebaseRecommendation.java
@@ -1,0 +1,81 @@
+package julius.game.chessengine.syzygy;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.figures.Color;
+import julius.game.chessengine.figures.PieceType;
+
+import java.util.Optional;
+
+/**
+ * Encapsulates a Syzygy recommendation mapped to the engine's move encoding.
+ * The {@link #encodedMove()} is cached so subsequent consumers can promote
+ * the move without re-running the mapping logic.
+ */
+public record TablebaseRecommendation(long boardHash, SyzygyMove syzygyMove, int encodedMove) {
+
+    public static Optional<TablebaseRecommendation> resolve(BitBoard board, SyzygyMove suggestion) {
+        if (board == null || suggestion == null) {
+            return Optional.empty();
+        }
+        Integer encoded = encodeMove(board, suggestion);
+        if (encoded == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new TablebaseRecommendation(board.getBoardStateHash(), suggestion, encoded));
+    }
+
+    public boolean matches(long hash) {
+        return this.boardHash == hash;
+    }
+
+    private static Integer encodeMove(BitBoard board, SyzygyMove suggestion) {
+        int from = suggestion.fromIndex();
+        int to = suggestion.toIndex();
+
+        PieceType mover = board.getPieceTypeAtIndex(from);
+        if (mover == null) {
+            return null;
+        }
+
+        Color moverColor = board.getPieceColorAtIndex(from);
+        if (moverColor == null) {
+            return null;
+        }
+        boolean isWhite = moverColor == Color.WHITE;
+
+        PieceType captured = null;
+        boolean isCapture = false;
+        boolean isEnPassant = false;
+        boolean isCastling = mover == PieceType.KING && Math.abs(from - to) == 2;
+
+        if (!isCastling && board.isOccupied(to)) {
+            Color targetColor = board.getPieceColorAtIndex(to);
+            if (targetColor == moverColor) {
+                return null;
+            }
+            captured = board.getPieceTypeAtIndex(to);
+            isCapture = captured != null;
+        } else if (!isCastling && mover == PieceType.PAWN) {
+            int epIndex = board.getEnPassantTargetIndex();
+            if (epIndex >= 0 && epIndex == to && !board.isOccupied(to)) {
+                isCapture = true;
+                isEnPassant = true;
+                captured = PieceType.PAWN;
+            }
+        }
+
+        PieceType promotion = null;
+        if (suggestion.promotionPieceTypeBits() != 0) {
+            promotion = MoveHelper.intToPieceType(suggestion.promotionPieceTypeBits());
+        }
+
+        boolean kingFirstMove = (mover == PieceType.KING) && board.hasKingNotMoved(isWhite);
+        boolean rookFirstMove = (mover == PieceType.ROOK) && !board.hasRookMoved(from);
+        int castlingStateBits = board.getCastlingStateBits();
+
+        return MoveHelper.createMoveInt(from, to, mover, isWhite, isCapture, isCastling, isEnPassant,
+                promotion, captured, kingFirstMove, rookFirstMove, castlingStateBits);
+    }
+}
+

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -7,6 +7,7 @@ import julius.game.chessengine.evaluation.*;
 import julius.game.chessengine.syzygy.SyzygyProbeResult;
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
 import julius.game.chessengine.syzygy.SyzygyWdl;
+import julius.game.chessengine.syzygy.TablebaseRecommendation;
 import julius.game.chessengine.syzygy.TablebaseResult;
 import julius.game.chessengine.tuning.EngineTuningBootstrap;
 import julius.game.chessengine.tuning.MoveOrderingParameters;
@@ -55,6 +56,8 @@ public class Score {
     @JsonIgnore
     private Integer tablebaseCentipawn;
     @JsonIgnore
+    private TablebaseRecommendation tablebaseRecommendation;
+    @JsonIgnore
     private boolean tablebaseBypassesEvaluation;
     @JsonIgnore
     private long tablebaseResultBoardHash = Long.MIN_VALUE;
@@ -99,6 +102,7 @@ public class Score {
             }
             this.tablebaseResult = other.tablebaseResult;
             this.tablebaseCentipawn = other.tablebaseCentipawn;
+            this.tablebaseRecommendation = other.tablebaseRecommendation;
             this.tablebaseBypassesEvaluation = other.tablebaseBypassesEvaluation;
         }
     }
@@ -333,6 +337,20 @@ public class Score {
         return tablebaseCentipawn != null ? OptionalInt.of(tablebaseCentipawn) : OptionalInt.empty();
     }
 
+    public Optional<TablebaseRecommendation> getTablebaseRecommendation() {
+        return Optional.ofNullable(tablebaseRecommendation);
+    }
+
+    public OptionalInt getTablebaseRecommendedMove() {
+        return tablebaseRecommendation != null
+                ? OptionalInt.of(tablebaseRecommendation.encodedMove())
+                : OptionalInt.empty();
+    }
+
+    public long getTablebaseResultBoardHash() {
+        return tablebaseResultBoardHash;
+    }
+
     private boolean updateTablebaseState(BitBoard bitBoard, EvaluationContext context) {
         SyzygyTablebaseService service = TABLEBASE_SERVICE;
         if (service == null || context == null) {
@@ -354,6 +372,9 @@ public class Score {
         this.tablebaseResult = resolved;
         this.tablebaseCentipawn = computeTablebaseCentipawn(resolved, bitBoard.isWhitesTurn(),
                 context.getHalfmoveClock());
+        this.tablebaseRecommendation = resolved.recommendedMove()
+                .flatMap(move -> TablebaseRecommendation.resolve(bitBoard, move))
+                .orElse(null);
         this.tablebaseBypassesEvaluation = true;
         this.tablebaseResultBoardHash = bitBoard.getBoardStateHash();
         return true;
@@ -362,6 +383,7 @@ public class Score {
     private void clearTablebaseState() {
         this.tablebaseResult = null;
         this.tablebaseCentipawn = null;
+        this.tablebaseRecommendation = null;
         this.tablebaseBypassesEvaluation = false;
         this.tablebaseResultBoardHash = Long.MIN_VALUE;
     }


### PR DESCRIPTION
## Summary
- encode Syzygy recommendations once via a new `TablebaseRecommendation` helper and expose them from the evaluation pipeline
- persist cached tablebase hints in `GameState` so AI move selection and promotion can consume them without re-scanning
- fall back to the original suggestion search only when the cached move is absent or outdated

## Testing
- `mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" test` *(fails: 502 Bad Gateway while downloading org.springframework.boot:spring-boot-starter:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68f039c46084832a9b70f993efc2d997