### PR TITLE
v3.9.9: Phase 2 - Deep AI refactoring (qsearch, move ordering, search helpers)

### DIFF
--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -10,10 +10,7 @@ import julius.game.chessengine.engine.Engine;
 import julius.game.chessengine.engine.GameState;
 import julius.game.chessengine.engine.GameStateEnum;
 import julius.game.chessengine.evaluation.EvaluationContext;
-import julius.game.chessengine.syzygy.SyzygyMove;
-import julius.game.chessengine.syzygy.SyzygyProbeResult;
 import julius.game.chessengine.syzygy.SyzygyTablebaseService;
-import julius.game.chessengine.syzygy.SyzygyWdl;
 import julius.game.chessengine.syzygy.TablebaseResult;
 import julius.game.chessengine.tuning.AiTuning;
 import julius.game.chessengine.tuning.AspirationParameters;
@@ -34,7 +31,6 @@ import java.util.function.IntFunction;
 
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.locks.StampedLock;
 
 import static julius.game.chessengine.helper.BitHelper.FileMasks;
 import static julius.game.chessengine.helper.KingHelper.KING_ATTACKS;
@@ -140,7 +136,6 @@ public class AI {
 
     private final MoveOrderer moveOrderer;
     private final MoveOrderingParameters.Snapshot moveOrderingParameters;
-    private final MoveBucket[] moveBucketOrder;
     private final double moveOrderingHistoryScale;
     private final int moveOrderingHistoryDecayDivisor;
     private final SearchPruningParameters.Snapshot searchPruningParameters;
@@ -154,8 +149,6 @@ public class AI {
     private final double nullSwingGuardDivisor;
     private final double quiescenceMaxDeltaPawn;
     private final double drawBias;
-    private final double ttMainWeight;
-    private final double ttCaptureWeight;
 
     /**
      * Per-thread heuristic state used during move ordering. The tables are
@@ -315,7 +308,6 @@ public class AI {
 
         this.moveOrderingParameters = MoveOrderingParameters.snapshot();
         this.moveOrderer = new MoveOrderer(this.moveOrderingParameters);
-        this.moveBucketOrder = moveOrderer.getBucketOrder();
         this.moveOrderingHistoryScale = Math.max(0.0, moveOrderingParameters.historyScale());
         this.moveOrderingHistoryDecayDivisor = Math.max(1, moveOrderingParameters.historyDecayDivisor());
         this.searchPruningParameters = SearchPruningParameters.snapshot();
@@ -332,8 +324,8 @@ public class AI {
         this.nullSwingGuardDivisor = Math.max(1e-9, Tuning.searchNullSwingGuardDivisor());
         this.quiescenceMaxDeltaPawn = Tuning.searchQsMaxDeltaPawn();
         this.drawBias = Tuning.searchDrawBias();
-        this.ttMainWeight = Math.max(1e-9, Tuning.searchTtMainWeight());
-        this.ttCaptureWeight = Math.max(1e-9, Tuning.searchTtCaptureWeight());
+        double ttMainWeight = Math.max(1e-9, Tuning.searchTtMainWeight());
+        double ttCaptureWeight = Math.max(1e-9, Tuning.searchTtCaptureWeight());
         this.globalHeuristics = new Heuristics(maxDepth);
         this.threadHeuristics = ThreadLocal.withInitial(() -> new Heuristics(maxDepth));
 

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2162,130 +2162,32 @@ public class AI {
     }
 
     private boolean attacksOpponentQueenNow(Engine e, boolean moverIsWhite) {
-        BitBoard bb = e.getBitBoard();
-        long enemyQueen = moverIsWhite ? bb.getBlackQueens() : bb.getWhiteQueens();
-        if (enemyQueen == 0) return false;
-        long myAttacks = bb.getAttackBitboard(moverIsWhite);
-        return (myAttacks & enemyQueen) != 0L;
+        return SearchHelpers.attacksOpponentQueenNow(e, moverIsWhite);
     }
 
     private boolean attacksOpponentKingZone(Engine e, boolean moverIsWhite) {
-        BitBoard bb = e.getBitBoard();
-        long enemyKing = moverIsWhite ? bb.getBlackKing() : bb.getWhiteKing();
-        if (enemyKing == 0L) {
-            return false;
-        }
-        int kingIndex = Long.numberOfTrailingZeros(enemyKing);
-        long kingZone = KING_ATTACKS[kingIndex];
-        long myAttacks = bb.getAttackBitboard(moverIsWhite);
-        return (myAttacks & kingZone) != 0L;
+        return SearchHelpers.attacksOpponentKingZone(e, moverIsWhite);
     }
 
     private int computeNullMoveReduction(BitBoard board, int depth, boolean isWhite, int mobility) {
-        int maxReduction = depth - 2;
-        if (maxReduction <= 0) {
-            return 0;
-        }
-
-        long pieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
-        long pawns = isWhite ? board.getWhitePawns() : board.getBlackPawns();
-        int nonPawnMaterial = Long.bitCount(pieces) - Long.bitCount(pawns);
-        if (nonPawnMaterial < 0) {
-            nonPawnMaterial = 0;
-        }
-
-        double reductionEstimate = getReductionEstimate(depth, mobility, nonPawnMaterial);
-
-        int reduction = (int) Math.floor(Math.max(0.0, reductionEstimate));
-        return Math.min(reduction, maxReduction);
-    }
-
-    private double getReductionEstimate(int depth, int mobility, int nonPawnMaterial) {
-        int depthCap = Math.max(1, nullMoveParameters.depthCap());
-        int materialCap = Math.max(1, nullMoveParameters.materialCap());
-        int mobilityCap = Math.max(1, nullMoveParameters.mobilityCap());
-
-        double depthFactor = Math.min(Math.max(depth, 0), depthCap) / (double) depthCap;
-        double materialFactor = Math.min(Math.max(nonPawnMaterial, 0), materialCap) / (double) materialCap;
-        double mobilityFactor = Math.min(Math.max(mobility, 0), mobilityCap) / (double) mobilityCap;
-
-        double reductionEstimate = nullMoveParameters.baseReduction()
-                + (depthFactor * nullMoveParameters.depthWeight())
-                + (materialFactor * nullMoveParameters.materialWeight())
-                + (mobilityFactor * nullMoveParameters.mobilityWeight());
-
-        if (nonPawnMaterial <= nullMoveParameters.lowMaterialThreshold()
-                || mobility <= nullMoveParameters.lowMobilityThreshold()) {
-            reductionEstimate -= nullMoveParameters.lowMaterialPenalty();
-        }
-        if (mobility <= nullMoveParameters.veryLowMobilityThreshold()) {
-            reductionEstimate -= nullMoveParameters.veryLowMobilityPenalty();
-        }
-        return reductionEstimate;
+        return SearchHelpers.computeNullMoveReduction(board, depth, isWhite, mobility, nullMoveParameters);
     }
 
     private int countPawnsOnFile(BitBoard board, long fileMask) {
-        if (fileMask == 0L) {
-            return 0;
-        }
-        long pawns = (board.getWhitePawns() | board.getBlackPawns()) & fileMask;
-        return Long.bitCount(pawns);
+        return SearchHelpers.countPawnsOnFile(board, fileMask);
     }
 
     private boolean openedFileTowardKing(BitBoard boardAfterMove, long kingFileMask,
                                          int pawnsBefore, boolean interactsWithKingFile) {
-        if (!interactsWithKingFile || kingFileMask == 0L || pawnsBefore <= 0) {
-            return false;
-        }
-        int pawnsAfter = countPawnsOnFile(boardAfterMove, kingFileMask);
-        return pawnsAfter < pawnsBefore;
+        return SearchHelpers.openedFileTowardKing(boardAfterMove, kingFileMask, pawnsBefore, interactsWithKingFile);
     }
 
     private int lmrReduction(int depth, int moveIndex, int historyScore) {
-        if (depth <= 1) {
-            return 0;
-        }
-
-        int clampedDepth = Math.min(depth, LMR_MAX_DEPTH);
-        int clampedMoveIndex = Math.max(0, Math.min(moveIndex, LMR_MAX_MOVES - 1));
-
-        int historyReductionMax = Math.max(0, searchPruningParameters.historyReductionMax());
-        int history = Math.max(0, Math.min(historyScore, historyReductionMax));
-        double normalized = historyReductionMax == 0
-                ? 0.0
-                : history / (double) historyReductionMax;
-        int buckets = Math.max(1, lmrBucketCount);
-        double bucketPosition = buckets == 1 ? 0.0 : normalized * (buckets - 1);
-        int lowerBucket = Math.max(0, (int) Math.floor(bucketPosition));
-        int upperBucket = Math.min(buckets - 1, lowerBucket + 1);
-        double fraction = bucketPosition - lowerBucket;
-
-        int lowerValue = lmrReductionTable[clampedDepth][clampedMoveIndex][lowerBucket];
-        if (upperBucket == lowerBucket) {
-            return Math.min(lowerValue, depth - 1);
-        }
-
-        int upperValue = lmrReductionTable[clampedDepth][clampedMoveIndex][upperBucket];
-        double interpolated = lowerValue + fraction * (upperValue - lowerValue);
-        int reduction = (int) Math.floor(interpolated + 1e-9);
-        int maxReduction = Math.max(0, depth - 1);
-        if (reduction < 0) {
-            reduction = 0;
-        }
-        if (reduction > maxReduction) {
-            reduction = maxReduction;
-        }
-        return reduction;
+        return SearchHelpers.lmrReduction(depth, moveIndex, historyScore, lmrReductionTable, lmrBucketCount, searchPruningParameters);
     }
 
     private int futilityMarginForRemainingDepth(int remainingDepth) {
-        if (remainingDepth <= 1) {
-            return searchPruningParameters.fpMarginDepth1();
-        }
-        if (remainingDepth == 2) {
-            return searchPruningParameters.fpMarginDepth2();
-        }
-        return 0;
+        return SearchHelpers.futilityMarginForRemainingDepth(remainingDepth, searchPruningParameters);
     }
 
     private double maximizer(Engine simulatorEngine, int depth, double alpha, double beta,
@@ -2912,14 +2814,7 @@ public class AI {
     }
 
     private boolean isZeroingMove(int move) {
-        if (move < 0) {
-            return false;
-        }
-        if (MoveHelper.isCapture(move)) {
-            return true;
-        }
-        int pieceBits = MoveHelper.derivePieceTypeBits(move);
-        return pieceBits == 1;
+        return SearchHelpers.isZeroingMove(move);
     }
 
     private boolean shouldUseTablebaseTieBreak(double candidateEval, double bestEval) {

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -346,6 +346,10 @@ public class AI {
 
         rebuildTranspositionTables();
 
+        // Wire quiescence searcher to its late-bound dependencies
+        this.quiescenceSearcher.setDependencies(moveOrderer, threadHeuristics,
+                transpositionTable, captureTranspositionTable);
+
         this.searchPool = createSearchPool();
 
         this.mainEngine.setOnPositionChanged(_ -> updateBoardStateHash());
@@ -389,6 +393,9 @@ public class AI {
         this.captureTranspositionTable = ttManager.getCaptureTable();
         this.transpositionTableCapacity = ttManager.getMainTableCapacity();
         this.captureTranspositionTableCapacity = ttManager.getCaptureTableCapacity();
+        if (quiescenceSearcher != null) {
+            quiescenceSearcher.updateTranspositionTables(transpositionTable, captureTranspositionTable);
+        }
     }
 
     /**
@@ -2151,8 +2158,7 @@ public class AI {
 
 
     private boolean isSideInCheck(Engine engine, boolean isWhite) {
-        GameStateEnum state = engine.getGameState().getState();
-        return (isWhite && state == GameStateEnum.WHITE_IN_CHECK) || (!isWhite && state == GameStateEnum.BLACK_IN_CHECK);
+        return QuiescenceSearcher.isSideInCheck(engine, isWhite);
     }
 
     private boolean attacksOpponentQueenNow(Engine e, boolean moverIsWhite) {
@@ -2880,183 +2886,7 @@ public class AI {
 
 
     public double evaluateBoard(Engine simulatorEngine, boolean isWhitesTurn, long deadline) {
-        if (simulatorEngine.getGameState().isInStateCheckMate()) {
-            return -CHECKMATE;
-        }
-
-        long boardStateHash = simulatorEngine.getBoardStateHash();
-
-        // Treat both terminal draws and insufficient-material as draw for evaluation
-        if (simulatorEngine.getGameState().isDrawForUIOrEval()) {
-            double scoreDiff = resolveScoreDifference(simulatorEngine.getGameState(), boardStateHash,
-                    simulatorEngine.whitesTurn());
-            if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
-                return DRAW - drawBias;
-            } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {
-                return DRAW + drawBias;
-            }
-            return DRAW;
-        }
-
-        double alpha = Double.NEGATIVE_INFINITY;
-        double beta = Double.POSITIVE_INFINITY;
-
-        CaptureTranspositionTableEntry entry = captureTranspositionTable.get(boardStateHash);
-        if (entry != null && entry.isWhite() == isWhitesTurn) {
-            return entry.getScore();
-        }
-
-        if (!isSideInCheck(simulatorEngine, isWhitesTurn)
-                && !hasImmediateTacticalMoves(simulatorEngine)) {
-            if (abortRequested(deadline)) {
-                return EXIT_FLAG;
-            }
-            double quietScore = evaluateStaticPosition(
-                    simulatorEngine.getGameState(), boardStateHash, isWhitesTurn, 0
-            );
-            captureTranspositionTable.put(
-                    boardStateHash, new CaptureTranspositionTableEntry(quietScore, isWhitesTurn), 0
-            );
-            return quietScore;
-        }
-
-        double score = quiescenceSearch(simulatorEngine, isWhitesTurn, alpha, beta, deadline, 0);
-        if (score != EXIT_FLAG) {
-            captureTranspositionTable.put(boardStateHash, new CaptureTranspositionTableEntry(score, isWhitesTurn), 0);
-        }
-        return score;
-    }
-
-    private double quiescenceSearch(Engine simulatorEngine,
-                                    boolean isWhitesTurn,
-                                    double alpha,
-                                    double beta,
-                                    long deadline,
-                                    int depth) {
-        // Early stop
-        if (abortRequested(deadline)) {
-            return AI.EXIT_FLAG;
-        }
-
-        GameState gameState = simulatorEngine.getGameState();
-        Optional<TablebaseResult> tablebase = gameState.getLastTablebaseResult();
-        if (tablebase.isPresent() && isExactWdl(tablebase.get())) {
-            long boardHash = simulatorEngine.getBoardStateHash();
-            return evaluateStaticPosition(gameState, boardHash, isWhitesTurn, depth);
-        }
-
-        // Never expand terminal nodes in qsearch: just evaluate
-        if (gameState.isTerminal()) {
-            long boardHash = simulatorEngine.getBoardStateHash();
-            return evaluateStaticPosition(gameState, boardHash, isWhitesTurn, depth);
-        }
-
-        final boolean inCheck = isSideInCheck(simulatorEngine, isWhitesTurn);
-
-        long boardHash = simulatorEngine.getBoardStateHash();
-        double standPat = evaluateStaticPosition(gameState, boardHash, isWhitesTurn, depth);
-
-        double alphaBeforeStandPat = alpha;
-
-        if (!inCheck) {
-            // Fail-hard beta cut on stand-pat
-            if (standPat >= beta) {
-                return beta;
-            }
-            // Raise alpha to stand-pat
-            if (standPat > alpha) {
-                alpha = standPat;
-            }
-        }
-
-        // Move gen: evasions if in check; else captures/promotions (and optional checking moves if you add them)
-        IntArrayList moves = inCheck
-                ? simulatorEngine.getAllLegalMoves()                // all evasions
-                : getPossibleCapturesOrPromotions(simulatorEngine);  // tactical moves only
-
-        if (!inCheck) {
-            if (moves.isEmpty()) {
-                return alpha;
-            }
-
-            double optimisticSwing = estimateMaxTacticalSwing(moves);
-            // Delta (futility-like) pruning in qsearch: compare against original alpha window
-            if (standPat + optimisticSwing <= alphaBeforeStandPat) {
-                return alpha;
-            }
-        }
-
-        // Order moves (MVV-LVA, history, hash-move etc.)
-        IntArrayList ordered = sortMovesByEfficiency(
-                moves, 0, simulatorEngine.getBoardStateHash(), -1, simulatorEngine
-        );
-
-        for (int i = 0; i < ordered.size(); i++) {
-            int m = ordered.getInt(i);
-
-            boolean isCapture   = MoveHelper.isCapture(m);
-            boolean isPromotion = MoveHelper.isPawnPromotionMove(m);
-            boolean isQuiet     = !isCapture && !isPromotion;
-
-            // In qsearch (not in check), we normally do NOT consider quiet moves.
-            // If you want to allow some checks, you can selectively allow quiet check moves.
-            if (!inCheck && isQuiet) {
-                continue;
-            }
-
-            // SEE pruning: drop clearly losing captures (keep promotions).
-            // Optionally keep losing captures that give check (aggressive but sometimes good).
-            if (!inCheck && isCapture && !isPromotion) {
-                int see = simulatorEngine.see(m, 0);
-                if (see < 0) {
-                    // Cheap “gives check?” probe; only spend the make/undo if node didn't turn terminal.
-                    if (!simulatorEngine.getGameState().isTerminal()) {
-                        simulatorEngine.performMove(m);
-                        boolean givesCheck = isSideInCheck(simulatorEngine, !isWhitesTurn);
-                        simulatorEngine.undoLastMove();
-                        if (!givesCheck) {
-                            continue; // prune losing capture that doesn't give check
-                        }
-                    } else {
-                        continue;
-                    }
-                }
-            }
-
-            // Safety guard before making the move (rare but keeps invariants)
-            if (simulatorEngine.getGameState().isTerminal()) {
-                return standPat; // nothing more to do from here
-            }
-
-            simulatorEngine.performMove(m);
-            Optional<TablebaseResult> childTablebase = resolveExactTablebaseResult(simulatorEngine);
-            double child;
-            if (childTablebase.isPresent()) {
-                long childHash = simulatorEngine.getBoardStateHash();
-                child = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !isWhitesTurn, depth + 1);
-            } else {
-                child = quiescenceSearch(simulatorEngine, !isWhitesTurn, -beta, -alpha, deadline, depth + 1);
-            }
-            simulatorEngine.undoLastMove();
-
-            if (child == EXIT_FLAG) {
-                return EXIT_FLAG;
-            }
-
-            double score = -child;
-            score = adjustMateFromChild(score);
-
-            // Fail-hard beta cutoff
-            if (score >= beta) {
-                return beta;
-            }
-            // Raise alpha
-            if (score > alpha) {
-                alpha = score;
-            }
-        }
-
-        return alpha;
+        return quiescenceSearcher.evaluateBoard(simulatorEngine, isWhitesTurn, deadline);
     }
 
 
@@ -3064,17 +2894,6 @@ public class AI {
         return quiescenceSearcher.evaluateStaticPosition(gameState, boardHash, isWhitesTurn, depthOrPly);
     }
 
-    private IntArrayList getPossibleCapturesOrPromotions(Engine simulatorEngine) {
-        return MoveContainerUtils.filterCapturesAndPromotions(simulatorEngine.getAllLegalMoves());
-    }
-
-    private boolean hasImmediateTacticalMoves(Engine simulatorEngine) {
-        return simulatorEngine.hasAnyCaptureOrPromotion();
-    }
-
-    private double estimateMaxTacticalSwing(IntArrayList moves) {
-        return quiescenceSearcher.estimateMaxTacticalSwing(moves);
-    }
 
     private boolean isMateValue(double score) {
         return QuiescenceSearcher.isMateValue(score);

--- a/src/main/java/julius/game/chessengine/ai/AI.java
+++ b/src/main/java/julius/game/chessengine/ai/AI.java
@@ -2204,8 +2204,7 @@ public class AI {
         final int[][] historyTable = heuristics.history;
 
         IntArrayList orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove, simulatorEngine);
-        final Map<Integer, Integer> seeCache = seeCacheThreadLocal.get();
-        seeCache.clear();
+        moveOrderer.getSeeCacheRef().get().clear();
         final SearchPruningParameters.Snapshot pruning = searchPruningParameters;
         final int hmpMinIndex = pruning.hmpMinIndex();
         final int hmpHistoryMax = pruning.hmpHistoryMax();
@@ -2496,8 +2495,7 @@ public class AI {
         final int[][] historyTable = heuristics.history;
 
         IntArrayList orderedMoves = sortMovesByEfficiency(moves, depth, boardHash, prevMove, simulatorEngine);
-        final Map<Integer, Integer> seeCache = seeCacheThreadLocal.get();
-        seeCache.clear();
+        moveOrderer.getSeeCacheRef().get().clear();
         final SearchPruningParameters.Snapshot pruning = searchPruningParameters;
         final int hmpMinIndex = pruning.hmpMinIndex();
         final int hmpHistoryMax = pruning.hmpHistoryMax();

--- a/src/main/java/julius/game/chessengine/ai/QuiescenceSearcher.java
+++ b/src/main/java/julius/game/chessengine/ai/QuiescenceSearcher.java
@@ -25,21 +25,19 @@ final class QuiescenceSearcher {
 
     private static final double MATE_SCORE_MARGIN = 2048.0;
     private static final double TABLEBASE_CLAMP = 2000.0 / 100.0;
+    static final double EXIT_FLAG = AI.EXIT_FLAG;
 
     private final double drawBias;
     private final double quiescenceMaxDeltaPawn;
     private final ThreadLocal<Long2DoubleOpenHashMap> staticEvalCache;
-
-    /**
-     * Callback to check if the search should abort. Avoids a circular
-     * dependency back to AI for deadline checking.
-     */
     private final LongPredicate abortChecker;
-
-    /**
-     * Delegate for tablebase probing (resolveExactTablebaseResult, isExactWdl, clampTablebaseEval).
-     */
     private final TablebaseProber tablebaseProber;
+
+    // Dependencies set after construction (avoids circular init with AI)
+    private MoveOrderer moveOrderer;
+    private ThreadLocal<Heuristics> threadHeuristics;
+    private TranspositionTable<TranspositionTableEntry> transpositionTable;
+    private TranspositionTable<CaptureTranspositionTableEntry> captureTranspositionTable;
 
     QuiescenceSearcher(double drawBias,
                        double quiescenceMaxDeltaPawn,
@@ -56,8 +54,188 @@ final class QuiescenceSearcher {
         });
     }
 
+    void setDependencies(MoveOrderer moveOrderer,
+                         ThreadLocal<Heuristics> threadHeuristics,
+                         TranspositionTable<TranspositionTableEntry> transpositionTable,
+                         TranspositionTable<CaptureTranspositionTableEntry> captureTranspositionTable) {
+        this.moveOrderer = moveOrderer;
+        this.threadHeuristics = threadHeuristics;
+        this.transpositionTable = transpositionTable;
+        this.captureTranspositionTable = captureTranspositionTable;
+    }
+
+    void updateTranspositionTables(TranspositionTable<TranspositionTableEntry> main,
+                                   TranspositionTable<CaptureTranspositionTableEntry> capture) {
+        this.transpositionTable = main;
+        this.captureTranspositionTable = capture;
+    }
+
     void clearCache() {
         staticEvalCache.get().clear();
+    }
+
+    // ---- Main entry points ----
+
+    double evaluateBoard(Engine simulatorEngine, boolean isWhitesTurn, long deadline) {
+        if (simulatorEngine.getGameState().isInStateCheckMate()) {
+            return -CHECKMATE;
+        }
+
+        long boardStateHash = simulatorEngine.getBoardStateHash();
+
+        if (simulatorEngine.getGameState().isDrawForUIOrEval()) {
+            double scoreDiff = resolveScoreDifference(simulatorEngine.getGameState(), boardStateHash,
+                    simulatorEngine.whitesTurn());
+            if ((isWhitesTurn && scoreDiff > 0) || (!isWhitesTurn && scoreDiff < 0)) {
+                return DRAW - drawBias;
+            } else if ((isWhitesTurn && scoreDiff < 0) || (!isWhitesTurn && scoreDiff > 0)) {
+                return DRAW + drawBias;
+            }
+            return DRAW;
+        }
+
+        double alpha = Double.NEGATIVE_INFINITY;
+        double beta = Double.POSITIVE_INFINITY;
+
+        CaptureTranspositionTableEntry entry = captureTranspositionTable.get(boardStateHash);
+        if (entry != null && entry.isWhite() == isWhitesTurn) {
+            return entry.getScore();
+        }
+
+        if (!isSideInCheck(simulatorEngine, isWhitesTurn)
+                && !simulatorEngine.hasAnyCaptureOrPromotion()) {
+            if (abortChecker.test(deadline)) return EXIT_FLAG;
+            double quietScore = evaluateStaticPosition(
+                    simulatorEngine.getGameState(), boardStateHash, isWhitesTurn, 0
+            );
+            captureTranspositionTable.put(
+                    boardStateHash, new CaptureTranspositionTableEntry(quietScore, isWhitesTurn), 0
+            );
+            return quietScore;
+        }
+
+        double score = quiescenceSearch(simulatorEngine, isWhitesTurn, alpha, beta, deadline, 0);
+        if (score != EXIT_FLAG) {
+            captureTranspositionTable.put(boardStateHash, new CaptureTranspositionTableEntry(score, isWhitesTurn), 0);
+        }
+        return score;
+    }
+
+    double quiescenceSearch(Engine simulatorEngine,
+                            boolean isWhitesTurn,
+                            double alpha,
+                            double beta,
+                            long deadline,
+                            int depth) {
+        if (abortChecker.test(deadline)) {
+            return EXIT_FLAG;
+        }
+
+        GameState gameState = simulatorEngine.getGameState();
+        Optional<TablebaseResult> tablebase = gameState.getLastTablebaseResult();
+        if (tablebase.isPresent() && tablebaseProber.isExactWdl(tablebase.get())) {
+            long boardHash = simulatorEngine.getBoardStateHash();
+            return evaluateStaticPosition(gameState, boardHash, isWhitesTurn, depth);
+        }
+
+        if (gameState.isTerminal()) {
+            long boardHash = simulatorEngine.getBoardStateHash();
+            return evaluateStaticPosition(gameState, boardHash, isWhitesTurn, depth);
+        }
+
+        final boolean inCheck = isSideInCheck(simulatorEngine, isWhitesTurn);
+
+        long boardHash = simulatorEngine.getBoardStateHash();
+        double standPat = evaluateStaticPosition(gameState, boardHash, isWhitesTurn, depth);
+
+        double alphaBeforeStandPat = alpha;
+
+        if (!inCheck) {
+            if (standPat >= beta) {
+                return beta;
+            }
+            if (standPat > alpha) {
+                alpha = standPat;
+            }
+        }
+
+        IntArrayList moves = inCheck
+                ? simulatorEngine.getAllLegalMoves()
+                : MoveContainerUtils.filterCapturesAndPromotions(simulatorEngine.getAllLegalMoves());
+
+        if (!inCheck) {
+            if (moves.isEmpty()) {
+                return alpha;
+            }
+            double optimisticSwing = estimateMaxTacticalSwing(moves);
+            if (standPat + optimisticSwing <= alphaBeforeStandPat) {
+                return alpha;
+            }
+        }
+
+        IntArrayList ordered = moveOrderer.sortMovesByEfficiency(
+                moves, 0, simulatorEngine.getBoardStateHash(), -1, simulatorEngine,
+                threadHeuristics.get(), transpositionTable
+        );
+
+        for (int i = 0; i < ordered.size(); i++) {
+            int m = ordered.getInt(i);
+
+            boolean isCapture = MoveHelper.isCapture(m);
+            boolean isPromotion = MoveHelper.isPawnPromotionMove(m);
+            boolean isQuiet = !isCapture && !isPromotion;
+
+            if (!inCheck && isQuiet) {
+                continue;
+            }
+
+            if (!inCheck && isCapture && !isPromotion) {
+                int see = simulatorEngine.see(m, 0);
+                if (see < 0) {
+                    if (!simulatorEngine.getGameState().isTerminal()) {
+                        simulatorEngine.performMove(m);
+                        boolean givesCheck = isSideInCheck(simulatorEngine, !isWhitesTurn);
+                        simulatorEngine.undoLastMove();
+                        if (!givesCheck) {
+                            continue;
+                        }
+                    } else {
+                        continue;
+                    }
+                }
+            }
+
+            if (simulatorEngine.getGameState().isTerminal()) {
+                return standPat;
+            }
+
+            simulatorEngine.performMove(m);
+            Optional<TablebaseResult> childTablebase = tablebaseProber.resolveExactTablebaseResult(simulatorEngine);
+            double child;
+            if (childTablebase.isPresent()) {
+                long childHash = simulatorEngine.getBoardStateHash();
+                child = evaluateStaticPosition(simulatorEngine.getGameState(), childHash, !isWhitesTurn, depth + 1);
+            } else {
+                child = quiescenceSearch(simulatorEngine, !isWhitesTurn, -beta, -alpha, deadline, depth + 1);
+            }
+            simulatorEngine.undoLastMove();
+
+            if (child == EXIT_FLAG) {
+                return EXIT_FLAG;
+            }
+
+            double score = -child;
+            score = adjustMateFromChild(score);
+
+            if (score >= beta) {
+                return beta;
+            }
+            if (score > alpha) {
+                alpha = score;
+            }
+        }
+
+        return alpha;
     }
 
     // ---- Static evaluation ----
@@ -162,6 +340,14 @@ final class QuiescenceSearcher {
         }
 
         return Math.min(bestSwing, quiescenceMaxDeltaPawn);
+    }
+
+    // ---- Board query helpers ----
+
+    static boolean isSideInCheck(Engine engine, boolean isWhite) {
+        julius.game.chessengine.engine.GameStateEnum state = engine.getGameState().getState();
+        return (isWhite && state == julius.game.chessengine.engine.GameStateEnum.WHITE_IN_CHECK)
+                || (!isWhite && state == julius.game.chessengine.engine.GameStateEnum.BLACK_IN_CHECK);
     }
 
     // ---- Score helpers ----

--- a/src/main/java/julius/game/chessengine/ai/SearchHelpers.java
+++ b/src/main/java/julius/game/chessengine/ai/SearchHelpers.java
@@ -1,0 +1,174 @@
+package julius.game.chessengine.ai;
+
+import julius.game.chessengine.board.BitBoard;
+import julius.game.chessengine.board.MoveHelper;
+import julius.game.chessengine.engine.Engine;
+import julius.game.chessengine.tuning.NullMoveParameters;
+import julius.game.chessengine.tuning.SearchPruningParameters;
+
+import static julius.game.chessengine.helper.BitHelper.FileMasks;
+import static julius.game.chessengine.helper.KingHelper.KING_ATTACKS;
+
+/**
+ * Static helper methods for the alpha-beta search tree: board queries,
+ * null-move reduction, LMR, futility margins, and tactical detection.
+ * Extracted from AI to keep the search loop focused on control flow.
+ */
+final class SearchHelpers {
+
+    private SearchHelpers() {
+    }
+
+    // ---- Board query helpers ----
+
+    static boolean attacksOpponentQueenNow(Engine e, boolean moverIsWhite) {
+        BitBoard bb = e.getBitBoard();
+        long enemyQueen = moverIsWhite ? bb.getBlackQueens() : bb.getWhiteQueens();
+        if (enemyQueen == 0) return false;
+        long myAttacks = bb.getAttackBitboard(moverIsWhite);
+        return (myAttacks & enemyQueen) != 0L;
+    }
+
+    static boolean attacksOpponentKingZone(Engine e, boolean moverIsWhite) {
+        BitBoard bb = e.getBitBoard();
+        long enemyKing = moverIsWhite ? bb.getBlackKing() : bb.getWhiteKing();
+        if (enemyKing == 0L) {
+            return false;
+        }
+        int kingIndex = Long.numberOfTrailingZeros(enemyKing);
+        long kingZone = KING_ATTACKS[kingIndex];
+        long myAttacks = bb.getAttackBitboard(moverIsWhite);
+        return (myAttacks & kingZone) != 0L;
+    }
+
+    static int countPawnsOnFile(BitBoard board, long fileMask) {
+        if (fileMask == 0L) {
+            return 0;
+        }
+        long pawns = (board.getWhitePawns() | board.getBlackPawns()) & fileMask;
+        return Long.bitCount(pawns);
+    }
+
+    static boolean openedFileTowardKing(BitBoard boardAfterMove, long kingFileMask,
+                                        int pawnsBefore, boolean interactsWithKingFile) {
+        if (!interactsWithKingFile || kingFileMask == 0L || pawnsBefore <= 0) {
+            return false;
+        }
+        int pawnsAfter = countPawnsOnFile(boardAfterMove, kingFileMask);
+        return pawnsAfter < pawnsBefore;
+    }
+
+    static boolean isZeroingMove(int move) {
+        if (move < 0) {
+            return false;
+        }
+        if (MoveHelper.isCapture(move)) {
+            return true;
+        }
+        int pieceBits = MoveHelper.derivePieceTypeBits(move);
+        return pieceBits == 1;
+    }
+
+    // ---- Null-move reduction ----
+
+    static int computeNullMoveReduction(BitBoard board, int depth, boolean isWhite, int mobility,
+                                        NullMoveParameters.Snapshot nullMoveParameters) {
+        int maxReduction = depth - 2;
+        if (maxReduction <= 0) {
+            return 0;
+        }
+
+        long pieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
+        long pawns = isWhite ? board.getWhitePawns() : board.getBlackPawns();
+        int nonPawnMaterial = Long.bitCount(pieces) - Long.bitCount(pawns);
+        if (nonPawnMaterial < 0) {
+            nonPawnMaterial = 0;
+        }
+
+        double reductionEstimate = getReductionEstimate(depth, mobility, nonPawnMaterial, nullMoveParameters);
+
+        int reduction = (int) Math.floor(Math.max(0.0, reductionEstimate));
+        return Math.min(reduction, maxReduction);
+    }
+
+    static double getReductionEstimate(int depth, int mobility, int nonPawnMaterial,
+                                       NullMoveParameters.Snapshot params) {
+        int depthCap = Math.max(1, params.depthCap());
+        int materialCap = Math.max(1, params.materialCap());
+        int mobilityCap = Math.max(1, params.mobilityCap());
+
+        double depthFactor = Math.min(Math.max(depth, 0), depthCap) / (double) depthCap;
+        double materialFactor = Math.min(Math.max(nonPawnMaterial, 0), materialCap) / (double) materialCap;
+        double mobilityFactor = Math.min(Math.max(mobility, 0), mobilityCap) / (double) mobilityCap;
+
+        double reductionEstimate = params.baseReduction()
+                + (depthFactor * params.depthWeight())
+                + (materialFactor * params.materialWeight())
+                + (mobilityFactor * params.mobilityWeight());
+
+        if (nonPawnMaterial <= params.lowMaterialThreshold()
+                || mobility <= params.lowMobilityThreshold()) {
+            reductionEstimate -= params.lowMaterialPenalty();
+        }
+        if (mobility <= params.veryLowMobilityThreshold()) {
+            reductionEstimate -= params.veryLowMobilityPenalty();
+        }
+        return reductionEstimate;
+    }
+
+    // ---- Late-move reduction ----
+
+    static int lmrReduction(int depth, int moveIndex, int historyScore,
+                            int[][][] lmrReductionTable, int lmrBucketCount,
+                            SearchPruningParameters.Snapshot pruning) {
+        if (depth <= 1) {
+            return 0;
+        }
+
+        int clampedDepth = Math.min(depth, lmrReductionTable.length - 1);
+        int clampedMoveIndex = Math.max(0, Math.min(moveIndex,
+                lmrReductionTable.length > 0 && lmrReductionTable[0].length > 0
+                        ? lmrReductionTable[0].length - 1 : 0));
+
+        int historyReductionMax = Math.max(0, pruning.historyReductionMax());
+        int history = Math.max(0, Math.min(historyScore, historyReductionMax));
+        double normalized = historyReductionMax == 0
+                ? 0.0
+                : history / (double) historyReductionMax;
+        int buckets = Math.max(1, lmrBucketCount);
+        double bucketPosition = buckets == 1 ? 0.0 : normalized * (buckets - 1);
+        int lowerBucket = Math.max(0, (int) Math.floor(bucketPosition));
+        int upperBucket = Math.min(buckets - 1, lowerBucket + 1);
+        double fraction = bucketPosition - lowerBucket;
+
+        int lowerValue = lmrReductionTable[clampedDepth][clampedMoveIndex][lowerBucket];
+        if (upperBucket == lowerBucket) {
+            return Math.min(lowerValue, depth - 1);
+        }
+
+        int upperValue = lmrReductionTable[clampedDepth][clampedMoveIndex][upperBucket];
+        double interpolated = lowerValue + fraction * (upperValue - lowerValue);
+        int reduction = (int) Math.floor(interpolated + 1e-9);
+        int maxReduction = Math.max(0, depth - 1);
+        if (reduction < 0) {
+            reduction = 0;
+        }
+        if (reduction > maxReduction) {
+            reduction = maxReduction;
+        }
+        return reduction;
+    }
+
+    // ---- Futility pruning ----
+
+    static int futilityMarginForRemainingDepth(int remainingDepth,
+                                               SearchPruningParameters.Snapshot pruning) {
+        if (remainingDepth <= 1) {
+            return pruning.fpMarginDepth1();
+        }
+        if (remainingDepth == 2) {
+            return pruning.fpMarginDepth2();
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
<![CDATA[## Summary

- **AI.java reduced from 4,358 to 2,873 lines (-34.1%)**
- Full quiescence search and move ordering logic moved to dedicated classes
- All search helper methods (pruning, tactical detection) extracted
- Dead code, unused imports, and obsolete fields cleaned up

## Changes since last merge

| Commit | Description |
|--------|-------------|
| `f88a18b` | Move evaluateBoard/quiescenceSearch into QuiescenceSearcher |
| `44df3d1` | Extract SearchHelpers (null-move, LMR, futility, tactical) |
| `58a0ec5` | Delegate SEE cache access to MoveOrderer |
| `aa14e39` | Clean up unused imports, fields, dead references |

## Architecture (11 extracted classes)

| Class | Lines | Responsibility |
|-------|-------|----------------|
| `QuiescenceSearcher` | 380 | evaluateBoard, qSearch, static eval, mate scores |
| `TablebaseProber` | 380 | Syzygy probing, WDL/DTZ, tie-breaking |
| `MoveOrderer` | 270 | sortMovesByEfficiency, bucket sort, MVV-LVA |
| `Heuristics` | 260 | Killer/history/counter tables |
| `SearchHelpers` | 180 | Null-move, LMR, futility, tactical detection |
| `TranspositionTableManager` | 120 | TT lifecycle, hash budget |
| `HeuristicsManager` | 110 | Lock management, snapshots, merge |
| `WorkerInstrumentation` | 110 | Worker diagnostics |
| `LockMetrics` | 40 | Lock contention tracking |

## Test plan

- [ ] Run `BestMoveSearchTest` — verify no regressions from refactoring
- [ ] Run full test suite
- [ ] Verify UCI compliance

https://claude.ai/code/session_01WSTYQg8gjYH62oozPodK3o]]>