### PR TITLE
Fix UCI stop handling

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1142,14 +1142,23 @@ public class AI {
         clearHistoryTable();
     }
 
-    public void stopCalculation() {
+    public void requestStop() {
         SearchTask task = activeSearch.get();
+        requestStop(task);
+    }
+
+    private void requestStop(SearchTask task) {
         if (task != null) {
             task.requestStop();
         }
 
         keepCalculating = false;
         calculationRequests.clear();
+    }
+
+    public void stopCalculation() {
+        SearchTask task = activeSearch.get();
+        requestStop(task);
 
         if (task != null) {
             task.awaitCompletion();

--- a/src/main/java/julius/game/chessengine/uci/UciHandler.java
+++ b/src/main/java/julius/game/chessengine/uci/UciHandler.java
@@ -360,9 +360,9 @@ public class UciHandler {
     }
 
     public void stop() {
-        ai.stopCalculation();
         Thread runningThread = searchThread;
         if (runningThread != null) {
+            ai.requestStop();
             if (runningThread != Thread.currentThread()) {
                 if (runningThread.isAlive()) {
                     runningThread.interrupt();
@@ -378,6 +378,8 @@ public class UciHandler {
             if (!runningThread.isAlive() || runningThread == Thread.currentThread()) {
                 searchThread = null;
             }
+        } else {
+            ai.stopCalculation();
         }
     }
 

--- a/src/test/java/julius/game/chessengine/uci/UciProtocolTest.java
+++ b/src/test/java/julius/game/chessengine/uci/UciProtocolTest.java
@@ -1,5 +1,6 @@
 package julius.game.chessengine.uci;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -7,8 +8,19 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Integration style tests verifying basic UCI command exchanges over
@@ -87,5 +99,73 @@ public class UciProtocolTest {
         assertEquals(1, bestmoveCount, output);
         assertTrue(output.contains("readyok"), output);
         assertTrue(output.indexOf("bestmove") < output.indexOf("readyok"), output);
+    }
+
+    @Test
+    void stopUsesPublishedBestMoveInsteadOfFallback() throws Exception {
+        var tablebaseService = mock(julius.game.chessengine.syzygy.SyzygyTablebaseService.class);
+        when(tablebaseService.getConfiguredDirectories()).thenReturn(null);
+
+        var engine = mock(julius.game.chessengine.engine.Engine.class);
+        var gameState = mock(julius.game.chessengine.engine.GameState.class);
+        when(engine.getGameState()).thenReturn(gameState);
+        when(gameState.isTerminal()).thenReturn(false);
+        when(gameState.getState()).thenReturn(julius.game.chessengine.engine.GameStateEnum.PLAY);
+        when(engine.getLastTablebaseResult()).thenReturn(Optional.empty());
+
+        int fallbackMove = julius.game.chessengine.board.MoveHelper.createMoveInt(
+                julius.game.chessengine.board.MoveHelper.convertStringToIndex("e2"),
+                julius.game.chessengine.board.MoveHelper.convertStringToIndex("e4"),
+                julius.game.chessengine.figures.PieceType.PAWN,
+                true, false, false, false, null, null, false, false, 0);
+        int bestMove = julius.game.chessengine.board.MoveHelper.createMoveInt(
+                julius.game.chessengine.board.MoveHelper.convertStringToIndex("g1"),
+                julius.game.chessengine.board.MoveHelper.convertStringToIndex("f3"),
+                julius.game.chessengine.figures.PieceType.KNIGHT,
+                true, false, false, false, null, null, false, false, 0);
+
+        IntArrayList legalMoves = new IntArrayList();
+        legalMoves.add(fallbackMove);
+        legalMoves.add(bestMove);
+        when(engine.getAllLegalMoves()).thenReturn(legalMoves);
+
+        var ai = mock(julius.game.chessengine.ai.AI.class);
+        when(ai.getMainEngine()).thenReturn(engine);
+        when(ai.getCalculatedLine()).thenReturn(List.of());
+        when(ai.getNodesVisited()).thenReturn(0L);
+
+        AtomicInteger bestMoveRef = new AtomicInteger(-1);
+        when(ai.getCurrentBestMoveInt()).then(inv -> bestMoveRef.get());
+        doAnswer(inv -> {
+            bestMoveRef.set(bestMove);
+            return null;
+        }).when(ai).startAutoPlay(anyBoolean(), anyBoolean());
+        doAnswer(inv -> {
+            bestMoveRef.set(-1);
+            return null;
+        }).when(ai).stopCalculation();
+        doAnswer(inv -> null).when(ai).requestStop();
+
+        Consumer<String> outputCollector;
+        List<String> outputs = Collections.synchronizedList(new ArrayList<>());
+        outputCollector = outputs::add;
+
+        UciHandler handler = new UciHandler(tablebaseService, engine, ai, outputCollector, () -> true);
+
+        handler.handle("position startpos");
+        handler.handle("go movetime 1000");
+        handler.handle("stop");
+
+        long deadline = System.nanoTime() + Duration.ofSeconds(1).toNanos();
+        while (outputs.stream().noneMatch(line -> line.startsWith("bestmove")) && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+
+        String bestmoveLine = outputs.stream()
+                .filter(line -> line.startsWith("bestmove"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("bestmove not emitted: " + outputs));
+
+        assertEquals("bestmove g1f3", bestmoveLine, outputs.toString());
     }
 }


### PR DESCRIPTION
## Summary
- add a requestStop hook in AI so the UCI layer can halt search threads without clearing results
- update the UCI handler to defer full cleanup until the worker finishes and keep the published best move intact
- extend the UCI protocol tests with a regression that verifies `stop` emits the computed best move rather than a fallback

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=UciProtocolTest test

------
https://chatgpt.com/codex/tasks/task_e_6906008dac0c832a9dbade43fd3cea60