### PR TITLE
Retune engine defaults to v390 profile

### DIFF
--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -1,84 +1,84 @@
 population:
-  - name: v389
+  - name: v390
     evaluation:
       modules:
         materialmodule:
-          midgame: 2.25
-          endgame: 1.0
+          midgame: 2.32
+          endgame: 1.08
         pawnstructuremodule:
-          midgame: 1.05
-          endgame: 1.05
+          midgame: 1.15
+          endgame: 1.12
         activitymodule:
-          midgame: 1.65
-          endgame: 1.1
+          midgame: 1.74
+          endgame: 1.22
         kingsafetymodule:
-          midgame: 1.25
-          endgame: 0.4
+          midgame: 1.38
+          endgame: 0.46
         threatmodule:
-          midgame: 1.55
-          endgame: 2.8
+          midgame: 1.68
+          endgame: 3.05
     numericParameters:
-      evaluation.blendscale: 768
-      material.pawnvalue: 125
-      material.knightvalue: 402
-      material.bishopvalue: 418
-      material.rookvalue: 575
-      material.queenvalue: 1110
-      material.bishoppairbonus: 54
-      pawnstructure.centerpawnbonus: 24
-      pawnstructure.passedpawnbonus: 44
-      pawnstructure.connectedpawnbonus: 8
-      pawnstructure.islandpenalty: -8
-      pawnstructure.doubledpawnpenalty: -11
-      pawnstructure.isolatedpawnpenalty: -10
-      pawnstructure.advancedpawnbonus: 13
-      pawnstructure.blockedpawnpenalty: -6
-      pawnstructure.backwardpawnpenalty: -20
-      pawnstructure.ownkingblockspassedpawnpenalty: -72
-      pawnstructure.passedpawnfreepathbonusperrank: 18
-      pawnstructure.rookhalfopenfilebonus: 44
-      pawnstructure.rookopenfilebonus: 36
-      threat.hangingpawnpenalty: -16
-      threat.hangingknightpenalty: -27
-      threat.hangingbishoppenalty: -16
-      threat.hangingrookpenalty: -61
-      threat.hangingqueenpenalty: -66
-      threat.pawnthreatknightpenalty: -11
-      threat.pawnthreatbishoppenalty: -10
-      threat.pawnthreatrookpenalty: -16
-      threat.pawnthreatqueenpenalty: -30
-      activity.midgamemobilityknight: 7
-      activity.midgamemobilitybishop: 13
-      activity.midgamemobilityrook: 13
-      activity.midgamemobilityqueen: 3
+      evaluation.blendscale: 832
+      material.pawnvalue: 128
+      material.knightvalue: 410
+      material.bishopvalue: 425
+      material.rookvalue: 580
+      material.queenvalue: 1125
+      material.bishoppairbonus: 58
+      pawnstructure.centerpawnbonus: 26
+      pawnstructure.passedpawnbonus: 48
+      pawnstructure.connectedpawnbonus: 10
+      pawnstructure.islandpenalty: -9
+      pawnstructure.doubledpawnpenalty: -13
+      pawnstructure.isolatedpawnpenalty: -11
+      pawnstructure.advancedpawnbonus: 15
+      pawnstructure.blockedpawnpenalty: -7
+      pawnstructure.backwardpawnpenalty: -22
+      pawnstructure.ownkingblockspassedpawnpenalty: -80
+      pawnstructure.passedpawnfreepathbonusperrank: 20
+      pawnstructure.rookhalfopenfilebonus: 48
+      pawnstructure.rookopenfilebonus: 40
+      threat.hangingpawnpenalty: -18
+      threat.hangingknightpenalty: -31
+      threat.hangingbishoppenalty: -18
+      threat.hangingrookpenalty: -66
+      threat.hangingqueenpenalty: -72
+      threat.pawnthreatknightpenalty: -12
+      threat.pawnthreatbishoppenalty: -11
+      threat.pawnthreatrookpenalty: -20
+      threat.pawnthreatqueenpenalty: -32
+      activity.midgamemobilityknight: 8
+      activity.midgamemobilitybishop: 14
+      activity.midgamemobilityrook: 14
+      activity.midgamemobilityqueen: 4
       activity.midgamemobilityking: 0
-      activity.endgamemobilityknight: 5
-      activity.endgamemobilitybishop: 2
-      activity.endgamemobilityrook: 2
-      activity.endgamemobilityqueen: 2
-      activity.endgamemobilityking: 3
-      activity.midgamecenterknight: 3
-      activity.midgamecenterbishop: 3
-      activity.midgamecenterrook: 1
-      activity.midgamecenterqueen: 2
+      activity.endgamemobilityknight: 6
+      activity.endgamemobilitybishop: 3
+      activity.endgamemobilityrook: 3
+      activity.endgamemobilityqueen: 3
+      activity.endgamemobilityking: 4
+      activity.midgamecenterknight: 4
+      activity.midgamecenterbishop: 4
+      activity.midgamecenterrook: 2
+      activity.midgamecenterqueen: 3
       activity.midgamecenterking: 0
-      activity.endgamecenterknight: 9
-      activity.endgamecenterbishop: -3
-      activity.endgamecenterrook: 4
-      activity.endgamecenterqueen: 4
-      activity.endgamecenterking: 5
-      kingsafety.missingpawnshieldpenalty: -28
-      kingsafety.halfopenfilepenalty: -4
-      kingsafety.openfilepenalty: -12
-      kingsafety.defenderbonus: 7
-      kingsafety.queenattackedpenalty: -78
-      kingsafety.backrankweaknessmidgamepenalty: -86
-      kingsafety.backrankweaknessendgamepenalty: -52
-      kingsafety.attackweightpawn: 8
-      kingsafety.attackweightknight: 21
-      kingsafety.attackweightbishop: 3
-      kingsafety.attackweightrook: 38
-      kingsafety.attackweightqueen: 26
+      activity.endgamecenterknight: 10
+      activity.endgamecenterbishop: -2
+      activity.endgamecenterrook: 5
+      activity.endgamecenterqueen: 5
+      activity.endgamecenterking: 6
+      kingsafety.missingpawnshieldpenalty: -32
+      kingsafety.halfopenfilepenalty: -6
+      kingsafety.openfilepenalty: -14
+      kingsafety.defenderbonus: 8
+      kingsafety.queenattackedpenalty: -84
+      kingsafety.backrankweaknessmidgamepenalty: -92
+      kingsafety.backrankweaknessendgamepenalty: -56
+      kingsafety.attackweightpawn: 9
+      kingsafety.attackweightknight: 23
+      kingsafety.attackweightbishop: 5
+      kingsafety.attackweightrook: 40
+      kingsafety.attackweightqueen: 28
       moveordering.category.tt: 7
       moveordering.category.promotion: 6
       moveordering.category.capturegood: 5
@@ -87,88 +87,88 @@ population:
       moveordering.category.killer1: 2
       moveordering.category.quiet: 1
       moveordering.category.capturebad: 0
-      moveordering.killermovescore: 10175
-      moveordering.promotionbonus: 1500
-      moveordering.killer0bonus: 15
-      moveordering.killer1bonus: 78
-      moveordering.countermovebonus: 502
-      moveordering.capturemvvmultiplier: 15
-      moveordering.captureseemultiplier: 104
-      moveordering.promotionseemultiplier: 25
-      moveordering.castlingbonus: 4300
-      moveordering.captureseeclamp: 640
-      moveordering.promotionseeclamp: 400
-      moveordering.maxscore: 16045354
-      moveordering.historyscale: 1.35
+      moveordering.killermovescore: 10600
+      moveordering.promotionbonus: 1650
+      moveordering.killer0bonus: 22
+      moveordering.killer1bonus: 68
+      moveordering.countermovebonus: 540
+      moveordering.capturemvvmultiplier: 16
+      moveordering.captureseemultiplier: 118
+      moveordering.promotionseemultiplier: 28
+      moveordering.castlingbonus: 4500
+      moveordering.captureseeclamp: 720
+      moveordering.promotionseeclamp: 480
+      moveordering.maxscore: 16000000
+      moveordering.historyscale: 1.42
       moveordering.historydecaydivisor: 2
-      search.fpMarginDepth1: 95
-      search.fpMarginDepth2: 210
-      search.lmpBase: 4
-      search.lmpPerDepth: 7
-      search.fpMaxDepth: 6
-      search.lmpMaxDepth: 4
-      search.hmpMinIndex: 48
-      search.hmpHistoryMax: 78
+      search.fpMarginDepth1: 120
+      search.fpMarginDepth2: 260
+      search.lmpBase: 5
+      search.lmpPerDepth: 8
+      search.fpMaxDepth: 7
+      search.lmpMaxDepth: 5
+      search.hmpMinIndex: 44
+      search.hmpHistoryMax: 82
       search.iidReduceDepth: 3
       search.lmrProtectPlyMax: 1
       search.lmrProtectIndexMax: 4
-      search.lmrCapGoodQuiet: 27
+      search.lmrCapGoodQuiet: 28
       search.lmrHistoryBuckets: 6
-      search.lmrHistoryWeightSlope: 0.72
-      search.lmrScaleDivisor: 2.05
-      search.lmrDepthLogOffset: 4.2
-      search.lmrMoveLogOffset: 3.4
+      search.lmrHistoryWeightSlope: 0.78
+      search.lmrScaleDivisor: 1.85
+      search.lmrDepthLogOffset: 3.8
+      search.lmrMoveLogOffset: 3.2
       search.maxCheckExtensionStreak: 2
-      search.seePruneNearRootPly: 2
-      search.historyReductionMax: 5400
-      search.aspMinSpanCp: 18
-      search.aspMaxSpanCp: 680
-      search.aspDefaultSpanCp: 36
-      search.aspHistoryBlend: 0.45
-      search.aspMomentumStepCp: 6
-      search.aspMomentumCap: 36
-      search.aspFailureRatio: 0.85
-      search.aspBaseOffsetCp: 10
-      search.aspSwingWeight: 0.18
-      search.aspVolatilityWeight: 0.8
-      search.aspDepthScale: 0.06
-      search.aspDepthPivot: 4
-      search.aspFloorBaseCp: 14
-      search.aspFloorVolWeight: 1.6
-      search.aspFloorStreakStepCp: 28
-      search.aspBumpBaseCp: 10
-      search.aspBumpStreakCp: 10
-      search.aspBumpDepthCp: 3
-      search.aspFullWindowScale: 2.2
-      search.aspLastSpanScale: 2.1
-      search.aspFullWindowMinMultiplier: 2.4
-      search.aspBlendBaselineWeight: 0.52
-      search.aspBlendCandidateWeight: 0.64
+      search.seePruneNearRootPly: 3
+      search.historyReductionMax: 5800
+      search.aspMinSpanCp: 14
+      search.aspMaxSpanCp: 640
+      search.aspDefaultSpanCp: 32
+      search.aspHistoryBlend: 0.5
+      search.aspMomentumStepCp: 5
+      search.aspMomentumCap: 32
+      search.aspFailureRatio: 0.82
+      search.aspBaseOffsetCp: 12
+      search.aspSwingWeight: 0.2
+      search.aspVolatilityWeight: 0.88
+      search.aspDepthScale: 0.065
+      search.aspDepthPivot: 5
+      search.aspFloorBaseCp: 16
+      search.aspFloorVolWeight: 1.55
+      search.aspFloorStreakStepCp: 26
+      search.aspBumpBaseCp: 11
+      search.aspBumpStreakCp: 11
+      search.aspBumpDepthCp: 4
+      search.aspFullWindowScale: 2.05
+      search.aspLastSpanScale: 1.9
+      search.aspFullWindowMinMultiplier: 2.3
+      search.aspBlendBaselineWeight: 0.55
+      search.aspBlendCandidateWeight: 0.62
       search.aspMaxRetriesBase: 3
-      search.aspMaxRetriesVolThresholdHigh: 96
-      search.aspMaxRetriesVolBonusHigh: 10
-      search.aspMaxRetriesVolThresholdMed: 220
+      search.aspMaxRetriesVolThresholdHigh: 90
+      search.aspMaxRetriesVolBonusHigh: 8
+      search.aspMaxRetriesVolThresholdMed: 190
       search.aspMaxRetriesVolBonusMed: 2
-      search.aspMaxRetriesDepthOffset: 18
+      search.aspMaxRetriesDepthOffset: 16
       search.aspMaxRetriesDepthDivisor: 1
       search.aspMaxRetriesMomentumDivisor: 3
       search.aspMaxRetriesMin: 1
       search.aspMaxRetriesMax: 3
-      search.nullBaseReduction: 3.2
-      search.nullDepthWeight: 0.55
-      search.nullMaterialWeight: 1.56
-      search.nullMobilityWeight: 0.12
-      search.nullDepthCap: 5
-      search.nullMaterialCap: 24
-      search.nullMobilityCap: 14
-      search.nullLowMaterialThreshold: 4
-      search.nullLowMobilityThreshold: 6
-      search.nullVeryLowMobilityThreshold: 9
-      search.nullLowMaterialPenalty: 0.85
-      search.nullVeryLowMobilityPenalty: 0.65
-      search.nullSwingGuardMinCp: 470
-      search.nullSwingGuardDivisor: 72
-      search.ttMainWeight: 3.6
-      search.ttCaptureWeight: 4.2
-      search.qsMaxDeltaPawn: 8.2
-      search.drawBias: 0.32
+      search.nullBaseReduction: 3.4
+      search.nullDepthWeight: 0.6
+      search.nullMaterialWeight: 1.62
+      search.nullMobilityWeight: 0.18
+      search.nullDepthCap: 6
+      search.nullMaterialCap: 26
+      search.nullMobilityCap: 16
+      search.nullLowMaterialThreshold: 5
+      search.nullLowMobilityThreshold: 5
+      search.nullVeryLowMobilityThreshold: 8
+      search.nullLowMaterialPenalty: 0.8
+      search.nullVeryLowMobilityPenalty: 0.6
+      search.nullSwingGuardMinCp: 420
+      search.nullSwingGuardDivisor: 68
+      search.ttMainWeight: 3.9
+      search.ttCaptureWeight: 4.5
+      search.qsMaxDeltaPawn: 7.8
+      search.drawBias: 0.28


### PR DESCRIPTION
## Summary
- replace the seed tuning configuration with the new v390 profile, refreshing evaluation module weights
- retune move ordering, pruning, aspiration, null-move, and transposition table parameters for better cutoffs and accuracy

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a745dac90832ab66e13e32b69429a