### PR TITLE
Retune engine seed configuration to v389

### DIFF
--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -1,84 +1,84 @@
 population:
-  - name: v369
+  - name: v389
     evaluation:
       modules:
         materialmodule:
-          midgame: 2.1
-          endgame: 0.9
-        pawnstructuremodule:
-          midgame: 1.0
+          midgame: 2.25
           endgame: 1.0
+        pawnstructuremodule:
+          midgame: 1.05
+          endgame: 1.05
         activitymodule:
-          midgame: 1.5
-          endgame: 0.9
+          midgame: 1.65
+          endgame: 1.1
         kingsafetymodule:
-          midgame: 1.1
-          endgame: 0.3
+          midgame: 1.25
+          endgame: 0.4
         threatmodule:
-          midgame: 1.4
-          endgame: 2.6
+          midgame: 1.55
+          endgame: 2.8
     numericParameters:
       evaluation.blendscale: 768
-      material.pawnvalue: 121
-      material.knightvalue: 400
-      material.bishopvalue: 420
-      material.rookvalue: 577
-      material.queenvalue: 1103
-      material.bishoppairbonus: 56
-      pawnstructure.centerpawnbonus: 22
-      pawnstructure.passedpawnbonus: 40
-      pawnstructure.connectedpawnbonus: 6
-      pawnstructure.islandpenalty: -7
-      pawnstructure.doubledpawnpenalty: -9
-      pawnstructure.isolatedpawnpenalty: -8
-      pawnstructure.advancedpawnbonus: 11
-      pawnstructure.blockedpawnpenalty: -5
-      pawnstructure.backwardpawnpenalty: -18
-      pawnstructure.ownkingblockspassedpawnpenalty: -77
-      pawnstructure.passedpawnfreepathbonusperrank: 15
-      pawnstructure.rookhalfopenfilebonus: 40
-      pawnstructure.rookopenfilebonus: 31
-      threat.hangingpawnpenalty: -13
-      threat.hangingknightpenalty: -25
-      threat.hangingbishoppenalty: -14
-      threat.hangingrookpenalty: -59
-      threat.hangingqueenpenalty: -62
-      threat.pawnthreatknightpenalty: -9
-      threat.pawnthreatbishoppenalty: -8
-      threat.pawnthreatrookpenalty: -14
-      threat.pawnthreatqueenpenalty: -28
-      activity.midgamemobilityknight: 6
-      activity.midgamemobilitybishop: 12
-      activity.midgamemobilityrook: 12
-      activity.midgamemobilityqueen: 2
+      material.pawnvalue: 125
+      material.knightvalue: 402
+      material.bishopvalue: 418
+      material.rookvalue: 575
+      material.queenvalue: 1110
+      material.bishoppairbonus: 54
+      pawnstructure.centerpawnbonus: 24
+      pawnstructure.passedpawnbonus: 44
+      pawnstructure.connectedpawnbonus: 8
+      pawnstructure.islandpenalty: -8
+      pawnstructure.doubledpawnpenalty: -11
+      pawnstructure.isolatedpawnpenalty: -10
+      pawnstructure.advancedpawnbonus: 13
+      pawnstructure.blockedpawnpenalty: -6
+      pawnstructure.backwardpawnpenalty: -20
+      pawnstructure.ownkingblockspassedpawnpenalty: -72
+      pawnstructure.passedpawnfreepathbonusperrank: 18
+      pawnstructure.rookhalfopenfilebonus: 44
+      pawnstructure.rookopenfilebonus: 36
+      threat.hangingpawnpenalty: -16
+      threat.hangingknightpenalty: -27
+      threat.hangingbishoppenalty: -16
+      threat.hangingrookpenalty: -61
+      threat.hangingqueenpenalty: -66
+      threat.pawnthreatknightpenalty: -11
+      threat.pawnthreatbishoppenalty: -10
+      threat.pawnthreatrookpenalty: -16
+      threat.pawnthreatqueenpenalty: -30
+      activity.midgamemobilityknight: 7
+      activity.midgamemobilitybishop: 13
+      activity.midgamemobilityrook: 13
+      activity.midgamemobilityqueen: 3
       activity.midgamemobilityking: 0
-      activity.endgamemobilityknight: 4
-      activity.endgamemobilitybishop: 0
-      activity.endgamemobilityrook: 0
-      activity.endgamemobilityqueen: 1
-      activity.endgamemobilityking: 2
-      activity.midgamecenterknight: 2
-      activity.midgamecenterbishop: 2
+      activity.endgamemobilityknight: 5
+      activity.endgamemobilitybishop: 2
+      activity.endgamemobilityrook: 2
+      activity.endgamemobilityqueen: 2
+      activity.endgamemobilityking: 3
+      activity.midgamecenterknight: 3
+      activity.midgamecenterbishop: 3
       activity.midgamecenterrook: 1
-      activity.midgamecenterqueen: 1
+      activity.midgamecenterqueen: 2
       activity.midgamecenterking: 0
-      activity.endgamecenterknight: 8
-      activity.endgamecenterbishop: -4
-      activity.endgamecenterrook: 3
-      activity.endgamecenterqueen: 3
-      activity.endgamecenterking: 4
-      kingsafety.missingpawnshieldpenalty: -22
-      kingsafety.halfopenfilepenalty: 0
-      kingsafety.openfilepenalty: -9
-      kingsafety.defenderbonus: 6
-      kingsafety.queenattackedpenalty: -71
-      kingsafety.backrankweaknessmidgamepenalty: -82
-      kingsafety.backrankweaknessendgamepenalty: -48
-      kingsafety.attackweightpawn: 7
-      kingsafety.attackweightknight: 19
-      kingsafety.attackweightbishop: 0
-      kingsafety.attackweightrook: 36
-      kingsafety.attackweightqueen: 24
+      activity.endgamecenterknight: 9
+      activity.endgamecenterbishop: -3
+      activity.endgamecenterrook: 4
+      activity.endgamecenterqueen: 4
+      activity.endgamecenterking: 5
+      kingsafety.missingpawnshieldpenalty: -28
+      kingsafety.halfopenfilepenalty: -4
+      kingsafety.openfilepenalty: -12
+      kingsafety.defenderbonus: 7
+      kingsafety.queenattackedpenalty: -78
+      kingsafety.backrankweaknessmidgamepenalty: -86
+      kingsafety.backrankweaknessendgamepenalty: -52
+      kingsafety.attackweightpawn: 8
+      kingsafety.attackweightknight: 21
+      kingsafety.attackweightbishop: 3
+      kingsafety.attackweightrook: 38
+      kingsafety.attackweightqueen: 26
       moveordering.category.tt: 7
       moveordering.category.promotion: 6
       moveordering.category.capturegood: 5
@@ -87,88 +87,88 @@ population:
       moveordering.category.killer1: 2
       moveordering.category.quiet: 1
       moveordering.category.capturebad: 0
-      moveordering.killermovescore: 10119
-      moveordering.promotionbonus: 1465
-      moveordering.killer0bonus: 0
-      moveordering.killer1bonus: 63
-      moveordering.countermovebonus: 464
+      moveordering.killermovescore: 10175
+      moveordering.promotionbonus: 1500
+      moveordering.killer0bonus: 15
+      moveordering.killer1bonus: 78
+      moveordering.countermovebonus: 502
       moveordering.capturemvvmultiplier: 15
-      moveordering.captureseemultiplier: 96
-      moveordering.promotionseemultiplier: 23
-      moveordering.castlingbonus: 4205
-      moveordering.captureseeclamp: 512
-      moveordering.promotionseeclamp: 322
+      moveordering.captureseemultiplier: 104
+      moveordering.promotionseemultiplier: 25
+      moveordering.castlingbonus: 4300
+      moveordering.captureseeclamp: 640
+      moveordering.promotionseeclamp: 400
       moveordering.maxscore: 16045354
-      moveordering.historyscale: 1.2
+      moveordering.historyscale: 1.35
       moveordering.historydecaydivisor: 2
-      search.fpMarginDepth1: 0
-      search.fpMarginDepth2: 0
-      search.lmpBase: 2
-      search.lmpPerDepth: 12
-      search.fpMaxDepth: 5
-      search.lmpMaxDepth: 3
-      search.hmpMinIndex: 64
-      search.hmpHistoryMax: 82
-      search.iidReduceDepth: 2
-      search.lmrProtectPlyMax: 0
-      search.lmrProtectIndexMax: 0
-      search.lmrCapGoodQuiet: 29
-      search.lmrHistoryBuckets: 5
-      search.lmrHistoryWeightSlope: 0.6
-      search.lmrScaleDivisor: 2.3
-      search.lmrDepthLogOffset: 4.0
-      search.lmrMoveLogOffset: 3.7
+      search.fpMarginDepth1: 95
+      search.fpMarginDepth2: 210
+      search.lmpBase: 4
+      search.lmpPerDepth: 7
+      search.fpMaxDepth: 6
+      search.lmpMaxDepth: 4
+      search.hmpMinIndex: 48
+      search.hmpHistoryMax: 78
+      search.iidReduceDepth: 3
+      search.lmrProtectPlyMax: 1
+      search.lmrProtectIndexMax: 4
+      search.lmrCapGoodQuiet: 27
+      search.lmrHistoryBuckets: 6
+      search.lmrHistoryWeightSlope: 0.72
+      search.lmrScaleDivisor: 2.05
+      search.lmrDepthLogOffset: 4.2
+      search.lmrMoveLogOffset: 3.4
       search.maxCheckExtensionStreak: 2
-      search.seePruneNearRootPly: 1
-      search.historyReductionMax: 5205
-      search.aspMinSpanCp: 11
-      search.aspMaxSpanCp: 640
-      search.aspDefaultSpanCp: 29
-      search.aspHistoryBlend: 0.4
-      search.aspMomentumStepCp: 4
-      search.aspMomentumCap: 32
-      search.aspFailureRatio: 1.0
-      search.aspBaseOffsetCp: 0
-      search.aspSwingWeight: 0.15
-      search.aspVolatilityWeight: 0.7
-      search.aspDepthScale: 0.05
-      search.aspDepthPivot: 3
-      search.aspFloorBaseCp: 10
-      search.aspFloorVolWeight: 1.5
-      search.aspFloorStreakStepCp: 32
-      search.aspBumpBaseCp: 13
-      search.aspBumpStreakCp: 11
-      search.aspBumpDepthCp: 2
-      search.aspFullWindowScale: 2.00
-      search.aspLastSpanScale: 2.0
-      search.aspFullWindowMinMultiplier: 2.1
-      search.aspBlendBaselineWeight: 0.6
-      search.aspBlendCandidateWeight: 0.6
+      search.seePruneNearRootPly: 2
+      search.historyReductionMax: 5400
+      search.aspMinSpanCp: 18
+      search.aspMaxSpanCp: 680
+      search.aspDefaultSpanCp: 36
+      search.aspHistoryBlend: 0.45
+      search.aspMomentumStepCp: 6
+      search.aspMomentumCap: 36
+      search.aspFailureRatio: 0.85
+      search.aspBaseOffsetCp: 10
+      search.aspSwingWeight: 0.18
+      search.aspVolatilityWeight: 0.8
+      search.aspDepthScale: 0.06
+      search.aspDepthPivot: 4
+      search.aspFloorBaseCp: 14
+      search.aspFloorVolWeight: 1.6
+      search.aspFloorStreakStepCp: 28
+      search.aspBumpBaseCp: 10
+      search.aspBumpStreakCp: 10
+      search.aspBumpDepthCp: 3
+      search.aspFullWindowScale: 2.2
+      search.aspLastSpanScale: 2.1
+      search.aspFullWindowMinMultiplier: 2.4
+      search.aspBlendBaselineWeight: 0.52
+      search.aspBlendCandidateWeight: 0.64
       search.aspMaxRetriesBase: 3
-      search.aspMaxRetriesVolThresholdHigh: 104
-      search.aspMaxRetriesVolBonusHigh: 8
-      search.aspMaxRetriesVolThresholdMed: 256
-      search.aspMaxRetriesVolBonusMed: 1
-      search.aspMaxRetriesDepthOffset: 16
+      search.aspMaxRetriesVolThresholdHigh: 96
+      search.aspMaxRetriesVolBonusHigh: 10
+      search.aspMaxRetriesVolThresholdMed: 220
+      search.aspMaxRetriesVolBonusMed: 2
+      search.aspMaxRetriesDepthOffset: 18
       search.aspMaxRetriesDepthDivisor: 1
       search.aspMaxRetriesMomentumDivisor: 3
       search.aspMaxRetriesMin: 1
-      search.aspMaxRetriesMax: 2
-      search.nullBaseReduction: 3.00
-      search.nullDepthWeight: 0.5
-      search.nullMaterialWeight: 1.43
-      search.nullMobilityWeight: 0.1
-      search.nullDepthCap: 4
-      search.nullMaterialCap: 22
-      search.nullMobilityCap: 10
-      search.nullLowMaterialThreshold: 3
-      search.nullLowMobilityThreshold: 5
-      search.nullVeryLowMobilityThreshold: 8
-      search.nullLowMaterialPenalty: 0.73
-      search.nullVeryLowMobilityPenalty: 0.6
-      search.nullSwingGuardMinCp: 451
-      search.nullSwingGuardDivisor: 80
-      search.ttMainWeight: 3.4
-      search.ttCaptureWeight: 4.0
-      search.qsMaxDeltaPawn: 8.8
-      search.drawBias: 0.3
+      search.aspMaxRetriesMax: 3
+      search.nullBaseReduction: 3.2
+      search.nullDepthWeight: 0.55
+      search.nullMaterialWeight: 1.56
+      search.nullMobilityWeight: 0.12
+      search.nullDepthCap: 5
+      search.nullMaterialCap: 24
+      search.nullMobilityCap: 14
+      search.nullLowMaterialThreshold: 4
+      search.nullLowMobilityThreshold: 6
+      search.nullVeryLowMobilityThreshold: 9
+      search.nullLowMaterialPenalty: 0.85
+      search.nullVeryLowMobilityPenalty: 0.65
+      search.nullSwingGuardMinCp: 470
+      search.nullSwingGuardDivisor: 72
+      search.ttMainWeight: 3.6
+      search.ttCaptureWeight: 4.2
+      search.qsMaxDeltaPawn: 8.2
+      search.drawBias: 0.32


### PR DESCRIPTION
## Summary
- replace the default seed tuning with the new v389 profile tuned for stronger pruning and evaluation balance
- rebalance evaluation module weights to emphasize activity, king safety, and tactical threats with refined material ratios
- tighten pruning, aspiration, null-move, and move-order heuristics to increase cutoffs without sacrificing stability

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a581e62c4832a87b91451c1224b91