### PR TITLE
Add move-ordering priority persistence and learning

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -76,6 +76,14 @@ public class AI {
     private final double rootFanoutRatio;
     private WorkerInstrumentation workerInstrumentation;
 
+    private final MoveOrderingPriority moveOrderingPriority;
+    private final boolean reviseGameEnabled;
+    private final Object gameTrackingLock = new Object();
+    private final IntArrayList engineMovesThisGame = new IntArrayList();
+    private Boolean enginePlayingWhite;
+    private boolean gameResultApplied;
+    private int lastKnownLineSize;
+
     private static final int ABS_PLY_LIMIT_MARGIN = 32;
 
     private final AtomicReference<SearchTask> activeSearch = new AtomicReference<>();
@@ -387,11 +395,15 @@ public class AI {
         this.globalHeuristics = new Heuristics(maxDepth);
         this.threadHeuristics = ThreadLocal.withInitial(() -> new Heuristics(maxDepth));
 
+        this.moveOrderingPriority = MoveOrderingPriority.getInstance();
+        this.reviseGameEnabled = moveOrderingPriority.isRevisionEnabled();
+        this.lastKnownLineSize = mainEngine.getLine().size();
+
         rebuildTranspositionTables();
 
         this.searchPool = createSearchPool();
 
-        this.mainEngine.setOnPositionChanged(_ -> updateBoardStateHash());
+        this.mainEngine.setOnPositionChanged(this::handlePositionChanged);
     }
 
     private ExecutorService createSearchPool() {
@@ -1150,6 +1162,10 @@ public class AI {
         calculatedLine = Collections.synchronizedList(new ArrayList<>());
         mainEngine.startNewGame();
         clearHistoryTable();
+        synchronized (gameTrackingLock) {
+            resetGameTrackingUnsafe();
+            lastKnownLineSize = 0;
+        }
     }
 
     public void stopCalculation() {
@@ -1300,12 +1316,26 @@ public class AI {
         }
 
         mainEngine.performMove(currentBestMove);
+        onMoveExecuted(currentBestMove);
         enqueueCalculationRequest();
         currentBestMove = -1; // don’t re-play it
         bestMoveForHash = -1;
         previousBestMove = -1;
         previousBestMoveHash = -1;
         searchResultReady = false;
+    }
+
+    public void onMoveExecuted(int move) {
+        if (!reviseGameEnabled || move < 0) {
+            return;
+        }
+        synchronized (gameTrackingLock) {
+            engineMovesThisGame.add(move);
+            if (enginePlayingWhite == null) {
+                enginePlayingWhite = MoveHelper.isWhitesMove(move);
+            }
+            gameResultApplied = false;
+        }
     }
 
 
@@ -3312,6 +3342,7 @@ public class AI {
             }
 
             moveBuffer[i] = moveInt;
+            score += moveOrderingPriority.getPriority(moveInt);
             int s = score;
             if (s < 0) {
                 s = 0;
@@ -3790,6 +3821,57 @@ public class AI {
 
     public void updateBoardStateHash() {
         enqueueCalculationRequest();
+    }
+
+    private void handlePositionChanged(long hash) {
+        updateBoardStateHash();
+
+        if (!reviseGameEnabled) {
+            lastKnownLineSize = mainEngine.getLine().size();
+            return;
+        }
+
+        IntArrayList movesSnapshot = null;
+        Boolean engineWon = null;
+
+        synchronized (gameTrackingLock) {
+            int lineSize = mainEngine.getLine().size();
+            if (lineSize < lastKnownLineSize) {
+                resetGameTrackingUnsafe();
+            }
+            lastKnownLineSize = lineSize;
+
+            GameState gameState = mainEngine.getGameState();
+            if (!gameResultApplied && gameState != null && gameState.isGameOver()
+                    && enginePlayingWhite != null && !engineMovesThisGame.isEmpty()) {
+                GameStateEnum result = gameState.getState();
+                if (result == GameStateEnum.WHITE_WON || result == GameStateEnum.BLACK_WON) {
+                    boolean won = (result == GameStateEnum.WHITE_WON && Boolean.TRUE.equals(enginePlayingWhite))
+                            || (result == GameStateEnum.BLACK_WON && Boolean.FALSE.equals(enginePlayingWhite));
+                    boolean lost = (result == GameStateEnum.WHITE_WON && Boolean.FALSE.equals(enginePlayingWhite))
+                            || (result == GameStateEnum.BLACK_WON && Boolean.TRUE.equals(enginePlayingWhite));
+                    if (won || lost) {
+                        movesSnapshot = new IntArrayList(engineMovesThisGame);
+                        engineWon = won;
+                    }
+                }
+                gameResultApplied = true;
+            }
+
+            if (!gameState.isGameOver() && lineSize == 0) {
+                resetGameTrackingUnsafe();
+            }
+        }
+
+        if (movesSnapshot != null && engineWon != null) {
+            moveOrderingPriority.applyGameResult(movesSnapshot, engineWon);
+        }
+    }
+
+    private void resetGameTrackingUnsafe() {
+        engineMovesThisGame.clear();
+        enginePlayingWhite = null;
+        gameResultApplied = false;
     }
 
     private void updateKillerMoves(int depth, int move) {

--- a/src/main/java/julius/game/chessengine/ai/MoveOrderingPriority.java
+++ b/src/main/java/julius/game/chessengine/ai/MoveOrderingPriority.java
@@ -1,0 +1,159 @@
+package julius.game.chessengine.ai;
+
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntComparators;
+import it.unimi.dsi.fastutil.ints.IntList;
+import lombok.extern.log4j.Log4j2;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Persistent store for simple move-ordering priorities keyed by move integers.
+ * <p>
+ * The table is loaded eagerly on first access and kept in-memory for fast lookups during
+ * move ordering. Updates are flushed to disk after every processed game so priority
+ * adjustments survive engine restarts.
+ */
+@Log4j2
+public final class MoveOrderingPriority {
+
+    private static final String FILE_PROPERTY = "chessengine.moveOrdering.priorityFile";
+    private static final String LEGACY_FLAG_PROPERTY = "ReviseGame";
+    private static final String FLAG_PROPERTY = "chessengine.moveOrdering.reviseGame";
+    private static final Path DEFAULT_PATH = Paths.get(System.getProperty("user.dir"), "logs", "move-ordering-priority.txt");
+
+    private static final MoveOrderingPriority INSTANCE = new MoveOrderingPriority();
+
+    private final Int2IntOpenHashMap priorities;
+    private final Path storagePath;
+
+    private MoveOrderingPriority() {
+        this.storagePath = resolveStoragePath();
+        this.priorities = new Int2IntOpenHashMap();
+        this.priorities.defaultReturnValue(0);
+        loadFromDisk();
+    }
+
+    public static MoveOrderingPriority getInstance() {
+        return INSTANCE;
+    }
+
+    public boolean isRevisionEnabled() {
+        return Boolean.getBoolean(LEGACY_FLAG_PROPERTY) || Boolean.getBoolean(FLAG_PROPERTY);
+    }
+
+    public synchronized int getPriority(int moveInt) {
+        return priorities.get(moveInt);
+    }
+
+    public synchronized void applyGameResult(IntArrayList moves, boolean won) {
+        Objects.requireNonNull(moves, "moves");
+        if (moves.isEmpty()) {
+            return;
+        }
+
+        int delta = won ? 1 : -1;
+        boolean changed = false;
+        for (int i = 0; i < moves.size(); i++) {
+            int move = moves.getInt(i);
+            int updated = priorities.get(move) + delta;
+            if (updated == 0) {
+                if (priorities.remove(move) != 0) {
+                    changed = true;
+                }
+            } else {
+                priorities.put(move, updated);
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            persist();
+        }
+    }
+
+    private Path resolveStoragePath() {
+        String override = System.getProperty(FILE_PROPERTY);
+        if (override != null && !override.isBlank()) {
+            return Paths.get(override.trim());
+        }
+        return DEFAULT_PATH;
+    }
+
+    private void loadFromDisk() {
+        if (!Files.exists(storagePath)) {
+            Path parent = storagePath.getParent();
+            if (parent != null) {
+                try {
+                    Files.createDirectories(parent);
+                } catch (IOException e) {
+                    log.warn("Failed to create move ordering priority directory {}", parent, e);
+                }
+            }
+            return;
+        }
+
+        try {
+            List<String> lines = Files.readAllLines(storagePath, StandardCharsets.UTF_8);
+            for (String raw : lines) {
+                if (raw == null) {
+                    continue;
+                }
+                String line = raw.trim();
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+                String[] tokens = line.split("\\s+");
+                if (tokens.length < 2) {
+                    continue;
+                }
+                try {
+                    int move = Integer.parseInt(tokens[0]);
+                    int score = Integer.parseInt(tokens[1]);
+                    if (score != 0) {
+                        priorities.put(move, score);
+                    }
+                } catch (NumberFormatException ex) {
+                    log.debug("Ignoring malformed priority line '{}': {}", line, ex.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            log.warn("Failed to load move ordering priorities from {}", storagePath, e);
+        }
+    }
+
+    private void persist() {
+        IntList keys = new IntArrayList(priorities.size());
+        for (Int2IntMap.Entry entry : priorities.int2IntEntrySet()) {
+            keys.add(entry.getIntKey());
+        }
+        keys.sort(IntComparators.NATURAL_COMPARATOR);
+
+        List<String> payload = new ArrayList<>(keys.size());
+        for (int i = 0; i < keys.size(); i++) {
+            int key = keys.getInt(i);
+            payload.add(key + " " + priorities.get(key));
+        }
+
+        try {
+            Path parent = storagePath.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            Files.write(storagePath, payload, StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+        } catch (IOException e) {
+            log.warn("Failed to persist move ordering priorities to {}", storagePath, e);
+        }
+    }
+}

--- a/src/main/java/julius/game/chessengine/tuning/MatchRunner.java
+++ b/src/main/java/julius/game/chessengine/tuning/MatchRunner.java
@@ -59,6 +59,7 @@ public final class MatchRunner {
                 int move = ms.getMove();
                 whiteEngine.performMove(move);
                 blackEngine.performMove(move);
+                mover.onMoveExecuted(move);
                 plies++;
             }
 

--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -429,6 +429,7 @@ public class UciHandler {
             output.accept("bestmove (none)");
         } else {
             engine.performMove(move);
+            ai.onMoveExecuted(move);
             output.accept("bestmove " + toUci(move));
         }
     }


### PR DESCRIPTION
## Summary
- add a MoveOrderingPriority utility that persists move-int counters and loads them during engine startup
- teach AI to track its executed moves, adjust priorities after wins or losses when the revise flag is enabled, and fold the learned scores into move ordering
- notify the AI when moves are applied through the UCI handler and match runner so learned data stays up to date

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68f43bb43198832ab91860e7738a5057