### PR TITLE
Weight Syzygy DTZ in tablebase evaluation

### DIFF
--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -367,31 +367,31 @@ public class Score {
     }
 
     public static int tablebaseToCentipawn(TablebaseResult result, boolean whiteToMove, int halfmoveClock) {
-        if (result == null) {
-            return DRAW;
-        }
+        if (result == null) return DRAW;
 
         SyzygyWdl wdl = result.wdl();
         int wdlScore = wdl.score();
-        if (wdlScore == 0 || wdlScore == Integer.MIN_VALUE) {
-            return DRAW;
-        }
+        if (wdlScore == 0 || wdlScore == Integer.MIN_VALUE) return DRAW;
 
-        int magnitude;
         switch (wdl) {
-            case CURSED_WIN, BLESSED_LOSS -> {
-                magnitude = evaluateFiftyMoveSensitiveMagnitude(result, halfmoveClock);
-                if (magnitude == DRAW) {
-                    return DRAW;
-                }
+            case CURSED_WIN: {
+                int m = evaluateFiftyMoveSensitiveMagnitude(result, halfmoveClock);
+                if (m == DRAW) return DRAW;
+                return whiteToMove ?  m : -m;
             }
-            case WIN, LOSS -> magnitude = evaluateDecisiveMagnitude(result);
-            default -> magnitude = CHECKMATE - 1; // should be unreachable due to early return, keep as fallback
+            case BLESSED_LOSS: {
+                int m = evaluateFiftyMoveSensitiveMagnitude(result, halfmoveClock);
+                if (m == DRAW) return DRAW;
+                return whiteToMove ? -m :  m;
+            }
+            case WIN:
+            case LOSS:
+                return evaluateDecisiveMagnitude(result, wdl, whiteToMove, halfmoveClock);
+            default:
+                return CHECKMATE - 1;
         }
-
-        int sign = whiteToMove ? Integer.signum(wdlScore) : -Integer.signum(wdlScore);
-        return sign * magnitude;
     }
+
 
     public static double tablebaseToEvaluation(TablebaseResult result, boolean whiteToMove) {
         return tablebaseToEvaluation(result, whiteToMove, UNSPECIFIED_HALFMOVE_CLOCK);
@@ -405,20 +405,36 @@ public class Score {
         return tablebaseToCentipawn(result, whiteToMove, halfmoveClock);
     }
 
-    private static int evaluateDecisiveMagnitude(TablebaseResult result) {
+    private static int evaluateDecisiveMagnitude(TablebaseResult result, SyzygyWdl wdl, boolean whiteToMove, int halfmoveClock) {
+        final int base = CHECKMATE - 1;
+
+        // If this node has just reset the 50-move clock (pawn move/capture), reward with max magnitude.
+        if (halfmoveClock == 0) {
+            return (wdl == SyzygyWdl.WIN)
+                    ? (whiteToMove ?  base : -base)
+                    : (whiteToMove ? -base :  base);
+        }
+
         OptionalInt dtzOpt = result.dtz();
-        if (dtzOpt.isEmpty()) {
-            return CHECKMATE - 1;
+        // No DTZ → near-mate fallback to keep ordering stable.
+        if (dtzOpt.isEmpty() || dtzOpt.getAsInt() == Integer.MIN_VALUE) {
+            int value = base - 1;
+            return (wdl == SyzygyWdl.WIN)
+                    ? (whiteToMove ?  value : -value)
+                    : (whiteToMove ? -value :  value);
         }
 
-        int raw = dtzOpt.getAsInt();
-        if (raw == Integer.MIN_VALUE) {
-            return CHECKMATE - 1;
-        }
+        int steps = Math.abs(dtzOpt.getAsInt());
+        if (steps < 1) steps = 1;
+        if (steps > base - 1) steps = base - 1;
 
-        int dtz = Math.abs(raw);
-        int penalty = Math.max(1, Math.min(dtz, CHECKMATE - 1));
-        return Math.max(1, CHECKMATE - penalty);
+        int value = base - steps; // smaller DTZ ⇒ larger value
+
+        if (wdl == SyzygyWdl.WIN) {
+            return whiteToMove ?  value : -value;
+        } else { // LOSS
+            return whiteToMove ? -value :  value;
+        }
     }
 
     private static int evaluateFiftyMoveSensitiveMagnitude(TablebaseResult result, int halfmoveClock) {

--- a/src/main/java/julius/game/chessengine/utils/Score.java
+++ b/src/main/java/julius/game/chessengine/utils/Score.java
@@ -385,7 +385,7 @@ public class Score {
                     return DRAW;
                 }
             }
-            case WIN, LOSS -> magnitude = CHECKMATE - 1;
+            case WIN, LOSS -> magnitude = evaluateDecisiveMagnitude(result);
             default -> magnitude = CHECKMATE - 1; // should be unreachable due to early return, keep as fallback
         }
 
@@ -403,6 +403,22 @@ public class Score {
 
     private int computeTablebaseCentipawn(TablebaseResult result, boolean whiteToMove, int halfmoveClock) {
         return tablebaseToCentipawn(result, whiteToMove, halfmoveClock);
+    }
+
+    private static int evaluateDecisiveMagnitude(TablebaseResult result) {
+        OptionalInt dtzOpt = result.dtz();
+        if (dtzOpt.isEmpty()) {
+            return CHECKMATE - 1;
+        }
+
+        int raw = dtzOpt.getAsInt();
+        if (raw == Integer.MIN_VALUE) {
+            return CHECKMATE - 1;
+        }
+
+        int dtz = Math.abs(raw);
+        int penalty = Math.max(1, Math.min(dtz, CHECKMATE - 1));
+        return Math.max(1, CHECKMATE - penalty);
     }
 
     private static int evaluateFiftyMoveSensitiveMagnitude(TablebaseResult result, int halfmoveClock) {

--- a/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
@@ -17,8 +17,24 @@ public final class BestMoveFixtures {
 
     private static final List<BestMoveTestCase> CASES = List.of(
             new BestMoveTestCase(
+                    "4k3/8/4K3/6Q1/8/8/8/8 w - - 0 1",
+                    List.of("Qe7", "Qg8")
+            ),
+            new BestMoveTestCase(
                     "1K6/8/1P1k4/7R/8/8/8/r7 w - - 27 135",
                     List.of("b7")
+            ),
+            new BestMoveTestCase(
+                    "1K6/1P6/3k4/7R/8/8/8/r7 b - - 0 1",
+                    List.of("Ra2", "Ra3", "Kd7", "Ra4")
+            ),
+            new BestMoveTestCase(
+                    "8/R7/3K4/7r/8/8/1p6/1k6 b - - 0 1",
+                    List.of("Rb5", "Rh3")
+            ),
+            new BestMoveTestCase(
+                    "8/R7/3K4/1r6/8/8/1p6/1k6 w - - 0 1",
+                    List.of("Rg7", "Rh7", "Rc7", "Re7", "Rf7", "Ra3", "Ra4", "Ra8", "Ke6", "Ra6", "Rd7", "Kd7", "Ke7")
             ),
             new BestMoveTestCase(
                     "r3k2r/pppq1ppp/n1nb4/3p4/8/P1N5/1P2BPPP/R1BQK2R w KQkq - 0 15",

--- a/src/test/java/julius/game/chessengine/tablebase/ScoreTablebaseIntegrationTest.java
+++ b/src/test/java/julius/game/chessengine/tablebase/ScoreTablebaseIntegrationTest.java
@@ -109,6 +109,34 @@ class ScoreTablebaseIntegrationTest {
     }
 
     @Test
+    void decisiveWinPrefersSmallerDtz() {
+        TablebaseResult fastWin = new TablebaseResult(SyzygyWdl.WIN, OptionalInt.of(3), OptionalInt.empty(), Optional.empty());
+        TablebaseResult slowWin = new TablebaseResult(SyzygyWdl.WIN, OptionalInt.of(7), OptionalInt.empty(), Optional.empty());
+
+        int fastWhite = Score.tablebaseToCentipawn(fastWin, true);
+        int slowWhite = Score.tablebaseToCentipawn(slowWin, true);
+        assertThat(fastWhite).isGreaterThan(slowWhite);
+
+        int fastBlack = Score.tablebaseToCentipawn(fastWin, false);
+        int slowBlack = Score.tablebaseToCentipawn(slowWin, false);
+        assertThat(fastBlack).isLessThan(slowBlack);
+    }
+
+    @Test
+    void decisiveLossPrefersLargerDtzForDefender() {
+        TablebaseResult fastLoss = new TablebaseResult(SyzygyWdl.LOSS, OptionalInt.of(-3), OptionalInt.empty(), Optional.empty());
+        TablebaseResult slowLoss = new TablebaseResult(SyzygyWdl.LOSS, OptionalInt.of(-9), OptionalInt.empty(), Optional.empty());
+
+        int fastWhite = Score.tablebaseToCentipawn(fastLoss, true);
+        int slowWhite = Score.tablebaseToCentipawn(slowLoss, true);
+        assertThat(fastWhite).isLessThan(slowWhite);
+
+        int fastBlack = Score.tablebaseToCentipawn(fastLoss, false);
+        int slowBlack = Score.tablebaseToCentipawn(slowLoss, false);
+        assertThat(fastBlack).isGreaterThan(slowBlack);
+    }
+
+    @Test
     void cursedWinEvaluationShrinksAsFiftyMoveClockExpires() {
         TablebaseResult earlyReset = new TablebaseResult(
                 SyzygyWdl.CURSED_WIN, OptionalInt.of(4), OptionalInt.empty(), Optional.empty());


### PR DESCRIPTION
## Summary
- weigh decisive tablebase centipawn magnitudes by the probed DTZ so faster zeroing wins score higher and slower lines score lower
- extend the tablebase integration tests to cover DTZ ordering for both wins and losses

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=ScoreTablebaseIntegrationTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f36495dd8832a9aaa7eb63e89dcef)