### PR TITLE
Expand learning-guided move ordering heuristics

### DIFF
--- a/scripts/auto-tuning-powershell-recipes.md
+++ b/scripts/auto-tuning-powershell-recipes.md
@@ -289,3 +289,19 @@ python .\scripts\auto_tuning_loop.py `
   --git-commit `
   --extra-maven-args -q
 ```
+
+python .\scripts\cutechess_tuning_loop.py --project-root C:\Development\Chess-Engine `
+--cutechess-cli "C:\Program Files (x86)\Cute Chess\cutechess-cli.exe" --stockfish C:\Development\cutechess\stockfish\stockfish-windows-x86-64-avx2.exe `
+--java java --engine-name Alieknek `
+--opponent-name SF --opponent-elo 1750 `
+--time-control 10+0.1 --concurrency 3 `
+--rounds 10 --pgn-out C:\Development\cutechess\match_tuning.pgn `
+--engine-gc zgc --engine-active-processor-count 24 `
+--engine-tt-mb 1024 --engine-threads 1 `
+--engine-lazy-threads 1 --mut-frac 0.22 `
+--mut-frac-min 0.18 --mut-frac-max 0.28 `
+--temp-start 0.25 --temp-min 0.05 `
+--temp-decay 14 --spectral-base 0.70 `
+--reheat-factor 1.0 --accept-worse `
+--accept-temp 0.08 --build-jar `
+--allow-pattern "^(learning.)" 

--- a/scripts/auto_tuning_loop.py
+++ b/scripts/auto_tuning_loop.py
@@ -1069,6 +1069,27 @@ PARAM_MUTATION_HINTS: Dict[str, Dict[str, object]] = {
         "soft_min": 1.0,
         "soft_max": 16.0,
     },
+    "moveordering.quietlearningweight": {
+        "step": 1.0,
+        "soft_min": 0.0,
+        "soft_max": 64.0,
+        "sentinel_probe": 0.08,
+        "sentinels": [0.0],
+    },
+    "moveordering.quietlearningclamp": {
+        "step": 32.0,
+        "soft_min": 0.0,
+        "soft_max": 2048.0,
+        "sentinel_probe": 0.08,
+        "sentinels": [0.0],
+    },
+    "moveordering.quietlearningmaxmoves": {
+        "step": 1.0,
+        "soft_min": 0.0,
+        "soft_max": 32.0,
+        "sentinel_probe": 0.08,
+        "sentinels": [0.0],
+    },
 }
 
 for layer_index, output_count, input_count in ((0, 8, 19), (1, 2, 8)):

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -11,6 +11,7 @@ import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.evaluation.EvaluationContext;
+import julius.game.chessengine.evaluation.learning.LearningEvaluationModule;
 import julius.game.chessengine.helper.KnightHelper;
 import julius.game.chessengine.syzygy.*;
 import julius.game.chessengine.tuning.*;
@@ -219,6 +220,9 @@ public class AI {
                 map.defaultReturnValue(Double.NaN);
                 return map;
             });
+
+    private final ThreadLocal<LearningMoveOrdering> learningMoveOrdering =
+            ThreadLocal.withInitial(LearningMoveOrdering::new);
 
     /**
      * Root-split worker simulations. Each search thread reuses its own clone to avoid
@@ -3501,6 +3505,19 @@ public class AI {
         final double quietHistoryMultiplier = moveOrderingParameters.quietHistoryMultiplier();
         final int quietHistoryBonus = moveOrderingParameters.quietHistoryBonus();
         final int maxScore = Math.max(1, moveOrderingParameters.maxScore());
+        final int quietLearningWeight = moveOrderingParameters.quietLearningWeight();
+        final int quietLearningClamp = Math.max(0, moveOrderingParameters.quietLearningClamp());
+        final int quietLearningMaxMoves = Math.max(0, moveOrderingParameters.quietLearningMaxMoves());
+        final boolean learningEnabled = quietLearningWeight != 0;
+        final LearningMoveOrdering[] learningProbeRef = new LearningMoveOrdering[1];
+        final int[] learningBudgetRef = new int[]{quietLearningMaxMoves};
+        final boolean learningUnlimited = quietLearningMaxMoves <= 0;
+        if (learningEnabled) {
+            LearningMoveOrdering candidateProbe = learningMoveOrdering.get();
+            if (candidateProbe.prepare(simulatorEngine)) {
+                learningProbeRef[0] = candidateProbe;
+            }
+        }
 
         // Hash move (TT)
         TranspositionTableEntry ttEntry = transpositionTable.get(boardHash);
@@ -3577,9 +3594,15 @@ public class AI {
                 }
             } else if (moveInt == k0) {
                 score = killerMoveScore + killer0Bonus;
+                score = applyLearningContribution(score, moveInt, learningEnabled,
+                        learningProbeRef, learningBudgetRef, learningUnlimited,
+                        quietLearningClamp, quietLearningWeight);
                 targetBucket = killer0Bucket;
             } else if (moveInt == k1) {
                 score = killerMoveScore + killer1Bonus;
+                score = applyLearningContribution(score, moveInt, learningEnabled,
+                        learningProbeRef, learningBudgetRef, learningUnlimited,
+                        quietLearningClamp, quietLearningWeight);
                 targetBucket = killer1Bucket;
             } else {
                 final int from = moveInt & 0x3F;
@@ -3603,6 +3626,9 @@ public class AI {
                 if (MoveHelper.isCastlingMove(moveInt)) {
                     score += castlingBonus;
                 }
+                score = applyLearningContribution(score, moveInt, learningEnabled,
+                        learningProbeRef, learningBudgetRef, learningUnlimited,
+                        quietLearningClamp, quietLearningWeight);
                 targetBucket = quietBucket;
             }
 
@@ -4119,6 +4145,134 @@ public class AI {
             globalHeuristics.clearCounter();
         } finally {
             releaseWriteLock(stamp);
+        }
+    }
+
+    private static int applyLearningContribution(int baseScore, int move,
+                                                 boolean learningEnabled,
+                                                 LearningMoveOrdering[] probeRef,
+                                                 int[] budgetRef,
+                                                 boolean learningUnlimited,
+                                                 int clamp,
+                                                 int weight) {
+        if (!learningEnabled) {
+            return baseScore;
+        }
+        LearningMoveOrdering probe = probeRef[0];
+        if (probe == null) {
+            return baseScore;
+        }
+        if (!learningUnlimited && budgetRef[0] <= 0) {
+            return baseScore;
+        }
+        int learningDelta = probe.scoreQuietMove(move);
+        if (!learningUnlimited) {
+            budgetRef[0]--;
+        }
+        if (learningDelta == LearningMoveOrdering.NO_SCORE) {
+            probeRef[0] = null;
+            return baseScore;
+        }
+        if (clamp > 0) {
+            learningDelta = Math.max(-clamp, Math.min(clamp, learningDelta));
+        }
+        long adjusted = (long) learningDelta * (long) weight;
+        long candidateScore = (long) baseScore + adjusted;
+        if (candidateScore > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        } else if (candidateScore < Integer.MIN_VALUE) {
+            return Integer.MIN_VALUE;
+        }
+        return (int) candidateScore;
+    }
+
+    private static final class LearningMoveOrdering {
+
+        private static final int NO_SCORE = Integer.MIN_VALUE;
+
+        private final LearningEvaluationModule module = new LearningEvaluationModule();
+        private BitBoard scratchBoard;
+        private EvaluationContext baseContext;
+        private EvaluationContext workContext;
+        private int baselineScore;
+        private boolean baselineWhiteToMove;
+        private final int blendScale = Math.max(1, Tuning.evaluationBlendScale());
+        private boolean ready;
+
+        boolean prepare(Engine engine) {
+            try {
+                BitBoard source = engine.getBitBoard();
+                if (source == null) {
+                    ready = false;
+                    return false;
+                }
+                scratchBoard = new BitBoard(source);
+                GameState gameState = engine.getGameState();
+                GameStateEnum state = (gameState != null) ? gameState.getState() : null;
+                if (baseContext == null) {
+                    baseContext = EvaluationContext.from(scratchBoard, state);
+                    workContext = baseContext.copy();
+                } else {
+                    baseContext.updateFrom(scratchBoard, state);
+                    workContext.updateFrom(scratchBoard, state);
+                }
+                module.initialize(baseContext);
+                baselineScore = blend(baseContext);
+                baselineWhiteToMove = scratchBoard.isWhitesTurn();
+                ready = true;
+                return true;
+            } catch (Exception ignored) {
+                ready = false;
+                return false;
+            }
+        }
+
+        int scoreQuietMove(int move) {
+            if (!ready || scratchBoard == null || workContext == null) {
+                return NO_SCORE;
+            }
+            boolean moved = false;
+            try {
+                scratchBoard.performMove(move);
+                moved = true;
+                workContext.updateFrom(scratchBoard, null);
+                module.markDirty();
+                module.evaluate(workContext);
+                int childScore = blend(workContext);
+                return baselineWhiteToMove ? (childScore - baselineScore) : (baselineScore - childScore);
+            } catch (Exception ignored) {
+                ready = false;
+                return NO_SCORE;
+            } finally {
+                if (moved) {
+                    try {
+                        scratchBoard.undoMove(move);
+                    } catch (Exception undoFailed) {
+                        ready = false;
+                    }
+                    if (workContext != null) {
+                        try {
+                            workContext.updateFrom(scratchBoard, null);
+                        } catch (Exception ignoredUpdate) {
+                            ready = false;
+                        }
+                    }
+                }
+            }
+        }
+
+        private int blend(EvaluationContext ctx) {
+            int phase = (ctx != null) ? ctx.getPhase() : 0;
+            if (phase < 0) {
+                phase = 0;
+            } else if (phase > blendScale) {
+                phase = blendScale;
+            }
+            int midgameWeight = blendScale - phase;
+            int endgameWeight = phase;
+            long total = (long) module.getMidgameScore() * midgameWeight
+                    + (long) module.getEndgameScore() * endgameWeight;
+            return (int) (total / (long) blendScale);
         }
     }
 

--- a/src/main/java/julius/game/chessengine/tuning/MoveOrderingParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/MoveOrderingParameters.java
@@ -45,7 +45,10 @@ public final class MoveOrderingParameters {
                 Tuning.moveOrderingQuietHistoryBonus(),
                 Tuning.moveOrderingMaxScore(),
                 Tuning.moveOrderingHistoryScale(),
-                Tuning.moveOrderingHistoryDecayDivisor()
+                Tuning.moveOrderingHistoryDecayDivisor(),
+                Tuning.moveOrderingQuietLearningWeight(),
+                Tuning.moveOrderingQuietLearningClamp(),
+                Tuning.moveOrderingQuietLearningMaxMoves()
         );
     }
 
@@ -91,6 +94,9 @@ public final class MoveOrderingParameters {
         defaults.put(ParamId.MOVE_ORDERING_MAX_SCORE.key(), ParamId.MOVE_ORDERING_MAX_SCORE.defaultValue());
         defaults.put(ParamId.MOVE_ORDERING_HISTORY_SCALE.key(), ParamId.MOVE_ORDERING_HISTORY_SCALE.defaultValue());
         defaults.put(ParamId.MOVE_ORDERING_HISTORY_DECAY_DIVISOR.key(), ParamId.MOVE_ORDERING_HISTORY_DECAY_DIVISOR.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_QUIET_LEARNING_WEIGHT.key(), ParamId.MOVE_ORDERING_QUIET_LEARNING_WEIGHT.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_QUIET_LEARNING_CLAMP.key(), ParamId.MOVE_ORDERING_QUIET_LEARNING_CLAMP.defaultValue());
+        defaults.put(ParamId.MOVE_ORDERING_QUIET_LEARNING_MAX_MOVES.key(), ParamId.MOVE_ORDERING_QUIET_LEARNING_MAX_MOVES.defaultValue());
         return Collections.unmodifiableMap(defaults);
     }
 
@@ -122,7 +128,10 @@ public final class MoveOrderingParameters {
             int quietHistoryBonus,
             int maxScore,
             double historyScale,
-            int historyDecayDivisor
+            int historyDecayDivisor,
+            int quietLearningWeight,
+            int quietLearningClamp,
+            int quietLearningMaxMoves
     ) {
         public Map<String, Number> asMap() {
             Map<String, Number> values = new LinkedHashMap<>();
@@ -154,6 +163,9 @@ public final class MoveOrderingParameters {
             values.put("moveOrdering.maxScore", maxScore);
             values.put("moveOrdering.historyScale", historyScale);
             values.put("moveOrdering.historyDecayDivisor", historyDecayDivisor);
+            values.put("moveOrdering.quietLearningWeight", quietLearningWeight);
+            values.put("moveOrdering.quietLearningClamp", quietLearningClamp);
+            values.put("moveOrdering.quietLearningMaxMoves", quietLearningMaxMoves);
             return Collections.unmodifiableMap(values);
         }
     }

--- a/src/main/java/julius/game/chessengine/tuning/ParamId.java
+++ b/src/main/java/julius/game/chessengine/tuning/ParamId.java
@@ -108,6 +108,9 @@ public enum ParamId {
     MOVE_ORDERING_MAX_SCORE("moveOrdering.maxScore", 0x00FFFFFF, 1024.0, 16777215.0),
     MOVE_ORDERING_HISTORY_SCALE("moveOrdering.historyScale", 1.0, 0.0, null),
     MOVE_ORDERING_HISTORY_DECAY_DIVISOR("moveOrdering.historyDecayDivisor", 2, 1.0, null),
+    MOVE_ORDERING_QUIET_LEARNING_WEIGHT("moveOrdering.quietLearningWeight", 12, 0.0, 256.0),
+    MOVE_ORDERING_QUIET_LEARNING_CLAMP("moveOrdering.quietLearningClamp", 320, 0.0, 4000.0),
+    MOVE_ORDERING_QUIET_LEARNING_MAX_MOVES("moveOrdering.quietLearningMaxMoves", 8, 0.0, 64.0),
 
     SEARCH_FP_MARGIN_DEPTH1("search.fpMarginDepth1", 0, 0.0, 4000.0),
     SEARCH_FP_MARGIN_DEPTH2("search.fpMarginDepth2", 0, 0.0, 8000.0),

--- a/src/main/java/julius/game/chessengine/tuning/Tuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/Tuning.java
@@ -111,6 +111,9 @@ public final class Tuning {
     private static int moveOrderingMaxScore;
     private static double moveOrderingHistoryScale;
     private static int moveOrderingHistoryDecayDivisor;
+    private static int moveOrderingQuietLearningWeight;
+    private static int moveOrderingQuietLearningClamp;
+    private static int moveOrderingQuietLearningMaxMoves;
 
     private static int searchFpMarginDepth1;
     private static int searchFpMarginDepth2;
@@ -593,6 +596,18 @@ public final class Tuning {
         return moveOrderingHistoryDecayDivisor;
     }
 
+    public static int moveOrderingQuietLearningWeight() {
+        return moveOrderingQuietLearningWeight;
+    }
+
+    public static int moveOrderingQuietLearningClamp() {
+        return moveOrderingQuietLearningClamp;
+    }
+
+    public static int moveOrderingQuietLearningMaxMoves() {
+        return moveOrderingQuietLearningMaxMoves;
+    }
+
     public static int searchFpMarginDepth1() {
         return searchFpMarginDepth1;
     }
@@ -1058,6 +1073,9 @@ public final class Tuning {
             moveOrderingMaxScore = loadInt(ParamId.MOVE_ORDERING_MAX_SCORE);
             moveOrderingHistoryScale = loadDouble(ParamId.MOVE_ORDERING_HISTORY_SCALE);
             moveOrderingHistoryDecayDivisor = loadInt(ParamId.MOVE_ORDERING_HISTORY_DECAY_DIVISOR);
+            moveOrderingQuietLearningWeight = loadInt(ParamId.MOVE_ORDERING_QUIET_LEARNING_WEIGHT);
+            moveOrderingQuietLearningClamp = loadInt(ParamId.MOVE_ORDERING_QUIET_LEARNING_CLAMP);
+            moveOrderingQuietLearningMaxMoves = loadInt(ParamId.MOVE_ORDERING_QUIET_LEARNING_MAX_MOVES);
 
             searchFpMarginDepth1 = loadInt(ParamId.SEARCH_FP_MARGIN_DEPTH1);
             searchFpMarginDepth2 = loadInt(ParamId.SEARCH_FP_MARGIN_DEPTH2);

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -3,55 +3,55 @@ population:
     evaluation:
       modules:
         MaterialModule:
-          midgame: 0.5
-          endgame: 0.5
+          midgame: 1
+          endgame: 1
         PawnStructureModule:
-          midgame: 0.5
-          endgame: 0.6
+          midgame: 1
+          endgame: 1
         ActivityModule:
-          midgame: 0.5
-          endgame: 0.5
+          midgame: 1
+          endgame: 1
         KingSafetyModule:
-          midgame: 0.5
-          endgame: 0.5
+          midgame: 1
+          endgame: 1
         ThreatModule:
-          midgame: 0.5
-          endgame: 0.4
+          midgame: 1
+          endgame: 1
         LearningEvaluationModule:
-          midgame: 1.0
-          endgame: 1.0
+          midgame: 1
+          endgame: 1
     numericParameters:
-      evaluation.blendscale: 764
-      material.pawnvalue: 112
-      material.knightvalue: 395
-      material.bishopvalue: 420
-      material.rookvalue: 636
-      material.queenvalue: 1120
-      material.bishoppairbonus: 58
-      pawnstructure.centerpawnbonus: 26
-      pawnstructure.passedpawnbonus: 52
-      pawnstructure.connectedpawnbonus: 7
+      evaluation.blendscale: 765
+      material.pawnvalue: 154
+      material.knightvalue: 287
+      material.bishopvalue: 411
+      material.rookvalue: 609
+      material.queenvalue: 1083
+      material.bishoppairbonus: 55
+      pawnstructure.centerpawnbonus: 32
+      pawnstructure.passedpawnbonus: 47
+      pawnstructure.connectedpawnbonus: 9
       pawnstructure.islandpenalty: -6
-      pawnstructure.doubledpawnpenalty: -10
-      pawnstructure.isolatedpawnpenalty: -7
-      pawnstructure.advancedpawnbonus: 11
-      pawnstructure.blockedpawnpenalty: -5
+      pawnstructure.doubledpawnpenalty: -11
+      pawnstructure.isolatedpawnpenalty: -6
+      pawnstructure.advancedpawnbonus: 9
+      pawnstructure.blockedpawnpenalty: -4
       pawnstructure.backwardpawnpenalty: -24
-      pawnstructure.ownkingblockspassedpawnpenalty: -85
+      pawnstructure.ownkingblockspassedpawnpenalty: -69
       pawnstructure.passedpawnfreepathbonusperrank: 15
-      pawnstructure.rookhalfopenfilebonus: 36
-      pawnstructure.rookopenfilebonus: 39
-      threat.hangingpawnpenalty: -11
+      pawnstructure.rookhalfopenfilebonus: 40
+      pawnstructure.rookopenfilebonus: 37
+      threat.hangingpawnpenalty: -9
       threat.hangingknightpenalty: -23
       threat.hangingbishoppenalty: -14
-      threat.hangingrookpenalty: -69
-      threat.hangingqueenpenalty: -58
+      threat.hangingrookpenalty: -91
+      threat.hangingqueenpenalty: -55
       threat.pawnthreatknightpenalty: -9
       threat.pawnthreatbishoppenalty: -8
-      threat.pawnthreatrookpenalty: -11
-      threat.pawnthreatqueenpenalty: -28
-      activity.midgamemobilityknight: 9
-      activity.midgamemobilitybishop: 12
+      threat.pawnthreatrookpenalty: -9
+      threat.pawnthreatqueenpenalty: -26
+      activity.midgamemobilityknight: 12
+      activity.midgamemobilitybishop: 9
       activity.midgamemobilityrook: 12
       activity.midgamemobilityqueen: 3
       activity.midgamemobilityking: 0
@@ -61,311 +61,311 @@ population:
       activity.endgamemobilityqueen: 1
       activity.endgamemobilityking: 2
       activity.midgamecenterknight: 4
-      activity.midgamecenterbishop: 3
-      activity.midgamecenterrook: 2
+      activity.midgamecenterbishop: 4
+      activity.midgamecenterrook: 3
       activity.midgamecenterqueen: 2
       activity.midgamecenterking: 0
-      activity.endgamecenterknight: 8
+      activity.endgamecenterknight: 6
       activity.endgamecenterbishop: -4
       activity.endgamecenterrook: 3
-      activity.endgamecenterqueen: 3
-      activity.endgamecenterking: 6
-      kingsafety.missingpawnshieldpenalty: -25
-      kingsafety.halfopenfilepenalty: -1
-      kingsafety.openfilepenalty: -15
-      kingsafety.defenderbonus: 8
-      kingsafety.queenattackedpenalty: -71
-      kingsafety.backrankweaknessmidgamepenalty: -75
-      kingsafety.backrankweaknessendgamepenalty: -51
-      kingsafety.attackweightpawn: 8
-      kingsafety.attackweightknight: 21
-      kingsafety.attackweightbishop: 14
+      activity.endgamecenterqueen: 4
+      activity.endgamecenterking: 5
+      kingsafety.missingpawnshieldpenalty: -21
+      kingsafety.halfopenfilepenalty: 0
+      kingsafety.openfilepenalty: -18
+      kingsafety.defenderbonus: 13
+      kingsafety.queenattackedpenalty: -76
+      kingsafety.backrankweaknessmidgamepenalty: -49
+      kingsafety.backrankweaknessendgamepenalty: -40
+      kingsafety.attackweightpawn: 9
+      kingsafety.attackweightknight: 22
+      kingsafety.attackweightbishop: 16
       kingsafety.attackweightrook: 34
-      kingsafety.attackweightqueen: 24
+      kingsafety.attackweightqueen: 22
       moveordering.category.tt: 8
-      moveordering.category.promotion: 6
+      moveordering.category.promotion: 7
       moveordering.category.capturegood: 4
       moveordering.category.captureequal: 4
       moveordering.category.killer0: 3
       moveordering.category.killer1: 2
       moveordering.category.quiet: 1
       moveordering.category.capturebad: 0
-      moveordering.killermovescore: 13233
-      moveordering.promotionbonus: 1390
-      moveordering.killer0bonus: 238
-      moveordering.killer1bonus: 256
-      moveordering.countermovebonus: 465
-      moveordering.capturemvvmultiplier: 22
-      moveordering.captureseemultiplier: 192
-      moveordering.promotionseemultiplier: 32
-      moveordering.castlingbonus: 54
+      moveordering.killermovescore: 14495
+      moveordering.promotionbonus: 1589
+      moveordering.killer0bonus: 174
+      moveordering.killer1bonus: 334
+      moveordering.countermovebonus: 624
+      moveordering.capturemvvmultiplier: 31
+      moveordering.captureseemultiplier: 186
+      moveordering.promotionseemultiplier: 43
+      moveordering.castlingbonus: 0
       moveordering.captureseeclamp: 512
-      moveordering.promotionseeclamp: 397
-      moveordering.capturegoodbonus: 946
-      moveordering.captureequalbonus: 187
+      moveordering.promotionseeclamp: 403
+      moveordering.capturegoodbonus: 955
+      moveordering.captureequalbonus: 164
       moveordering.capturebadbonus: -517
       moveordering.capturelosingseepenalty: 1
       moveordering.quiethistorymultiplier: 3.8
-      moveordering.quiethistorybonus: 3409
-      moveordering.maxscore: 16764829
+      moveordering.quiethistorybonus: 2944
+      moveordering.maxscore: 16686158
       moveordering.historyscale: 4.0
       moveordering.historydecaydivisor: 2
-      moveordering.quietlearningweight: 10
-      moveordering.quietlearningclamp: 503
+      moveordering.quietlearningweight: 0
+      moveordering.quietlearningclamp: 608
       moveordering.quietlearningmaxmoves: 0
-      search.fpMarginDepth1: 0
-      search.fpMarginDepth2: 729
-      search.lmpBase: 1
-      search.lmpPerDepth: 18
-      search.fpMaxDepth: 11
-      search.lmpMaxDepth: 14
-      search.hmpMinIndex: -1
-      search.hmpHistoryMax: 235
+      search.fpMarginDepth1: 44
+      search.fpMarginDepth2: 30
+      search.lmpBase: 0
+      search.lmpPerDepth: 20
+      search.fpMaxDepth: 14
+      search.lmpMaxDepth: 15
+      search.hmpMinIndex: 0
+      search.hmpHistoryMax: -1
       search.iidReduceDepth: 0
       search.lmrProtectPlyMax: 0
-      search.lmrProtectIndexMax: 2
-      search.lmrCapGoodQuiet: 31
+      search.lmrProtectIndexMax: 0
+      search.lmrCapGoodQuiet: 44
       search.lmrHistoryBuckets: 3
-      search.lmrHistoryWeightSlope: 1.06
-      search.lmrScaleDivisor: 3.5
-      search.lmrDepthLogOffset: 6.4
-      search.lmrMoveLogOffset: 8.7
+      search.lmrHistoryWeightSlope: 1.48
+      search.lmrScaleDivisor: 4.0
+      search.lmrDepthLogOffset: 7.3
+      search.lmrMoveLogOffset: 8.4
       search.maxCheckExtensionStreak: 0
-      search.seePruneNearRootPly: 14
-      search.historyReductionMax: 8000
+      search.seePruneNearRootPly: 15
+      search.historyReductionMax: 7434
       search.rootStaticBlend: 0.0
       search.rootStaticOverrideCp: 0
-      search.rootQueenAttackBonusCp: 425
-      search.rootEarlyStopMarginCp: 358
-      search.rootFutilityMarginCp: 199
-      search.rootFutilityLeadCp: 393
-      search.rootCaptureValueThresholdCp: 564
-      search.rootCaptureGainThresholdCp: 365
-      search.rootRunnerUpMarginCp: 71
-      search.rootDespairMarginCp: 488
-      search.rootDespairMinEvals: 8
+      search.rootQueenAttackBonusCp: 567
+      search.rootEarlyStopMarginCp: 215
+      search.rootFutilityMarginCp: 282
+      search.rootFutilityLeadCp: 357
+      search.rootCaptureValueThresholdCp: 552
+      search.rootCaptureGainThresholdCp: 499
+      search.rootRunnerUpMarginCp: 53
+      search.rootDespairMarginCp: 681
+      search.rootDespairMinEvals: 11
       search.rootDespairRunnerRatio: 0.5
-      search.rootDespairAbsThresholdCp: 751
-      search.rootDespairMinEvalsAbs: 7
-      search.rootHopelessMarginCp: 119
-      search.absPlyLimitMargin: 30
-      search.aspMinSpanCp: 34
-      search.aspMaxSpanCp: 585
-      search.aspDefaultSpanCp: 139
-      search.aspHistoryBlend: 0.4
-      search.aspMomentumStepCp: 6
-      search.aspMomentumCap: 32
-      search.aspFailureRatio: 0.7
+      search.rootDespairAbsThresholdCp: 820
+      search.rootDespairMinEvalsAbs: 6
+      search.rootHopelessMarginCp: 193
+      search.absPlyLimitMargin: 44
+      search.aspMinSpanCp: 32
+      search.aspMaxSpanCp: 492
+      search.aspDefaultSpanCp: 128
+      search.aspHistoryBlend: 0.3
+      search.aspMomentumStepCp: 7
+      search.aspMomentumCap: 28
+      search.aspFailureRatio: 0.8
       search.aspBaseOffsetCp: 0
-      search.aspSwingWeight: 0.13
+      search.aspSwingWeight: 0.12
       search.aspVolatilityWeight: 0.7
-      search.aspDepthScale: 0.05
+      search.aspDepthScale: 0.08
       search.aspDepthPivot: 3
-      search.aspFloorBaseCp: 12
+      search.aspFloorBaseCp: 10
       search.aspFloorVolWeight: 1.5
-      search.aspFloorStreakStepCp: 25
-      search.aspBumpBaseCp: 12
-      search.aspBumpStreakCp: 12
+      search.aspFloorStreakStepCp: 26
+      search.aspBumpBaseCp: 13
+      search.aspBumpStreakCp: 11
       search.aspBumpDepthCp: 2
-      search.aspFullWindowScale: 2.00
-      search.aspLastSpanScale: 1.9
-      search.aspFullWindowMinMultiplier: 2.2
-      search.aspBlendBaselineWeight: 0.7
+      search.aspFullWindowScale: 1.88
+      search.aspLastSpanScale: 2.0
+      search.aspFullWindowMinMultiplier: 2.5
+      search.aspBlendBaselineWeight: 1.0
       search.aspBlendCandidateWeight: 0.6
       search.aspMaxRetriesBase: 0
-      search.aspMaxRetriesVolThresholdHigh: 92
+      search.aspMaxRetriesVolThresholdHigh: 91
       search.aspMaxRetriesVolBonusHigh: 8
-      search.aspMaxRetriesVolThresholdMed: 244
+      search.aspMaxRetriesVolThresholdMed: 215
       search.aspMaxRetriesVolBonusMed: 1
-      search.aspMaxRetriesDepthOffset: 15
+      search.aspMaxRetriesDepthOffset: 16
       search.aspMaxRetriesDepthDivisor: 1
       search.aspMaxRetriesMomentumDivisor: 3
       search.aspMaxRetriesMin: 0
       search.aspMaxRetriesMax: 0
-      search.nullBaseReduction: 7.6
-      search.nullDepthWeight: 0.8
-      search.nullMaterialWeight: 1.98
+      search.nullBaseReduction: 7.5
+      search.nullDepthWeight: 0.7
+      search.nullMaterialWeight: 2.00
       search.nullMobilityWeight: 0.14
-      search.nullDepthCap: 11
+      search.nullDepthCap: 8
       search.nullMaterialCap: 22
-      search.nullMobilityCap: 10
+      search.nullMobilityCap: 11
       search.nullLowMaterialThreshold: 3
-      search.nullLowMobilityThreshold: 5
+      search.nullLowMobilityThreshold: 4
       search.nullVeryLowMobilityThreshold: 8
-      search.nullLowMaterialPenalty: 0.68
+      search.nullLowMaterialPenalty: 0.56
       search.nullVeryLowMobilityPenalty: 0.6
-      search.nullSwingGuardMinCp: 270
-      search.nullSwingGuardDivisor: 74
-      search.ttMainWeight: 4.1
-      search.ttCaptureWeight: 5.1
-      search.qsMaxDeltaPawn: 3.3
+      search.nullSwingGuardMinCp: 230
+      search.nullSwingGuardDivisor: 106
+      search.ttMainWeight: 5.8
+      search.ttCaptureWeight: 5.9
+      search.qsMaxDeltaPawn: 3.6
       search.drawBias: 0.0
       search.preferFastMate: 1.0
       search.tbTieBreak: 1.0
-      learning.layer0.neuron0.weight0: 0.08
-      learning.layer0.neuron0.weight1: 0.06
-      learning.layer0.neuron0.weight2: 0.07
-      learning.layer0.neuron0.weight3: -0.01
-      learning.layer0.neuron0.weight4: 0.01
-      learning.layer0.neuron0.weight5: 0.06
-      learning.layer0.neuron0.weight6: 0.03
-      learning.layer0.neuron0.weight7: 0.05
-      learning.layer0.neuron0.weight8: -0.01
-      learning.layer0.neuron0.weight9: 0.04
+      learning.layer0.neuron0.weight0: 0.07
+      learning.layer0.neuron0.weight1: 0.04
+      learning.layer0.neuron0.weight2: 0.05
+      learning.layer0.neuron0.weight3: -0.00
+      learning.layer0.neuron0.weight4: 0.05
+      learning.layer0.neuron0.weight5: 0.03
+      learning.layer0.neuron0.weight6: 0.02
+      learning.layer0.neuron0.weight7: 0.09
+      learning.layer0.neuron0.weight8: 0.01
+      learning.layer0.neuron0.weight9: 0.06
       learning.layer0.neuron0.weight10: -0.03
       learning.layer0.neuron0.weight11: 0.00
-      learning.layer0.neuron0.weight12: 0.02
-      learning.layer0.neuron0.weight13: 0.01
-      learning.layer0.neuron0.weight14: 0.00
+      learning.layer0.neuron0.weight12: 0.03
+      learning.layer0.neuron0.weight13: -0.00
+      learning.layer0.neuron0.weight14: 0.03
       learning.layer0.neuron0.weight15: 0.0
-      learning.layer0.neuron0.weight16: 0.08
-      learning.layer0.neuron0.weight17: -0.01
+      learning.layer0.neuron0.weight16: 0.10
+      learning.layer0.neuron0.weight17: -0.00
       learning.layer0.neuron0.weight18: -0.02
-      learning.layer0.neuron1.weight0: 0.03
+      learning.layer0.neuron1.weight0: 0.07
       learning.layer0.neuron1.weight1: -0.01
       learning.layer0.neuron1.weight2: -0.0
-      learning.layer0.neuron1.weight3: 0.05
-      learning.layer0.neuron1.weight4: 0.02
-      learning.layer0.neuron1.weight5: 0.05
-      learning.layer0.neuron1.weight6: 0.00
+      learning.layer0.neuron1.weight3: 0.07
+      learning.layer0.neuron1.weight4: 0.03
+      learning.layer0.neuron1.weight5: 0.08
+      learning.layer0.neuron1.weight6: -0.00
       learning.layer0.neuron1.weight7: 0.03
-      learning.layer0.neuron1.weight8: 0.0
-      learning.layer0.neuron1.weight9: 0.06
-      learning.layer0.neuron1.weight10: 0.02
-      learning.layer0.neuron1.weight11: -0.03
-      learning.layer0.neuron1.weight12: 0.02
+      learning.layer0.neuron1.weight8: -0.0
+      learning.layer0.neuron1.weight9: 0.12
+      learning.layer0.neuron1.weight10: 0.04
+      learning.layer0.neuron1.weight11: -0.04
+      learning.layer0.neuron1.weight12: 0.04
       learning.layer0.neuron1.weight13: 0.12
       learning.layer0.neuron1.weight14: -0.0
-      learning.layer0.neuron1.weight15: 0.05
-      learning.layer0.neuron1.weight16: -0.03
-      learning.layer0.neuron1.weight17: -0.02
-      learning.layer0.neuron1.weight18: -0.10
+      learning.layer0.neuron1.weight15: 0.09
+      learning.layer0.neuron1.weight16: -0.01
+      learning.layer0.neuron1.weight17: -0.01
+      learning.layer0.neuron1.weight18: -0.11
       learning.layer0.neuron2.weight0: -0.02
-      learning.layer0.neuron2.weight1: 0.02
-      learning.layer0.neuron2.weight2: 0.04
-      learning.layer0.neuron2.weight3: 0.10
+      learning.layer0.neuron2.weight1: 0.01
+      learning.layer0.neuron2.weight2: 0.05
+      learning.layer0.neuron2.weight3: 0.11
       learning.layer0.neuron2.weight4: 0.07
-      learning.layer0.neuron2.weight5: 0.06
-      learning.layer0.neuron2.weight6: 0.09
+      learning.layer0.neuron2.weight5: 0.07
+      learning.layer0.neuron2.weight6: 0.10
       learning.layer0.neuron2.weight7: 0.08
-      learning.layer0.neuron2.weight8: 0.08
-      learning.layer0.neuron2.weight9: 0.00
+      learning.layer0.neuron2.weight8: 0.10
+      learning.layer0.neuron2.weight9: -0.02
       learning.layer0.neuron2.weight10: 0.06
-      learning.layer0.neuron2.weight11: 0.04
-      learning.layer0.neuron2.weight12: 0.02
-      learning.layer0.neuron2.weight13: -0.0
-      learning.layer0.neuron2.weight14: 0.01
-      learning.layer0.neuron2.weight15: -0.03
-      learning.layer0.neuron2.weight16: -0.02
-      learning.layer0.neuron2.weight17: -0.04
-      learning.layer0.neuron2.weight18: -0.04
+      learning.layer0.neuron2.weight11: 0.08
+      learning.layer0.neuron2.weight12: 0.00
+      learning.layer0.neuron2.weight13: 0.0
+      learning.layer0.neuron2.weight14: 0.03
+      learning.layer0.neuron2.weight15: -0.06
+      learning.layer0.neuron2.weight16: -0.00
+      learning.layer0.neuron2.weight17: 0.01
+      learning.layer0.neuron2.weight18: -0.06
       learning.layer0.neuron3.weight0: 0.0
       learning.layer0.neuron3.weight1: 0.0
-      learning.layer0.neuron3.weight2: 0.01
-      learning.layer0.neuron3.weight3: 0.12
-      learning.layer0.neuron3.weight4: 0.02
+      learning.layer0.neuron3.weight2: 0.03
+      learning.layer0.neuron3.weight3: 0.14
+      learning.layer0.neuron3.weight4: -0.00
       learning.layer0.neuron3.weight5: -0.0
-      learning.layer0.neuron3.weight6: 0.06
+      learning.layer0.neuron3.weight6: 0.05
       learning.layer0.neuron3.weight7: 0.04
-      learning.layer0.neuron3.weight8: 0.04
+      learning.layer0.neuron3.weight8: 0.05
       learning.layer0.neuron3.weight9: 0.03
-      learning.layer0.neuron3.weight10: 0.02
+      learning.layer0.neuron3.weight10: 0.05
       learning.layer0.neuron3.weight11: 0.0
-      learning.layer0.neuron3.weight12: 0.05
-      learning.layer0.neuron3.weight13: 0.03
+      learning.layer0.neuron3.weight12: 0.08
+      learning.layer0.neuron3.weight13: 0.05
       learning.layer0.neuron3.weight14: -0.03
-      learning.layer0.neuron3.weight15: -0.05
-      learning.layer0.neuron3.weight16: -0.03
+      learning.layer0.neuron3.weight15: -0.09
+      learning.layer0.neuron3.weight16: -0.04
       learning.layer0.neuron3.weight17: -0.0
       learning.layer0.neuron3.weight18: -0.00
-      learning.layer0.neuron4.weight0: 0.01
-      learning.layer0.neuron4.weight1: -0.04
-      learning.layer0.neuron4.weight2: 0.01
-      learning.layer0.neuron4.weight3: -0.0
-      learning.layer0.neuron4.weight4: -0.01
-      learning.layer0.neuron4.weight5: -0.05
-      learning.layer0.neuron4.weight6: -0.04
-      learning.layer0.neuron4.weight7: 0.0
-      learning.layer0.neuron4.weight8: 0.03
-      learning.layer0.neuron4.weight9: 0.02
+      learning.layer0.neuron4.weight0: 0.05
+      learning.layer0.neuron4.weight1: -0.03
+      learning.layer0.neuron4.weight2: -0.01
+      learning.layer0.neuron4.weight3: 0.0
+      learning.layer0.neuron4.weight4: 0.00
+      learning.layer0.neuron4.weight5: -0.07
+      learning.layer0.neuron4.weight6: -0.06
+      learning.layer0.neuron4.weight7: -0.0
+      learning.layer0.neuron4.weight8: 0.04
+      learning.layer0.neuron4.weight9: 0.06
       learning.layer0.neuron4.weight10: -0.00
-      learning.layer0.neuron4.weight11: 0.06
-      learning.layer0.neuron4.weight12: 0.06
-      learning.layer0.neuron4.weight13: 0.0
-      learning.layer0.neuron4.weight14: -0.03
-      learning.layer0.neuron4.weight15: -0.05
+      learning.layer0.neuron4.weight11: 0.05
+      learning.layer0.neuron4.weight12: 0.05
+      learning.layer0.neuron4.weight13: -0.0
+      learning.layer0.neuron4.weight14: -0.04
+      learning.layer0.neuron4.weight15: -0.07
       learning.layer0.neuron4.weight16: -0.05
-      learning.layer0.neuron4.weight17: -0.01
-      learning.layer0.neuron4.weight18: 0.01
-      learning.layer0.neuron5.weight0: 0.01
-      learning.layer0.neuron5.weight1: 0.00
-      learning.layer0.neuron5.weight2: -0.0
-      learning.layer0.neuron5.weight3: -0.01
-      learning.layer0.neuron5.weight4: 0.02
-      learning.layer0.neuron5.weight5: 0.06
-      learning.layer0.neuron5.weight6: 0.06
-      learning.layer0.neuron5.weight7: 0.04
+      learning.layer0.neuron4.weight17: 0.00
+      learning.layer0.neuron4.weight18: 0.05
+      learning.layer0.neuron5.weight0: -0.02
+      learning.layer0.neuron5.weight1: 0.01
+      learning.layer0.neuron5.weight2: 0.0
+      learning.layer0.neuron5.weight3: -0.03
+      learning.layer0.neuron5.weight4: -0.02
+      learning.layer0.neuron5.weight5: 0.07
+      learning.layer0.neuron5.weight6: 0.05
+      learning.layer0.neuron5.weight7: 0.05
       learning.layer0.neuron5.weight8: -0.0
-      learning.layer0.neuron5.weight9: -0.00
-      learning.layer0.neuron5.weight10: 0.01
-      learning.layer0.neuron5.weight11: -0.01
-      learning.layer0.neuron5.weight12: -0.03
-      learning.layer0.neuron5.weight13: 0.02
-      learning.layer0.neuron5.weight14: 0.0
-      learning.layer0.neuron5.weight15: 0.06
-      learning.layer0.neuron5.weight16: -0.00
+      learning.layer0.neuron5.weight9: 0.02
+      learning.layer0.neuron5.weight10: 0.04
+      learning.layer0.neuron5.weight11: -0.02
+      learning.layer0.neuron5.weight12: -0.05
+      learning.layer0.neuron5.weight13: 0.01
+      learning.layer0.neuron5.weight14: -0.0
+      learning.layer0.neuron5.weight15: 0.05
+      learning.layer0.neuron5.weight16: -0.01
       learning.layer0.neuron5.weight17: 0.04
-      learning.layer0.neuron5.weight18: 0.08
-      learning.layer0.neuron6.weight0: 0.10
-      learning.layer0.neuron6.weight1: 0.06
-      learning.layer0.neuron6.weight2: 0.03
-      learning.layer0.neuron6.weight3: 0.00
+      learning.layer0.neuron5.weight18: 0.07
+      learning.layer0.neuron6.weight0: 0.14
+      learning.layer0.neuron6.weight1: 0.07
+      learning.layer0.neuron6.weight2: 0.00
+      learning.layer0.neuron6.weight3: -0.02
       learning.layer0.neuron6.weight4: 0.0
       learning.layer0.neuron6.weight5: 0.06
-      learning.layer0.neuron6.weight6: 0.04
-      learning.layer0.neuron6.weight7: -0.01
+      learning.layer0.neuron6.weight6: 0.06
+      learning.layer0.neuron6.weight7: -0.03
       learning.layer0.neuron6.weight8: -0.0
       learning.layer0.neuron6.weight9: -0.01
-      learning.layer0.neuron6.weight10: -0.02
-      learning.layer0.neuron6.weight11: -0.03
-      learning.layer0.neuron6.weight12: 0.05
-      learning.layer0.neuron6.weight13: 0.01
+      learning.layer0.neuron6.weight10: -0.01
+      learning.layer0.neuron6.weight11: -0.01
+      learning.layer0.neuron6.weight12: 0.04
+      learning.layer0.neuron6.weight13: 0.04
       learning.layer0.neuron6.weight14: -0.03
       learning.layer0.neuron6.weight15: 0.04
       learning.layer0.neuron6.weight16: -0.0
-      learning.layer0.neuron6.weight17: 0.05
-      learning.layer0.neuron6.weight18: 0.01
-      learning.layer0.neuron7.weight0: 0.02
-      learning.layer0.neuron7.weight1: -0.05
-      learning.layer0.neuron7.weight2: 0.00
-      learning.layer0.neuron7.weight3: -0.04
-      learning.layer0.neuron7.weight4: 0.00
-      learning.layer0.neuron7.weight5: -0.02
+      learning.layer0.neuron6.weight17: 0.07
+      learning.layer0.neuron6.weight18: 0.00
+      learning.layer0.neuron7.weight0: -0.01
+      learning.layer0.neuron7.weight1: -0.06
+      learning.layer0.neuron7.weight2: -0.00
+      learning.layer0.neuron7.weight3: -0.02
+      learning.layer0.neuron7.weight4: 0.02
+      learning.layer0.neuron7.weight5: -0.03
       learning.layer0.neuron7.weight6: -0.01
-      learning.layer0.neuron7.weight7: -0.03
+      learning.layer0.neuron7.weight7: -0.04
       learning.layer0.neuron7.weight8: -0.05
-      learning.layer0.neuron7.weight9: 0.03
+      learning.layer0.neuron7.weight9: 0.05
       learning.layer0.neuron7.weight10: -0.08
-      learning.layer0.neuron7.weight11: 0.10
+      learning.layer0.neuron7.weight11: 0.14
       learning.layer0.neuron7.weight12: -0.0
-      learning.layer0.neuron7.weight13: 0.04
-      learning.layer0.neuron7.weight14: 0.05
-      learning.layer0.neuron7.weight15: 0.04
-      learning.layer0.neuron7.weight16: 0.03
-      learning.layer0.neuron7.weight17: 0.04
+      learning.layer0.neuron7.weight13: 0.03
+      learning.layer0.neuron7.weight14: 0.06
+      learning.layer0.neuron7.weight15: 0.02
+      learning.layer0.neuron7.weight16: 0.00
+      learning.layer0.neuron7.weight17: 0.02
       learning.layer0.neuron7.weight18: 0.07
-      learning.layer0.neuron0.bias: 0.03
-      learning.layer0.neuron1.bias: -0.04
+      learning.layer0.neuron0.bias: 0.01
+      learning.layer0.neuron1.bias: -0.06
       learning.layer0.neuron2.bias: 0.0
       learning.layer0.neuron3.bias: 0.08
-      learning.layer0.neuron4.bias: 0.01
+      learning.layer0.neuron4.bias: -0.00
       learning.layer0.neuron5.bias: 0.0
       learning.layer0.neuron6.bias: 0.05
-      learning.layer0.neuron7.bias: 0.02
+      learning.layer0.neuron7.bias: 0.01
       learning.layer1.neuron0.weight0: 0.6
-      learning.layer1.neuron0.weight1: 0.3
+      learning.layer1.neuron0.weight1: 0.4
       learning.layer1.neuron0.weight2: 0.1
-      learning.layer1.neuron0.weight3: -0.0
+      learning.layer1.neuron0.weight3: 0.0
       learning.layer1.neuron0.weight4: -0.1
       learning.layer1.neuron0.weight5: 0.3
       learning.layer1.neuron0.weight6: 0.2
@@ -374,11 +374,11 @@ population:
       learning.layer1.neuron1.weight1: -0.1
       learning.layer1.neuron1.weight2: 0.0
       learning.layer1.neuron1.weight3: 0.1
-      learning.layer1.neuron1.weight4: 0.2
+      learning.layer1.neuron1.weight4: 0.3
       learning.layer1.neuron1.weight5: -0.2
       learning.layer1.neuron1.weight6: -0.1
       learning.layer1.neuron1.weight7: 0.4
       learning.layer1.neuron0.bias: -0.0
       learning.layer1.neuron1.bias: -0.0
-      learning.outputMidgameScale: 67.5
-      learning.outputEndgameScale: 101.0
+      learning.outputMidgameScale: 35.0
+      learning.outputEndgameScale: 109.0

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -26,7 +26,7 @@ population:
       material.knightvalue: 395
       material.bishopvalue: 420
       material.rookvalue: 636
-      material.queenvalue: 1106
+      material.queenvalue: 1120
       material.bishoppairbonus: 58
       pawnstructure.centerpawnbonus: 26
       pawnstructure.passedpawnbonus: 52
@@ -36,11 +36,11 @@ population:
       pawnstructure.isolatedpawnpenalty: -7
       pawnstructure.advancedpawnbonus: 11
       pawnstructure.blockedpawnpenalty: -5
-      pawnstructure.backwardpawnpenalty: -25
-      pawnstructure.ownkingblockspassedpawnpenalty: -84
+      pawnstructure.backwardpawnpenalty: -24
+      pawnstructure.ownkingblockspassedpawnpenalty: -85
       pawnstructure.passedpawnfreepathbonusperrank: 15
-      pawnstructure.rookhalfopenfilebonus: 40
-      pawnstructure.rookopenfilebonus: 40
+      pawnstructure.rookhalfopenfilebonus: 36
+      pawnstructure.rookopenfilebonus: 39
       threat.hangingpawnpenalty: -11
       threat.hangingknightpenalty: -23
       threat.hangingbishoppenalty: -14
@@ -48,8 +48,8 @@ population:
       threat.hangingqueenpenalty: -58
       threat.pawnthreatknightpenalty: -9
       threat.pawnthreatbishoppenalty: -8
-      threat.pawnthreatrookpenalty: -12
-      threat.pawnthreatqueenpenalty: -27
+      threat.pawnthreatrookpenalty: -11
+      threat.pawnthreatqueenpenalty: -28
       activity.midgamemobilityknight: 9
       activity.midgamemobilitybishop: 12
       activity.midgamemobilityrook: 12
@@ -71,15 +71,15 @@ population:
       activity.endgamecenterqueen: 3
       activity.endgamecenterking: 6
       kingsafety.missingpawnshieldpenalty: -25
-      kingsafety.halfopenfilepenalty: 0
+      kingsafety.halfopenfilepenalty: -1
       kingsafety.openfilepenalty: -15
       kingsafety.defenderbonus: 8
-      kingsafety.queenattackedpenalty: -69
-      kingsafety.backrankweaknessmidgamepenalty: -70
+      kingsafety.queenattackedpenalty: -71
+      kingsafety.backrankweaknessmidgamepenalty: -75
       kingsafety.backrankweaknessendgamepenalty: -51
       kingsafety.attackweightpawn: 8
       kingsafety.attackweightknight: 21
-      kingsafety.attackweightbishop: 12
+      kingsafety.attackweightbishop: 14
       kingsafety.attackweightrook: 34
       kingsafety.attackweightqueen: 24
       moveordering.category.tt: 8
@@ -90,59 +90,59 @@ population:
       moveordering.category.killer1: 2
       moveordering.category.quiet: 1
       moveordering.category.capturebad: 0
-      moveordering.killermovescore: 13159
-      moveordering.promotionbonus: 1523
+      moveordering.killermovescore: 13233
+      moveordering.promotionbonus: 1390
       moveordering.killer0bonus: 238
-      moveordering.killer1bonus: 293
-      moveordering.countermovebonus: 603
-      moveordering.capturemvvmultiplier: 23
+      moveordering.killer1bonus: 256
+      moveordering.countermovebonus: 465
+      moveordering.capturemvvmultiplier: 22
       moveordering.captureseemultiplier: 192
       moveordering.promotionseemultiplier: 32
-      moveordering.castlingbonus: 0
-      moveordering.captureseeclamp: 517
-      moveordering.promotionseeclamp: 399
+      moveordering.castlingbonus: 54
+      moveordering.captureseeclamp: 512
+      moveordering.promotionseeclamp: 397
       moveordering.capturegoodbonus: 946
       moveordering.captureequalbonus: 187
       moveordering.capturebadbonus: -517
-      moveordering.capturelosingseepenalty: 0
+      moveordering.capturelosingseepenalty: 1
       moveordering.quiethistorymultiplier: 3.8
-      moveordering.quiethistorybonus: 3376
+      moveordering.quiethistorybonus: 3409
       moveordering.maxscore: 16764829
       moveordering.historyscale: 4.0
       moveordering.historydecaydivisor: 2
       moveordering.quietlearningweight: 10
       moveordering.quietlearningclamp: 503
       moveordering.quietlearningmaxmoves: 0
-      search.fpMarginDepth1: 414
-      search.fpMarginDepth2: 723
+      search.fpMarginDepth1: 0
+      search.fpMarginDepth2: 729
       search.lmpBase: 1
       search.lmpPerDepth: 18
-      search.fpMaxDepth: 12
+      search.fpMaxDepth: 11
       search.lmpMaxDepth: 14
       search.hmpMinIndex: -1
-      search.hmpHistoryMax: 242
+      search.hmpHistoryMax: 235
       search.iidReduceDepth: 0
       search.lmrProtectPlyMax: 0
       search.lmrProtectIndexMax: 2
-      search.lmrCapGoodQuiet: 32
+      search.lmrCapGoodQuiet: 31
       search.lmrHistoryBuckets: 3
-      search.lmrHistoryWeightSlope: 1.12
+      search.lmrHistoryWeightSlope: 1.06
       search.lmrScaleDivisor: 3.5
       search.lmrDepthLogOffset: 6.4
       search.lmrMoveLogOffset: 8.7
       search.maxCheckExtensionStreak: 0
       search.seePruneNearRootPly: 14
-      search.historyReductionMax: 7963
+      search.historyReductionMax: 8000
       search.rootStaticBlend: 0.0
       search.rootStaticOverrideCp: 0
       search.rootQueenAttackBonusCp: 425
-      search.rootEarlyStopMarginCp: 317
-      search.rootFutilityMarginCp: 197
-      search.rootFutilityLeadCp: 386
-      search.rootCaptureValueThresholdCp: 561
+      search.rootEarlyStopMarginCp: 358
+      search.rootFutilityMarginCp: 199
+      search.rootFutilityLeadCp: 393
+      search.rootCaptureValueThresholdCp: 564
       search.rootCaptureGainThresholdCp: 365
-      search.rootRunnerUpMarginCp: 82
-      search.rootDespairMarginCp: 464
+      search.rootRunnerUpMarginCp: 71
+      search.rootDespairMarginCp: 488
       search.rootDespairMinEvals: 8
       search.rootDespairRunnerRatio: 0.5
       search.rootDespairAbsThresholdCp: 751
@@ -150,8 +150,8 @@ population:
       search.rootHopelessMarginCp: 119
       search.absPlyLimitMargin: 30
       search.aspMinSpanCp: 34
-      search.aspMaxSpanCp: 640
-      search.aspDefaultSpanCp: 138
+      search.aspMaxSpanCp: 585
+      search.aspDefaultSpanCp: 139
       search.aspHistoryBlend: 0.4
       search.aspMomentumStepCp: 6
       search.aspMomentumCap: 32
@@ -161,28 +161,28 @@ population:
       search.aspVolatilityWeight: 0.7
       search.aspDepthScale: 0.05
       search.aspDepthPivot: 3
-      search.aspFloorBaseCp: 10
+      search.aspFloorBaseCp: 12
       search.aspFloorVolWeight: 1.5
       search.aspFloorStreakStepCp: 25
       search.aspBumpBaseCp: 12
-      search.aspBumpStreakCp: 11
+      search.aspBumpStreakCp: 12
       search.aspBumpDepthCp: 2
       search.aspFullWindowScale: 2.00
-      search.aspLastSpanScale: 2.0
+      search.aspLastSpanScale: 1.9
       search.aspFullWindowMinMultiplier: 2.2
       search.aspBlendBaselineWeight: 0.7
       search.aspBlendCandidateWeight: 0.6
       search.aspMaxRetriesBase: 0
-      search.aspMaxRetriesVolThresholdHigh: 94
+      search.aspMaxRetriesVolThresholdHigh: 92
       search.aspMaxRetriesVolBonusHigh: 8
-      search.aspMaxRetriesVolThresholdMed: 252
+      search.aspMaxRetriesVolThresholdMed: 244
       search.aspMaxRetriesVolBonusMed: 1
       search.aspMaxRetriesDepthOffset: 15
       search.aspMaxRetriesDepthDivisor: 1
       search.aspMaxRetriesMomentumDivisor: 3
       search.aspMaxRetriesMin: 0
       search.aspMaxRetriesMax: 0
-      search.nullBaseReduction: 7.8
+      search.nullBaseReduction: 7.6
       search.nullDepthWeight: 0.8
       search.nullMaterialWeight: 1.98
       search.nullMobilityWeight: 0.14
@@ -192,34 +192,34 @@ population:
       search.nullLowMaterialThreshold: 3
       search.nullLowMobilityThreshold: 5
       search.nullVeryLowMobilityThreshold: 8
-      search.nullLowMaterialPenalty: 0.66
+      search.nullLowMaterialPenalty: 0.68
       search.nullVeryLowMobilityPenalty: 0.6
-      search.nullSwingGuardMinCp: 214
+      search.nullSwingGuardMinCp: 270
       search.nullSwingGuardDivisor: 74
-      search.ttMainWeight: 4.2
+      search.ttMainWeight: 4.1
       search.ttCaptureWeight: 5.1
       search.qsMaxDeltaPawn: 3.3
       search.drawBias: 0.0
       search.preferFastMate: 1.0
       search.tbTieBreak: 1.0
-      learning.layer0.neuron0.weight0: 0.09
-      learning.layer0.neuron0.weight1: 0.04
-      learning.layer0.neuron0.weight2: 0.06
-      learning.layer0.neuron0.weight3: -0.00
-      learning.layer0.neuron0.weight4: 0.02
+      learning.layer0.neuron0.weight0: 0.08
+      learning.layer0.neuron0.weight1: 0.06
+      learning.layer0.neuron0.weight2: 0.07
+      learning.layer0.neuron0.weight3: -0.01
+      learning.layer0.neuron0.weight4: 0.01
       learning.layer0.neuron0.weight5: 0.06
       learning.layer0.neuron0.weight6: 0.03
       learning.layer0.neuron0.weight7: 0.05
       learning.layer0.neuron0.weight8: -0.01
-      learning.layer0.neuron0.weight9: 0.02
+      learning.layer0.neuron0.weight9: 0.04
       learning.layer0.neuron0.weight10: -0.03
       learning.layer0.neuron0.weight11: 0.00
       learning.layer0.neuron0.weight12: 0.02
       learning.layer0.neuron0.weight13: 0.01
-      learning.layer0.neuron0.weight14: 0.01
+      learning.layer0.neuron0.weight14: 0.00
       learning.layer0.neuron0.weight15: 0.0
       learning.layer0.neuron0.weight16: 0.08
-      learning.layer0.neuron0.weight17: -0.02
+      learning.layer0.neuron0.weight17: -0.01
       learning.layer0.neuron0.weight18: -0.02
       learning.layer0.neuron1.weight0: 0.03
       learning.layer0.neuron1.weight1: -0.01
@@ -227,12 +227,12 @@ population:
       learning.layer0.neuron1.weight3: 0.05
       learning.layer0.neuron1.weight4: 0.02
       learning.layer0.neuron1.weight5: 0.05
-      learning.layer0.neuron1.weight6: -0.01
-      learning.layer0.neuron1.weight7: 0.02
+      learning.layer0.neuron1.weight6: 0.00
+      learning.layer0.neuron1.weight7: 0.03
       learning.layer0.neuron1.weight8: 0.0
       learning.layer0.neuron1.weight9: 0.06
       learning.layer0.neuron1.weight10: 0.02
-      learning.layer0.neuron1.weight11: -0.04
+      learning.layer0.neuron1.weight11: -0.03
       learning.layer0.neuron1.weight12: 0.02
       learning.layer0.neuron1.weight13: 0.12
       learning.layer0.neuron1.weight14: -0.0
@@ -240,106 +240,106 @@ population:
       learning.layer0.neuron1.weight16: -0.03
       learning.layer0.neuron1.weight17: -0.02
       learning.layer0.neuron1.weight18: -0.10
-      learning.layer0.neuron2.weight0: -0.03
-      learning.layer0.neuron2.weight1: 0.01
+      learning.layer0.neuron2.weight0: -0.02
+      learning.layer0.neuron2.weight1: 0.02
       learning.layer0.neuron2.weight2: 0.04
       learning.layer0.neuron2.weight3: 0.10
       learning.layer0.neuron2.weight4: 0.07
       learning.layer0.neuron2.weight5: 0.06
-      learning.layer0.neuron2.weight6: 0.08
+      learning.layer0.neuron2.weight6: 0.09
       learning.layer0.neuron2.weight7: 0.08
       learning.layer0.neuron2.weight8: 0.08
       learning.layer0.neuron2.weight9: 0.00
       learning.layer0.neuron2.weight10: 0.06
       learning.layer0.neuron2.weight11: 0.04
-      learning.layer0.neuron2.weight12: 0.01
+      learning.layer0.neuron2.weight12: 0.02
       learning.layer0.neuron2.weight13: -0.0
       learning.layer0.neuron2.weight14: 0.01
-      learning.layer0.neuron2.weight15: -0.04
-      learning.layer0.neuron2.weight16: -0.03
-      learning.layer0.neuron2.weight17: -0.02
-      learning.layer0.neuron2.weight18: -0.05
+      learning.layer0.neuron2.weight15: -0.03
+      learning.layer0.neuron2.weight16: -0.02
+      learning.layer0.neuron2.weight17: -0.04
+      learning.layer0.neuron2.weight18: -0.04
       learning.layer0.neuron3.weight0: 0.0
-      learning.layer0.neuron3.weight1: -0.0
+      learning.layer0.neuron3.weight1: 0.0
       learning.layer0.neuron3.weight2: 0.01
       learning.layer0.neuron3.weight3: 0.12
-      learning.layer0.neuron3.weight4: 0.01
-      learning.layer0.neuron3.weight5: 0.0
-      learning.layer0.neuron3.weight6: 0.05
+      learning.layer0.neuron3.weight4: 0.02
+      learning.layer0.neuron3.weight5: -0.0
+      learning.layer0.neuron3.weight6: 0.06
       learning.layer0.neuron3.weight7: 0.04
-      learning.layer0.neuron3.weight8: 0.05
-      learning.layer0.neuron3.weight9: 0.02
+      learning.layer0.neuron3.weight8: 0.04
+      learning.layer0.neuron3.weight9: 0.03
       learning.layer0.neuron3.weight10: 0.02
       learning.layer0.neuron3.weight11: 0.0
       learning.layer0.neuron3.weight12: 0.05
       learning.layer0.neuron3.weight13: 0.03
       learning.layer0.neuron3.weight14: -0.03
       learning.layer0.neuron3.weight15: -0.05
-      learning.layer0.neuron3.weight16: -0.04
+      learning.layer0.neuron3.weight16: -0.03
       learning.layer0.neuron3.weight17: -0.0
       learning.layer0.neuron3.weight18: -0.00
       learning.layer0.neuron4.weight0: 0.01
       learning.layer0.neuron4.weight1: -0.04
-      learning.layer0.neuron4.weight2: -0.00
+      learning.layer0.neuron4.weight2: 0.01
       learning.layer0.neuron4.weight3: -0.0
       learning.layer0.neuron4.weight4: -0.01
       learning.layer0.neuron4.weight5: -0.05
       learning.layer0.neuron4.weight6: -0.04
       learning.layer0.neuron4.weight7: 0.0
-      learning.layer0.neuron4.weight8: 0.04
-      learning.layer0.neuron4.weight9: 0.03
+      learning.layer0.neuron4.weight8: 0.03
+      learning.layer0.neuron4.weight9: 0.02
       learning.layer0.neuron4.weight10: -0.00
       learning.layer0.neuron4.weight11: 0.06
       learning.layer0.neuron4.weight12: 0.06
       learning.layer0.neuron4.weight13: 0.0
-      learning.layer0.neuron4.weight14: -0.04
+      learning.layer0.neuron4.weight14: -0.03
       learning.layer0.neuron4.weight15: -0.05
       learning.layer0.neuron4.weight16: -0.05
       learning.layer0.neuron4.weight17: -0.01
-      learning.layer0.neuron4.weight18: 0.02
-      learning.layer0.neuron5.weight0: 0.00
+      learning.layer0.neuron4.weight18: 0.01
+      learning.layer0.neuron5.weight0: 0.01
       learning.layer0.neuron5.weight1: 0.00
-      learning.layer0.neuron5.weight2: 0.0
+      learning.layer0.neuron5.weight2: -0.0
       learning.layer0.neuron5.weight3: -0.01
       learning.layer0.neuron5.weight4: 0.02
       learning.layer0.neuron5.weight5: 0.06
-      learning.layer0.neuron5.weight6: 0.05
-      learning.layer0.neuron5.weight7: 0.03
-      learning.layer0.neuron5.weight8: 0.0
-      learning.layer0.neuron5.weight9: -0.01
-      learning.layer0.neuron5.weight10: 0.02
-      learning.layer0.neuron5.weight11: -0.02
+      learning.layer0.neuron5.weight6: 0.06
+      learning.layer0.neuron5.weight7: 0.04
+      learning.layer0.neuron5.weight8: -0.0
+      learning.layer0.neuron5.weight9: -0.00
+      learning.layer0.neuron5.weight10: 0.01
+      learning.layer0.neuron5.weight11: -0.01
       learning.layer0.neuron5.weight12: -0.03
       learning.layer0.neuron5.weight13: 0.02
-      learning.layer0.neuron5.weight14: -0.0
+      learning.layer0.neuron5.weight14: 0.0
       learning.layer0.neuron5.weight15: 0.06
-      learning.layer0.neuron5.weight16: 0.00
+      learning.layer0.neuron5.weight16: -0.00
       learning.layer0.neuron5.weight17: 0.04
       learning.layer0.neuron5.weight18: 0.08
       learning.layer0.neuron6.weight0: 0.10
       learning.layer0.neuron6.weight1: 0.06
-      learning.layer0.neuron6.weight2: 0.02
+      learning.layer0.neuron6.weight2: 0.03
       learning.layer0.neuron6.weight3: 0.00
       learning.layer0.neuron6.weight4: 0.0
       learning.layer0.neuron6.weight5: 0.06
       learning.layer0.neuron6.weight6: 0.04
-      learning.layer0.neuron6.weight7: -0.02
-      learning.layer0.neuron6.weight8: 0.0
+      learning.layer0.neuron6.weight7: -0.01
+      learning.layer0.neuron6.weight8: -0.0
       learning.layer0.neuron6.weight9: -0.01
       learning.layer0.neuron6.weight10: -0.02
       learning.layer0.neuron6.weight11: -0.03
       learning.layer0.neuron6.weight12: 0.05
-      learning.layer0.neuron6.weight13: 0.02
+      learning.layer0.neuron6.weight13: 0.01
       learning.layer0.neuron6.weight14: -0.03
       learning.layer0.neuron6.weight15: 0.04
-      learning.layer0.neuron6.weight16: 0.0
+      learning.layer0.neuron6.weight16: -0.0
       learning.layer0.neuron6.weight17: 0.05
-      learning.layer0.neuron6.weight18: -0.00
-      learning.layer0.neuron7.weight0: 0.01
+      learning.layer0.neuron6.weight18: 0.01
+      learning.layer0.neuron7.weight0: 0.02
       learning.layer0.neuron7.weight1: -0.05
-      learning.layer0.neuron7.weight2: 0.01
-      learning.layer0.neuron7.weight3: -0.03
-      learning.layer0.neuron7.weight4: 0.01
+      learning.layer0.neuron7.weight2: 0.00
+      learning.layer0.neuron7.weight3: -0.04
+      learning.layer0.neuron7.weight4: 0.00
       learning.layer0.neuron7.weight5: -0.02
       learning.layer0.neuron7.weight6: -0.01
       learning.layer0.neuron7.weight7: -0.03
@@ -352,7 +352,7 @@ population:
       learning.layer0.neuron7.weight14: 0.05
       learning.layer0.neuron7.weight15: 0.04
       learning.layer0.neuron7.weight16: 0.03
-      learning.layer0.neuron7.weight17: 0.03
+      learning.layer0.neuron7.weight17: 0.04
       learning.layer0.neuron7.weight18: 0.07
       learning.layer0.neuron0.bias: 0.03
       learning.layer0.neuron1.bias: -0.04
@@ -361,7 +361,7 @@ population:
       learning.layer0.neuron4.bias: 0.01
       learning.layer0.neuron5.bias: 0.0
       learning.layer0.neuron6.bias: 0.05
-      learning.layer0.neuron7.bias: 0.01
+      learning.layer0.neuron7.bias: 0.02
       learning.layer1.neuron0.weight0: 0.6
       learning.layer1.neuron0.weight1: 0.3
       learning.layer1.neuron0.weight2: 0.1
@@ -379,6 +379,6 @@ population:
       learning.layer1.neuron1.weight6: -0.1
       learning.layer1.neuron1.weight7: 0.4
       learning.layer1.neuron0.bias: -0.0
-      learning.layer1.neuron1.bias: 0.0
+      learning.layer1.neuron1.bias: -0.0
       learning.outputMidgameScale: 67.5
-      learning.outputEndgameScale: 103.2
+      learning.outputEndgameScale: 101.0

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -3,23 +3,23 @@ population:
     evaluation:
       modules:
         MaterialModule:
-          midgame: 1
-          endgame: 1
+          midgame: 1.0
+          endgame: 1.0
         PawnStructureModule:
-          midgame: 1
-          endgame: 1
+          midgame: 1.0
+          endgame: 1.0
         ActivityModule:
-          midgame: 1
-          endgame: 1
+          midgame: 1.0
+          endgame: 1.0
         KingSafetyModule:
-          midgame: 1
-          endgame: 1
+          midgame: 1.0
+          endgame: 1.0
         ThreatModule:
-          midgame: 1
-          endgame: 1
+          midgame: 1.0
+          endgame: 1.0
         LearningEvaluationModule:
-          midgame: 1
-          endgame: 1
+          midgame: 1.0
+          endgame: 1.0
     numericParameters:
       evaluation.blendscale: 765
       material.pawnvalue: 154

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -110,6 +110,9 @@ population:
       moveordering.maxscore: 16464490
       moveordering.historyscale: 3.8
       moveordering.historydecaydivisor: 2
+      moveordering.quietlearningweight: 12
+      moveordering.quietlearningclamp: 320
+      moveordering.quietlearningmaxmoves: 8
       search.fpMarginDepth1: 348
       search.fpMarginDepth2: 883
       search.lmpBase: 0

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -7,7 +7,7 @@ population:
           endgame: 0.5
         PawnStructureModule:
           midgame: 0.5
-          endgame: 0.5
+          endgame: 0.6
         ActivityModule:
           midgame: 0.5
           endgame: 0.5
@@ -16,41 +16,41 @@ population:
           endgame: 0.5
         ThreatModule:
           midgame: 0.5
-          endgame: 0.5
+          endgame: 0.4
         LearningEvaluationModule:
           midgame: 1.0
           endgame: 1.0
     numericParameters:
-      evaluation.blendscale: 616
+      evaluation.blendscale: 764
       material.pawnvalue: 112
-      material.knightvalue: 389
+      material.knightvalue: 395
       material.bishopvalue: 420
-      material.rookvalue: 640
-      material.queenvalue: 1120
+      material.rookvalue: 636
+      material.queenvalue: 1106
       material.bishoppairbonus: 58
       pawnstructure.centerpawnbonus: 26
       pawnstructure.passedpawnbonus: 52
       pawnstructure.connectedpawnbonus: 7
       pawnstructure.islandpenalty: -6
-      pawnstructure.doubledpawnpenalty: -9
+      pawnstructure.doubledpawnpenalty: -10
       pawnstructure.isolatedpawnpenalty: -7
-      pawnstructure.advancedpawnbonus: 13
+      pawnstructure.advancedpawnbonus: 11
       pawnstructure.blockedpawnpenalty: -5
-      pawnstructure.backwardpawnpenalty: -22
+      pawnstructure.backwardpawnpenalty: -25
       pawnstructure.ownkingblockspassedpawnpenalty: -84
       pawnstructure.passedpawnfreepathbonusperrank: 15
       pawnstructure.rookhalfopenfilebonus: 40
-      pawnstructure.rookopenfilebonus: 39
-      threat.hangingpawnpenalty: -12
+      pawnstructure.rookopenfilebonus: 40
+      threat.hangingpawnpenalty: -11
       threat.hangingknightpenalty: -23
       threat.hangingbishoppenalty: -14
-      threat.hangingrookpenalty: -63
+      threat.hangingrookpenalty: -69
       threat.hangingqueenpenalty: -58
       threat.pawnthreatknightpenalty: -9
       threat.pawnthreatbishoppenalty: -8
-      threat.pawnthreatrookpenalty: -15
-      threat.pawnthreatqueenpenalty: -28
-      activity.midgamemobilityknight: 8
+      threat.pawnthreatrookpenalty: -12
+      threat.pawnthreatqueenpenalty: -27
+      activity.midgamemobilityknight: 9
       activity.midgamemobilitybishop: 12
       activity.midgamemobilityrook: 12
       activity.midgamemobilityqueen: 3
@@ -69,18 +69,18 @@ population:
       activity.endgamecenterbishop: -4
       activity.endgamecenterrook: 3
       activity.endgamecenterqueen: 3
-      activity.endgamecenterking: 7
-      kingsafety.missingpawnshieldpenalty: -23
+      activity.endgamecenterking: 6
+      kingsafety.missingpawnshieldpenalty: -25
       kingsafety.halfopenfilepenalty: 0
-      kingsafety.openfilepenalty: -14
-      kingsafety.defenderbonus: 7
+      kingsafety.openfilepenalty: -15
+      kingsafety.defenderbonus: 8
       kingsafety.queenattackedpenalty: -69
-      kingsafety.backrankweaknessmidgamepenalty: -84
+      kingsafety.backrankweaknessmidgamepenalty: -70
       kingsafety.backrankweaknessendgamepenalty: -51
-      kingsafety.attackweightpawn: 7
+      kingsafety.attackweightpawn: 8
       kingsafety.attackweightknight: 21
       kingsafety.attackweightbishop: 12
-      kingsafety.attackweightrook: 36
+      kingsafety.attackweightrook: 34
       kingsafety.attackweightqueen: 24
       moveordering.category.tt: 8
       moveordering.category.promotion: 6
@@ -90,92 +90,92 @@ population:
       moveordering.category.killer1: 2
       moveordering.category.quiet: 1
       moveordering.category.capturebad: 0
-      moveordering.killermovescore: 13114
-      moveordering.promotionbonus: 1492
-      moveordering.killer0bonus: 307
-      moveordering.killer1bonus: 289
-      moveordering.countermovebonus: 605
+      moveordering.killermovescore: 13159
+      moveordering.promotionbonus: 1523
+      moveordering.killer0bonus: 238
+      moveordering.killer1bonus: 293
+      moveordering.countermovebonus: 603
       moveordering.capturemvvmultiplier: 23
-      moveordering.captureseemultiplier: 179
+      moveordering.captureseemultiplier: 192
       moveordering.promotionseemultiplier: 32
-      moveordering.castlingbonus: 38
-      moveordering.captureseeclamp: 581
-      moveordering.promotionseeclamp: 400
-      moveordering.capturegoodbonus: 948
-      moveordering.captureequalbonus: 195
+      moveordering.castlingbonus: 0
+      moveordering.captureseeclamp: 517
+      moveordering.promotionseeclamp: 399
+      moveordering.capturegoodbonus: 946
+      moveordering.captureequalbonus: 187
       moveordering.capturebadbonus: -517
-      moveordering.capturelosingseepenalty: 1
+      moveordering.capturelosingseepenalty: 0
       moveordering.quiethistorymultiplier: 3.8
-      moveordering.quiethistorybonus: 2643
-      moveordering.maxscore: 16609430
-      moveordering.historyscale: 3.9
+      moveordering.quiethistorybonus: 3376
+      moveordering.maxscore: 16764829
+      moveordering.historyscale: 4.0
       moveordering.historydecaydivisor: 2
       moveordering.quietlearningweight: 10
-      moveordering.quietlearningclamp: 407
+      moveordering.quietlearningclamp: 503
       moveordering.quietlearningmaxmoves: 0
-      search.fpMarginDepth1: 348
-      search.fpMarginDepth2: 883
-      search.lmpBase: 0
+      search.fpMarginDepth1: 414
+      search.fpMarginDepth2: 723
+      search.lmpBase: 1
       search.lmpPerDepth: 18
       search.fpMaxDepth: 12
-      search.lmpMaxDepth: 12
-      search.hmpMinIndex: 16
-      search.hmpHistoryMax: 241
+      search.lmpMaxDepth: 14
+      search.hmpMinIndex: -1
+      search.hmpHistoryMax: 242
       search.iidReduceDepth: 0
       search.lmrProtectPlyMax: 0
       search.lmrProtectIndexMax: 2
-      search.lmrCapGoodQuiet: 26
-      search.lmrHistoryBuckets: 4
-      search.lmrHistoryWeightSlope: 0.94
+      search.lmrCapGoodQuiet: 32
+      search.lmrHistoryBuckets: 3
+      search.lmrHistoryWeightSlope: 1.12
       search.lmrScaleDivisor: 3.5
-      search.lmrDepthLogOffset: 6.5
-      search.lmrMoveLogOffset: 7.3
+      search.lmrDepthLogOffset: 6.4
+      search.lmrMoveLogOffset: 8.7
       search.maxCheckExtensionStreak: 0
       search.seePruneNearRootPly: 14
-      search.historyReductionMax: 8000
+      search.historyReductionMax: 7963
       search.rootStaticBlend: 0.0
       search.rootStaticOverrideCp: 0
-      search.rootQueenAttackBonusCp: 426
-      search.rootEarlyStopMarginCp: 315
-      search.rootFutilityMarginCp: 191
-      search.rootFutilityLeadCp: 432
+      search.rootQueenAttackBonusCp: 425
+      search.rootEarlyStopMarginCp: 317
+      search.rootFutilityMarginCp: 197
+      search.rootFutilityLeadCp: 386
       search.rootCaptureValueThresholdCp: 561
-      search.rootCaptureGainThresholdCp: 288
-      search.rootRunnerUpMarginCp: 70
+      search.rootCaptureGainThresholdCp: 365
+      search.rootRunnerUpMarginCp: 82
       search.rootDespairMarginCp: 464
       search.rootDespairMinEvals: 8
       search.rootDespairRunnerRatio: 0.5
-      search.rootDespairAbsThresholdCp: 731
-      search.rootDespairMinEvalsAbs: 8
-      search.rootHopelessMarginCp: 96
+      search.rootDespairAbsThresholdCp: 751
+      search.rootDespairMinEvalsAbs: 7
+      search.rootHopelessMarginCp: 119
       search.absPlyLimitMargin: 30
       search.aspMinSpanCp: 34
-      search.aspMaxSpanCp: 546
-      search.aspDefaultSpanCp: 166
+      search.aspMaxSpanCp: 640
+      search.aspDefaultSpanCp: 138
       search.aspHistoryBlend: 0.4
-      search.aspMomentumStepCp: 5
-      search.aspMomentumCap: 30
+      search.aspMomentumStepCp: 6
+      search.aspMomentumCap: 32
       search.aspFailureRatio: 0.7
       search.aspBaseOffsetCp: 0
-      search.aspSwingWeight: 0.15
+      search.aspSwingWeight: 0.13
       search.aspVolatilityWeight: 0.7
-      search.aspDepthScale: 0.03
+      search.aspDepthScale: 0.05
       search.aspDepthPivot: 3
-      search.aspFloorBaseCp: 12
+      search.aspFloorBaseCp: 10
       search.aspFloorVolWeight: 1.5
       search.aspFloorStreakStepCp: 25
       search.aspBumpBaseCp: 12
       search.aspBumpStreakCp: 11
       search.aspBumpDepthCp: 2
-      search.aspFullWindowScale: 1.89
-      search.aspLastSpanScale: 1.8
-      search.aspFullWindowMinMultiplier: 1.9
+      search.aspFullWindowScale: 2.00
+      search.aspLastSpanScale: 2.0
+      search.aspFullWindowMinMultiplier: 2.2
       search.aspBlendBaselineWeight: 0.7
       search.aspBlendCandidateWeight: 0.6
       search.aspMaxRetriesBase: 0
-      search.aspMaxRetriesVolThresholdHigh: 92
-      search.aspMaxRetriesVolBonusHigh: 7
-      search.aspMaxRetriesVolThresholdMed: 234
+      search.aspMaxRetriesVolThresholdHigh: 94
+      search.aspMaxRetriesVolBonusHigh: 8
+      search.aspMaxRetriesVolThresholdMed: 252
       search.aspMaxRetriesVolBonusMed: 1
       search.aspMaxRetriesDepthOffset: 15
       search.aspMaxRetriesDepthDivisor: 1
@@ -184,201 +184,201 @@ population:
       search.aspMaxRetriesMax: 0
       search.nullBaseReduction: 7.8
       search.nullDepthWeight: 0.8
-      search.nullMaterialWeight: 1.68
+      search.nullMaterialWeight: 1.98
       search.nullMobilityWeight: 0.14
-      search.nullDepthCap: 13
-      search.nullMaterialCap: 24
+      search.nullDepthCap: 11
+      search.nullMaterialCap: 22
       search.nullMobilityCap: 10
       search.nullLowMaterialThreshold: 3
       search.nullLowMobilityThreshold: 5
       search.nullVeryLowMobilityThreshold: 8
-      search.nullLowMaterialPenalty: 0.72
+      search.nullLowMaterialPenalty: 0.66
       search.nullVeryLowMobilityPenalty: 0.6
-      search.nullSwingGuardMinCp: 234
-      search.nullSwingGuardDivisor: 61
+      search.nullSwingGuardMinCp: 214
+      search.nullSwingGuardDivisor: 74
       search.ttMainWeight: 4.2
-      search.ttCaptureWeight: 4.2
+      search.ttCaptureWeight: 5.1
       search.qsMaxDeltaPawn: 3.3
       search.drawBias: 0.0
       search.preferFastMate: 1.0
       search.tbTieBreak: 1.0
       learning.layer0.neuron0.weight0: 0.09
-      learning.layer0.neuron0.weight1: 0.05
-      learning.layer0.neuron0.weight2: 0.07
-      learning.layer0.neuron0.weight3: 0.01
+      learning.layer0.neuron0.weight1: 0.04
+      learning.layer0.neuron0.weight2: 0.06
+      learning.layer0.neuron0.weight3: -0.00
       learning.layer0.neuron0.weight4: 0.02
       learning.layer0.neuron0.weight5: 0.06
       learning.layer0.neuron0.weight6: 0.03
-      learning.layer0.neuron0.weight7: 0.03
+      learning.layer0.neuron0.weight7: 0.05
       learning.layer0.neuron0.weight8: -0.01
       learning.layer0.neuron0.weight9: 0.02
-      learning.layer0.neuron0.weight10: -0.02
-      learning.layer0.neuron0.weight11: 0.01
+      learning.layer0.neuron0.weight10: -0.03
+      learning.layer0.neuron0.weight11: 0.00
       learning.layer0.neuron0.weight12: 0.02
       learning.layer0.neuron0.weight13: 0.01
       learning.layer0.neuron0.weight14: 0.01
       learning.layer0.neuron0.weight15: 0.0
-      learning.layer0.neuron0.weight16: 0.06
+      learning.layer0.neuron0.weight16: 0.08
       learning.layer0.neuron0.weight17: -0.02
       learning.layer0.neuron0.weight18: -0.02
-      learning.layer0.neuron1.weight0: 0.01
+      learning.layer0.neuron1.weight0: 0.03
       learning.layer0.neuron1.weight1: -0.01
-      learning.layer0.neuron1.weight2: 0.0
-      learning.layer0.neuron1.weight3: 0.04
-      learning.layer0.neuron1.weight4: 0.03
+      learning.layer0.neuron1.weight2: -0.0
+      learning.layer0.neuron1.weight3: 0.05
+      learning.layer0.neuron1.weight4: 0.02
       learning.layer0.neuron1.weight5: 0.05
       learning.layer0.neuron1.weight6: -0.01
       learning.layer0.neuron1.weight7: 0.02
       learning.layer0.neuron1.weight8: 0.0
       learning.layer0.neuron1.weight9: 0.06
       learning.layer0.neuron1.weight10: 0.02
-      learning.layer0.neuron1.weight11: -0.02
+      learning.layer0.neuron1.weight11: -0.04
       learning.layer0.neuron1.weight12: 0.02
-      learning.layer0.neuron1.weight13: 0.10
+      learning.layer0.neuron1.weight13: 0.12
       learning.layer0.neuron1.weight14: -0.0
-      learning.layer0.neuron1.weight15: 0.03
+      learning.layer0.neuron1.weight15: 0.05
       learning.layer0.neuron1.weight16: -0.03
       learning.layer0.neuron1.weight17: -0.02
       learning.layer0.neuron1.weight18: -0.10
       learning.layer0.neuron2.weight0: -0.03
-      learning.layer0.neuron2.weight1: 0.02
+      learning.layer0.neuron2.weight1: 0.01
       learning.layer0.neuron2.weight2: 0.04
       learning.layer0.neuron2.weight3: 0.10
-      learning.layer0.neuron2.weight4: 0.08
+      learning.layer0.neuron2.weight4: 0.07
       learning.layer0.neuron2.weight5: 0.06
-      learning.layer0.neuron2.weight6: 0.07
+      learning.layer0.neuron2.weight6: 0.08
       learning.layer0.neuron2.weight7: 0.08
-      learning.layer0.neuron2.weight8: 0.09
-      learning.layer0.neuron2.weight9: 0.01
+      learning.layer0.neuron2.weight8: 0.08
+      learning.layer0.neuron2.weight9: 0.00
       learning.layer0.neuron2.weight10: 0.06
       learning.layer0.neuron2.weight11: 0.04
       learning.layer0.neuron2.weight12: 0.01
-      learning.layer0.neuron2.weight13: 0.0
-      learning.layer0.neuron2.weight14: -0.00
+      learning.layer0.neuron2.weight13: -0.0
+      learning.layer0.neuron2.weight14: 0.01
       learning.layer0.neuron2.weight15: -0.04
       learning.layer0.neuron2.weight16: -0.03
       learning.layer0.neuron2.weight17: -0.02
       learning.layer0.neuron2.weight18: -0.05
       learning.layer0.neuron3.weight0: 0.0
-      learning.layer0.neuron3.weight1: 0.0
+      learning.layer0.neuron3.weight1: -0.0
       learning.layer0.neuron3.weight2: 0.01
-      learning.layer0.neuron3.weight3: 0.10
-      learning.layer0.neuron3.weight4: 0.02
+      learning.layer0.neuron3.weight3: 0.12
+      learning.layer0.neuron3.weight4: 0.01
       learning.layer0.neuron3.weight5: 0.0
       learning.layer0.neuron3.weight6: 0.05
       learning.layer0.neuron3.weight7: 0.04
       learning.layer0.neuron3.weight8: 0.05
       learning.layer0.neuron3.weight9: 0.02
       learning.layer0.neuron3.weight10: 0.02
-      learning.layer0.neuron3.weight11: -0.0
-      learning.layer0.neuron3.weight12: 0.03
-      learning.layer0.neuron3.weight13: 0.01
+      learning.layer0.neuron3.weight11: 0.0
+      learning.layer0.neuron3.weight12: 0.05
+      learning.layer0.neuron3.weight13: 0.03
       learning.layer0.neuron3.weight14: -0.03
-      learning.layer0.neuron3.weight15: -0.04
-      learning.layer0.neuron3.weight16: -0.03
+      learning.layer0.neuron3.weight15: -0.05
+      learning.layer0.neuron3.weight16: -0.04
       learning.layer0.neuron3.weight17: -0.0
-      learning.layer0.neuron3.weight18: 0.01
-      learning.layer0.neuron4.weight0: -0.01
-      learning.layer0.neuron4.weight1: -0.02
-      learning.layer0.neuron4.weight2: 0.00
-      learning.layer0.neuron4.weight3: 0.0
-      learning.layer0.neuron4.weight4: -0.00
-      learning.layer0.neuron4.weight5: -0.04
-      learning.layer0.neuron4.weight6: -0.03
+      learning.layer0.neuron3.weight18: -0.00
+      learning.layer0.neuron4.weight0: 0.01
+      learning.layer0.neuron4.weight1: -0.04
+      learning.layer0.neuron4.weight2: -0.00
+      learning.layer0.neuron4.weight3: -0.0
+      learning.layer0.neuron4.weight4: -0.01
+      learning.layer0.neuron4.weight5: -0.05
+      learning.layer0.neuron4.weight6: -0.04
       learning.layer0.neuron4.weight7: 0.0
       learning.layer0.neuron4.weight8: 0.04
       learning.layer0.neuron4.weight9: 0.03
-      learning.layer0.neuron4.weight10: 0.00
+      learning.layer0.neuron4.weight10: -0.00
       learning.layer0.neuron4.weight11: 0.06
-      learning.layer0.neuron4.weight12: 0.04
+      learning.layer0.neuron4.weight12: 0.06
       learning.layer0.neuron4.weight13: 0.0
       learning.layer0.neuron4.weight14: -0.04
-      learning.layer0.neuron4.weight15: -0.04
+      learning.layer0.neuron4.weight15: -0.05
       learning.layer0.neuron4.weight16: -0.05
       learning.layer0.neuron4.weight17: -0.01
-      learning.layer0.neuron4.weight18: 0.01
+      learning.layer0.neuron4.weight18: 0.02
       learning.layer0.neuron5.weight0: 0.00
       learning.layer0.neuron5.weight1: 0.00
       learning.layer0.neuron5.weight2: 0.0
       learning.layer0.neuron5.weight3: -0.01
-      learning.layer0.neuron5.weight4: 0.01
+      learning.layer0.neuron5.weight4: 0.02
       learning.layer0.neuron5.weight5: 0.06
-      learning.layer0.neuron5.weight6: 0.03
+      learning.layer0.neuron5.weight6: 0.05
       learning.layer0.neuron5.weight7: 0.03
-      learning.layer0.neuron5.weight8: -0.0
+      learning.layer0.neuron5.weight8: 0.0
       learning.layer0.neuron5.weight9: -0.01
-      learning.layer0.neuron5.weight10: -0.00
+      learning.layer0.neuron5.weight10: 0.02
       learning.layer0.neuron5.weight11: -0.02
       learning.layer0.neuron5.weight12: -0.03
       learning.layer0.neuron5.weight13: 0.02
-      learning.layer0.neuron5.weight14: 0.0
-      learning.layer0.neuron5.weight15: 0.04
-      learning.layer0.neuron5.weight16: -0.00
+      learning.layer0.neuron5.weight14: -0.0
+      learning.layer0.neuron5.weight15: 0.06
+      learning.layer0.neuron5.weight16: 0.00
       learning.layer0.neuron5.weight17: 0.04
-      learning.layer0.neuron5.weight18: 0.07
+      learning.layer0.neuron5.weight18: 0.08
       learning.layer0.neuron6.weight0: 0.10
       learning.layer0.neuron6.weight1: 0.06
-      learning.layer0.neuron6.weight2: 0.03
-      learning.layer0.neuron6.weight3: 0.01
+      learning.layer0.neuron6.weight2: 0.02
+      learning.layer0.neuron6.weight3: 0.00
       learning.layer0.neuron6.weight4: 0.0
       learning.layer0.neuron6.weight5: 0.06
       learning.layer0.neuron6.weight6: 0.04
-      learning.layer0.neuron6.weight7: -0.01
-      learning.layer0.neuron6.weight8: -0.0
-      learning.layer0.neuron6.weight9: 0.01
+      learning.layer0.neuron6.weight7: -0.02
+      learning.layer0.neuron6.weight8: 0.0
+      learning.layer0.neuron6.weight9: -0.01
       learning.layer0.neuron6.weight10: -0.02
-      learning.layer0.neuron6.weight11: -0.01
-      learning.layer0.neuron6.weight12: 0.03
+      learning.layer0.neuron6.weight11: -0.03
+      learning.layer0.neuron6.weight12: 0.05
       learning.layer0.neuron6.weight13: 0.02
       learning.layer0.neuron6.weight14: -0.03
-      learning.layer0.neuron6.weight15: 0.02
-      learning.layer0.neuron6.weight16: -0.0
-      learning.layer0.neuron6.weight17: 0.03
+      learning.layer0.neuron6.weight15: 0.04
+      learning.layer0.neuron6.weight16: 0.0
+      learning.layer0.neuron6.weight17: 0.05
       learning.layer0.neuron6.weight18: -0.00
-      learning.layer0.neuron7.weight0: 0.03
-      learning.layer0.neuron7.weight1: -0.04
+      learning.layer0.neuron7.weight0: 0.01
+      learning.layer0.neuron7.weight1: -0.05
       learning.layer0.neuron7.weight2: 0.01
-      learning.layer0.neuron7.weight3: -0.04
-      learning.layer0.neuron7.weight4: -0.01
-      learning.layer0.neuron7.weight5: 0.00
+      learning.layer0.neuron7.weight3: -0.03
+      learning.layer0.neuron7.weight4: 0.01
+      learning.layer0.neuron7.weight5: -0.02
       learning.layer0.neuron7.weight6: -0.01
-      learning.layer0.neuron7.weight7: -0.02
+      learning.layer0.neuron7.weight7: -0.03
       learning.layer0.neuron7.weight8: -0.05
       learning.layer0.neuron7.weight9: 0.03
-      learning.layer0.neuron7.weight10: -0.07
-      learning.layer0.neuron7.weight11: 0.08
-      learning.layer0.neuron7.weight12: 0.0
+      learning.layer0.neuron7.weight10: -0.08
+      learning.layer0.neuron7.weight11: 0.10
+      learning.layer0.neuron7.weight12: -0.0
       learning.layer0.neuron7.weight13: 0.04
       learning.layer0.neuron7.weight14: 0.05
-      learning.layer0.neuron7.weight15: 0.05
+      learning.layer0.neuron7.weight15: 0.04
       learning.layer0.neuron7.weight16: 0.03
       learning.layer0.neuron7.weight17: 0.03
-      learning.layer0.neuron7.weight18: 0.06
-      learning.layer0.neuron0.bias: 0.04
-      learning.layer0.neuron1.bias: -0.01
-      learning.layer0.neuron2.bias: -0.0
-      learning.layer0.neuron3.bias: 0.07
+      learning.layer0.neuron7.weight18: 0.07
+      learning.layer0.neuron0.bias: 0.03
+      learning.layer0.neuron1.bias: -0.04
+      learning.layer0.neuron2.bias: 0.0
+      learning.layer0.neuron3.bias: 0.08
       learning.layer0.neuron4.bias: 0.01
-      learning.layer0.neuron5.bias: -0.0
-      learning.layer0.neuron6.bias: 0.04
-      learning.layer0.neuron7.bias: 0.02
-      learning.layer1.neuron0.weight0: 0.5
+      learning.layer0.neuron5.bias: 0.0
+      learning.layer0.neuron6.bias: 0.05
+      learning.layer0.neuron7.bias: 0.01
+      learning.layer1.neuron0.weight0: 0.6
       learning.layer1.neuron0.weight1: 0.3
       learning.layer1.neuron0.weight2: 0.1
-      learning.layer1.neuron0.weight3: 0.0
+      learning.layer1.neuron0.weight3: -0.0
       learning.layer1.neuron0.weight4: -0.1
       learning.layer1.neuron0.weight5: 0.3
       learning.layer1.neuron0.weight6: 0.2
       learning.layer1.neuron0.weight7: -0.2
       learning.layer1.neuron1.weight0: -0.2
       learning.layer1.neuron1.weight1: -0.1
-      learning.layer1.neuron1.weight2: -0.0
+      learning.layer1.neuron1.weight2: 0.0
       learning.layer1.neuron1.weight3: 0.1
       learning.layer1.neuron1.weight4: 0.2
       learning.layer1.neuron1.weight5: -0.2
       learning.layer1.neuron1.weight6: -0.1
       learning.layer1.neuron1.weight7: 0.4
       learning.layer1.neuron0.bias: -0.0
-      learning.layer1.neuron1.bias: -0.0
-      learning.outputMidgameScale: 67.3
-      learning.outputEndgameScale: 96.7
+      learning.layer1.neuron1.bias: 0.0
+      learning.outputMidgameScale: 67.5
+      learning.outputEndgameScale: 103.2

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -3,20 +3,20 @@ population:
     evaluation:
       modules:
         MaterialModule:
-          midgame: 0.0
-          endgame: 0.0
+          midgame: 0.2
+          endgame: 0.2
         PawnStructureModule:
-          midgame: 0.0
-          endgame: 0.0
+          midgame: 0.2
+          endgame: 0.2
         ActivityModule:
-          midgame: 0.0
-          endgame: 0.0
+          midgame: 0.2
+          endgame: 0.2
         KingSafetyModule:
-          midgame: 0.0
-          endgame: 0.0
+          midgame: 0.2
+          endgame: 0.2
         ThreatModule:
-          midgame: 0.0
-          endgame: 0.0
+          midgame: 0.2
+          endgame: 0.2
         LearningEvaluationModule:
           midgame: 1.0
           endgame: 1.0
@@ -84,35 +84,35 @@ population:
       kingsafety.attackweightqueen: 24
       moveordering.category.tt: 8
       moveordering.category.promotion: 6
-      moveordering.category.capturegood: 6
+      moveordering.category.capturegood: 4
       moveordering.category.captureequal: 4
       moveordering.category.killer0: 3
       moveordering.category.killer1: 2
       moveordering.category.quiet: 1
       moveordering.category.capturebad: 0
-      moveordering.killermovescore: 9122
-      moveordering.promotionbonus: 1598
-      moveordering.killer0bonus: 640
-      moveordering.killer1bonus: 283
-      moveordering.countermovebonus: 466
-      moveordering.capturemvvmultiplier: 19
-      moveordering.captureseemultiplier: 129
-      moveordering.promotionseemultiplier: 21
-      moveordering.castlingbonus: 244
-      moveordering.captureseeclamp: 577
-      moveordering.promotionseeclamp: 339
-      moveordering.capturegoodbonus: 1178
-      moveordering.captureequalbonus: 258
-      moveordering.capturebadbonus: -665
+      moveordering.killermovescore: 9452
+      moveordering.promotionbonus: 1600
+      moveordering.killer0bonus: 435
+      moveordering.killer1bonus: 285
+      moveordering.countermovebonus: 512
+      moveordering.capturemvvmultiplier: 21
+      moveordering.captureseemultiplier: 155
+      moveordering.promotionseemultiplier: 27
+      moveordering.castlingbonus: 49
+      moveordering.captureseeclamp: 632
+      moveordering.promotionseeclamp: 398
+      moveordering.capturegoodbonus: 949
+      moveordering.captureequalbonus: 237
+      moveordering.capturebadbonus: -605
       moveordering.capturelosingseepenalty: 0
-      moveordering.quiethistorymultiplier: 3.0
-      moveordering.quiethistorybonus: 1189
-      moveordering.maxscore: 16464490
+      moveordering.quiethistorymultiplier: 3.5
+      moveordering.quiethistorybonus: 1982
+      moveordering.maxscore: 16777215
       moveordering.historyscale: 3.8
       moveordering.historydecaydivisor: 2
-      moveordering.quietlearningweight: 12
-      moveordering.quietlearningclamp: 320
-      moveordering.quietlearningmaxmoves: 8
+      moveordering.quietlearningweight: 11
+      moveordering.quietlearningclamp: 313
+      moveordering.quietlearningmaxmoves: 6
       search.fpMarginDepth1: 348
       search.fpMarginDepth2: 883
       search.lmpBase: 0
@@ -203,22 +203,22 @@ population:
       search.preferFastMate: 1.0
       search.tbTieBreak: 1.0
       learning.layer0.neuron0.weight0: 0.09
-      learning.layer0.neuron0.weight1: 0.05
+      learning.layer0.neuron0.weight1: 0.06
       learning.layer0.neuron0.weight2: 0.04
       learning.layer0.neuron0.weight3: 0.02
-      learning.layer0.neuron0.weight4: 0.01
+      learning.layer0.neuron0.weight4: 0.02
       learning.layer0.neuron0.weight5: 0.06
       learning.layer0.neuron0.weight6: 0.03
       learning.layer0.neuron0.weight7: 0.01
-      learning.layer0.neuron0.weight8: 0.00
+      learning.layer0.neuron0.weight8: -0.00
       learning.layer0.neuron0.weight9: 0.03
-      learning.layer0.neuron0.weight10: -0.00
+      learning.layer0.neuron0.weight10: -0.01
       learning.layer0.neuron0.weight11: 0.01
       learning.layer0.neuron0.weight12: 0.02
       learning.layer0.neuron0.weight13: 0.01
-      learning.layer0.neuron0.weight14: -0.00
+      learning.layer0.neuron0.weight14: 0.01
       learning.layer0.neuron0.weight15: 0.0
-      learning.layer0.neuron0.weight16: 0.03
+      learning.layer0.neuron0.weight16: 0.04
       learning.layer0.neuron0.weight17: -0.01
       learning.layer0.neuron0.weight18: -0.03
       learning.layer0.neuron1.weight0: 0.01
@@ -226,9 +226,9 @@ population:
       learning.layer0.neuron1.weight2: -0.0
       learning.layer0.neuron1.weight3: 0.03
       learning.layer0.neuron1.weight4: 0.03
-      learning.layer0.neuron1.weight5: 0.01
-      learning.layer0.neuron1.weight6: -0.04
-      learning.layer0.neuron1.weight7: -0.00
+      learning.layer0.neuron1.weight5: 0.02
+      learning.layer0.neuron1.weight6: -0.03
+      learning.layer0.neuron1.weight7: 0.01
       learning.layer0.neuron1.weight8: 0.0
       learning.layer0.neuron1.weight9: 0.05
       learning.layer0.neuron1.weight10: 0.01
@@ -241,60 +241,60 @@ population:
       learning.layer0.neuron1.weight17: -0.02
       learning.layer0.neuron1.weight18: -0.09
       learning.layer0.neuron2.weight0: -0.01
-      learning.layer0.neuron2.weight1: 0.01
-      learning.layer0.neuron2.weight2: 0.03
+      learning.layer0.neuron2.weight1: 0.02
+      learning.layer0.neuron2.weight2: 0.04
       learning.layer0.neuron2.weight3: 0.10
       learning.layer0.neuron2.weight4: 0.07
       learning.layer0.neuron2.weight5: 0.04
       learning.layer0.neuron2.weight6: 0.06
-      learning.layer0.neuron2.weight7: 0.05
-      learning.layer0.neuron2.weight8: 0.09
-      learning.layer0.neuron2.weight9: 0.03
-      learning.layer0.neuron2.weight10: 0.05
+      learning.layer0.neuron2.weight7: 0.06
+      learning.layer0.neuron2.weight8: 0.08
+      learning.layer0.neuron2.weight9: 0.02
+      learning.layer0.neuron2.weight10: 0.06
       learning.layer0.neuron2.weight11: 0.03
       learning.layer0.neuron2.weight12: 0.01
       learning.layer0.neuron2.weight13: 0.0
       learning.layer0.neuron2.weight14: -0.00
       learning.layer0.neuron2.weight15: -0.04
       learning.layer0.neuron2.weight16: -0.02
-      learning.layer0.neuron2.weight17: -0.04
-      learning.layer0.neuron2.weight18: -0.04
+      learning.layer0.neuron2.weight17: -0.03
+      learning.layer0.neuron2.weight18: -0.05
       learning.layer0.neuron3.weight0: 0.0
       learning.layer0.neuron3.weight1: 0.0
       learning.layer0.neuron3.weight2: 0.01
       learning.layer0.neuron3.weight3: 0.06
-      learning.layer0.neuron3.weight4: 0.01
+      learning.layer0.neuron3.weight4: 0.02
       learning.layer0.neuron3.weight5: 0.0
       learning.layer0.neuron3.weight6: 0.06
       learning.layer0.neuron3.weight7: 0.03
-      learning.layer0.neuron3.weight8: 0.04
+      learning.layer0.neuron3.weight8: 0.05
       learning.layer0.neuron3.weight9: 0.02
       learning.layer0.neuron3.weight10: 0.02
       learning.layer0.neuron3.weight11: 0.0
-      learning.layer0.neuron3.weight12: 0.03
+      learning.layer0.neuron3.weight12: 0.04
       learning.layer0.neuron3.weight13: -0.02
       learning.layer0.neuron3.weight14: -0.03
-      learning.layer0.neuron3.weight15: -0.04
+      learning.layer0.neuron3.weight15: -0.03
       learning.layer0.neuron3.weight16: -0.02
       learning.layer0.neuron3.weight17: 0.0
       learning.layer0.neuron3.weight18: 0.01
       learning.layer0.neuron4.weight0: -0.01
       learning.layer0.neuron4.weight1: -0.02
-      learning.layer0.neuron4.weight2: -0.00
+      learning.layer0.neuron4.weight2: 0.00
       learning.layer0.neuron4.weight3: 0.0
-      learning.layer0.neuron4.weight4: 0.01
+      learning.layer0.neuron4.weight4: 0.00
       learning.layer0.neuron4.weight5: -0.03
       learning.layer0.neuron4.weight6: -0.02
       learning.layer0.neuron4.weight7: -0.0
       learning.layer0.neuron4.weight8: 0.03
       learning.layer0.neuron4.weight9: 0.01
-      learning.layer0.neuron4.weight10: 0.02
+      learning.layer0.neuron4.weight10: 0.01
       learning.layer0.neuron4.weight11: 0.05
       learning.layer0.neuron4.weight12: 0.03
       learning.layer0.neuron4.weight13: -0.0
-      learning.layer0.neuron4.weight14: -0.03
+      learning.layer0.neuron4.weight14: -0.04
       learning.layer0.neuron4.weight15: -0.03
-      learning.layer0.neuron4.weight16: -0.03
+      learning.layer0.neuron4.weight16: -0.02
       learning.layer0.neuron4.weight17: -0.01
       learning.layer0.neuron4.weight18: 0.00
       learning.layer0.neuron5.weight0: -0.01
@@ -304,8 +304,8 @@ population:
       learning.layer0.neuron5.weight4: 0.00
       learning.layer0.neuron5.weight5: 0.06
       learning.layer0.neuron5.weight6: 0.02
-      learning.layer0.neuron5.weight7: 0.02
-      learning.layer0.neuron5.weight8: 0.0
+      learning.layer0.neuron5.weight7: 0.03
+      learning.layer0.neuron5.weight8: -0.0
       learning.layer0.neuron5.weight9: -0.01
       learning.layer0.neuron5.weight10: -0.00
       learning.layer0.neuron5.weight11: -0.02
@@ -320,14 +320,14 @@ population:
       learning.layer0.neuron6.weight1: 0.04
       learning.layer0.neuron6.weight2: 0.04
       learning.layer0.neuron6.weight3: 0.03
-      learning.layer0.neuron6.weight4: 0.0
+      learning.layer0.neuron6.weight4: -0.0
       learning.layer0.neuron6.weight5: 0.05
-      learning.layer0.neuron6.weight6: 0.02
+      learning.layer0.neuron6.weight6: 0.03
       learning.layer0.neuron6.weight7: -0.01
       learning.layer0.neuron6.weight8: 0.0
       learning.layer0.neuron6.weight9: 0.01
       learning.layer0.neuron6.weight10: -0.02
-      learning.layer0.neuron6.weight11: 0.00
+      learning.layer0.neuron6.weight11: -0.01
       learning.layer0.neuron6.weight12: 0.00
       learning.layer0.neuron6.weight13: -0.00
       learning.layer0.neuron6.weight14: -0.03
@@ -340,25 +340,25 @@ population:
       learning.layer0.neuron7.weight2: -0.03
       learning.layer0.neuron7.weight3: -0.04
       learning.layer0.neuron7.weight4: -0.03
-      learning.layer0.neuron7.weight5: -0.00
+      learning.layer0.neuron7.weight5: -0.01
       learning.layer0.neuron7.weight6: -0.01
       learning.layer0.neuron7.weight7: 0.00
       learning.layer0.neuron7.weight8: -0.05
-      learning.layer0.neuron7.weight9: -0.01
+      learning.layer0.neuron7.weight9: 0.01
       learning.layer0.neuron7.weight10: -0.05
-      learning.layer0.neuron7.weight11: 0.06
+      learning.layer0.neuron7.weight11: 0.07
       learning.layer0.neuron7.weight12: 0.0
       learning.layer0.neuron7.weight13: 0.04
       learning.layer0.neuron7.weight14: 0.02
-      learning.layer0.neuron7.weight15: 0.05
+      learning.layer0.neuron7.weight15: 0.06
       learning.layer0.neuron7.weight16: 0.04
       learning.layer0.neuron7.weight17: 0.04
       learning.layer0.neuron7.weight18: 0.06
-      learning.layer0.neuron0.bias: 0.02
+      learning.layer0.neuron0.bias: 0.03
       learning.layer0.neuron1.bias: -0.01
       learning.layer0.neuron2.bias: -0.0
-      learning.layer0.neuron3.bias: 0.03
-      learning.layer0.neuron4.bias: 0.00
+      learning.layer0.neuron3.bias: 0.04
+      learning.layer0.neuron4.bias: -0.00
       learning.layer0.neuron5.bias: 0.0
       learning.layer0.neuron6.bias: 0.02
       learning.layer0.neuron7.bias: 0.00
@@ -380,5 +380,5 @@ population:
       learning.layer1.neuron1.weight7: 0.4
       learning.layer1.neuron0.bias: -0.0
       learning.layer1.neuron1.bias: 0.0
-      learning.outputMidgameScale: 73.6
+      learning.outputMidgameScale: 80.9
       learning.outputEndgameScale: 89.3

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -3,20 +3,20 @@ population:
     evaluation:
       modules:
         MaterialModule:
-          midgame: 0.2
-          endgame: 0.2
+          midgame: 0.5
+          endgame: 0.5
         PawnStructureModule:
-          midgame: 0.2
-          endgame: 0.2
+          midgame: 0.5
+          endgame: 0.5
         ActivityModule:
-          midgame: 0.2
-          endgame: 0.2
+          midgame: 0.5
+          endgame: 0.5
         KingSafetyModule:
-          midgame: 0.2
-          endgame: 0.2
+          midgame: 0.5
+          endgame: 0.5
         ThreatModule:
-          midgame: 0.2
-          endgame: 0.2
+          midgame: 0.5
+          endgame: 0.5
         LearningEvaluationModule:
           midgame: 1.0
           endgame: 1.0
@@ -90,29 +90,29 @@ population:
       moveordering.category.killer1: 2
       moveordering.category.quiet: 1
       moveordering.category.capturebad: 0
-      moveordering.killermovescore: 9452
-      moveordering.promotionbonus: 1600
-      moveordering.killer0bonus: 435
-      moveordering.killer1bonus: 285
-      moveordering.countermovebonus: 512
-      moveordering.capturemvvmultiplier: 21
-      moveordering.captureseemultiplier: 155
-      moveordering.promotionseemultiplier: 27
-      moveordering.castlingbonus: 49
-      moveordering.captureseeclamp: 632
-      moveordering.promotionseeclamp: 398
-      moveordering.capturegoodbonus: 949
-      moveordering.captureequalbonus: 237
-      moveordering.capturebadbonus: -605
-      moveordering.capturelosingseepenalty: 0
-      moveordering.quiethistorymultiplier: 3.5
-      moveordering.quiethistorybonus: 1982
-      moveordering.maxscore: 16777215
-      moveordering.historyscale: 3.8
+      moveordering.killermovescore: 13114
+      moveordering.promotionbonus: 1492
+      moveordering.killer0bonus: 307
+      moveordering.killer1bonus: 289
+      moveordering.countermovebonus: 605
+      moveordering.capturemvvmultiplier: 23
+      moveordering.captureseemultiplier: 179
+      moveordering.promotionseemultiplier: 32
+      moveordering.castlingbonus: 38
+      moveordering.captureseeclamp: 581
+      moveordering.promotionseeclamp: 400
+      moveordering.capturegoodbonus: 948
+      moveordering.captureequalbonus: 195
+      moveordering.capturebadbonus: -517
+      moveordering.capturelosingseepenalty: 1
+      moveordering.quiethistorymultiplier: 3.8
+      moveordering.quiethistorybonus: 2643
+      moveordering.maxscore: 16609430
+      moveordering.historyscale: 3.9
       moveordering.historydecaydivisor: 2
-      moveordering.quietlearningweight: 11
-      moveordering.quietlearningclamp: 313
-      moveordering.quietlearningmaxmoves: 6
+      moveordering.quietlearningweight: 10
+      moveordering.quietlearningclamp: 407
+      moveordering.quietlearningmaxmoves: 0
       search.fpMarginDepth1: 348
       search.fpMarginDepth2: 883
       search.lmpBase: 0
@@ -203,165 +203,165 @@ population:
       search.preferFastMate: 1.0
       search.tbTieBreak: 1.0
       learning.layer0.neuron0.weight0: 0.09
-      learning.layer0.neuron0.weight1: 0.06
-      learning.layer0.neuron0.weight2: 0.04
-      learning.layer0.neuron0.weight3: 0.02
+      learning.layer0.neuron0.weight1: 0.05
+      learning.layer0.neuron0.weight2: 0.07
+      learning.layer0.neuron0.weight3: 0.01
       learning.layer0.neuron0.weight4: 0.02
       learning.layer0.neuron0.weight5: 0.06
       learning.layer0.neuron0.weight6: 0.03
-      learning.layer0.neuron0.weight7: 0.01
-      learning.layer0.neuron0.weight8: -0.00
-      learning.layer0.neuron0.weight9: 0.03
-      learning.layer0.neuron0.weight10: -0.01
+      learning.layer0.neuron0.weight7: 0.03
+      learning.layer0.neuron0.weight8: -0.01
+      learning.layer0.neuron0.weight9: 0.02
+      learning.layer0.neuron0.weight10: -0.02
       learning.layer0.neuron0.weight11: 0.01
       learning.layer0.neuron0.weight12: 0.02
       learning.layer0.neuron0.weight13: 0.01
       learning.layer0.neuron0.weight14: 0.01
       learning.layer0.neuron0.weight15: 0.0
-      learning.layer0.neuron0.weight16: 0.04
-      learning.layer0.neuron0.weight17: -0.01
-      learning.layer0.neuron0.weight18: -0.03
+      learning.layer0.neuron0.weight16: 0.06
+      learning.layer0.neuron0.weight17: -0.02
+      learning.layer0.neuron0.weight18: -0.02
       learning.layer0.neuron1.weight0: 0.01
-      learning.layer0.neuron1.weight1: -0.02
-      learning.layer0.neuron1.weight2: -0.0
-      learning.layer0.neuron1.weight3: 0.03
+      learning.layer0.neuron1.weight1: -0.01
+      learning.layer0.neuron1.weight2: 0.0
+      learning.layer0.neuron1.weight3: 0.04
       learning.layer0.neuron1.weight4: 0.03
-      learning.layer0.neuron1.weight5: 0.02
-      learning.layer0.neuron1.weight6: -0.03
-      learning.layer0.neuron1.weight7: 0.01
+      learning.layer0.neuron1.weight5: 0.05
+      learning.layer0.neuron1.weight6: -0.01
+      learning.layer0.neuron1.weight7: 0.02
       learning.layer0.neuron1.weight8: 0.0
-      learning.layer0.neuron1.weight9: 0.05
-      learning.layer0.neuron1.weight10: 0.01
+      learning.layer0.neuron1.weight9: 0.06
+      learning.layer0.neuron1.weight10: 0.02
       learning.layer0.neuron1.weight11: -0.02
       learning.layer0.neuron1.weight12: 0.02
-      learning.layer0.neuron1.weight13: 0.07
-      learning.layer0.neuron1.weight14: 0.0
+      learning.layer0.neuron1.weight13: 0.10
+      learning.layer0.neuron1.weight14: -0.0
       learning.layer0.neuron1.weight15: 0.03
       learning.layer0.neuron1.weight16: -0.03
       learning.layer0.neuron1.weight17: -0.02
-      learning.layer0.neuron1.weight18: -0.09
-      learning.layer0.neuron2.weight0: -0.01
+      learning.layer0.neuron1.weight18: -0.10
+      learning.layer0.neuron2.weight0: -0.03
       learning.layer0.neuron2.weight1: 0.02
       learning.layer0.neuron2.weight2: 0.04
       learning.layer0.neuron2.weight3: 0.10
-      learning.layer0.neuron2.weight4: 0.07
-      learning.layer0.neuron2.weight5: 0.04
-      learning.layer0.neuron2.weight6: 0.06
-      learning.layer0.neuron2.weight7: 0.06
-      learning.layer0.neuron2.weight8: 0.08
-      learning.layer0.neuron2.weight9: 0.02
+      learning.layer0.neuron2.weight4: 0.08
+      learning.layer0.neuron2.weight5: 0.06
+      learning.layer0.neuron2.weight6: 0.07
+      learning.layer0.neuron2.weight7: 0.08
+      learning.layer0.neuron2.weight8: 0.09
+      learning.layer0.neuron2.weight9: 0.01
       learning.layer0.neuron2.weight10: 0.06
-      learning.layer0.neuron2.weight11: 0.03
+      learning.layer0.neuron2.weight11: 0.04
       learning.layer0.neuron2.weight12: 0.01
       learning.layer0.neuron2.weight13: 0.0
       learning.layer0.neuron2.weight14: -0.00
       learning.layer0.neuron2.weight15: -0.04
-      learning.layer0.neuron2.weight16: -0.02
-      learning.layer0.neuron2.weight17: -0.03
+      learning.layer0.neuron2.weight16: -0.03
+      learning.layer0.neuron2.weight17: -0.02
       learning.layer0.neuron2.weight18: -0.05
       learning.layer0.neuron3.weight0: 0.0
       learning.layer0.neuron3.weight1: 0.0
       learning.layer0.neuron3.weight2: 0.01
-      learning.layer0.neuron3.weight3: 0.06
+      learning.layer0.neuron3.weight3: 0.10
       learning.layer0.neuron3.weight4: 0.02
       learning.layer0.neuron3.weight5: 0.0
-      learning.layer0.neuron3.weight6: 0.06
-      learning.layer0.neuron3.weight7: 0.03
+      learning.layer0.neuron3.weight6: 0.05
+      learning.layer0.neuron3.weight7: 0.04
       learning.layer0.neuron3.weight8: 0.05
       learning.layer0.neuron3.weight9: 0.02
       learning.layer0.neuron3.weight10: 0.02
-      learning.layer0.neuron3.weight11: 0.0
-      learning.layer0.neuron3.weight12: 0.04
-      learning.layer0.neuron3.weight13: -0.02
+      learning.layer0.neuron3.weight11: -0.0
+      learning.layer0.neuron3.weight12: 0.03
+      learning.layer0.neuron3.weight13: 0.01
       learning.layer0.neuron3.weight14: -0.03
-      learning.layer0.neuron3.weight15: -0.03
-      learning.layer0.neuron3.weight16: -0.02
-      learning.layer0.neuron3.weight17: 0.0
+      learning.layer0.neuron3.weight15: -0.04
+      learning.layer0.neuron3.weight16: -0.03
+      learning.layer0.neuron3.weight17: -0.0
       learning.layer0.neuron3.weight18: 0.01
       learning.layer0.neuron4.weight0: -0.01
       learning.layer0.neuron4.weight1: -0.02
       learning.layer0.neuron4.weight2: 0.00
       learning.layer0.neuron4.weight3: 0.0
-      learning.layer0.neuron4.weight4: 0.00
-      learning.layer0.neuron4.weight5: -0.03
-      learning.layer0.neuron4.weight6: -0.02
-      learning.layer0.neuron4.weight7: -0.0
-      learning.layer0.neuron4.weight8: 0.03
-      learning.layer0.neuron4.weight9: 0.01
-      learning.layer0.neuron4.weight10: 0.01
-      learning.layer0.neuron4.weight11: 0.05
-      learning.layer0.neuron4.weight12: 0.03
-      learning.layer0.neuron4.weight13: -0.0
+      learning.layer0.neuron4.weight4: -0.00
+      learning.layer0.neuron4.weight5: -0.04
+      learning.layer0.neuron4.weight6: -0.03
+      learning.layer0.neuron4.weight7: 0.0
+      learning.layer0.neuron4.weight8: 0.04
+      learning.layer0.neuron4.weight9: 0.03
+      learning.layer0.neuron4.weight10: 0.00
+      learning.layer0.neuron4.weight11: 0.06
+      learning.layer0.neuron4.weight12: 0.04
+      learning.layer0.neuron4.weight13: 0.0
       learning.layer0.neuron4.weight14: -0.04
-      learning.layer0.neuron4.weight15: -0.03
-      learning.layer0.neuron4.weight16: -0.02
+      learning.layer0.neuron4.weight15: -0.04
+      learning.layer0.neuron4.weight16: -0.05
       learning.layer0.neuron4.weight17: -0.01
-      learning.layer0.neuron4.weight18: 0.00
-      learning.layer0.neuron5.weight0: -0.01
+      learning.layer0.neuron4.weight18: 0.01
+      learning.layer0.neuron5.weight0: 0.00
       learning.layer0.neuron5.weight1: 0.00
       learning.layer0.neuron5.weight2: 0.0
       learning.layer0.neuron5.weight3: -0.01
-      learning.layer0.neuron5.weight4: 0.00
+      learning.layer0.neuron5.weight4: 0.01
       learning.layer0.neuron5.weight5: 0.06
-      learning.layer0.neuron5.weight6: 0.02
+      learning.layer0.neuron5.weight6: 0.03
       learning.layer0.neuron5.weight7: 0.03
       learning.layer0.neuron5.weight8: -0.0
       learning.layer0.neuron5.weight9: -0.01
       learning.layer0.neuron5.weight10: -0.00
       learning.layer0.neuron5.weight11: -0.02
       learning.layer0.neuron5.weight12: -0.03
-      learning.layer0.neuron5.weight13: -0.00
+      learning.layer0.neuron5.weight13: 0.02
       learning.layer0.neuron5.weight14: 0.0
       learning.layer0.neuron5.weight15: 0.04
-      learning.layer0.neuron5.weight16: 0.01
+      learning.layer0.neuron5.weight16: -0.00
       learning.layer0.neuron5.weight17: 0.04
-      learning.layer0.neuron5.weight18: 0.06
-      learning.layer0.neuron6.weight0: 0.09
-      learning.layer0.neuron6.weight1: 0.04
-      learning.layer0.neuron6.weight2: 0.04
-      learning.layer0.neuron6.weight3: 0.03
-      learning.layer0.neuron6.weight4: -0.0
-      learning.layer0.neuron6.weight5: 0.05
-      learning.layer0.neuron6.weight6: 0.03
+      learning.layer0.neuron5.weight18: 0.07
+      learning.layer0.neuron6.weight0: 0.10
+      learning.layer0.neuron6.weight1: 0.06
+      learning.layer0.neuron6.weight2: 0.03
+      learning.layer0.neuron6.weight3: 0.01
+      learning.layer0.neuron6.weight4: 0.0
+      learning.layer0.neuron6.weight5: 0.06
+      learning.layer0.neuron6.weight6: 0.04
       learning.layer0.neuron6.weight7: -0.01
-      learning.layer0.neuron6.weight8: 0.0
+      learning.layer0.neuron6.weight8: -0.0
       learning.layer0.neuron6.weight9: 0.01
       learning.layer0.neuron6.weight10: -0.02
       learning.layer0.neuron6.weight11: -0.01
-      learning.layer0.neuron6.weight12: 0.00
-      learning.layer0.neuron6.weight13: -0.00
+      learning.layer0.neuron6.weight12: 0.03
+      learning.layer0.neuron6.weight13: 0.02
       learning.layer0.neuron6.weight14: -0.03
       learning.layer0.neuron6.weight15: 0.02
       learning.layer0.neuron6.weight16: -0.0
-      learning.layer0.neuron6.weight17: 0.01
-      learning.layer0.neuron6.weight18: 0.01
-      learning.layer0.neuron7.weight0: 0.02
-      learning.layer0.neuron7.weight1: -0.02
-      learning.layer0.neuron7.weight2: -0.03
+      learning.layer0.neuron6.weight17: 0.03
+      learning.layer0.neuron6.weight18: -0.00
+      learning.layer0.neuron7.weight0: 0.03
+      learning.layer0.neuron7.weight1: -0.04
+      learning.layer0.neuron7.weight2: 0.01
       learning.layer0.neuron7.weight3: -0.04
-      learning.layer0.neuron7.weight4: -0.03
-      learning.layer0.neuron7.weight5: -0.01
+      learning.layer0.neuron7.weight4: -0.01
+      learning.layer0.neuron7.weight5: 0.00
       learning.layer0.neuron7.weight6: -0.01
-      learning.layer0.neuron7.weight7: 0.00
+      learning.layer0.neuron7.weight7: -0.02
       learning.layer0.neuron7.weight8: -0.05
-      learning.layer0.neuron7.weight9: 0.01
-      learning.layer0.neuron7.weight10: -0.05
-      learning.layer0.neuron7.weight11: 0.07
+      learning.layer0.neuron7.weight9: 0.03
+      learning.layer0.neuron7.weight10: -0.07
+      learning.layer0.neuron7.weight11: 0.08
       learning.layer0.neuron7.weight12: 0.0
       learning.layer0.neuron7.weight13: 0.04
-      learning.layer0.neuron7.weight14: 0.02
-      learning.layer0.neuron7.weight15: 0.06
-      learning.layer0.neuron7.weight16: 0.04
-      learning.layer0.neuron7.weight17: 0.04
+      learning.layer0.neuron7.weight14: 0.05
+      learning.layer0.neuron7.weight15: 0.05
+      learning.layer0.neuron7.weight16: 0.03
+      learning.layer0.neuron7.weight17: 0.03
       learning.layer0.neuron7.weight18: 0.06
-      learning.layer0.neuron0.bias: 0.03
+      learning.layer0.neuron0.bias: 0.04
       learning.layer0.neuron1.bias: -0.01
       learning.layer0.neuron2.bias: -0.0
-      learning.layer0.neuron3.bias: 0.04
-      learning.layer0.neuron4.bias: -0.00
-      learning.layer0.neuron5.bias: 0.0
-      learning.layer0.neuron6.bias: 0.02
-      learning.layer0.neuron7.bias: 0.00
+      learning.layer0.neuron3.bias: 0.07
+      learning.layer0.neuron4.bias: 0.01
+      learning.layer0.neuron5.bias: -0.0
+      learning.layer0.neuron6.bias: 0.04
+      learning.layer0.neuron7.bias: 0.02
       learning.layer1.neuron0.weight0: 0.5
       learning.layer1.neuron0.weight1: 0.3
       learning.layer1.neuron0.weight2: 0.1
@@ -372,13 +372,13 @@ population:
       learning.layer1.neuron0.weight7: -0.2
       learning.layer1.neuron1.weight0: -0.2
       learning.layer1.neuron1.weight1: -0.1
-      learning.layer1.neuron1.weight2: 0.0
+      learning.layer1.neuron1.weight2: -0.0
       learning.layer1.neuron1.weight3: 0.1
       learning.layer1.neuron1.weight4: 0.2
       learning.layer1.neuron1.weight5: -0.2
       learning.layer1.neuron1.weight6: -0.1
       learning.layer1.neuron1.weight7: 0.4
       learning.layer1.neuron0.bias: -0.0
-      learning.layer1.neuron1.bias: 0.0
-      learning.outputMidgameScale: 80.9
-      learning.outputEndgameScale: 89.3
+      learning.layer1.neuron1.bias: -0.0
+      learning.outputMidgameScale: 67.3
+      learning.outputEndgameScale: 96.7


### PR DESCRIPTION
## Summary
- apply learning-model quiet move deltas to killer move scoring using a reusable helper
- add auto-tuning hints for the quiet-learning move ordering parameters

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITest_MoveOrderingBuckets test

------
https://chatgpt.com/codex/tasks/task_e_68f73cdd7cf4832aacf8e193c39e7f87