### PR TITLE
Add v390 tuning profile for evaluation and search

### DIFF
--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -1,84 +1,84 @@
 population:
-  - name: v389
+  - name: v390
     evaluation:
       modules:
         materialmodule:
-          midgame: 2.25
-          endgame: 1.0
+          midgame: 2.35
+          endgame: 1.08
         pawnstructuremodule:
-          midgame: 1.05
-          endgame: 1.05
+          midgame: 1.12
+          endgame: 1.15
         activitymodule:
-          midgame: 1.65
-          endgame: 1.1
+          midgame: 1.72
+          endgame: 1.18
         kingsafetymodule:
-          midgame: 1.25
-          endgame: 0.4
+          midgame: 1.32
+          endgame: 0.45
         threatmodule:
-          midgame: 1.55
-          endgame: 2.8
+          midgame: 1.65
+          endgame: 2.95
     numericParameters:
-      evaluation.blendscale: 768
-      material.pawnvalue: 125
-      material.knightvalue: 402
-      material.bishopvalue: 418
-      material.rookvalue: 575
-      material.queenvalue: 1110
-      material.bishoppairbonus: 54
-      pawnstructure.centerpawnbonus: 24
-      pawnstructure.passedpawnbonus: 44
-      pawnstructure.connectedpawnbonus: 8
-      pawnstructure.islandpenalty: -8
-      pawnstructure.doubledpawnpenalty: -11
-      pawnstructure.isolatedpawnpenalty: -10
-      pawnstructure.advancedpawnbonus: 13
-      pawnstructure.blockedpawnpenalty: -6
-      pawnstructure.backwardpawnpenalty: -20
-      pawnstructure.ownkingblockspassedpawnpenalty: -72
-      pawnstructure.passedpawnfreepathbonusperrank: 18
-      pawnstructure.rookhalfopenfilebonus: 44
-      pawnstructure.rookopenfilebonus: 36
-      threat.hangingpawnpenalty: -16
-      threat.hangingknightpenalty: -27
-      threat.hangingbishoppenalty: -16
-      threat.hangingrookpenalty: -61
-      threat.hangingqueenpenalty: -66
-      threat.pawnthreatknightpenalty: -11
-      threat.pawnthreatbishoppenalty: -10
-      threat.pawnthreatrookpenalty: -16
-      threat.pawnthreatqueenpenalty: -30
-      activity.midgamemobilityknight: 7
-      activity.midgamemobilitybishop: 13
-      activity.midgamemobilityrook: 13
-      activity.midgamemobilityqueen: 3
+      evaluation.blendscale: 832
+      material.pawnvalue: 128
+      material.knightvalue: 405
+      material.bishopvalue: 422
+      material.rookvalue: 580
+      material.queenvalue: 1130
+      material.bishoppairbonus: 56
+      pawnstructure.centerpawnbonus: 26
+      pawnstructure.passedpawnbonus: 48
+      pawnstructure.connectedpawnbonus: 10
+      pawnstructure.islandpenalty: -9
+      pawnstructure.doubledpawnpenalty: -13
+      pawnstructure.isolatedpawnpenalty: -12
+      pawnstructure.advancedpawnbonus: 15
+      pawnstructure.blockedpawnpenalty: -5
+      pawnstructure.backwardpawnpenalty: -24
+      pawnstructure.ownkingblockspassedpawnpenalty: -74
+      pawnstructure.passedpawnfreepathbonusperrank: 20
+      pawnstructure.rookhalfopenfilebonus: 48
+      pawnstructure.rookopenfilebonus: 40
+      threat.hangingpawnpenalty: -18
+      threat.hangingknightpenalty: -30
+      threat.hangingbishoppenalty: -22
+      threat.hangingrookpenalty: -64
+      threat.hangingqueenpenalty: -72
+      threat.pawnthreatknightpenalty: -13
+      threat.pawnthreatbishoppenalty: -12
+      threat.pawnthreatrookpenalty: -20
+      threat.pawnthreatqueenpenalty: -32
+      activity.midgamemobilityknight: 8
+      activity.midgamemobilitybishop: 14
+      activity.midgamemobilityrook: 14
+      activity.midgamemobilityqueen: 4
       activity.midgamemobilityking: 0
-      activity.endgamemobilityknight: 5
-      activity.endgamemobilitybishop: 2
-      activity.endgamemobilityrook: 2
-      activity.endgamemobilityqueen: 2
-      activity.endgamemobilityking: 3
-      activity.midgamecenterknight: 3
-      activity.midgamecenterbishop: 3
-      activity.midgamecenterrook: 1
-      activity.midgamecenterqueen: 2
+      activity.endgamemobilityknight: 6
+      activity.endgamemobilitybishop: 3
+      activity.endgamemobilityrook: 3
+      activity.endgamemobilityqueen: 3
+      activity.endgamemobilityking: 4
+      activity.midgamecenterknight: 4
+      activity.midgamecenterbishop: 4
+      activity.midgamecenterrook: 2
+      activity.midgamecenterqueen: 3
       activity.midgamecenterking: 0
-      activity.endgamecenterknight: 9
-      activity.endgamecenterbishop: -3
-      activity.endgamecenterrook: 4
-      activity.endgamecenterqueen: 4
-      activity.endgamecenterking: 5
-      kingsafety.missingpawnshieldpenalty: -28
-      kingsafety.halfopenfilepenalty: -4
-      kingsafety.openfilepenalty: -12
-      kingsafety.defenderbonus: 7
-      kingsafety.queenattackedpenalty: -78
-      kingsafety.backrankweaknessmidgamepenalty: -86
-      kingsafety.backrankweaknessendgamepenalty: -52
-      kingsafety.attackweightpawn: 8
-      kingsafety.attackweightknight: 21
-      kingsafety.attackweightbishop: 3
-      kingsafety.attackweightrook: 38
-      kingsafety.attackweightqueen: 26
+      activity.endgamecenterknight: 10
+      activity.endgamecenterbishop: -2
+      activity.endgamecenterrook: 5
+      activity.endgamecenterqueen: 5
+      activity.endgamecenterking: 6
+      kingsafety.missingpawnshieldpenalty: -32
+      kingsafety.halfopenfilepenalty: -6
+      kingsafety.openfilepenalty: -14
+      kingsafety.defenderbonus: 8
+      kingsafety.queenattackedpenalty: -84
+      kingsafety.backrankweaknessmidgamepenalty: -90
+      kingsafety.backrankweaknessendgamepenalty: -56
+      kingsafety.attackweightpawn: 9
+      kingsafety.attackweightknight: 24
+      kingsafety.attackweightbishop: 6
+      kingsafety.attackweightrook: 40
+      kingsafety.attackweightqueen: 28
       moveordering.category.tt: 7
       moveordering.category.promotion: 6
       moveordering.category.capturegood: 5
@@ -87,88 +87,88 @@ population:
       moveordering.category.killer1: 2
       moveordering.category.quiet: 1
       moveordering.category.capturebad: 0
-      moveordering.killermovescore: 10175
-      moveordering.promotionbonus: 1500
-      moveordering.killer0bonus: 15
-      moveordering.killer1bonus: 78
-      moveordering.countermovebonus: 502
+      moveordering.killermovescore: 10200
+      moveordering.promotionbonus: 1520
+      moveordering.killer0bonus: 68
+      moveordering.killer1bonus: 92
+      moveordering.countermovebonus: 540
       moveordering.capturemvvmultiplier: 15
-      moveordering.captureseemultiplier: 104
-      moveordering.promotionseemultiplier: 25
-      moveordering.castlingbonus: 4300
-      moveordering.captureseeclamp: 640
-      moveordering.promotionseeclamp: 400
-      moveordering.maxscore: 16045354
-      moveordering.historyscale: 1.35
+      moveordering.captureseemultiplier: 128
+      moveordering.promotionseemultiplier: 28
+      moveordering.castlingbonus: 4400
+      moveordering.captureseeclamp: 512
+      moveordering.promotionseeclamp: 384
+      moveordering.maxscore: 16060000
+      moveordering.historyscale: 1.42
       moveordering.historydecaydivisor: 2
-      search.fpMarginDepth1: 95
-      search.fpMarginDepth2: 210
-      search.lmpBase: 4
-      search.lmpPerDepth: 7
+      search.fpMarginDepth1: 85
+      search.fpMarginDepth2: 190
+      search.lmpBase: 5
+      search.lmpPerDepth: 6
       search.fpMaxDepth: 6
-      search.lmpMaxDepth: 4
-      search.hmpMinIndex: 48
-      search.hmpHistoryMax: 78
-      search.iidReduceDepth: 3
+      search.lmpMaxDepth: 5
+      search.hmpMinIndex: 44
+      search.hmpHistoryMax: 72
+      search.iidReduceDepth: 2
       search.lmrProtectPlyMax: 1
-      search.lmrProtectIndexMax: 4
-      search.lmrCapGoodQuiet: 27
-      search.lmrHistoryBuckets: 6
-      search.lmrHistoryWeightSlope: 0.72
-      search.lmrScaleDivisor: 2.05
-      search.lmrDepthLogOffset: 4.2
-      search.lmrMoveLogOffset: 3.4
+      search.lmrProtectIndexMax: 5
+      search.lmrCapGoodQuiet: 26
+      search.lmrHistoryBuckets: 7
+      search.lmrHistoryWeightSlope: 0.78
+      search.lmrScaleDivisor: 1.92
+      search.lmrDepthLogOffset: 3.8
+      search.lmrMoveLogOffset: 3.2
       search.maxCheckExtensionStreak: 2
       search.seePruneNearRootPly: 2
-      search.historyReductionMax: 5400
-      search.aspMinSpanCp: 18
-      search.aspMaxSpanCp: 680
-      search.aspDefaultSpanCp: 36
-      search.aspHistoryBlend: 0.45
+      search.historyReductionMax: 5600
+      search.aspMinSpanCp: 20
+      search.aspMaxSpanCp: 640
+      search.aspDefaultSpanCp: 40
+      search.aspHistoryBlend: 0.48
       search.aspMomentumStepCp: 6
-      search.aspMomentumCap: 36
-      search.aspFailureRatio: 0.85
-      search.aspBaseOffsetCp: 10
-      search.aspSwingWeight: 0.18
-      search.aspVolatilityWeight: 0.8
-      search.aspDepthScale: 0.06
+      search.aspMomentumCap: 40
+      search.aspFailureRatio: 0.82
+      search.aspBaseOffsetCp: 12
+      search.aspSwingWeight: 0.22
+      search.aspVolatilityWeight: 0.82
+      search.aspDepthScale: 0.07
       search.aspDepthPivot: 4
-      search.aspFloorBaseCp: 14
-      search.aspFloorVolWeight: 1.6
-      search.aspFloorStreakStepCp: 28
-      search.aspBumpBaseCp: 10
-      search.aspBumpStreakCp: 10
-      search.aspBumpDepthCp: 3
-      search.aspFullWindowScale: 2.2
-      search.aspLastSpanScale: 2.1
-      search.aspFullWindowMinMultiplier: 2.4
-      search.aspBlendBaselineWeight: 0.52
-      search.aspBlendCandidateWeight: 0.64
+      search.aspFloorBaseCp: 16
+      search.aspFloorVolWeight: 1.8
+      search.aspFloorStreakStepCp: 30
+      search.aspBumpBaseCp: 12
+      search.aspBumpStreakCp: 12
+      search.aspBumpDepthCp: 4
+      search.aspFullWindowScale: 2.3
+      search.aspLastSpanScale: 2.2
+      search.aspFullWindowMinMultiplier: 2.5
+      search.aspBlendBaselineWeight: 0.5
+      search.aspBlendCandidateWeight: 0.66
       search.aspMaxRetriesBase: 3
-      search.aspMaxRetriesVolThresholdHigh: 96
+      search.aspMaxRetriesVolThresholdHigh: 100
       search.aspMaxRetriesVolBonusHigh: 10
-      search.aspMaxRetriesVolThresholdMed: 220
-      search.aspMaxRetriesVolBonusMed: 2
-      search.aspMaxRetriesDepthOffset: 18
+      search.aspMaxRetriesVolThresholdMed: 200
+      search.aspMaxRetriesVolBonusMed: 3
+      search.aspMaxRetriesDepthOffset: 16
       search.aspMaxRetriesDepthDivisor: 1
       search.aspMaxRetriesMomentumDivisor: 3
       search.aspMaxRetriesMin: 1
       search.aspMaxRetriesMax: 3
-      search.nullBaseReduction: 3.2
-      search.nullDepthWeight: 0.55
-      search.nullMaterialWeight: 1.56
-      search.nullMobilityWeight: 0.12
-      search.nullDepthCap: 5
-      search.nullMaterialCap: 24
-      search.nullMobilityCap: 14
+      search.nullBaseReduction: 3.4
+      search.nullDepthWeight: 0.6
+      search.nullMaterialWeight: 1.62
+      search.nullMobilityWeight: 0.18
+      search.nullDepthCap: 6
+      search.nullMaterialCap: 26
+      search.nullMobilityCap: 16
       search.nullLowMaterialThreshold: 4
       search.nullLowMobilityThreshold: 6
       search.nullVeryLowMobilityThreshold: 9
-      search.nullLowMaterialPenalty: 0.85
-      search.nullVeryLowMobilityPenalty: 0.65
-      search.nullSwingGuardMinCp: 470
-      search.nullSwingGuardDivisor: 72
-      search.ttMainWeight: 3.6
-      search.ttCaptureWeight: 4.2
-      search.qsMaxDeltaPawn: 8.2
-      search.drawBias: 0.32
+      search.nullLowMaterialPenalty: 0.82
+      search.nullVeryLowMobilityPenalty: 0.62
+      search.nullSwingGuardMinCp: 440
+      search.nullSwingGuardDivisor: 70
+      search.ttMainWeight: 3.8
+      search.ttCaptureWeight: 4.4
+      search.qsMaxDeltaPawn: 8.8
+      search.drawBias: 0.28


### PR DESCRIPTION
## Summary
- replace the bundled v389 tuning profile with a new v390 configuration
- rebalance evaluation module weights and material/pawn/king safety coefficients to favor sharper tactical judgment
- retune move ordering, aspiration window, futility, null-move, and transposition heuristics to increase beta cutoffs and stability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690a745dac90832ab66e13e32b69429a