### PR TITLE
Prevent tablebase move selection from forcing immediate repetition draws

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2267,6 +2267,9 @@ public class AI {
             return false;
         }
         int parentSign = Integer.signum(parentResult.wdl().score());
+        if (parentSign > 0 && continuation.forcesImmediateDraw()) {
+            return false;
+        }
         int childSign = Integer.signum(continuation.result().wdl().score());
         if (parentSign == 0) {
             return childSign == 0;

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -219,7 +219,7 @@ public class AI {
     }
 
     private record TablebaseContinuation(int move, double evaluation, TablebaseResult result,
-                                         boolean zeroingMove) {
+                                         boolean zeroingMove, boolean forcesImmediateDraw) {
     }
 
     private record TablebaseInfo(int dtz, int dtm, int whiteWdlSign) {
@@ -2236,7 +2236,12 @@ public class AI {
             TablebaseResult result = childResult.get();
             double evaluation = clampTablebaseEval(Score.tablebaseToEvaluation(result, simulatorEngine.whitesTurn(),
                     simulatorEngine.getGameState().getHalfmoveClock()));
-            return Optional.of(new TablebaseContinuation(move, evaluation, result, zeroing));
+            GameState state = simulatorEngine.getGameState();
+            boolean forcesImmediateDraw = state.isThreefoldRepetition() || state.isFiftyMoveRule();
+            if (forcesImmediateDraw) {
+                evaluation = 0.0;
+            }
+            return Optional.of(new TablebaseContinuation(move, evaluation, result, zeroing, forcesImmediateDraw));
         } finally {
             simulatorEngine.undoLastMove();
         }
@@ -2304,6 +2309,9 @@ public class AI {
     }
 
     private boolean preferWinningContinuation(TablebaseContinuation candidate, TablebaseContinuation incumbent) {
+        if (candidate.forcesImmediateDraw() != incumbent.forcesImmediateDraw()) {
+            return !candidate.forcesImmediateDraw();
+        }
         int candidateDtz = normaliseDistance(candidate.result().dtz(), Integer.MAX_VALUE);
         int incumbentDtz = normaliseDistance(incumbent.result().dtz(), Integer.MAX_VALUE);
         if (candidateDtz != incumbentDtz) {
@@ -2323,6 +2331,9 @@ public class AI {
     }
 
     private boolean preferDefensiveContinuation(TablebaseContinuation candidate, TablebaseContinuation incumbent) {
+        if (candidate.forcesImmediateDraw() != incumbent.forcesImmediateDraw()) {
+            return candidate.forcesImmediateDraw();
+        }
         int candidateDtz = normaliseDistance(candidate.result().dtz(), Integer.MIN_VALUE);
         int incumbentDtz = normaliseDistance(incumbent.result().dtz(), Integer.MIN_VALUE);
         if (candidateDtz != incumbentDtz) {
@@ -2342,6 +2353,9 @@ public class AI {
     }
 
     private boolean preferDrawingContinuation(TablebaseContinuation candidate, TablebaseContinuation incumbent) {
+        if (candidate.forcesImmediateDraw() != incumbent.forcesImmediateDraw()) {
+            return candidate.forcesImmediateDraw();
+        }
         int candidateDtz = normaliseDistance(candidate.result().dtz(), Integer.MAX_VALUE);
         int incumbentDtz = normaliseDistance(incumbent.result().dtz(), Integer.MAX_VALUE);
         if (candidateDtz != incumbentDtz) {

--- a/src/test/java/julius/game/chessengine/ai/AITablebaseRecommendationTest.java
+++ b/src/test/java/julius/game/chessengine/ai/AITablebaseRecommendationTest.java
@@ -73,6 +73,73 @@ class AITablebaseRecommendationTest {
         assertThat(MoveHelper.convertIndexToString(MoveHelper.deriveToIndex(best.getMove()))).isEqualTo("b6");
     }
 
+    @Test
+    void avoidsImmediateThreefoldRepetitionWhenWinning() {
+        Engine engine = new Engine();
+        engine.importBoardFromFen("6K1/8/4B3/6P1/4P3/3P4/8/k7 w - - 19 69");
+
+        int kh8 = findMatchingMove(engine,
+                MoveHelper.convertStringToIndex("g8"), MoveHelper.convertStringToIndex("h8"));
+        int g6 = findMatchingMove(engine,
+                MoveHelper.convertStringToIndex("g5"), MoveHelper.convertStringToIndex("g6"));
+
+        String parentFen = engine.translateBoardToFen().getRenderBoard();
+
+        Engine simulation = engine.createSimulation();
+        simulation.performMove(kh8);
+        String kh8Fen = simulation.translateBoardToFen().getRenderBoard();
+        long kh8Hash = simulation.getBoardStateHash();
+        simulation.undoLastMove();
+
+        simulation.performMove(g6);
+        String g6Fen = simulation.translateBoardToFen().getRenderBoard();
+        simulation.undoLastMove();
+
+        engine.getGameState().getRepetition().put(kh8Hash, 2);
+
+        SyzygyProbeResult parentProbe = new SyzygyProbeResult(
+                SyzygyWdl.WIN,
+                OptionalInt.of(4),
+                OptionalInt.empty(),
+                Optional.empty()
+        );
+        SyzygyProbeResult kh8Probe = new SyzygyProbeResult(
+                SyzygyWdl.LOSS,
+                OptionalInt.of(3),
+                OptionalInt.empty(),
+                Optional.empty()
+        );
+        SyzygyProbeResult g6Probe = new SyzygyProbeResult(
+                SyzygyWdl.LOSS,
+                OptionalInt.of(3),
+                OptionalInt.empty(),
+                Optional.empty()
+        );
+
+        TestSyzygyTablebaseService service = TestSyzygyTablebaseService.fromResponses(Map.of(
+                parentFen, parentProbe,
+                kh8Fen, kh8Probe,
+                g6Fen, g6Probe
+        ));
+
+        engine.getGameState().setLastTablebaseResult(TablebaseResult.from(parentProbe));
+
+        AiTuning tuning = AiTuning.builder()
+                .searchThreads(1)
+                .lazySmpThreads(1)
+                .hashSizeMb(16)
+                .maxDepth(6)
+                .timeLimitMillis(200)
+                .build();
+
+        AI ai = new AI(engine, tuning, service);
+        int chosen = invokeDetermineTablebaseBestMove(ai, engine, TablebaseResult.from(parentProbe));
+        ai.shutdown();
+
+        assertThat(MoveHelper.convertIndexToString(MoveHelper.deriveFromIndex(chosen))).isEqualTo("g5");
+        assertThat(MoveHelper.convertIndexToString(MoveHelper.deriveToIndex(chosen))).isEqualTo("g6");
+    }
+
     private int invokeDetermineTablebaseBestMove(AI ai, Engine engine, TablebaseResult result) {
         try {
             var method = AI.class.getDeclaredMethod("determineTablebaseBestMove", Engine.class, TablebaseResult.class, boolean.class);


### PR DESCRIPTION
## Summary
- avoid picking tablebase continuations that immediately trigger threefold repetition or the fifty-move rule when a win is available
- extend the tie-breakers to treat instant draws as losing choices for the winning side and attractive when defending
- add a regression test that reproduces the Kh8 loop and verifies the engine now follows the g6 winning plan

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=AITablebaseRecommendationTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e0719c878832ab0df19732f639c07)