### PR TITLE
Add PGNs for additional opening variations

### DIFF
--- a/src/main/resources/opening/french_defense_classical_steinitz_variation.pgn
+++ b/src/main/resources/opening/french_defense_classical_steinitz_variation.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Nf6 4. Bg5 Be7 5. e5 Nfd7 *

--- a/src/main/resources/opening/french_defense_closed_traditional.pgn
+++ b/src/main/resources/opening/french_defense_closed_traditional.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Nf6 4. e5 Nfd7 5. f4 c5 *

--- a/src/main/resources/opening/french_defense_winawer_advance_variation.pgn
+++ b/src/main/resources/opening/french_defense_winawer_advance_variation.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e6 2. d4 d5 3. Nc3 Bb4 4. e5 c5 5. a3 Bxc3+ *

--- a/src/main/resources/opening/nimzowitsch_defense_franco_nimzowitsch_variation.pgn
+++ b/src/main/resources/opening/nimzowitsch_defense_franco_nimzowitsch_variation.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 Nc6 2. d4 e5 3. d5 Nce7 4. Nf3 Ng6 5. h4 h5 *

--- a/src/main/resources/opening/scotch_game_classical_variation.pgn
+++ b/src/main/resources/opening/scotch_game_classical_variation.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 e5 2. Nf3 Nc6 3. d4 exd4 4. Nxd4 Bc5 5. Be3 Qf6 *

--- a/src/main/resources/opening/sicilian_defense_closed_traditional.pgn
+++ b/src/main/resources/opening/sicilian_defense_closed_traditional.pgn
@@ -1,0 +1,5 @@
+[Event "Test"]
+[Site "Local"]
+[Result "*"]
+
+1. e4 c5 2. Nc3 Nc6 3. g3 g6 4. Bg2 Bg7 5. d3 d6 *


### PR DESCRIPTION
## Summary
- add 10-ply PGNs for the Scotch Game Classical Variation and Nimzowitsch Defense Franco-Nimzowitsch Variation
- include 10-ply PGNs for multiple French Defense branches and the Sicilian Defense Closed Traditional line

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f11334e98832a99c4a0770af33408)