### PR TITLE
Fix root PVS search and normalize diagnostics scoring

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -230,6 +230,7 @@ public class AI {
     private static final double MATE_SCORE_MARGIN = 2048.0;
     private static final double TB_TIE_EPSILON = 0.01;
     private static final double TABLEBASE_CLAMP = 2000.0 / 100.0;
+    private static final double ROOT_PVS_EPSILON = 1e-3;
 
     private ScheduledExecutorService scheduler;
 
@@ -2044,14 +2045,12 @@ public class AI {
 
     private RootSearchResult getBestMove(Engine simulatorEngine, boolean isWhitesTurn, int depth, long deadline,
                                          double alpha, double beta, SplittableRandom rng) {
-        int bestMove = -1;
-        double bestScore = isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
-
-        boolean aborted = false;
-        boolean bestFromTablebase = false;
-
         IntArrayList sortedMoves = sortMovesByEfficiency(simulatorEngine.getAllLegalMoves(), depth,
                 simulatorEngine.getBoardStateHash(), -1, simulatorEngine);
+        if (sortedMoves.isEmpty()) {
+            return RootSearchResult.completed(null);
+        }
+
         maybeRotateRootMoves(sortedMoves, rng);
         promoteTablebaseMove(sortedMoves, simulatorEngine);
 
@@ -2065,50 +2064,150 @@ public class AI {
             }
         }
 
+        final double rootAlpha = toRootLowerBound(alpha, beta, isWhitesTurn);
+        final double rootBeta = toRootUpperBound(alpha, beta, isWhitesTurn);
+        final double[] fullWindowWhiteBounds = toWhiteBounds(rootAlpha, rootBeta, isWhitesTurn);
+
+        int bestMove = -1;
+        double bestScoreWhite = isWhitesTurn ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+        double bestScoreRoot = Double.NEGATIVE_INFINITY;
+        boolean bestFromTablebase = false;
+        boolean aborted = false;
+
+        double currentAlpha = rootAlpha;
+
         for (int idx = 0; idx < sortedMoves.size(); idx++) {
-            int moveInt = sortedMoves.getInt(idx);
             if (abortRequested(deadline)) {
                 aborted = true;
                 break;
             }
 
-            simulatorEngine.performMove(moveInt);
+            int moveInt = sortedMoves.getInt(idx);
+            boolean[] tablebaseFlag = new boolean[1];
+            double scoreWhite;
+
+            if (idx == 0) {
+                scoreWhite = evaluateRootChild(simulatorEngine, moveInt, depth, deadline,
+                        fullWindowWhiteBounds[0], fullWindowWhiteBounds[1], isWhitesTurn, tablebaseFlag);
+            } else {
+                double probeAlpha = Math.max(currentAlpha, bestScoreRoot);
+                double probeBeta = computeRootPvsBeta(probeAlpha, rootBeta);
+                double[] probeBounds = toWhiteBounds(probeAlpha, probeBeta, isWhitesTurn);
+
+                scoreWhite = evaluateRootChild(simulatorEngine, moveInt, depth, deadline,
+                        probeBounds[0], probeBounds[1], isWhitesTurn, tablebaseFlag);
+
+                double scoreRoot = normalizeForRoot(scoreWhite, isWhitesTurn);
+                if (scoreWhite != EXIT_FLAG && scoreRoot > currentAlpha && scoreRoot < rootBeta) {
+                    scoreWhite = evaluateRootChild(simulatorEngine, moveInt, depth, deadline,
+                            fullWindowWhiteBounds[0], fullWindowWhiteBounds[1], isWhitesTurn, tablebaseFlag);
+                }
+            }
+
+            if (scoreWhite == EXIT_FLAG) {
+                aborted = true;
+                break;
+            }
+
+            double scoreRoot = normalizeForRoot(scoreWhite, isWhitesTurn);
+
+            if (bestMove == -1 || scoreRoot > bestScoreRoot) {
+                bestMove = moveInt;
+                bestScoreWhite = scoreWhite;
+                bestScoreRoot = scoreRoot;
+                bestFromTablebase = tablebaseFlag[0];
+            }
+
+            if (scoreRoot > currentAlpha) {
+                currentAlpha = scoreRoot;
+            }
+
+            if (currentAlpha >= rootBeta) {
+                break;
+            }
+        }
+
+        MoveAndScore candidate = bestMove != -1 ? createCandidate(bestMove, bestScoreWhite, bestFromTablebase) : null;
+        return aborted ? RootSearchResult.aborted(candidate) : RootSearchResult.completed(candidate);
+    }
+
+    private double evaluateRootChild(Engine simulatorEngine, int moveInt, int depth, long deadline,
+                                     double alphaWhite, double betaWhite, boolean parentIsWhite,
+                                     boolean[] tablebaseExactHolder) {
+        simulatorEngine.performMove(moveInt);
+        double score;
+        boolean moveTablebaseExact = false;
+        try {
             long childHash = simulatorEngine.getBoardStateHash();
-            double score;
-            boolean moveTablebaseExact = false;
             if (simulatorEngine.getGameState().isInStateCheckMate()) {
-                score = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
+                score = parentIsWhite ? (CHECKMATE - 1) : -(CHECKMATE - 1);
             } else if (simulatorEngine.getGameState().isTerminal()) {
-                score = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !isWhitesTurn, depth);
-                if (isWhitesTurn) score = -score; // convert to WHITE-perspective
+                score = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !parentIsWhite, depth);
+                if (parentIsWhite) score = -score;
             } else {
                 Optional<TablebaseResult> childTablebase = resolveExactTablebaseResult(simulatorEngine);
                 if (childTablebase.isPresent()) {
                     moveTablebaseExact = true;
-                    score = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !isWhitesTurn, depth);
-                    if (isWhitesTurn) score = -score; // to WHITE-perspective
+                    score = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !parentIsWhite, depth);
+                    if (parentIsWhite) score = -score;
                 } else {
-                    score = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, moveInt, 1, 0);
-                    if (score == EXIT_FLAG || abortRequested(deadline)) {
-                        simulatorEngine.undoLastMove();
-                        aborted = true;
-                        break;
-                    }
+                    score = alphaBeta(simulatorEngine, depth - 1, alphaWhite, betaWhite,
+                            !parentIsWhite, deadline, moveInt, 1, 0);
                 }
             }
+        } finally {
             simulatorEngine.undoLastMove();
-
-            if (isBetterScore(isWhitesTurn, score, bestScore)) {
-                bestScore = score;
-                bestMove = moveInt;
-                bestFromTablebase = moveTablebaseExact;
-            }
-            if (isWhitesTurn) alpha = Math.max(alpha, score);
-            else beta = Math.min(beta, score);
-            if (alpha >= beta) break;
         }
-        MoveAndScore candidate = bestMove != -1 ? createCandidate(bestMove, bestScore, bestFromTablebase) : null;
-        return aborted ? RootSearchResult.aborted(candidate) : RootSearchResult.completed(candidate);
+
+        if (tablebaseExactHolder != null) {
+            tablebaseExactHolder[0] = moveTablebaseExact;
+        }
+
+        if (score == EXIT_FLAG || abortRequested(deadline)) {
+            return EXIT_FLAG;
+        }
+
+        return score;
+    }
+
+    private static double toRootLowerBound(double alphaWhite, double betaWhite, boolean rootIsWhite) {
+        if (rootIsWhite) {
+            return alphaWhite;
+        }
+        return -betaWhite;
+    }
+
+    private static double toRootUpperBound(double alphaWhite, double betaWhite, boolean rootIsWhite) {
+        if (rootIsWhite) {
+            return betaWhite;
+        }
+        return -alphaWhite;
+    }
+
+    private static double[] toWhiteBounds(double rootAlpha, double rootBeta, boolean rootIsWhite) {
+        if (rootIsWhite) {
+            return new double[]{rootAlpha, rootBeta};
+        }
+        return new double[]{-rootBeta, -rootAlpha};
+    }
+
+    private static double computeRootPvsBeta(double alpha, double beta) {
+        if (Double.compare(alpha, Double.NEGATIVE_INFINITY) == 0) {
+            return beta;
+        }
+        double epsilon = Math.max(ROOT_PVS_EPSILON, Math.ulp(alpha));
+        double candidate = alpha + epsilon;
+        if (candidate > beta) {
+            candidate = beta;
+        }
+        if (candidate <= alpha) {
+            candidate = Math.nextUp(alpha);
+        }
+        return candidate;
+    }
+
+    private static double normalizeForRoot(double whiteScore, boolean rootIsWhite) {
+        return rootIsWhite ? whiteScore : -whiteScore;
     }
 
     private MoveAndScore createCandidate(int move, double score, boolean tablebaseExact) {

--- a/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
@@ -161,7 +161,7 @@ public final class BestMoveFixtures {
             ),
             new BestMoveTestCase(
                     "rn1qk2r/p1pbpp2/1p1p2pb/3P3p/1QPNPP2/2N4P/PP2B1P1/R4RK1 b kq - 0 14",
-                    List.of("O-O","c5", "e5", "a5", "a6", "a3")
+                    List.of("O-O","c5", "e5", "a5", "a6")
             ),
             new BestMoveTestCase(
                     "r1b1kbnr/ppp1p1pp/3q4/2N2p2/1n1pP3/5N2/P1PP1PPP/R1BQKB1R w KQkq - 0 7",

--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -441,7 +441,7 @@ public class BestMoveSearchTest {
         // Compute cpLoss from the static evaluations of the best and chosen moves.
         // Skip only when either value is unavailable or non-finite.
         double cpLoss = Double.isFinite(bestScore) && Double.isFinite(chosenStaticScore)
-                ? bestScore - chosenStaticScore
+                ? Math.max(0.0, bestScore - chosenStaticScore)
                 : Double.NaN;
 
         double chosenDisplayedScore = chosenEvaluation != null ? chosenEvaluation.score() : Double.NaN;
@@ -1324,7 +1324,7 @@ public class BestMoveSearchTest {
 
             if (bestEvaluation != null) {
                 double deltaVsChosen = chosenEvaluation != null && Double.isFinite(cpLoss)
-                        ? -cpLoss
+                        ? cpLoss
                         : Double.NaN;
                 sb.append("Engine top move: ").append(bestEvaluation.move())
                         .append(" -> ").append(formatScore(bestEvaluation.score())).append(" pawns");
@@ -1372,7 +1372,7 @@ public class BestMoveSearchTest {
 
             if (Double.isFinite(cpLoss)) {
                 sb.append("Evaluation delta vs engine best: ")
-                        .append(formatScore(-cpLoss)).append(" pawns")
+                        .append(formatScore(cpLoss)).append(" pawns")
                         .append(System.lineSeparator());
             }
 
@@ -1783,12 +1783,10 @@ public class BestMoveSearchTest {
         }
 
         List<String> segments = new ArrayList<>(pv.size());
-        boolean moverIsWhite = whiteToMove;
         for (MoveAndScore moveAndScore : pv) {
             String notation = Move.convertIntToMove(moveAndScore.getMove()).toString();
-            double orientedScore = moverIsWhite ? moveAndScore.getScore() : -moveAndScore.getScore();
-            segments.add(notation + " (" + formatScore(orientedScore) + " pawns)");
-            moverIsWhite = !moverIsWhite;
+            double normalized = orientScoreForMover(whiteToMove, moveAndScore.getScore());
+            segments.add(notation + " (" + formatScore(normalized) + " pawns)");
         }
         return String.join(" -> ", segments);
     }


### PR DESCRIPTION
## Summary
- implement a fail-hard root search with proper PVS re-search windows and helper conversions in `AI`
- normalize principal-variation output and cpLoss reporting to the mover's perspective in the diagnostics harness
- remove an illegal root candidate from the best-move fixtures

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=BestMoveEvaluationDiagnosticsTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691237fdac88832ab877c5d4053297ab)