### PR TITLE
Ensure learning evaluation reloads on tuning refresh

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/learning/LearningEvaluationModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/learning/LearningEvaluationModule.java
@@ -9,7 +9,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
+import java.util.WeakHashMap;
 
 /**
  * Evaluation module that converts the {@link EvaluationContext} into a lightweight feature tensor
@@ -18,6 +21,14 @@ import java.util.Objects;
 public final class LearningEvaluationModule implements EvaluationModule, MaterialModule.PawnChangeListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(LearningEvaluationModule.class);
+
+    private static final LearningModelStore SHARED_STORE = new LearningModelStore();
+    private static final Set<LearningEvaluationModule> SHARED_INSTANCES = Collections.synchronizedSet(
+            Collections.newSetFromMap(new WeakHashMap<>()));
+
+    static {
+        Tuning.registerRefreshListener(LearningEvaluationModule::refreshSharedStore);
+    }
 
     public static final int FEATURE_VECTOR_SIZE = 19;
 
@@ -34,14 +45,31 @@ public final class LearningEvaluationModule implements EvaluationModule, Materia
     private boolean dirty = true;
 
     public LearningEvaluationModule() {
-        this(new LearningModelStore());
+        this(SHARED_STORE, true);
     }
 
     LearningEvaluationModule(LearningModelStore store) {
-        this.modelStore = Objects.requireNonNull(store, "store");
-        if (store.inputSize() != 0 && store.inputSize() != FEATURE_VECTOR_SIZE) {
+        this(store, store == SHARED_STORE);
+    }
+
+    private LearningEvaluationModule(LearningModelStore store, boolean registerShared) {
+        LearningModelStore resolved = Objects.requireNonNull(store, "store");
+        if (resolved.inputSize() != 0 && resolved.inputSize() != FEATURE_VECTOR_SIZE) {
             throw new IllegalArgumentException("Learning model expects feature length " + store.inputSize()
                     + " but module provides " + FEATURE_VECTOR_SIZE);
+        }
+        this.modelStore = resolved;
+        if (registerShared) {
+            SHARED_INSTANCES.add(this);
+        }
+    }
+
+    private static void refreshSharedStore() {
+        SHARED_STORE.reloadFromParameters();
+        synchronized (SHARED_INSTANCES) {
+            for (LearningEvaluationModule module : SHARED_INSTANCES) {
+                module.markDirty();
+            }
         }
     }
 

--- a/src/main/java/julius/game/chessengine/tuning/Tuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/Tuning.java
@@ -8,6 +8,8 @@ package julius.game.chessengine.tuning;
 public final class Tuning {
 
     private static final Object LOCK = new Object();
+    private static final java.util.concurrent.CopyOnWriteArrayList<Runnable> REFRESH_LISTENERS =
+            new java.util.concurrent.CopyOnWriteArrayList<>();
 
     private static int pawnValue;
     private static int knightValue;
@@ -949,6 +951,17 @@ public final class Tuning {
         return searchTbTieBreak;
     }
 
+    public static void registerRefreshListener(Runnable listener) {
+        java.util.Objects.requireNonNull(listener, "listener");
+        REFRESH_LISTENERS.addIfAbsent(listener);
+    }
+
+    public static void unregisterRefreshListener(Runnable listener) {
+        if (listener != null) {
+            REFRESH_LISTENERS.remove(listener);
+        }
+    }
+
     /**
      * Reloads all cached tuning values from the current {@link ParameterRegistry} snapshot.
      * Callers should invoke this once after applying a new parameter set (e.g. via hot reload).
@@ -1148,6 +1161,28 @@ public final class Tuning {
             absPlyLimitMargin = loadInt(ParamId.SEARCH_ABS_PLY_LIMIT_MARGIN);
             searchPreferFastMate = loadBoolean(ParamId.SEARCH_PREFER_FAST_MATE);
             searchTbTieBreak = loadBoolean(ParamId.SEARCH_TB_TIE_BREAK);
+        }
+        notifyRefreshListeners();
+    }
+
+    private static void notifyRefreshListeners() {
+        if (REFRESH_LISTENERS.isEmpty()) {
+            return;
+        }
+        RuntimeException failure = null;
+        for (Runnable listener : REFRESH_LISTENERS) {
+            try {
+                listener.run();
+            } catch (RuntimeException ex) {
+                if (failure == null) {
+                    failure = ex;
+                } else {
+                    failure.addSuppressed(ex);
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
         }
     }
 

--- a/src/test/java/julius/game/chessengine/evaluation/learning/LearningEvaluationModuleTest.java
+++ b/src/test/java/julius/game/chessengine/evaluation/learning/LearningEvaluationModuleTest.java
@@ -6,12 +6,16 @@ import julius.game.chessengine.board.MoveHelper;
 import julius.game.chessengine.evaluation.EvaluationContext;
 import julius.game.chessengine.evaluation.MoveContext;
 import julius.game.chessengine.figures.PieceType;
+import julius.game.chessengine.tuning.NumericTuningParameters;
+import julius.game.chessengine.tuning.Tuning;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 class LearningEvaluationModuleTest {
 
@@ -105,6 +109,50 @@ class LearningEvaluationModuleTest {
             assertThat(Math.abs(midgameScore) + Math.abs(endgameScore)).as("Scaled output for FEN %s", fen)
                     .isNotZero();
         }
+    }
+
+    @Test
+    void sharedStoreReloadsWhenTuningRefreshes() throws Exception {
+        LearningEvaluationModule module = new LearningEvaluationModule();
+
+        BitBoard board = FEN.translateFENtoBitBoard(START_FEN);
+        applyMoves(board,
+                MoveHelper.createMoveInt(index("e2"), index("e4"), PieceType.PAWN, true, false,
+                        false, false, null, null, false, false, packCastlingState(board)),
+                MoveHelper.createMoveInt(index("d7"), index("d5"), PieceType.PAWN, false, false,
+                        false, false, null, null, false, false, packCastlingState(board)),
+                MoveHelper.createMoveInt(index("e4"), index("d5"), PieceType.PAWN, true, true,
+                        false, false, null, PieceType.PAWN, false, false, packCastlingState(board)));
+
+        EvaluationContext context = EvaluationContext.from(board, null);
+        module.initialize(context);
+        module.evaluate(context);
+
+        int baselineMid = module.getMidgameScore();
+        int baselineEnd = module.getEndgameScore();
+        double baselineMidScale = Tuning.learningOutputMidgameScale();
+        double baselineEndScale = Tuning.learningOutputEndgameScale();
+
+        double newMidScale = baselineMidScale * 1.5;
+        double newEndScale = baselineEndScale * 0.75;
+
+        try (AutoCloseable overrides = NumericTuningParameters.use(Map.of(
+                "learning.outputMidgameScale", newMidScale,
+                "learning.outputEndgameScale", newEndScale
+        ))) {
+            Tuning.refresh();
+            module.evaluate(context);
+            assertThat((double) module.getMidgameScore())
+                    .isCloseTo(baselineMid * (newMidScale / baselineMidScale), within(1.0));
+            assertThat((double) module.getEndgameScore())
+                    .isCloseTo(baselineEnd * (newEndScale / baselineEndScale), within(1.0));
+        } finally {
+            Tuning.refresh();
+        }
+
+        module.evaluate(context);
+        assertThat(module.getMidgameScore()).isEqualTo(baselineMid);
+        assertThat(module.getEndgameScore()).isEqualTo(baselineEnd);
     }
 
     private static LearningModelStore buildLinearStore(double midgameScale, double endgameScale) {


### PR DESCRIPTION
## Summary
- add refresh listener support to `Tuning` so modules can react to hot reloads
- share a global `LearningEvaluationModule` model store and mark modules dirty when tuning changes
- cover the shared-store refresh behaviour with a dedicated unit test

## Testing
- `mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=LearningEvaluationModuleTest test`

------
https://chatgpt.com/codex/tasks/task_e_68f6942ea478832a8383da0625a3fe64