### PR TITLE
Fix root PVS handling and normalize evaluation reporting

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -1601,34 +1601,15 @@ public class AI {
             return RootSearchResult.aborted(null);
         }
 
-        simulatorEngine.performMove(firstMove);
-        long firstMoveHash = simulatorEngine.getBoardStateHash();
-        double firstScore;
-        boolean firstTablebaseExact = false;
-        if (simulatorEngine.getGameState().isInStateCheckMate()) {
-            firstScore = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
-        } else if (simulatorEngine.getGameState().isTerminal()) {
-            firstScore = evaluateStaticPosition(simulatorEngine.getGameState(), firstMoveHash, !isWhitesTurn, depth);
-            if (isWhitesTurn) firstScore = -firstScore;
-        } else {
-            Optional<TablebaseResult> firstTablebase = resolveExactTablebaseResult(simulatorEngine);
-            if (firstTablebase.isPresent()) {
-                firstTablebaseExact = true;
-                firstScore = evaluateStaticPosition(simulatorEngine.getGameState(), firstMoveHash, !isWhitesTurn, depth);
-                if (isWhitesTurn) firstScore = -firstScore;
-            } else {
-                firstScore = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, firstMove, 1, 0);
-                if (firstScore == EXIT_FLAG || abortRequested(deadline)) {
-                    simulatorEngine.undoLastMove();
-                    return RootSearchResult.aborted(null);
-                }
-            }
+        RootMoveEvaluation firstEvaluation = evaluateRootMove(simulatorEngine, isWhitesTurn, depth, deadline,
+                alpha, beta, firstMove, true);
+        if (firstEvaluation.aborted()) {
+            return RootSearchResult.aborted(null);
         }
-        simulatorEngine.undoLastMove();
 
         bestMove = firstMove;
-        bestScore = firstScore;
-        bestFromTablebase = firstTablebaseExact;
+        bestScore = firstEvaluation.score();
+        bestFromTablebase = firstEvaluation.tablebaseExact();
 
         if (logFanout) {
             log.info("Root fanout diag start: task={}, depth={}, legalMoves={}, helperCapacity={}, baseFanout={}, fanout={}, firstMove={}",
@@ -1636,8 +1617,8 @@ public class AI {
                     Move.convertIntToMove(firstMove));
         }
 
-        if (isWhitesTurn) alpha = Math.max(alpha, firstScore);
-        else beta = Math.min(beta, firstScore);
+        if (isWhitesTurn) alpha = Math.max(alpha, bestScore);
+        else beta = Math.min(beta, bestScore);
         if (alpha >= beta) {
             MoveAndScore candidate = createCandidate(bestMove, bestScore, bestFromTablebase);
             return RootSearchResult.completed(candidate);
@@ -1822,33 +1803,15 @@ public class AI {
 
                 int moveInt = orderedMoves.getInt(i);
                 sequentialProcessed++;
-                simulatorEngine.performMove(moveInt);
-
-                double score;
-                boolean moveTablebaseExact = false;
-                if (simulatorEngine.getGameState().isInStateCheckMate()) {
-                    score = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
-                } else if (simulatorEngine.getGameState().isTerminal()) {
-                    long childHash = simulatorEngine.getBoardStateHash();
-                    score = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !isWhitesTurn, depth);
-                    if (isWhitesTurn) score = -score;
-                } else {
-                    Optional<TablebaseResult> childTablebase = resolveExactTablebaseResult(simulatorEngine);
-                    if (childTablebase.isPresent()) {
-                        moveTablebaseExact = true;
-                        long childHash = simulatorEngine.getBoardStateHash();
-                        score = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !isWhitesTurn, depth);
-                        if (isWhitesTurn) score = -score;
-                    } else {
-                        score = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, moveInt, 1, 0);
-                        if (score == EXIT_FLAG || abortRequested(deadline)) {
-                            simulatorEngine.undoLastMove();
-                            aborted = true;
-                            break;
-                        }
-                    }
+                RootMoveEvaluation evaluation = evaluateRootMove(simulatorEngine, isWhitesTurn, depth, deadline,
+                        alpha, beta, moveInt, false);
+                if (evaluation.aborted()) {
+                    aborted = true;
+                    break;
                 }
-                simulatorEngine.undoLastMove();
+
+                double score = evaluation.score();
+                boolean moveTablebaseExact = evaluation.tablebaseExact();
 
                 if (isBetterScore(isWhitesTurn, score, bestScore)) {
                     bestScore = score;
@@ -2072,43 +2035,134 @@ public class AI {
                 break;
             }
 
-            simulatorEngine.performMove(moveInt);
-            long childHash = simulatorEngine.getBoardStateHash();
-            double score;
-            boolean moveTablebaseExact = false;
-            if (simulatorEngine.getGameState().isInStateCheckMate()) {
-                score = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
-            } else if (simulatorEngine.getGameState().isTerminal()) {
-                score = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !isWhitesTurn, depth);
-                if (isWhitesTurn) score = -score; // convert to WHITE-perspective
-            } else {
-                Optional<TablebaseResult> childTablebase = resolveExactTablebaseResult(simulatorEngine);
-                if (childTablebase.isPresent()) {
-                    moveTablebaseExact = true;
-                    score = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !isWhitesTurn, depth);
-                    if (isWhitesTurn) score = -score; // to WHITE-perspective
-                } else {
-                    score = alphaBeta(simulatorEngine, depth - 1, alpha, beta, !isWhitesTurn, deadline, moveInt, 1, 0);
-                    if (score == EXIT_FLAG || abortRequested(deadline)) {
-                        simulatorEngine.undoLastMove();
-                        aborted = true;
-                        break;
-                    }
-                }
+            RootMoveEvaluation evaluation = evaluateRootMove(simulatorEngine, isWhitesTurn, depth, deadline,
+                    alpha, beta, moveInt, idx == 0);
+            if (evaluation.aborted()) {
+                aborted = true;
+                break;
             }
-            simulatorEngine.undoLastMove();
+
+            double score = evaluation.score();
+            boolean moveTablebaseExact = evaluation.tablebaseExact();
 
             if (isBetterScore(isWhitesTurn, score, bestScore)) {
                 bestScore = score;
                 bestMove = moveInt;
                 bestFromTablebase = moveTablebaseExact;
             }
-            if (isWhitesTurn) alpha = Math.max(alpha, score);
-            else beta = Math.min(beta, score);
-            if (alpha >= beta) break;
+            if (isWhitesTurn) {
+                alpha = Math.max(alpha, score);
+            } else {
+                beta = Math.min(beta, score);
+            }
+            if (alpha >= beta) {
+                break;
+            }
         }
         MoveAndScore candidate = bestMove != -1 ? createCandidate(bestMove, bestScore, bestFromTablebase) : null;
         return aborted ? RootSearchResult.aborted(candidate) : RootSearchResult.completed(candidate);
+    }
+
+    private RootMoveEvaluation evaluateRootMove(Engine simulatorEngine,
+                                                boolean isWhitesTurn,
+                                                int depth,
+                                                long deadline,
+                                                double alpha,
+                                                double beta,
+                                                int moveInt,
+                                                boolean firstMove) {
+        simulatorEngine.performMove(moveInt);
+        try {
+            if (abortRequested(deadline)) {
+                return RootMoveEvaluation.abortedResult();
+            }
+
+            GameState gameState = simulatorEngine.getGameState();
+            long childHash = simulatorEngine.getBoardStateHash();
+
+            if (gameState.isInStateCheckMate()) {
+                double score = isWhitesTurn ? (CHECKMATE - 1) : -(CHECKMATE - 1);
+                return RootMoveEvaluation.of(score, false);
+            }
+            if (gameState.isTerminal()) {
+                double score = evaluateStaticPosition(gameState, childHash, !isWhitesTurn, depth);
+                if (isWhitesTurn) score = -score;
+                return RootMoveEvaluation.of(score, false);
+            }
+
+            Optional<TablebaseResult> childTablebase = resolveExactTablebaseResult(simulatorEngine);
+            if (childTablebase.isPresent()) {
+                double score = evaluateStaticPosition(gameState, childHash, !isWhitesTurn, depth);
+                if (isWhitesTurn) score = -score;
+                return RootMoveEvaluation.of(score, true);
+            }
+
+            double searchAlpha = alpha;
+            double searchBeta = beta;
+            boolean usePvsWindow = !firstMove;
+            if (usePvsWindow) {
+                if (isWhitesTurn) {
+                    if (!Double.isFinite(alpha)) {
+                        usePvsWindow = false;
+                    } else {
+                        double candidate = Math.nextAfter(alpha, Double.POSITIVE_INFINITY);
+                        if (!(candidate > alpha)) {
+                            usePvsWindow = false;
+                        } else if (Double.isFinite(beta) && candidate >= beta) {
+                            usePvsWindow = false;
+                        } else {
+                            searchBeta = candidate;
+                        }
+                    }
+                } else {
+                    if (!Double.isFinite(beta)) {
+                        usePvsWindow = false;
+                    } else {
+                        double candidate = Math.nextAfter(beta, Double.NEGATIVE_INFINITY);
+                        if (!(candidate < beta)) {
+                            usePvsWindow = false;
+                        } else if (Double.isFinite(alpha) && candidate <= alpha) {
+                            usePvsWindow = false;
+                        } else {
+                            searchAlpha = candidate;
+                        }
+                    }
+                }
+            }
+
+            double probe = alphaBeta(simulatorEngine, depth - 1, searchAlpha, searchBeta,
+                    !isWhitesTurn, deadline, moveInt, 1, 0);
+            if (probe == EXIT_FLAG || abortRequested(deadline)) {
+                return RootMoveEvaluation.abortedResult();
+            }
+
+            double resultScore = probe;
+            if (usePvsWindow) {
+                boolean failHigh = isWhitesTurn ? resultScore > alpha : resultScore < beta;
+                if (failHigh) {
+                    double full = alphaBeta(simulatorEngine, depth - 1, alpha, beta,
+                            !isWhitesTurn, deadline, moveInt, 1, 0);
+                    if (full == EXIT_FLAG || abortRequested(deadline)) {
+                        return RootMoveEvaluation.abortedResult();
+                    }
+                    resultScore = full;
+                }
+            }
+
+            return RootMoveEvaluation.of(resultScore, false);
+        } finally {
+            simulatorEngine.undoLastMove();
+        }
+    }
+
+    private record RootMoveEvaluation(double score, boolean tablebaseExact, boolean aborted) {
+        static RootMoveEvaluation abortedResult() {
+            return new RootMoveEvaluation(Double.NaN, false, true);
+        }
+
+        static RootMoveEvaluation of(double score, boolean tablebaseExact) {
+            return new RootMoveEvaluation(score, tablebaseExact, false);
+        }
     }
 
     private MoveAndScore createCandidate(int move, double score, boolean tablebaseExact) {

--- a/src/test/java/julius/game/chessengine/ai/BestMoveEvaluationDiagnosticsTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveEvaluationDiagnosticsTest.java
@@ -70,7 +70,7 @@ class BestMoveEvaluationDiagnosticsTest {
             int moveInt = legalMoves.getInt(i);
             engine.performMove(moveInt);
             double scoreDiff = engine.getGameState().getScore().getScoreDifference();
-            double orientedScore = orientScoreForMover(whiteToMove, scoreDiff);
+            double orientedScore = normalizeScoreForRoot(whiteToMove, scoreDiff);
             engine.undoLastMove();
             evaluations.add(new MoveEvaluation(Move.convertIntToMove(moveInt).toString(), orientedScore));
         }
@@ -89,7 +89,9 @@ class BestMoveEvaluationDiagnosticsTest {
                 .toList();
         MoveEvaluation bestExpected = expectedEvaluations.isEmpty() ? null : expectedEvaluations.getFirst();
 
-        double cpLoss = (bestMove != null && bestExpected != null) ? bestMove.score() - bestExpected.score() : Double.NaN;
+        double cpLoss = (bestMove != null && bestExpected != null)
+                ? Math.max(0.0, bestMove.score() - bestExpected.score())
+                : Double.NaN;
         List<MoveEvaluation> topCandidates = evaluations.subList(0, Math.min(5, evaluations.size()));
 
         return new EvaluationGap(
@@ -146,8 +148,8 @@ class BestMoveEvaluationDiagnosticsTest {
         return sb.toString();
     }
 
-    private static double orientScoreForMover(boolean whiteToMove, double scoreDifference) {
-        return whiteToMove ? scoreDifference : -scoreDifference;
+    private static double normalizeScoreForRoot(boolean whiteToMove, double whitePerspectiveScore) {
+        return whiteToMove ? whitePerspectiveScore : -whitePerspectiveScore;
     }
 
     private static String formatCentipawns(double centipawns) {

--- a/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveFixtures.java
@@ -161,7 +161,7 @@ public final class BestMoveFixtures {
             ),
             new BestMoveTestCase(
                     "rn1qk2r/p1pbpp2/1p1p2pb/3P3p/1QPNPP2/2N4P/PP2B1P1/R4RK1 b kq - 0 14",
-                    List.of("O-O","c5", "e5", "a5", "a6", "a3")
+                    List.of("O-O","c5", "e5", "a5", "a6")
             ),
             new BestMoveTestCase(
                     "r1b1kbnr/ppp1p1pp/3q4/2N2p2/1n1pP3/5N2/P1PP1PPP/R1BQKB1R w KQkq - 0 7",

--- a/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
+++ b/src/test/java/julius/game/chessengine/ai/BestMoveSearchTest.java
@@ -374,7 +374,7 @@ public class BestMoveSearchTest {
         analysisEngine.importBoardFromFen(fen);
 
         boolean whiteToMove = fen.split(" ")[1].equals("w");
-        double baselineForMover = orientScoreForMover(
+        double baselineForMover = normalizeScoreForRoot(
                 whiteToMove,
                 analysisEngine.getGameState().getScore().getScoreDifference()
         );
@@ -392,7 +392,7 @@ public class BestMoveSearchTest {
         for (int moveInt : legalMoves) {
             analysisEngine.performMove(moveInt);
             double scoreDiff = analysisEngine.getGameState().getScore().getScoreDifference();
-            double moverScore = orientScoreForMover(whiteToMove, scoreDiff);
+            double moverScore = normalizeScoreForRoot(whiteToMove, scoreDiff);
             analysisEngine.undoLastMove();
 
             String san = Move.convertIntToMove(moveInt).toString();
@@ -415,7 +415,7 @@ public class BestMoveSearchTest {
         MoveEvaluation staticChosenEvaluation = evaluationMap.get(chosenMove);
         MoveEvaluation chosenEvaluation = staticChosenEvaluation;
         if (searchResult != null) {
-            double oriented = orientScoreForMover(whiteToMove, searchResult.getScore());
+            double oriented = normalizeScoreForRoot(whiteToMove, searchResult.getScore());
             chosenEvaluation = new MoveEvaluation(chosenMove, oriented);
         }
 
@@ -441,7 +441,7 @@ public class BestMoveSearchTest {
         // Compute cpLoss from the static evaluations of the best and chosen moves.
         // Skip only when either value is unavailable or non-finite.
         double cpLoss = Double.isFinite(bestScore) && Double.isFinite(chosenStaticScore)
-                ? bestScore - chosenStaticScore
+                ? Math.max(0.0, bestScore - chosenStaticScore)
                 : Double.NaN;
 
         double chosenDisplayedScore = chosenEvaluation != null ? chosenEvaluation.score() : Double.NaN;
@@ -841,6 +841,8 @@ public class BestMoveSearchTest {
             sb.append("Expected best moves: ")
                     .append(String.join(", ", expectedMoves)).append(System.lineSeparator());
 
+            boolean whiteToMove = fen.split(" ")[1].equals("w");
+
             sb.append(depthCoverageSummary()).append(System.lineSeparator());
             int target = targetDepth;
             if (target > 0 && deepestCompletedDepth() < target) {
@@ -851,8 +853,9 @@ public class BestMoveSearchTest {
             if (result == null) {
                 sb.append("<no move found>");
             } else {
+                double normalized = normalizeScoreForRoot(whiteToMove, result.score);
                 sb.append(formatMove(result.move)).append(" (score=")
-                        .append(String.format(Locale.ROOT, "%.2f", result.score)).append(')');
+                        .append(String.format(Locale.ROOT, "%.2f", normalized)).append(')');
             }
             sb.append(System.lineSeparator());
 
@@ -1010,7 +1013,7 @@ public class BestMoveSearchTest {
             void record(int moveInt, int order, EvaluationResult evaluation, long nodesSpent, long nanosSpent,
                         double alphaBefore, double betaBefore, double alphaAfter, double betaAfter) {
                 moves.add(new RootMoveTrace(moveInt, order, evaluation, nodesSpent, nanosSpent,
-                        alphaBefore, betaBefore, alphaAfter, betaAfter));
+                        alphaBefore, betaBefore, alphaAfter, betaAfter, this.whiteToMove));
             }
 
             void addNote(String note) {
@@ -1101,9 +1104,11 @@ public class BestMoveSearchTest {
             private final double betaBefore;
             private final double alphaAfter;
             private final double betaAfter;
+            private final boolean rootWhiteToMove;
 
             RootMoveTrace(int moveInt, int order, EvaluationResult evaluation, long nodesSpent, long nanosSpent,
-                          double alphaBefore, double betaBefore, double alphaAfter, double betaAfter) {
+                          double alphaBefore, double betaBefore, double alphaAfter, double betaAfter,
+                          boolean rootWhiteToMove) {
                 this.moveInt = moveInt;
                 this.order = order;
                 this.evaluation = evaluation;
@@ -1113,6 +1118,7 @@ public class BestMoveSearchTest {
                 this.betaBefore = betaBefore;
                 this.alphaAfter = alphaAfter;
                 this.betaAfter = betaAfter;
+                this.rootWhiteToMove = rootWhiteToMove;
             }
 
             int order() {
@@ -1138,7 +1144,8 @@ public class BestMoveSearchTest {
                 } else if (evaluation.score == null) {
                     sb.append("<none>");
                 } else {
-                    sb.append(String.format(Locale.ROOT, "%.2f", evaluation.score));
+                    double oriented = normalizeScoreForRoot(rootWhiteToMove, evaluation.score);
+                    sb.append(String.format(Locale.ROOT, "%.2f", oriented));
                 }
 
                 sb.append(" (via ").append(evaluation.reason).append(')');
@@ -1783,18 +1790,21 @@ public class BestMoveSearchTest {
         }
 
         List<String> segments = new ArrayList<>(pv.size());
-        boolean moverIsWhite = whiteToMove;
-        for (MoveAndScore moveAndScore : pv) {
+        for (int i = 0; i < pv.size(); i++) {
+            MoveAndScore moveAndScore = pv.get(i);
             String notation = Move.convertIntToMove(moveAndScore.getMove()).toString();
-            double orientedScore = moverIsWhite ? moveAndScore.getScore() : -moveAndScore.getScore();
-            segments.add(notation + " (" + formatScore(orientedScore) + " pawns)");
-            moverIsWhite = !moverIsWhite;
+            if (i == 0) {
+                double orientedScore = normalizeScoreForRoot(whiteToMove, moveAndScore.getScore());
+                segments.add(notation + " (" + formatScore(orientedScore) + " pawns)");
+            } else {
+                segments.add(notation);
+            }
         }
         return String.join(" -> ", segments);
     }
 
-    private static double orientScoreForMover(boolean whiteToMove, double scoreDifference) {
-        return whiteToMove ? scoreDifference : -scoreDifference;
+    private static double normalizeScoreForRoot(boolean whiteToMove, double whitePerspectiveScore) {
+        return whiteToMove ? whitePerspectiveScore : -whitePerspectiveScore;
     }
 
     private static String formatScore(double pawns) {


### PR DESCRIPTION
## Summary
- add a reusable root-move evaluation helper so sequential and parallel root searches perform proper PVS re-searches instead of clamping scores
- normalise diagnostic reporting to the side-to-move, clamp cp-loss at zero, and show a single PV score for the root move
- drop the illegal `a3` entry from the affected test fixture

## Testing
- mvn -Djava.version=21 -Dmaven.compiler.release=21 -Dmaven.compiler.enablePreview=true -DargLine="--enable-preview" -Dtest=BestMoveEvaluationDiagnosticsTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691237fdac88832ab877c5d4053297ab)