### PR TITLE
Log interim standings during genetic tuning

### DIFF
--- a/src/main/java/julius/game/chessengine/tuning/GeneticOptimizer.java
+++ b/src/main/java/julius/game/chessengine/tuning/GeneticOptimizer.java
@@ -23,6 +23,8 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public final class GeneticOptimizer {
 
+    private static final int STANDINGS_PROGRESS_LOG_INTERVAL = 100;
+
     private final MatchRunner matchRunner;
     private final Random random;
 
@@ -121,6 +123,14 @@ public final class GeneticOptimizer {
                                 String.format(Locale.ROOT, "%.2f", result.blackScore()),
                                 result.finalState(),
                                 result.plies());
+                    }
+                    if (log.isInfoEnabled()
+                            && STANDINGS_PROGRESS_LOG_INTERVAL > 0
+                            && stats.totalMatches() % STANDINGS_PROGRESS_LOG_INTERVAL == 0) {
+                        log.info("Generation {} interim standings after {} matches:\n{}",
+                                generationIndex,
+                                stats.totalMatches(),
+                                stats.formatTable(8));
                     }
                 }
 


### PR DESCRIPTION
## Summary
- add a tuning progress constant and log interim standings after every 100 matches per generation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa7eff9004832a92f1ecbccfdc70c9