### PR TITLE
v3.9.9: Improve evaluation - passed pawn king proximity + tuning

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -152,8 +152,8 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         int whiteOpenFiles = countOpenFilesWithRooks(whiteRooks, allPawns) * rookOpenFileBonus;
         int blackOpenFiles = countOpenFilesWithRooks(blackRooks, allPawns) * rookOpenFileBonus;
 
-        int whitePassed = calculatePassedPawnBonus(whitePawns, blackPawns, allPieces, whiteKing, true);
-        int blackPassed = calculatePassedPawnBonus(blackPawns, whitePawns, allPieces, blackKing, false);
+        int whitePassed = calculatePassedPawnBonus(whitePawns, blackPawns, allPieces, whiteKing, blackKing, true);
+        int blackPassed = calculatePassedPawnBonus(blackPawns, whitePawns, allPieces, blackKing, whiteKing, false);
 
         int whiteAdvanceBase = calculatePawnAdvanceBonus(whitePawns, allPieces, blackAttacks, true);
         int blackAdvanceBase = calculatePawnAdvanceBonus(blackPawns, allPieces, whiteAttacks, false);
@@ -351,7 +351,8 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         return penalty;
     }
 
-    private int calculatePassedPawnBonus(long pawns, long opponentPawns, long allPieces, long ownKing, boolean isWhite) {
+    private int calculatePassedPawnBonus(long pawns, long opponentPawns, long allPieces,
+                                         long ownKing, long enemyKing, boolean isWhite) {
         if (pawns == 0) {
             return 0;
         }
@@ -360,6 +361,7 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         int[] rankWeights = isWhite ? PASSED_RANK_WEIGHT_WHITE : PASSED_RANK_WEIGHT_BLACK;
         int[] distances = isWhite ? DISTANCE_TO_PROMOTION_WHITE : DISTANCE_TO_PROMOTION_BLACK;
         int color = isWhite ? WHITE : BLACK;
+        int enemyKingSquare = enemyKing != 0 ? Long.numberOfTrailingZeros(enemyKing) : -1;
         long remaining = pawns;
         while (remaining != 0) {
             int square = Long.numberOfTrailingZeros(remaining);
@@ -381,9 +383,23 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
                 base += passedPawnFreePathBonusPerRank * distances[square];
             }
 
+            // Bonus when enemy king is far from the passed pawn (endgame relevance)
+            if (enemyKingSquare >= 0) {
+                int promotionSquare = isWhite ? (square & 7) + 56 : (square & 7);
+                int enemyKingDist = chebyshevDistance(enemyKingSquare, promotionSquare);
+                // Bonus scales with distance: further king = bigger bonus
+                base += enemyKingDist * 5;
+            }
+
             bonus += base;
         }
         return bonus;
+    }
+
+    private static int chebyshevDistance(int sq1, int sq2) {
+        int fileDiff = Math.abs((sq1 & 7) - (sq2 & 7));
+        int rankDiff = Math.abs((sq1 >> 3) - (sq2 >> 3));
+        return Math.max(fileDiff, rankDiff);
     }
 
     private int countHalfOpenFilesWithRooks(long rooksBitboard, long friendlyPawns, long enemyPawns) {

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -62,7 +62,7 @@ population:
       activity.midgamecenterrook: 1.8432445714151602
       moveordering.castlingbonus: 5201.548534057966
       search.lmrhistorybuckets: 5.482618134712996
-      kingsafety.attackweightbishop: 5.218071331769895
+      kingsafety.attackweightbishop: 10.0
       search.iidreducedepth: 2.6220408788985017
       moveordering.killer0bonus: 22.89496494174806
       search.nullbasereduction: 3.5471370734329564
@@ -77,7 +77,7 @@ population:
       search.aspmaxretriesmin: 0.9197031238160355
       search.aspbumpbasecp: 9.190120892166506
       search.aspmaxretriesdepthoffset: 19.066082695041672
-      pawnstructure.backwardpawnpenalty: -23.499313850270582
+      pawnstructure.backwardpawnpenalty: -28.0
       search.aspmomentumstepcp: 4.956424756732777
       moveordering.killermovescore: 12430.726452180897
       search.nullmobilityweight: 0.18651868207862868
@@ -105,7 +105,7 @@ population:
       search.lmrdepthlogoffset: 4.324817915338708
       threat.hangingbishoppenalty: -17.706926071941474
       search.historyreductionmax: 6540.9051731841755
-      kingsafety.attackweightrook: 43.58382642236998
+      kingsafety.attackweightrook: 50.0
       search.lmrprotectindexmax: 4.531491799106837
       search.aspmaxretriesdepthdivisor: 1.0156193437773624
       activity.endgamecenterking: 6.429792404182555
@@ -123,7 +123,7 @@ population:
       pawnstructure.doubledpawnpenalty: -9.678139647521522
       search.seeprunenearrootply: 3.6760425768212808
       moveordering.historydecaydivisor: 1.7521454615607943
-      pawnstructure.passedpawnbonus: 42.41131117676474
+      pawnstructure.passedpawnbonus: 50.0
       activity.midgamecenterknight: 3.702564587417092
       activity.midgamecenterqueen: 3.4406529878224257
       search.aspbumpdepthcp: 3.7085655999707887
@@ -136,7 +136,7 @@ population:
       kingsafety.backrankweaknessmidgamepenalty: -75.32017160398253
       search.aspmomentumcap: 35.4865521311111
       threat.pawnthreatrookpenalty: -35.0
-      pawnstructure.connectedpawnbonus: 8.937080015008842
+      pawnstructure.connectedpawnbonus: 12.0
       moveordering.promotionseeclamp: 539.9279351366326
       pawnstructure.centerpawnbonus: 24.855828462710395
       threat.hangingrookpenalty: -90.0
@@ -145,7 +145,7 @@ population:
       moveordering.category.quiet: 1.1224931271842804
       search.ttcaptureweight: 3.1042332176359375
       search.fpmaxdepth: 8.64019895338565
-      pawnstructure.rookopenfilebonus: 39.3090618731208
+      pawnstructure.rookopenfilebonus: 45.0
       threat.pawnthreatqueenpenalty: -28.358904604133688
       threat.rooknopawncoverpenalty: -25.0
       search.aspmaxretriesbase: 2.7662430510295968
@@ -164,7 +164,7 @@ population:
       activity.endgamecenterbishop: -1.9533029790428362
       search.lmrprotectplymax: 0.8325077540309972
       threat.hangingqueenpenalty: -63.96989260202807
-      pawnstructure.isolatedpawnpenalty: -10.820633376214122
+      pawnstructure.isolatedpawnpenalty: -15.0
       moveordering.promotionbonus: 1698.2326743213698
       moveordering.capturemvvmultiplier: 14.997337966397541
       search.aspmaxretriesvolthresholdhigh: 65.92221191205527


### PR DESCRIPTION
<![CDATA[## Summary

- Add enemy king distance bonus for passed pawns (Chebyshev distance × 5 cp)
- Strengthen king safety, pawn structure, and rook evaluation weights

## Evaluation changes

### New feature: Passed pawn king proximity
Passed pawns now score higher when the enemy king is far from the promotion square. Uses Chebyshev distance (max of file/rank difference). This is critical in endgames where a distant king cannot stop promotion.

### Tuning adjustments

| Parameter | Before | After | Rationale |
|-----------|--------|-------|-----------|
| Bishop attack weight | 5.2 | 10.0 | Bishops were undervalued as king attackers |
| Rook attack weight | 43.6 | 50.0 | Rooks are strong king zone attackers |
| Passed pawn bonus | 42.4 | 50.0 | Passed pawns are the strongest endgame feature |
| Connected pawn bonus | 8.9 | 12.0 | Connected pawns support each other |
| Backward pawn penalty | -23.5 | -28.0 | Backward pawns are significant weaknesses |
| Isolated pawn penalty | -10.8 | -15.0 | Isolated pawns need stronger penalty |
| Rook open file bonus | 39.3 | 45.0 | Rooks on open files are very valuable |

## Test plan

- [ ] Run BestMoveSearchTest — target fewer failures in endgame positions
- [ ] Run full test suite

https://claude.ai/code/session_01WSTYQg8gjYH62oozPodK3o]]>