### PR TITLE
Fix root PVS re-search and normalize diagnostics

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2045,7 +2045,8 @@ public class AI {
     private RootSearchResult getBestMove(Engine simulatorEngine, boolean isWhitesTurn, int depth, long deadline,
                                          double alpha, double beta, SplittableRandom rng) {
         int bestMove = -1;
-        double bestScore = isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+        double bestWhiteScore = Double.NaN;
+        double bestRootScore = Double.NEGATIVE_INFINITY;
 
         boolean aborted = false;
         boolean bestFromTablebase = false;
@@ -2065,6 +2066,9 @@ public class AI {
             }
         }
 
+        double rootAlpha = isWhitesTurn ? alpha : -beta;
+        double rootBeta = isWhitesTurn ? beta : -alpha;
+
         for (int idx = 0; idx < sortedMoves.size(); idx++) {
             int moveInt = sortedMoves.getInt(idx);
             if (abortRequested(deadline)) {
@@ -2074,41 +2078,154 @@ public class AI {
 
             simulatorEngine.performMove(moveInt);
             long childHash = simulatorEngine.getBoardStateHash();
-            double score;
+
             boolean moveTablebaseExact = false;
+            boolean moveAborted = false;
+            double scoreWhite = Double.NaN;
+            double rootScore = Double.NaN;
+
             if (simulatorEngine.getGameState().isInStateCheckMate()) {
-                score = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
+                scoreWhite = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
+                rootScore = orientScoreForRoot(isWhitesTurn, scoreWhite);
             } else if (simulatorEngine.getGameState().isTerminal()) {
-                score = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !isWhitesTurn, depth);
-                if (isWhitesTurn) score = -score; // convert to WHITE-perspective
+                scoreWhite = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !isWhitesTurn, depth);
+                if (isWhitesTurn) scoreWhite = -scoreWhite; // convert to WHITE-perspective
+                rootScore = orientScoreForRoot(isWhitesTurn, scoreWhite);
             } else {
                 Optional<TablebaseResult> childTablebase = resolveExactTablebaseResult(simulatorEngine);
                 if (childTablebase.isPresent()) {
                     moveTablebaseExact = true;
-                    score = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !isWhitesTurn, depth);
-                    if (isWhitesTurn) score = -score; // to WHITE-perspective
+                    scoreWhite = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !isWhitesTurn, depth);
+                    if (isWhitesTurn) scoreWhite = -scoreWhite; // to WHITE-perspective
+                    rootScore = orientScoreForRoot(isWhitesTurn, scoreWhite);
                 } else {
-                    score = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, moveInt, 1, 0);
-                    if (score == EXIT_FLAG || abortRequested(deadline)) {
-                        simulatorEngine.undoLastMove();
-                        aborted = true;
-                        break;
+                    RootMoveComputation computation = searchRootMoveWithPvs(
+                            simulatorEngine,
+                            depth - 1,
+                            deadline,
+                            isWhitesTurn,
+                            moveInt,
+                            idx == 0,
+                            rootAlpha,
+                            rootBeta
+                    );
+                    if (computation.aborted()) {
+                        moveAborted = true;
+                    } else {
+                        scoreWhite = computation.whiteScore();
+                        rootScore = computation.rootScore();
                     }
                 }
             }
+
             simulatorEngine.undoLastMove();
 
-            if (isBetterScore(isWhitesTurn, score, bestScore)) {
-                bestScore = score;
+            if (moveAborted) {
+                aborted = true;
+                break;
+            }
+
+            if (Double.isNaN(rootScore)) {
+                continue;
+            }
+
+            if (rootScore > bestRootScore) {
+                bestRootScore = rootScore;
+                bestWhiteScore = scoreWhite;
                 bestMove = moveInt;
                 bestFromTablebase = moveTablebaseExact;
             }
-            if (isWhitesTurn) alpha = Math.max(alpha, score);
-            else beta = Math.min(beta, score);
-            if (alpha >= beta) break;
+
+            if (rootScore > rootAlpha) {
+                rootAlpha = rootScore;
+            }
+
+            if (isWhitesTurn) {
+                alpha = Math.max(alpha, scoreWhite);
+            } else {
+                beta = Math.min(beta, scoreWhite);
+            }
+
+            if (rootAlpha >= rootBeta) {
+                break;
+            }
         }
-        MoveAndScore candidate = bestMove != -1 ? createCandidate(bestMove, bestScore, bestFromTablebase) : null;
+
+        MoveAndScore candidate = (bestMove != -1 && Double.isFinite(bestWhiteScore))
+                ? createCandidate(bestMove, bestWhiteScore, bestFromTablebase)
+                : null;
         return aborted ? RootSearchResult.aborted(candidate) : RootSearchResult.completed(candidate);
+    }
+
+    private RootMoveComputation searchRootMoveWithPvs(Engine simulatorEngine,
+                                                      int depth,
+                                                      long deadline,
+                                                      boolean rootIsWhite,
+                                                      int moveInt,
+                                                      boolean firstMove,
+                                                      double rootAlpha,
+                                                      double rootBeta) {
+        if (firstMove) {
+            double whiteScore = searchChildWithWindow(simulatorEngine, depth, rootAlpha, rootBeta, rootIsWhite, deadline, moveInt);
+            if (whiteScore == EXIT_FLAG || abortRequested(deadline)) {
+                return RootMoveComputation.abortedResult();
+            }
+            return new RootMoveComputation(whiteScore, orientScoreForRoot(rootIsWhite, whiteScore), false);
+        }
+
+        double narrowBetaRoot = Math.min(rootBeta, Math.nextUp(rootAlpha));
+        if (narrowBetaRoot <= rootAlpha) {
+            double whiteScore = searchChildWithWindow(simulatorEngine, depth, rootAlpha, rootBeta, rootIsWhite, deadline, moveInt);
+            if (whiteScore == EXIT_FLAG || abortRequested(deadline)) {
+                return RootMoveComputation.abortedResult();
+            }
+            return new RootMoveComputation(whiteScore, orientScoreForRoot(rootIsWhite, whiteScore), false);
+        }
+
+        double probeWhiteScore = searchChildWithWindow(simulatorEngine, depth, rootAlpha, narrowBetaRoot, rootIsWhite, deadline, moveInt);
+        if (probeWhiteScore == EXIT_FLAG || abortRequested(deadline)) {
+            return RootMoveComputation.abortedResult();
+        }
+        double probeRootScore = orientScoreForRoot(rootIsWhite, probeWhiteScore);
+        if (probeRootScore > rootAlpha && probeRootScore < rootBeta) {
+            double whiteScore = searchChildWithWindow(simulatorEngine, depth, rootAlpha, rootBeta, rootIsWhite, deadline, moveInt);
+            if (whiteScore == EXIT_FLAG || abortRequested(deadline)) {
+                return RootMoveComputation.abortedResult();
+            }
+            return new RootMoveComputation(whiteScore, orientScoreForRoot(rootIsWhite, whiteScore), false);
+        }
+
+        return new RootMoveComputation(probeWhiteScore, probeRootScore, false);
+    }
+
+    private double searchChildWithWindow(Engine simulatorEngine,
+                                         int depth,
+                                         double rootAlpha,
+                                         double rootBeta,
+                                         boolean rootIsWhite,
+                                         long deadline,
+                                         int moveInt) {
+        double whiteAlpha = rootToWhiteAlpha(rootAlpha, rootBeta, rootIsWhite);
+        double whiteBeta = rootToWhiteBeta(rootAlpha, rootBeta, rootIsWhite);
+        return alphaBeta(simulatorEngine, depth, whiteAlpha, whiteBeta, !rootIsWhite, deadline, moveInt, 1, 0);
+    }
+
+    private static double orientScoreForRoot(boolean rootIsWhite, double whitePerspectiveScore) {
+        return rootIsWhite ? whitePerspectiveScore : -whitePerspectiveScore;
+    }
+
+    private static double rootToWhiteAlpha(double rootAlpha, double rootBeta, boolean rootIsWhite) {
+        return rootIsWhite ? rootAlpha : -rootBeta;
+    }
+
+    private static double rootToWhiteBeta(double rootAlpha, double rootBeta, boolean rootIsWhite) {
+        return rootIsWhite ? rootBeta : -rootAlpha;
+    }
+
+    private record RootMoveComputation(double whiteScore, double rootScore, boolean aborted) {
+        static RootMoveComputation abortedResult() {
+            return new RootMoveComputation(Double.NaN, Double.NaN, true);
+        }
     }
 
     private MoveAndScore createCandidate(int move, double score, boolean tablebaseExact) {

--- a/src/test/java/julius/game/chessengine/ai/AITest_MateThreatDiagnostics.java
+++ b/src/test/java/julius/game/chessengine/ai/AITest_MateThreatDiagnostics.java
@@ -389,12 +389,15 @@ class AITest_MateThreatDiagnostics {
             sb.append("Expected defensive resources: ")
                     .append(String.join(", ", lifesavingMoves)).append(System.lineSeparator());
 
+            boolean whiteToMove = fen.split(" ")[1].equals("w");
+
             sb.append("Search result: ");
             if (result == null) {
                 sb.append("<no move found>");
             } else {
+                double oriented = whiteToMove ? result.score : -result.score;
                 sb.append(formatMove(result.move)).append(" (score=")
-                        .append(String.format(Locale.ROOT, "%.2f", result.score)).append(')');
+                        .append(String.format(Locale.ROOT, "%.2f", oriented)).append(')');
             }
             sb.append(System.lineSeparator());
 

--- a/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
@@ -161,7 +161,7 @@ public final class BestMoveFixtures {
             ),
             new BestMoveTestCase(
                     "rn1qk2r/p1pbpp2/1p1p2pb/3P3p/1QPNPP2/2N4P/PP2B1P1/R4RK1 b kq - 0 14",
-                    List.of("O-O","c5", "e5", "a5", "a6", "a3")
+                    List.of("O-O", "c5", "e5", "a5", "a6")
             ),
             new BestMoveTestCase(
                     "r1b1kbnr/ppp1p1pp/3q4/2N2p2/1n1pP3/5N2/P1PP1PPP/R1BQKB1R w KQkq - 0 7",

--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -441,7 +441,7 @@ public class BestMoveSearchTest {
         // Compute cpLoss from the static evaluations of the best and chosen moves.
         // Skip only when either value is unavailable or non-finite.
         double cpLoss = Double.isFinite(bestScore) && Double.isFinite(chosenStaticScore)
-                ? bestScore - chosenStaticScore
+                ? Math.max(0.0, bestScore - chosenStaticScore)
                 : Double.NaN;
 
         double chosenDisplayedScore = chosenEvaluation != null ? chosenEvaluation.score() : Double.NaN;
@@ -847,12 +847,15 @@ public class BestMoveSearchTest {
                 sb.append("WARNING: target depth not reached before abort").append(System.lineSeparator());
             }
 
+            boolean whiteToMove = fen.split(" ")[1].equals("w");
+
             sb.append("Search result: ");
             if (result == null) {
                 sb.append("<no move found>");
             } else {
+                double oriented = orientScoreForMover(whiteToMove, result.score);
                 sb.append(formatMove(result.move)).append(" (score=")
-                        .append(String.format(Locale.ROOT, "%.2f", result.score)).append(')');
+                        .append(String.format(Locale.ROOT, "%.2f", oriented)).append(')');
             }
             sb.append(System.lineSeparator());
 
@@ -1783,12 +1786,10 @@ public class BestMoveSearchTest {
         }
 
         List<String> segments = new ArrayList<>(pv.size());
-        boolean moverIsWhite = whiteToMove;
         for (MoveAndScore moveAndScore : pv) {
             String notation = Move.convertIntToMove(moveAndScore.getMove()).toString();
-            double orientedScore = moverIsWhite ? moveAndScore.getScore() : -moveAndScore.getScore();
+            double orientedScore = orientScoreForMover(whiteToMove, moveAndScore.getScore());
             segments.add(notation + " (" + formatScore(orientedScore) + " pawns)");
-            moverIsWhite = !moverIsWhite;
         }
         return String.join(" -> ", segments);
     }


### PR DESCRIPTION
## Summary
- update the root search to perform proper PVS re-searches and orient windows from the mover’s perspective
- normalize search diagnostics and principal variation rendering to the side-to-move, ensuring cpLoss never goes negative
- remove an illegal move from the best-move fixtures so every listed candidate is legal

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -DskipTests package

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691236390a04832aa763cf3a57bbcb9d)