### PR TITLE
Tune engine defaults with v389 seed config

### DIFF
--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -1,84 +1,84 @@
 population:
-  - name: v369
+  - name: v389
     evaluation:
       modules:
         materialmodule:
-          midgame: 2.1
-          endgame: 0.9
+          midgame: 2.25
+          endgame: 0.95
         pawnstructuremodule:
-          midgame: 1.0
-          endgame: 1.0
+          midgame: 1.12
+          endgame: 1.05
         activitymodule:
-          midgame: 1.5
-          endgame: 0.9
+          midgame: 1.6
+          endgame: 1.05
         kingsafetymodule:
-          midgame: 1.1
-          endgame: 0.3
+          midgame: 1.3
+          endgame: 0.4
         threatmodule:
-          midgame: 1.4
-          endgame: 2.6
+          midgame: 1.55
+          endgame: 2.85
     numericParameters:
-      evaluation.blendscale: 768
-      material.pawnvalue: 121
-      material.knightvalue: 400
-      material.bishopvalue: 420
-      material.rookvalue: 577
-      material.queenvalue: 1103
-      material.bishoppairbonus: 56
-      pawnstructure.centerpawnbonus: 22
-      pawnstructure.passedpawnbonus: 40
-      pawnstructure.connectedpawnbonus: 6
-      pawnstructure.islandpenalty: -7
-      pawnstructure.doubledpawnpenalty: -9
-      pawnstructure.isolatedpawnpenalty: -8
-      pawnstructure.advancedpawnbonus: 11
-      pawnstructure.blockedpawnpenalty: -5
-      pawnstructure.backwardpawnpenalty: -18
-      pawnstructure.ownkingblockspassedpawnpenalty: -77
-      pawnstructure.passedpawnfreepathbonusperrank: 15
-      pawnstructure.rookhalfopenfilebonus: 40
-      pawnstructure.rookopenfilebonus: 31
-      threat.hangingpawnpenalty: -13
-      threat.hangingknightpenalty: -25
-      threat.hangingbishoppenalty: -14
-      threat.hangingrookpenalty: -59
-      threat.hangingqueenpenalty: -62
-      threat.pawnthreatknightpenalty: -9
-      threat.pawnthreatbishoppenalty: -8
-      threat.pawnthreatrookpenalty: -14
-      threat.pawnthreatqueenpenalty: -28
-      activity.midgamemobilityknight: 6
-      activity.midgamemobilitybishop: 12
-      activity.midgamemobilityrook: 12
-      activity.midgamemobilityqueen: 2
+      evaluation.blendscale: 832
+      material.pawnvalue: 123
+      material.knightvalue: 405
+      material.bishopvalue: 421
+      material.rookvalue: 582
+      material.queenvalue: 1125
+      material.bishoppairbonus: 60
+      pawnstructure.centerpawnbonus: 24
+      pawnstructure.passedpawnbonus: 46
+      pawnstructure.connectedpawnbonus: 8
+      pawnstructure.islandpenalty: -6
+      pawnstructure.doubledpawnpenalty: -11
+      pawnstructure.isolatedpawnpenalty: -9
+      pawnstructure.advancedpawnbonus: 12
+      pawnstructure.blockedpawnpenalty: -6
+      pawnstructure.backwardpawnpenalty: -20
+      pawnstructure.ownkingblockspassedpawnpenalty: -82
+      pawnstructure.passedpawnfreepathbonusperrank: 18
+      pawnstructure.rookhalfopenfilebonus: 42
+      pawnstructure.rookopenfilebonus: 34
+      threat.hangingpawnpenalty: -14
+      threat.hangingknightpenalty: -28
+      threat.hangingbishoppenalty: -18
+      threat.hangingrookpenalty: -62
+      threat.hangingqueenpenalty: -68
+      threat.pawnthreatknightpenalty: -11
+      threat.pawnthreatbishoppenalty: -10
+      threat.pawnthreatrookpenalty: -16
+      threat.pawnthreatqueenpenalty: -30
+      activity.midgamemobilityknight: 7
+      activity.midgamemobilitybishop: 13
+      activity.midgamemobilityrook: 13
+      activity.midgamemobilityqueen: 3
       activity.midgamemobilityking: 0
-      activity.endgamemobilityknight: 4
-      activity.endgamemobilitybishop: 0
-      activity.endgamemobilityrook: 0
-      activity.endgamemobilityqueen: 1
-      activity.endgamemobilityking: 2
-      activity.midgamecenterknight: 2
-      activity.midgamecenterbishop: 2
+      activity.endgamemobilityknight: 5
+      activity.endgamemobilitybishop: 1
+      activity.endgamemobilityrook: 1
+      activity.endgamemobilityqueen: 2
+      activity.endgamemobilityking: 3
+      activity.midgamecenterknight: 3
+      activity.midgamecenterbishop: 3
       activity.midgamecenterrook: 1
       activity.midgamecenterqueen: 1
       activity.midgamecenterking: 0
-      activity.endgamecenterknight: 8
-      activity.endgamecenterbishop: -4
-      activity.endgamecenterrook: 3
-      activity.endgamecenterqueen: 3
-      activity.endgamecenterking: 4
-      kingsafety.missingpawnshieldpenalty: -22
-      kingsafety.halfopenfilepenalty: 0
-      kingsafety.openfilepenalty: -9
-      kingsafety.defenderbonus: 6
-      kingsafety.queenattackedpenalty: -71
-      kingsafety.backrankweaknessmidgamepenalty: -82
-      kingsafety.backrankweaknessendgamepenalty: -48
-      kingsafety.attackweightpawn: 7
-      kingsafety.attackweightknight: 19
-      kingsafety.attackweightbishop: 0
-      kingsafety.attackweightrook: 36
-      kingsafety.attackweightqueen: 24
+      activity.endgamecenterknight: 9
+      activity.endgamecenterbishop: -3
+      activity.endgamecenterrook: 4
+      activity.endgamecenterqueen: 4
+      activity.endgamecenterking: 5
+      kingsafety.missingpawnshieldpenalty: -28
+      kingsafety.halfopenfilepenalty: -6
+      kingsafety.openfilepenalty: -14
+      kingsafety.defenderbonus: 8
+      kingsafety.queenattackedpenalty: -78
+      kingsafety.backrankweaknessmidgamepenalty: -88
+      kingsafety.backrankweaknessendgamepenalty: -54
+      kingsafety.attackweightpawn: 8
+      kingsafety.attackweightknight: 21
+      kingsafety.attackweightbishop: 6
+      kingsafety.attackweightrook: 40
+      kingsafety.attackweightqueen: 27
       moveordering.category.tt: 7
       moveordering.category.promotion: 6
       moveordering.category.capturegood: 5
@@ -86,89 +86,89 @@ population:
       moveordering.category.killer0: 3
       moveordering.category.killer1: 2
       moveordering.category.quiet: 1
-      moveordering.category.capturebad: 0
-      moveordering.killermovescore: 10119
-      moveordering.promotionbonus: 1465
-      moveordering.killer0bonus: 0
-      moveordering.killer1bonus: 63
-      moveordering.countermovebonus: 464
-      moveordering.capturemvvmultiplier: 15
-      moveordering.captureseemultiplier: 96
-      moveordering.promotionseemultiplier: 23
-      moveordering.castlingbonus: 4205
-      moveordering.captureseeclamp: 512
-      moveordering.promotionseeclamp: 322
-      moveordering.maxscore: 16045354
-      moveordering.historyscale: 1.2
+      moveordering.category.capturebad: -1
+      moveordering.killermovescore: 10250
+      moveordering.promotionbonus: 1520
+      moveordering.killer0bonus: 82
+      moveordering.killer1bonus: 56
+      moveordering.countermovebonus: 540
+      moveordering.capturemvvmultiplier: 17
+      moveordering.captureseemultiplier: 112
+      moveordering.promotionseemultiplier: 28
+      moveordering.castlingbonus: 4400
+      moveordering.captureseeclamp: 768
+      moveordering.promotionseeclamp: 360
+      moveordering.maxscore: 16252928
+      moveordering.historyscale: 1.28
       moveordering.historydecaydivisor: 2
-      search.fpMarginDepth1: 0
-      search.fpMarginDepth2: 0
-      search.lmpBase: 2
-      search.lmpPerDepth: 12
-      search.fpMaxDepth: 5
-      search.lmpMaxDepth: 3
-      search.hmpMinIndex: 64
-      search.hmpHistoryMax: 82
+      search.fpMarginDepth1: 120
+      search.fpMarginDepth2: 380
+      search.lmpBase: 5
+      search.lmpPerDepth: 9
+      search.fpMaxDepth: 6
+      search.lmpMaxDepth: 4
+      search.hmpMinIndex: 40
+      search.hmpHistoryMax: 96
       search.iidReduceDepth: 2
-      search.lmrProtectPlyMax: 0
-      search.lmrProtectIndexMax: 0
-      search.lmrCapGoodQuiet: 29
+      search.lmrProtectPlyMax: 1
+      search.lmrProtectIndexMax: 6
+      search.lmrCapGoodQuiet: 24
       search.lmrHistoryBuckets: 5
-      search.lmrHistoryWeightSlope: 0.6
-      search.lmrScaleDivisor: 2.3
-      search.lmrDepthLogOffset: 4.0
-      search.lmrMoveLogOffset: 3.7
+      search.lmrHistoryWeightSlope: 0.72
+      search.lmrScaleDivisor: 2.2
+      search.lmrDepthLogOffset: 3.2
+      search.lmrMoveLogOffset: 3.4
       search.maxCheckExtensionStreak: 2
-      search.seePruneNearRootPly: 1
-      search.historyReductionMax: 5205
-      search.aspMinSpanCp: 11
-      search.aspMaxSpanCp: 640
-      search.aspDefaultSpanCp: 29
-      search.aspHistoryBlend: 0.4
-      search.aspMomentumStepCp: 4
-      search.aspMomentumCap: 32
-      search.aspFailureRatio: 1.0
-      search.aspBaseOffsetCp: 0
-      search.aspSwingWeight: 0.15
-      search.aspVolatilityWeight: 0.7
-      search.aspDepthScale: 0.05
-      search.aspDepthPivot: 3
-      search.aspFloorBaseCp: 10
-      search.aspFloorVolWeight: 1.5
-      search.aspFloorStreakStepCp: 32
-      search.aspBumpBaseCp: 13
-      search.aspBumpStreakCp: 11
-      search.aspBumpDepthCp: 2
-      search.aspFullWindowScale: 2.00
-      search.aspLastSpanScale: 2.0
-      search.aspFullWindowMinMultiplier: 2.1
-      search.aspBlendBaselineWeight: 0.6
-      search.aspBlendCandidateWeight: 0.6
+      search.seePruneNearRootPly: 2
+      search.historyReductionMax: 6000
+      search.aspMinSpanCp: 18
+      search.aspMaxSpanCp: 560
+      search.aspDefaultSpanCp: 44
+      search.aspHistoryBlend: 0.45
+      search.aspMomentumStepCp: 6
+      search.aspMomentumCap: 28
+      search.aspFailureRatio: 0.58
+      search.aspBaseOffsetCp: 14
+      search.aspSwingWeight: 0.21
+      search.aspVolatilityWeight: 0.75
+      search.aspDepthScale: 0.06
+      search.aspDepthPivot: 4
+      search.aspFloorBaseCp: 12
+      search.aspFloorVolWeight: 1.7
+      search.aspFloorStreakStepCp: 28
+      search.aspBumpBaseCp: 16
+      search.aspBumpStreakCp: 13
+      search.aspBumpDepthCp: 3
+      search.aspFullWindowScale: 2.1
+      search.aspLastSpanScale: 2.15
+      search.aspFullWindowMinMultiplier: 2.4
+      search.aspBlendBaselineWeight: 0.62
+      search.aspBlendCandidateWeight: 0.58
       search.aspMaxRetriesBase: 3
-      search.aspMaxRetriesVolThresholdHigh: 104
-      search.aspMaxRetriesVolBonusHigh: 8
-      search.aspMaxRetriesVolThresholdMed: 256
-      search.aspMaxRetriesVolBonusMed: 1
-      search.aspMaxRetriesDepthOffset: 16
+      search.aspMaxRetriesVolThresholdHigh: 112
+      search.aspMaxRetriesVolBonusHigh: 9
+      search.aspMaxRetriesVolThresholdMed: 240
+      search.aspMaxRetriesVolBonusMed: 2
+      search.aspMaxRetriesDepthOffset: 18
       search.aspMaxRetriesDepthDivisor: 1
       search.aspMaxRetriesMomentumDivisor: 3
       search.aspMaxRetriesMin: 1
       search.aspMaxRetriesMax: 2
-      search.nullBaseReduction: 3.00
-      search.nullDepthWeight: 0.5
-      search.nullMaterialWeight: 1.43
-      search.nullMobilityWeight: 0.1
-      search.nullDepthCap: 4
-      search.nullMaterialCap: 22
-      search.nullMobilityCap: 10
-      search.nullLowMaterialThreshold: 3
-      search.nullLowMobilityThreshold: 5
-      search.nullVeryLowMobilityThreshold: 8
-      search.nullLowMaterialPenalty: 0.73
-      search.nullVeryLowMobilityPenalty: 0.6
-      search.nullSwingGuardMinCp: 451
-      search.nullSwingGuardDivisor: 80
-      search.ttMainWeight: 3.4
-      search.ttCaptureWeight: 4.0
-      search.qsMaxDeltaPawn: 8.8
-      search.drawBias: 0.3
+      search.nullBaseReduction: 3.25
+      search.nullDepthWeight: 0.55
+      search.nullMaterialWeight: 1.35
+      search.nullMobilityWeight: 0.12
+      search.nullDepthCap: 6
+      search.nullMaterialCap: 20
+      search.nullMobilityCap: 12
+      search.nullLowMaterialThreshold: 4
+      search.nullLowMobilityThreshold: 6
+      search.nullVeryLowMobilityThreshold: 9
+      search.nullLowMaterialPenalty: 0.65
+      search.nullVeryLowMobilityPenalty: 0.5
+      search.nullSwingGuardMinCp: 430
+      search.nullSwingGuardDivisor: 68
+      search.ttMainWeight: 3.8
+      search.ttCaptureWeight: 4.4
+      search.qsMaxDeltaPawn: 9.6
+      search.drawBias: 0.32


### PR DESCRIPTION
## Summary
- replace the bundled tuning seed with the new v389 profile
- rebalance evaluation weights, move-ordering priorities, and pruning knobs to improve cutoffs and accuracy

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_690a581e62c4832a87b91451c1224b91