### PR TITLE
Gate root history move pruning behind allowLatePrune

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2806,6 +2806,7 @@ public class AI {
         final int hmpHistoryMax = pruning.hmpHistoryMax();
         final int lmpBase = pruning.lmpBase();
         final int lmpPerDepth = pruning.lmpPerDepth();
+        final int lmpMaxDepth = Math.max(0, pruning.lmpMaxDepth());
         final int iidReduceDepth = pruning.iidReduceDepth();
         final int lmrProtectPlyMax = pruning.lmrProtectPlyMax();
         final int lmrProtectIndexMax = pruning.lmrProtectIndexMax();
@@ -2856,7 +2857,8 @@ public class AI {
                 }
             }
 
-            if (!inCheckAtNode
+            if (allowLatePrune
+                    && !inCheckAtNode
                     && isQuiet
                     && depth >= 2
                     && hmpMinIndex >= 0
@@ -3128,6 +3130,7 @@ public class AI {
         final int hmpHistoryMax = pruning.hmpHistoryMax();
         final int lmpBase = pruning.lmpBase();
         final int lmpPerDepth = pruning.lmpPerDepth();
+        final int lmpMaxDepth = Math.max(0, pruning.lmpMaxDepth());
         final int iidReduceDepth = pruning.iidReduceDepth();
         final int lmrProtectPlyMax = pruning.lmrProtectPlyMax();
         final int lmrProtectIndexMax = pruning.lmrProtectIndexMax();


### PR DESCRIPTION
## Summary
- gate history move pruning on allowLatePrune to avoid pruning expected quiet root moves
- read the late move pruning max depth from the pruning snapshot in both search branches

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691226fb3530832a943d60a2284a90f4)