### PR TITLE
Improve genetic tuning telemetry and naming

### DIFF
--- a/src/main/java/julius/game/chessengine/tuning/GeneticOptimizer.java
+++ b/src/main/java/julius/game/chessengine/tuning/GeneticOptimizer.java
@@ -1,19 +1,18 @@
 package julius.game.chessengine.tuning;
 
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
-import java.util.UUID;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.stream.Collectors;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -36,10 +35,6 @@ public final class GeneticOptimizer {
         this.random = Objects.requireNonNull(random, "random");
     }
 
-    private static String newName() {
-        return UUID.randomUUID().toString();
-    }
-
     public GeneticResult evolve(EngineTuningSet seedPopulation, GeneticOptions options) {
         Objects.requireNonNull(seedPopulation, "seedPopulation");
         Objects.requireNonNull(options, "options");
@@ -47,7 +42,18 @@ public final class GeneticOptimizer {
             throw new IllegalArgumentException("Seed population must contain at least one tuning");
         }
 
-        List<EngineTuning> population = new ArrayList<>(seedPopulation.population());
+        FriendlyNameGenerator names = new FriendlyNameGenerator(random);
+        List<EngineTuning> population = new ArrayList<>(seedPopulation.population().size());
+        for (EngineTuning tuning : seedPopulation.population()) {
+            EngineTuning participant = tuning;
+            if (names.isBoringName(participant.name())) {
+                participant = participant.rename(names.next());
+            } else {
+                names.registerName(participant.name());
+            }
+            population.add(participant);
+        }
+
         log.info("Starting genetic evolution with {} seed configurations (target population {}, generations {}, retain {}, mutation strength {}, matches per pair {}, match threads {}).",
                 seedPopulation.population().size(),
                 options.populationSize(),
@@ -61,7 +67,7 @@ public final class GeneticOptimizer {
         }
         while (population.size() < options.populationSize()) {
             EngineTuning parent = population.get(random.nextInt(population.size()));
-            population.add(parent.mutate(random, options.mutationStrength()).rename(newName()));
+            population.add(parent.mutate(random, options.mutationStrength()).rename(names.next()));
         }
         if (log.isDebugEnabled()) {
             log.debug("Expanded initial population to {} entries: {}", population.size(),
@@ -77,7 +83,8 @@ public final class GeneticOptimizer {
         try {
             for (int generation = 0; generation < options.generations(); generation++) {
                 int generationIndex = generation + 1;
-                Map<EngineTuning, Double> scoreboard = new HashMap<>();
+                MatchStatisticsCollector stats = new MatchStatisticsCollector();
+                stats.registerParticipants(population);
                 List<ScheduledMatch> scheduledMatches = new ArrayList<>();
 
                 for (int i = 0; i < population.size(); i++) {
@@ -101,14 +108,10 @@ public final class GeneticOptimizer {
                     allMatches.add(completed.result());
                     EngineTuning a = completed.assignment().first();
                     EngineTuning b = completed.assignment().second();
+                    EngineTuning white = completed.assignment().swapped() ? b : a;
+                    EngineTuning black = completed.assignment().swapped() ? a : b;
                     MatchRunner.MatchResult result = completed.result();
-                    if (completed.assignment().swapped()) {
-                        scoreboard.merge(a, result.blackScore(), Double::sum);
-                        scoreboard.merge(b, result.whiteScore(), Double::sum);
-                    } else {
-                        scoreboard.merge(a, result.whiteScore(), Double::sum);
-                        scoreboard.merge(b, result.blackScore(), Double::sum);
-                    }
+                    stats.recordMatch(white, black, result);
                     if (log.isDebugEnabled()) {
                         log.debug("Generation {} match: {} vs {} => {}-{} ({}, {} plies)",
                                 generationIndex,
@@ -121,28 +124,27 @@ public final class GeneticOptimizer {
                     }
                 }
 
-                if (scoreboard.isEmpty()) {
-                    for (EngineTuning tuning : population) {
-                        scoreboard.putIfAbsent(tuning, 0.0);
-                    }
-                }
-
-                List<Map.Entry<EngineTuning, Double>> leaderboard = scoreboard.entrySet().stream()
-                        .sorted(Map.Entry.<EngineTuning, Double>comparingByValue(Comparator.reverseOrder()))
-                        .toList();
+                List<MatchStatisticsCollector.ScoreCard> leaderboard = stats.leaderboard();
 
                 if (log.isInfoEnabled()) {
-                    log.info("Generation {} leaderboard:", generationIndex);
-                    leaderboard.stream()
-                            .limit(Math.min(5, leaderboard.size()))
-                            .forEach(entry -> log.info("  {} -> {}", entry.getKey().name(),
-                                    String.format(Locale.ROOT, "%.2f", entry.getValue())));
+                    String decisive = String.format(Locale.ROOT, "%.1f%%", stats.decisiveRate());
+                    log.info("Generation {} summary: {} games | decisive {} | white wins {} | black wins {} | draws {} | avg plies {:.1f} (min {} max {})",
+                            generationIndex,
+                            stats.totalMatches(),
+                            decisive,
+                            stats.whiteWins(),
+                            stats.blackWins(),
+                            stats.draws(),
+                            stats.averagePlies(),
+                            stats.minPlies(),
+                            stats.maxPlies());
+                    log.info("Generation {} standings:\n{}", generationIndex, stats.formatTable(8));
                 }
 
                 List<EngineTuning> retained = leaderboard.stream()
                         .limit(Math.max(options.retainCount(), 2))
-                        .map(Map.Entry::getKey)
-                        .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
+                        .map(MatchStatisticsCollector.ScoreCard::tuning)
+                        .collect(Collectors.toCollection(ArrayList::new));
 
                 population = new ArrayList<>(retained);
                 int retainedCount = population.size();
@@ -150,7 +152,7 @@ public final class GeneticOptimizer {
                 while (population.size() < options.populationSize()) {
                     EngineTuning parent = population.get(random.nextInt(population.size()));
                     EngineTuning offspring = parent.mutate(random, options.mutationStrength())
-                            .rename(newName());
+                            .rename(names.next());
                     population.add(offspring);
                     if (log.isDebugEnabled()) {
                         log.debug("Generation {}: created offspring {} from parent {}", generationIndex,
@@ -238,5 +240,84 @@ public final class GeneticOptimizer {
     }
 
     private record CompletedMatch(ScheduledMatch assignment, MatchRunner.MatchResult result) {
+    }
+
+    private static final class FriendlyNameGenerator {
+        private static final String UUID_PATTERN = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$";
+        private static final String[] ADJECTIVES = {
+                "Agile", "Brilliant", "Cheeky", "Cunning", "Daring", "Electric", "Feisty", "Gleaming",
+                "Hyper", "Inventive", "Jazzy", "Keen", "Lively", "Mischievous", "Nimble", "Oddball",
+                "Playful", "Quirky", "Radiant", "Sassy", "Tenacious", "Unruly", "Vibrant", "Whimsical",
+                "Xenial", "Yearning", "Zesty"
+        };
+        private static final String[] CREATURES = {
+                "Badger", "Basilisk", "Bison", "Dragon", "Falcon", "Fox", "Griffin", "Hedgehog",
+                "Kraken", "Leopard", "Lynx", "Mammoth", "Mongoose", "Octopus", "Otter", "Panther",
+                "Phoenix", "Puffin", "Raccoon", "Seahorse", "Shark", "Sphinx", "Stoat", "Tiger",
+                "Walrus", "Wolf", "Wyvern", "Yak"
+        };
+        private static final String[] CHESS_TERMS = {
+                "Fork", "Gambit", "Pin", "Battery", "Skewer", "Outpost", "Storm", "Swindle",
+                "Tempo", "Thrust", "Zug", "Bind", "Clamp", "Echo", "Fianchetto", "Flurry",
+                "KingHunt", "Lifeline", "MatingNet", "Midden", "Pressure", "Sac", "Snowplow", "Squeeze"
+        };
+
+        private final Random random;
+        private final Set<String> usedNames = new HashSet<>();
+
+        private FriendlyNameGenerator(Random random) {
+            this.random = Objects.requireNonNull(random, "random");
+        }
+
+        boolean isBoringName(String name) {
+            if (name == null || name.isBlank()) {
+                return true;
+            }
+            if (name.endsWith("_mut")) {
+                return true;
+            }
+            return name.matches(UUID_PATTERN);
+        }
+
+        void registerName(String name) {
+            if (name != null && !name.isBlank()) {
+                usedNames.add(name);
+            }
+        }
+
+        String next() {
+            for (int attempt = 0; attempt < 64; attempt++) {
+                String candidate = buildCandidate(false);
+                if (usedNames.add(candidate)) {
+                    return candidate;
+                }
+            }
+            for (int attempt = 0; attempt < 128; attempt++) {
+                String candidate = buildCandidate(true);
+                if (usedNames.add(candidate)) {
+                    return candidate;
+                }
+            }
+            String fallback = String.format(Locale.ROOT, "Tuning-%04d", random.nextInt(10_000));
+            if (usedNames.add(fallback)) {
+                return fallback;
+            }
+            return fallback + "-" + Integer.toHexString(random.nextInt()).toUpperCase(Locale.ROOT);
+        }
+
+        private String buildCandidate(boolean allowSuffix) {
+            String adjective = ADJECTIVES[random.nextInt(ADJECTIVES.length)];
+            String creature = CREATURES[random.nextInt(CREATURES.length)];
+            String base = adjective + "-" + creature;
+            if (random.nextDouble() < 0.55) {
+                String tactic = CHESS_TERMS[random.nextInt(CHESS_TERMS.length)];
+                base = base + "-" + tactic;
+            }
+            if (allowSuffix) {
+                int suffix = 10 + random.nextInt(90);
+                base = base + "-" + suffix;
+            }
+            return base;
+        }
     }
 }

--- a/src/main/java/julius/game/chessengine/tuning/GeneticTuningMain.java
+++ b/src/main/java/julius/game/chessengine/tuning/GeneticTuningMain.java
@@ -6,8 +6,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -55,8 +53,9 @@ public final class GeneticTuningMain {
         GeneticOptimizer.GeneticResult result = optimizer.evolve(seed, options);
         Duration duration = Duration.between(start, Instant.now());
 
+        MatchStatisticsCollector overallStats = MatchStatisticsCollector.fromMatches(result.matches());
         // Build leaderboard and persist only the top performer
-        List<Map.Entry<EngineTuning, Double>> leaderboard = buildLeaderboard(result.matches());
+        List<Map.Entry<EngineTuning, Double>> leaderboard = overallStats.toPointRanking();
         EngineTuningSet evolvedPopulation = result.population();
         if (!leaderboard.isEmpty()) {
             evolvedPopulation = new EngineTuningSet(List.of(leaderboard.get(0).getKey()));
@@ -79,30 +78,24 @@ public final class GeneticTuningMain {
 
         System.out.printf("Evolution completed in %d seconds.%n", Math.max(1, duration.getSeconds()));
         System.out.printf("Saved %d configurations to %s%n", evolvedPopulation.population().size(), cli.outputFile.toAbsolutePath());
-        printLeaderboard(leaderboard);
+        printLeaderboard(overallStats);
     }
 
-    private static List<Map.Entry<EngineTuning, Double>> buildLeaderboard(List<MatchRunner.MatchResult> matches) {
-        Map<EngineTuning, Double> scoreboard = new HashMap<>();
-        matches.forEach(match -> {
-            scoreboard.merge(match.whiteTuning(), match.whiteScore(), Double::sum);
-            scoreboard.merge(match.blackTuning(), match.blackScore(), Double::sum);
-        });
-        return scoreboard.entrySet().stream()
-                .sorted(Map.Entry.<EngineTuning, Double>comparingByValue(Comparator.reverseOrder()))
-                .toList();
-    }
-
-    private static void printLeaderboard(List<Map.Entry<EngineTuning, Double>> leaderboard) {
-        if (leaderboard.isEmpty()) {
+    private static void printLeaderboard(MatchStatisticsCollector stats) {
+        if (stats == null || stats.isEmpty()) {
             System.out.println("No matches were played.");
             return;
         }
 
+        String decisive = String.format(Locale.ROOT, "%.1f%%", stats.decisiveRate());
+        System.out.printf("Matches played: %d (decisive %s — white wins %d, black wins %d, draws %d).%n",
+                stats.totalMatches(), decisive, stats.whiteWins(), stats.blackWins(), stats.draws());
+        if (stats.totalMatches() > 0) {
+            System.out.printf(Locale.ROOT, "Average plies %.1f (min %d, max %d).%n",
+                    stats.averagePlies(), stats.minPlies(), stats.maxPlies());
+        }
         System.out.println("Top performers (higher score is better):");
-        leaderboard.stream()
-                .limit(10)
-                .forEach(entry -> System.out.printf("  %-24s %.2f%n", entry.getKey().name(), entry.getValue()));
+        System.out.print(stats.formatTable(10));
     }
 
     private static void writeMatchLog(List<MatchRunner.MatchResult> matches, Path destination) throws IOException {

--- a/src/main/java/julius/game/chessengine/tuning/MatchStatisticsCollector.java
+++ b/src/main/java/julius/game/chessengine/tuning/MatchStatisticsCollector.java
@@ -1,0 +1,269 @@
+package julius.game.chessengine.tuning;
+
+import julius.game.chessengine.engine.GameStateEnum;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.IntSummaryStatistics;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Collects match outcomes for a set of {@link EngineTuning} participants and provides aggregated
+ * statistics that can be rendered in human-friendly tables. Designed for tuning sessions where we
+ * want to keep an eye on leaderboards and colour performance trends while matches are running.
+ */
+public final class MatchStatisticsCollector {
+
+    private static final int TABLE_NAME_WIDTH = 22;
+
+    private final Map<EngineTuning, ScoreCard> scoreboard = new LinkedHashMap<>();
+    private final IntSummaryStatistics plies = new IntSummaryStatistics();
+
+    private int totalMatches;
+    private int whiteWins;
+    private int blackWins;
+    private int draws;
+
+    public void registerParticipant(EngineTuning tuning) {
+        if (tuning != null) {
+            scoreboard.computeIfAbsent(tuning, ScoreCard::new);
+        }
+    }
+
+    public void registerParticipants(Collection<EngineTuning> tunings) {
+        if (tunings == null) {
+            return;
+        }
+        tunings.forEach(this::registerParticipant);
+    }
+
+    public void recordMatch(EngineTuning white, EngineTuning black, MatchRunner.MatchResult result) {
+        Objects.requireNonNull(white, "white");
+        Objects.requireNonNull(black, "black");
+        Objects.requireNonNull(result, "result");
+
+        registerParticipant(white);
+        registerParticipant(black);
+
+        totalMatches++;
+        plies.accept(result.plies());
+
+        GameStateEnum state = result.finalState();
+        switch (state) {
+            case WHITE_WON -> whiteWins++;
+            case BLACK_WON -> blackWins++;
+            case DRAW -> draws++;
+            default -> draws++;
+        }
+
+        scoreboard.get(white).record(state, result.whiteScore(), true, result.plies());
+        scoreboard.get(black).record(state, result.blackScore(), false, result.plies());
+    }
+
+    public List<ScoreCard> leaderboard() {
+        return scoreboard.values().stream()
+                .sorted(ScoreCard.LEADERBOARD_ORDER)
+                .toList();
+    }
+
+    public String formatTable(int maxRows) {
+        if (scoreboard.isEmpty()) {
+            return "  (no participants)\n";
+        }
+        List<ScoreCard> ordered = leaderboard();
+        int display = maxRows <= 0 ? ordered.size() : Math.min(maxRows, ordered.size());
+        StringBuilder table = new StringBuilder();
+        table.append(String.format(Locale.ROOT, "%-4s  %-" + TABLE_NAME_WIDTH + "s  %6s  %9s  %9s  %9s  %8s%n",
+                "Rank", "Engine", "Points", "W-D-L", "White", "Black", "AvgPl"));
+        for (int i = 0; i < display; i++) {
+            ScoreCard card = ordered.get(i);
+            String points = String.format(Locale.ROOT, "%.2f", card.points());
+            String avg = card.games() > 0
+                    ? String.format(Locale.ROOT, "%.1f", card.averagePlies())
+                    : "-";
+            table.append(String.format(Locale.ROOT, "%4d  %-" + TABLE_NAME_WIDTH + "s  %6s  %9s  %9s  %9s  %8s%n",
+                    i + 1,
+                    ellipsize(card.tuning().name(), TABLE_NAME_WIDTH),
+                    points,
+                    card.recordSummary(),
+                    card.whiteSummary(),
+                    card.blackSummary(),
+                    avg));
+        }
+        return table.toString();
+    }
+
+    public int totalMatches() {
+        return totalMatches;
+    }
+
+    public int whiteWins() {
+        return whiteWins;
+    }
+
+    public int blackWins() {
+        return blackWins;
+    }
+
+    public int draws() {
+        return draws;
+    }
+
+    public double decisiveRate() {
+        if (totalMatches == 0) {
+            return 0.0;
+        }
+        return ((double) (whiteWins + blackWins) * 100.0) / totalMatches;
+    }
+
+    public double averagePlies() {
+        return totalMatches == 0 ? 0.0 : plies.getAverage();
+    }
+
+    public int minPlies() {
+        return totalMatches == 0 ? 0 : plies.getMin();
+    }
+
+    public int maxPlies() {
+        return totalMatches == 0 ? 0 : plies.getMax();
+    }
+
+    public boolean isEmpty() {
+        return scoreboard.isEmpty();
+    }
+
+    public List<Map.Entry<EngineTuning, Double>> toPointRanking() {
+        return leaderboard().stream()
+                .map(card -> Map.entry(card.tuning(), card.points()))
+                .toList();
+    }
+
+    public static MatchStatisticsCollector fromMatches(List<MatchRunner.MatchResult> matches) {
+        MatchStatisticsCollector collector = new MatchStatisticsCollector();
+        if (matches != null) {
+            for (MatchRunner.MatchResult match : matches) {
+                collector.recordMatch(match.whiteTuning(), match.blackTuning(), match);
+            }
+        }
+        return collector;
+    }
+
+    private static String ellipsize(String value, int maxLength) {
+        if (value == null) {
+            return "";
+        }
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        if (maxLength <= 3) {
+            return value.substring(0, maxLength);
+        }
+        return value.substring(0, maxLength - 3) + "...";
+    }
+
+    public static final class ScoreCard {
+        private static final Comparator<ScoreCard> LEADERBOARD_ORDER = Comparator
+                .comparingDouble(ScoreCard::points).reversed()
+                .thenComparingInt(ScoreCard::wins).reversed()
+                .thenComparingInt(ScoreCard::games).reversed()
+                .thenComparing(card -> card.tuning().name(), String.CASE_INSENSITIVE_ORDER);
+
+        private final EngineTuning tuning;
+        private double points;
+        private int games;
+        private int wins;
+        private int draws;
+        private int losses;
+        private int whiteWins;
+        private int whiteDraws;
+        private int whiteLosses;
+        private int blackWins;
+        private int blackDraws;
+        private int blackLosses;
+        private int totalPlies;
+
+        private ScoreCard(EngineTuning tuning) {
+            this.tuning = tuning;
+        }
+
+        public EngineTuning tuning() {
+            return tuning;
+        }
+
+        public double points() {
+            return points;
+        }
+
+        public int games() {
+            return games;
+        }
+
+        public int wins() {
+            return wins;
+        }
+
+        public double averagePlies() {
+            return games == 0 ? 0.0 : (double) totalPlies / games;
+        }
+
+        private void record(GameStateEnum state, double score, boolean asWhite, int plies) {
+            this.points += score;
+            this.games++;
+            this.totalPlies += plies;
+
+            switch (state) {
+                case WHITE_WON -> {
+                    if (asWhite) {
+                        wins++;
+                        whiteWins++;
+                    } else {
+                        losses++;
+                        blackLosses++;
+                    }
+                }
+                case BLACK_WON -> {
+                    if (asWhite) {
+                        losses++;
+                        whiteLosses++;
+                    } else {
+                        wins++;
+                        blackWins++;
+                    }
+                }
+                case DRAW -> {
+                    draws++;
+                    if (asWhite) {
+                        whiteDraws++;
+                    } else {
+                        blackDraws++;
+                    }
+                }
+                default -> {
+                    draws++;
+                    if (asWhite) {
+                        whiteDraws++;
+                    } else {
+                        blackDraws++;
+                    }
+                }
+            }
+        }
+
+        public String recordSummary() {
+            return wins + "-" + draws + "-" + losses;
+        }
+
+        public String whiteSummary() {
+            return whiteWins + "-" + whiteDraws + "-" + whiteLosses;
+        }
+
+        public String blackSummary() {
+            return blackWins + "-" + blackDraws + "-" + blackLosses;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a reusable MatchStatisticsCollector that captures wins, colour splits, plies and renders ASCII leaderboards
- log richer generation summaries during tuning and replace UUID player names with fun dictionary-based handles
- surface the new summary table and aggregate stats in the GeneticTuningMain CLI output

## Testing
- `mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68fa7011fb5c832a8f60d28dc71d9210