### PR TITLE
Scale learning evaluation outputs via tunable parameters

### DIFF
--- a/scripts/auto_tuning_loop.py
+++ b/scripts/auto_tuning_loop.py
@@ -138,6 +138,16 @@ PARAM_MUTATION_HINTS: Dict[str, Dict[str, object]] = {
         "soft_min": 128.0,
         "soft_max": 768.0,
     },
+    "learning.outputmidgamescale": {
+        "step": 10.0,
+        "soft_min": -512.0,
+        "soft_max": 512.0,
+    },
+    "learning.outputendgamescale": {
+        "step": 10.0,
+        "soft_min": -512.0,
+        "soft_max": 512.0,
+    },
     "material.pawnvalue": {
         "step": 1.0,
         "soft_min": 60.0,

--- a/src/main/java/julius/game/chessengine/evaluation/learning/LearningEvaluationModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/learning/LearningEvaluationModule.java
@@ -190,12 +190,17 @@ public final class LearningEvaluationModule implements EvaluationModule, Materia
     }
 
     private void runInference() {
-        double[] output = modelStore.infer(features);
+        LearningModelStore.InferenceResult result = modelStore.inferWithScales(features);
+        double[] output = result.output();
+        double[] scales = result.outputScales();
         if (output.length != 2) {
             throw new IllegalStateException("Learning model must output two values but returned " + output.length);
         }
-        midgameScore = (int) Math.round(output[0]);
-        endgameScore = (int) Math.round(output[1]);
+        if (scales.length != 2) {
+            throw new IllegalStateException("Learning model must provide two output scales but returned " + scales.length);
+        }
+        midgameScore = (int) Math.round(output[0] * scales[0]);
+        endgameScore = (int) Math.round(output[1] * scales[1]);
         if (LOG.isInfoEnabled()) {
             LOG.info("Learning evaluation scores: midgame={}, endgame={}", midgameScore, endgameScore);
         }

--- a/src/main/java/julius/game/chessengine/evaluation/learning/LearningModelStore.java
+++ b/src/main/java/julius/game/chessengine/evaluation/learning/LearningModelStore.java
@@ -1,8 +1,10 @@
 package julius.game.chessengine.evaluation.learning;
 
+import julius.game.chessengine.tuning.ParamId;
 import julius.game.chessengine.tuning.ParameterRegistry;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -43,6 +45,8 @@ public final class LearningModelStore {
             {0.0, 0.0}
     };
 
+    private static final double[] DEFAULT_OUTPUT_SCALES = {120.0, 80.0};
+
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
     private volatile LearningModel model;
@@ -62,6 +66,10 @@ public final class LearningModelStore {
     }
 
     public double[] infer(double[] features) {
+        return inferWithScales(features).output();
+    }
+
+    public InferenceResult inferWithScales(double[] features) {
         Objects.requireNonNull(features, "features");
         LearningModel local = model;
         if (local == null) {
@@ -69,7 +77,8 @@ public final class LearningModelStore {
         }
         lock.readLock().lock();
         try {
-            return local.infer(features);
+            double[] output = local.infer(features);
+            return new InferenceResult(output, local.outputScales());
         } finally {
             lock.readLock().unlock();
         }
@@ -108,7 +117,8 @@ public final class LearningModelStore {
             layers.add(new LayerDefinition(weights, bias, LAYER_ACTIVATIONS[layerIndex].name()));
             previousWidth = outputWidth;
         }
-        return new Definition(INPUT_SIZE, layers);
+        double[] outputScales = resolveOutputScales(previousWidth);
+        return new Definition(INPUT_SIZE, layers, outputScales);
     }
 
     private static double[][] resolveWeights(int layerIndex, int inputWidth, double[][] defaults) {
@@ -137,6 +147,20 @@ public final class LearningModelStore {
         return bias;
     }
 
+    private static double[] resolveOutputScales(int outputSize) {
+        double[] scales = new double[outputSize];
+        for (int i = 0; i < outputSize; i++) {
+            double fallback = DEFAULT_OUTPUT_SCALES.length > i ? DEFAULT_OUTPUT_SCALES[i] : 1.0;
+            double value = switch (i) {
+                case 0 -> ParameterRegistry.get(ParamId.LEARNING_OUTPUT_MIDGAME_SCALE);
+                case 1 -> ParameterRegistry.get(ParamId.LEARNING_OUTPUT_ENDGAME_SCALE);
+                default -> ParameterRegistry.get(outputScaleKey(i), fallback);
+            };
+            scales[i] = value;
+        }
+        return scales;
+    }
+
     private static String weightKey(int layerIndex, int neuronIndex, int inputIndex) {
         return "learning.layer" + layerIndex + ".neuron" + neuronIndex + ".weight" + inputIndex;
     }
@@ -145,7 +169,11 @@ public final class LearningModelStore {
         return "learning.layer" + layerIndex + ".neuron" + neuronIndex + ".bias";
     }
 
-    private record LearningModel(int inputSize, List<Layer> layers) {
+    private static String outputScaleKey(int outputIndex) {
+        return "learning.output.scale" + outputIndex;
+    }
+
+    private record LearningModel(int inputSize, List<Layer> layers, double[] outputScales) {
 
         static LearningModel fromDefinition(Definition definition) {
             Objects.requireNonNull(definition, "definition");
@@ -156,7 +184,8 @@ public final class LearningModelStore {
                 compiled.add(Layer.fromDefinition(layer, previousWidth));
                 previousWidth = layer.outputSize();
             }
-            return new LearningModel(input, Collections.unmodifiableList(compiled));
+            double[] resolvedScales = resolveScales(definition.outputScalesRaw(), previousWidth);
+            return new LearningModel(input, Collections.unmodifiableList(compiled), resolvedScales);
         }
 
         double[] infer(double[] features) {
@@ -169,6 +198,25 @@ public final class LearningModelStore {
                 current = layer.forward(current);
             }
             return current;
+        }
+
+        public double[] outputScales() {
+            return outputScales.clone();
+        }
+
+        private static double[] resolveScales(double[] candidate, int expectedLength) {
+            double[] resolved;
+            if (candidate == null || candidate.length == 0) {
+                resolved = new double[expectedLength];
+                Arrays.fill(resolved, 1.0);
+            } else {
+                if (candidate.length != expectedLength) {
+                    throw new IllegalArgumentException("Output scales length " + candidate.length
+                            + " does not match output width " + expectedLength);
+                }
+                resolved = candidate.clone();
+            }
+            return resolved;
         }
     }
 
@@ -256,10 +304,16 @@ public final class LearningModelStore {
     public static final class Definition {
         private final int inputSize;
         private final List<LayerDefinition> layers;
+        private final double[] outputScales;
 
         public Definition(int inputSize, List<LayerDefinition> layers) {
+            this(inputSize, layers, null);
+        }
+
+        public Definition(int inputSize, List<LayerDefinition> layers, double[] outputScales) {
             this.inputSize = inputSize;
             this.layers = (layers == null ? List.of() : List.copyOf(layers));
+            this.outputScales = outputScales == null ? null : outputScales.clone();
         }
 
         public int inputSize() {
@@ -268,6 +322,14 @@ public final class LearningModelStore {
 
         public List<LayerDefinition> layers() {
             return layers;
+        }
+
+        double[] outputScalesRaw() {
+            return outputScales == null ? null : outputScales.clone();
+        }
+
+        public double[] outputScales() {
+            return outputScalesRaw();
         }
 
         Definition validate() {
@@ -282,6 +344,10 @@ public final class LearningModelStore {
                 layer.validate(previousWidth);
                 previousWidth = layer.outputSize();
             }
+            if (outputScales != null && outputScales.length != previousWidth) {
+                throw new IllegalArgumentException("Output scales length " + outputScales.length
+                        + " must match final layer output width " + previousWidth);
+            }
             return this;
         }
 
@@ -289,7 +355,24 @@ public final class LearningModelStore {
             double[][] weights = new double[2][inputSize];
             double[] bias = new double[2];
             List<LayerDefinition> layers = List.of(new LayerDefinition(weights, bias, "LINEAR"));
-            return new Definition(inputSize, layers);
+            double[] scales = new double[] {1.0, 1.0};
+            return new Definition(inputSize, layers, scales);
+        }
+    }
+
+    public record InferenceResult(double[] output, double[] outputScales) {
+
+        public InferenceResult {
+            output = output.clone();
+            outputScales = outputScales.clone();
+        }
+
+        public double[] output() {
+            return output.clone();
+        }
+
+        public double[] outputScales() {
+            return outputScales.clone();
         }
     }
 

--- a/src/main/java/julius/game/chessengine/tuning/ParamId.java
+++ b/src/main/java/julius/game/chessengine/tuning/ParamId.java
@@ -76,6 +76,8 @@ public enum ParamId {
     THREAT_PAWN_THREAT_QUEEN_PENALTY("threat.pawnThreatQueenPenalty", -25),
 
     EVALUATION_BLEND_SCALE("evaluation.blendScale", 256, 1.0, 1024.0),
+    LEARNING_OUTPUT_MIDGAME_SCALE("learning.outputMidgameScale", 120.0, -1024.0, 1024.0),
+    LEARNING_OUTPUT_ENDGAME_SCALE("learning.outputEndgameScale", 80.0, -1024.0, 1024.0),
 
     MOVE_ORDERING_CATEGORY_TT("moveOrdering.category.tt", 7, 6.0, 8.0),
     MOVE_ORDERING_CATEGORY_PROMOTION("moveOrdering.category.promotion", 6, 5.0, 7.0),

--- a/src/main/java/julius/game/chessengine/tuning/Tuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/Tuning.java
@@ -80,6 +80,8 @@ public final class Tuning {
     private static int pawnThreatQueenPenalty;
 
     private static int evaluationBlendScale;
+    private static double learningOutputMidgameScale;
+    private static double learningOutputEndgameScale;
 
     private static int moveOrderingCategoryTt;
     private static int moveOrderingCategoryPromotion;
@@ -469,6 +471,14 @@ public final class Tuning {
 
     public static int evaluationBlendScale() {
         return evaluationBlendScale;
+    }
+
+    public static double learningOutputMidgameScale() {
+        return learningOutputMidgameScale;
+    }
+
+    public static double learningOutputEndgameScale() {
+        return learningOutputEndgameScale;
     }
 
     public static int moveOrderingCategoryTt() {
@@ -1017,6 +1027,8 @@ public final class Tuning {
 
 
             evaluationBlendScale = loadInt(ParamId.EVALUATION_BLEND_SCALE);
+            learningOutputMidgameScale = loadDouble(ParamId.LEARNING_OUTPUT_MIDGAME_SCALE);
+            learningOutputEndgameScale = loadDouble(ParamId.LEARNING_OUTPUT_ENDGAME_SCALE);
 
             moveOrderingCategoryTt = loadInt(ParamId.MOVE_ORDERING_CATEGORY_TT);
             moveOrderingCategoryPromotion = loadInt(ParamId.MOVE_ORDERING_CATEGORY_PROMOTION);

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -198,6 +198,8 @@ population:
       learning.layer1.neuron1.weight5: -0.2
       learning.layer1.neuron1.weight6: -0.1
       learning.layer1.neuron1.weight7: 0.3
+      learning.outputMidgameScale: 120.0
+      learning.outputEndgameScale: 80.0
       learning.layer1.neuron0.bias: 0.0
       learning.layer1.neuron1.bias: 0.0
       material.pawnvalue: 112

--- a/src/test/java/julius/game/chessengine/evaluation/learning/LearningEvaluationModuleTest.java
+++ b/src/test/java/julius/game/chessengine/evaluation/learning/LearningEvaluationModuleTest.java
@@ -87,16 +87,37 @@ class LearningEvaluationModuleTest {
         assertThat(module.getEndgameScore()).isEqualTo(rebuild.getEndgameScore());
     }
 
-    private static LearningModelStore buildLinearStore(double midgameWeight, double endgameWeight) {
+    @Test
+    void defaultDefinitionProducesNonZeroScoresForCommonPositions() {
+        LearningEvaluationModule module = new LearningEvaluationModule();
+
+        List<String> representativeFens = List.of(
+                "8/8/2k5/8/4K3/6P1/8/8 w - - 0 1",
+                "4k3/8/8/8/8/8/8/3K4 w - - 0 1"
+        );
+        for (String fen : representativeFens) {
+            BitBoard board = FEN.translateFENtoBitBoard(fen);
+            EvaluationContext context = EvaluationContext.from(board, null);
+            module.initialize(context);
+            module.evaluate(context);
+            int midgameScore = module.getMidgameScore();
+            int endgameScore = module.getEndgameScore();
+            assertThat(Math.abs(midgameScore) + Math.abs(endgameScore)).as("Scaled output for FEN %s", fen)
+                    .isNotZero();
+        }
+    }
+
+    private static LearningModelStore buildLinearStore(double midgameScale, double endgameScale) {
         double[][] weights = new double[2][LearningEvaluationModule.FEATURE_VECTOR_SIZE];
-        weights[0][0] = midgameWeight;
-        weights[1][0] = endgameWeight;
+        weights[0][0] = 1.0;
+        weights[1][0] = 1.0;
         double[] bias = new double[] {0.0, 0.0};
+        double[] scales = new double[] {midgameScale, endgameScale};
         LearningModelStore.LayerDefinition layer =
                 new LearningModelStore.LayerDefinition(weights, bias, "LINEAR");
         LearningModelStore.Definition definition =
                 new LearningModelStore.Definition(LearningEvaluationModule.FEATURE_VECTOR_SIZE,
-                        List.of(layer));
+                        List.of(layer), scales);
         return new LearningModelStore(definition);
     }
 


### PR DESCRIPTION
## Summary
- extend the learning model definition and runtime inference flow to carry per-output scale factors sourced from the tuning registry
- register default scale values, expose them through the tuning cache, and add auto-tuning hints so the scaler can be optimized alongside network weights
- update the learning evaluation tests to cover scaled outputs and ensure representative positions yield non-zero centipawn scores

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=LearningEvaluationModuleTest test

------
https://chatgpt.com/codex/tasks/task_e_68f68dfdc23c832ab9e971896aa197e6