### PR TITLE
Guard history pruning near root and tune defaults

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -3183,6 +3183,16 @@ public class AI {
                 }
             }
 
+            if (allowLatePrune
+                    && !inCheckAtNode
+                    && isQuiet
+                    && depth >= 2
+                    && hmpMinIndex >= 0
+                    && index >= hmpMinIndex
+                    && historyScore <= hmpHistoryMax) {
+                continue;
+            }
+
             int seeGain = 0;
             boolean seeEvaluated = false;
             boolean seeWinsMaterial = false;

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -138,12 +138,12 @@ population:
       search.fpmargindepth3: 260.0
       search.fpmaxdepth: 6.0
       search.historyreductionmax: 6540.9051731841755
-      search.hmphistorymax: 121.92808472289505
-      search.hmpminindex: 38.73678917772546
+      search.hmpHistoryMax: 121.92808472289505
+      search.hmpMinIndex: 38.73678917772546
       search.iidreducedepth: 2.6220408788985017
-      search.lmpbase: 6.0
-      search.lmpmaxdepth: 4.0
-      search.lmpperdepth: 10.0
+      search.lmpBase: 6.0
+      search.lmpMaxDepth: 4.0
+      search.lmpPerDepth: 10.0
       search.lmrcapgoodquiet: 16.0
       search.lmrdepthlogoffset: 4.8
       search.lmrhistorybuckets: 6.0


### PR DESCRIPTION
## Summary
- prevent the minimizer branch from applying history move pruning before the root guard kicks in by aligning it with the maximizer logic
- expose the history and late-move pruning parameters in seed-tunings so tuning picks up the defaults with the expected key casing

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69122a35c52c832aa90b5ad9c8093ca2)