### PR TITLE
Add LMP max depth to pruning snapshot

### DIFF
--- a/src/main/java/julius/game/chessengine/tuning/SearchPruningParameters.java
+++ b/src/main/java/julius/game/chessengine/tuning/SearchPruningParameters.java
@@ -29,6 +29,7 @@ public final class SearchPruningParameters {
                 Tuning.searchProbCutSeeMin(),
                 Tuning.searchLmpBase(),
                 Tuning.searchLmpPerDepth(),
+                Tuning.searchLmpMaxDepth(),
                 Tuning.searchHmpMinIndex(),
                 Tuning.searchHmpHistoryMax(),
                 Tuning.searchIidReduceDepth(),
@@ -60,6 +61,7 @@ public final class SearchPruningParameters {
         defaults.put(ParamId.SEARCH_PROB_CUT_SEE_MIN.key(), ParamId.SEARCH_PROB_CUT_SEE_MIN.defaultValue());
         defaults.put(ParamId.SEARCH_LMP_BASE.key(), ParamId.SEARCH_LMP_BASE.defaultValue());
         defaults.put(ParamId.SEARCH_LMP_PER_DEPTH.key(), ParamId.SEARCH_LMP_PER_DEPTH.defaultValue());
+        defaults.put(ParamId.SEARCH_LMP_MAX_DEPTH.key(), ParamId.SEARCH_LMP_MAX_DEPTH.defaultValue());
         defaults.put(ParamId.SEARCH_HMP_MIN_INDEX.key(), ParamId.SEARCH_HMP_MIN_INDEX.defaultValue());
         defaults.put(ParamId.SEARCH_HMP_HISTORY_MAX.key(), ParamId.SEARCH_HMP_HISTORY_MAX.defaultValue());
         defaults.put(ParamId.SEARCH_IID_REDUCE_DEPTH.key(), ParamId.SEARCH_IID_REDUCE_DEPTH.defaultValue());
@@ -90,6 +92,7 @@ public final class SearchPruningParameters {
             int probCutSeeMin,
             int lmpBase,
             int lmpPerDepth,
+            int lmpMaxDepth,
             int hmpMinIndex,
             int hmpHistoryMax,
             int iidReduceDepth,


### PR DESCRIPTION
## Summary
- expose the `search.lmpMaxDepth` tuning value through `SearchPruningParameters.Snapshot`
- add the parameter to the pruning defaults map so seed tuning covers the new field

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -DskipTests package

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691228a388a8832ab41f576a90b6a507)