### PR TITLE
Fix module name casing in tuning outputs

### DIFF
--- a/src/main/java/julius/game/chessengine/tuning/EngineTuningLoader.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuningLoader.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -120,11 +121,13 @@ public final class EngineTuningLoader {
         if (config == null || config.modules == null || config.modules.isEmpty()) {
             return EvaluationTuning.identity();
         }
-        Map<String, EvaluationTuning.ModuleConfig> modules = config.modules.entrySet().stream()
-                .collect(Collectors.toMap(
-                        entry -> entry.getKey().toLowerCase(Locale.ROOT),
-                        entry -> new EvaluationTuning.ModuleConfig(entry.getValue().midgame, entry.getValue().endgame)
-                ));
+        Map<String, EvaluationTuning.ModuleConfig> modules = new LinkedHashMap<>();
+        config.modules.forEach((name, moduleConfig) -> {
+            if (name == null || name.isBlank() || moduleConfig == null) {
+                return;
+            }
+            modules.put(name, new EvaluationTuning.ModuleConfig(moduleConfig.midgame, moduleConfig.endgame));
+        });
         return EvaluationTuning.of(modules);
     }
 

--- a/src/main/java/julius/game/chessengine/tuning/EngineTuningWriter.java
+++ b/src/main/java/julius/game/chessengine/tuning/EngineTuningWriter.java
@@ -98,7 +98,8 @@ public final class EngineTuningWriter {
             Map<String, Object> module = new LinkedHashMap<>();
             module.put("midgame", moduleConfig.midgame());
             module.put("endgame", moduleConfig.endgame());
-            serializedModules.put(name, module);
+            String displayName = tuning.displayNameFor(name);
+            serializedModules.put(displayName, module);
         });
         config.put("modules", serializedModules);
         return config;

--- a/src/main/java/julius/game/chessengine/tuning/EvaluationTuning.java
+++ b/src/main/java/julius/game/chessengine/tuning/EvaluationTuning.java
@@ -1,7 +1,13 @@
 package julius.game.chessengine.tuning;
 
+import julius.game.chessengine.evaluation.ActivityModule;
 import julius.game.chessengine.evaluation.EvaluationModule;
 import julius.game.chessengine.evaluation.EvaluationWeights;
+import julius.game.chessengine.evaluation.KingSafetyModule;
+import julius.game.chessengine.evaluation.MaterialModule;
+import julius.game.chessengine.evaluation.PawnStructureModule;
+import julius.game.chessengine.evaluation.ThreatModule;
+import julius.game.chessengine.evaluation.learning.LearningEvaluationModule;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -17,16 +23,20 @@ import java.util.stream.Collectors;
  */
 public final class EvaluationTuning {
 
+    private static final Map<String, String> KNOWN_MODULE_NAMES = createKnownModuleNames();
+
     private final Map<String, ModuleConfig> modules;
+    private final Map<String, String> displayNames;
     private final EvaluationWeights weights;
 
-    private EvaluationTuning(Map<String, ModuleConfig> modules) {
+    private EvaluationTuning(Map<String, ModuleConfig> modules, Map<String, String> displayNames) {
         this.modules = modules;
+        this.displayNames = displayNames;
         this.weights = buildWeights(modules);
     }
 
     public static EvaluationTuning identity() {
-        return new EvaluationTuning(Collections.emptyMap());
+        return new EvaluationTuning(Collections.emptyMap(), Collections.emptyMap());
     }
 
     public static EvaluationTuning of(Map<String, ModuleConfig> modules) {
@@ -34,20 +44,33 @@ public final class EvaluationTuning {
             return identity();
         }
         Map<String, ModuleConfig> normalized = new LinkedHashMap<>();
+        Map<String, String> names = new LinkedHashMap<>();
         modules.forEach((name, cfg) -> {
             if (name == null || name.isBlank() || cfg == null) {
                 return;
             }
-            normalized.put(normalize(name), cfg);
+            String normalizedName = normalize(name);
+            normalized.put(normalizedName, cfg);
+            names.put(normalizedName, deriveDisplayName(name));
         });
         if (normalized.isEmpty()) {
             return identity();
         }
-        return new EvaluationTuning(Collections.unmodifiableMap(normalized));
+        return new EvaluationTuning(
+                Collections.unmodifiableMap(normalized),
+                Collections.unmodifiableMap(names)
+        );
     }
 
     public Map<String, ModuleConfig> modules() {
         return modules;
+    }
+
+    public String displayNameFor(String moduleKey) {
+        if (moduleKey == null || moduleKey.isBlank()) {
+            return moduleKey;
+        }
+        return displayNames.getOrDefault(moduleKey, moduleKey);
     }
 
     public EvaluationWeights toWeights() {
@@ -64,12 +87,17 @@ public final class EvaluationTuning {
             return this;
         }
         Map<String, ModuleConfig> mutated = new LinkedHashMap<>();
+        Map<String, String> mutatedNames = new LinkedHashMap<>();
         modules.forEach((name, cfg) -> {
             double mid = mutateWeight(cfg.midgame(), random, strength);
             double end = mutateWeight(cfg.endgame(), random, strength);
             mutated.put(name, new ModuleConfig(mid, end));
+            mutatedNames.put(name, displayNameFor(name));
         });
-        return EvaluationTuning.of(mutated);
+        return new EvaluationTuning(
+                Collections.unmodifiableMap(mutated),
+                Collections.unmodifiableMap(mutatedNames)
+        );
     }
 
     private static EvaluationWeights buildWeights(Map<String, ModuleConfig> modules) {
@@ -98,6 +126,36 @@ public final class EvaluationTuning {
 
     private static String normalize(String name) {
         return name.toLowerCase(Locale.ROOT);
+    }
+
+    private static String deriveDisplayName(String name) {
+        if (name == null || name.isBlank()) {
+            return name;
+        }
+        String normalized = normalize(name);
+        String known = KNOWN_MODULE_NAMES.get(normalized);
+        if (known != null) {
+            return known;
+        }
+        if (!name.equals(name.toLowerCase(Locale.ROOT))) {
+            return name;
+        }
+        return Character.toUpperCase(normalized.charAt(0)) + normalized.substring(1);
+    }
+
+    private static Map<String, String> createKnownModuleNames() {
+        Map<String, String> names = new LinkedHashMap<>();
+        register(names, MaterialModule.class);
+        register(names, PawnStructureModule.class);
+        register(names, ActivityModule.class);
+        register(names, KingSafetyModule.class);
+        register(names, ThreatModule.class);
+        register(names, LearningEvaluationModule.class);
+        return Collections.unmodifiableMap(names);
+    }
+
+    private static void register(Map<String, String> names, Class<? extends EvaluationModule> moduleClass) {
+        names.put(normalize(moduleClass.getSimpleName()), moduleClass.getSimpleName());
     }
 
     /**

--- a/src/main/resources/tuning/seed-population.yaml
+++ b/src/main/resources/tuning/seed-population.yaml
@@ -2,22 +2,22 @@ population:
   - name: BlackKingSafetyFocus
     evaluation:
       modules:
-        materialmodule:
+        MaterialModule:
           midgame: 1.0314324365479237
           endgame: 0.8146668764295991
-        pawnstructuremodule:
+        PawnStructureModule:
           midgame: 1.0722065841300916
           endgame: 0.7534380842328654
-        learningevaluationmodule:
+        LearningEvaluationModule:
           midgame: 1.0002747607801374
           endgame: 0.7828844159704904
-        activitymodule:
+        ActivityModule:
           midgame: 1.1128477838456594
           endgame: 0.8784594397828086
-        threatmodule:
+        ThreatModule:
           midgame: 0.8014576935626078
           endgame: 1.6217167466224227
-        kingsafetymodule:
+        KingSafetyModule:
           midgame: 0.8468382695161973
           endgame: 0.5419087610696045
     numericParameters:

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -2,22 +2,22 @@ population:
   - name: BlackKingSafetyFocus
     evaluation:
       modules:
-        materialmodule:
+        MaterialModule:
           midgame: 1.0314324365479237
           endgame: 0.8146668764295991
-        pawnstructuremodule:
+        PawnStructureModule:
           midgame: 1.0722065841300916
           endgame: 0.7534380842328654
-        learningevaluationmodule:
+        LearningEvaluationModule:
           midgame: 1.0002747607801374
           endgame: 0.7828844159704904
-        activitymodule:
+        ActivityModule:
           midgame: 1.1128477838456594
           endgame: 0.8784594397828086
-        threatmodule:
+        ThreatModule:
           midgame: 0.8014576935626078
           endgame: 1.6217167466224227
-        kingsafetymodule:
+        KingSafetyModule:
           midgame: 0.8468382695161973
           endgame: 0.5419087610696045
     numericParameters:


### PR DESCRIPTION
## Summary
- preserve canonical evaluation module names when loading and writing tuning data
- reuse the stored display names when serializing YAML so outputs keep their original casing
- correct the seed tuning YAML files to use the proper module names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa77ee82ec832abd08d63ef2c84c5c