### PR TITLE
v3.9.9: Knight outposts, rook 7th rank, improved threats

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
@@ -154,6 +154,16 @@ public final class ActivityModule implements EvaluationModule {
     private long blackPieces;
     private long allPieces;
     private long sliderSquares;
+    private long whitePawns;
+    private long blackPawns;
+
+    // Bonus constants for positional features
+    private static final int KNIGHT_OUTPOST_MIDGAME = 15;
+    private static final int KNIGHT_OUTPOST_ENDGAME = 10;
+    private static final int ROOK_SEVENTH_RANK_MIDGAME = 20;
+    private static final int ROOK_SEVENTH_RANK_ENDGAME = 30;
+    private static final long RANK_7 = 0x00FF000000000000L;
+    private static final long RANK_2 = 0x000000000000FF00L;
 
     private int midgameScoreCache;
     private int endgameScoreCache;
@@ -476,8 +486,10 @@ public final class ActivityModule implements EvaluationModule {
         whitePieces = 0L;
         blackPieces = 0L;
         sliderSquares = 0L;
+        whitePawns = board.getWhitePawns();
+        blackPawns = board.getBlackPawns();
 
-        registerPieces(board.getWhitePawns(), WHITE, PAWN);
+        registerPieces(whitePawns, WHITE, PAWN);
         registerPieces(board.getWhiteKnights(), WHITE, KNIGHT);
         registerPieces(board.getWhiteBishops(), WHITE, BISHOP);
         registerPieces(board.getWhiteRooks(), WHITE, ROOK);
@@ -499,8 +511,82 @@ public final class ActivityModule implements EvaluationModule {
             }
         }
 
+        addPositionalBonuses(board);
         updateScoreCache();
         dirty = false;
+    }
+
+    /**
+     * Adds positional bonuses that go beyond simple mobility:
+     * - Knight outpost bonus (supported by own pawn, can't be attacked by enemy pawns)
+     * - Rook on 7th rank bonus (strong attacking position)
+     */
+    private void addPositionalBonuses(ImmutableBoardView board) {
+        // Knight outposts: knights on rank 4-6 supported by own pawn and not attackable by enemy pawns
+        addKnightOutpostBonus(board.getWhiteKnights(), whitePawns, blackPawns, true);
+        addKnightOutpostBonus(board.getBlackKnights(), blackPawns, whitePawns, false);
+
+        // Rook on 7th rank bonus
+        addRookSeventhRankBonus(board.getWhiteRooks(), RANK_7, board.getBlackKing(), true);
+        addRookSeventhRankBonus(board.getBlackRooks(), RANK_2, board.getWhiteKing(), false);
+    }
+
+    private void addKnightOutpostBonus(long knights, long friendlyPawns, long enemyPawns, boolean isWhite) {
+        int friendlyPawnColor = isWhite ? WHITE : BLACK;
+        int enemyPawnColor = isWhite ? BLACK : WHITE;
+        int colorIdx = isWhite ? WHITE : BLACK;
+        long remaining = knights;
+        while (remaining != 0) {
+            int sq = Long.numberOfTrailingZeros(remaining);
+            remaining &= remaining - 1;
+            int rank = sq >> 3;
+            // Only consider outpost squares on ranks 4-6 for white, 3-5 for black
+            boolean onOutpostRank = isWhite ? (rank >= 3 && rank <= 5) : (rank >= 2 && rank <= 4);
+            if (!onOutpostRank) continue;
+
+            // Check if supported by own pawn
+            long knightMask = 1L << sq;
+            long friendlyPawnAttacks = computePawnAttackMaskForSquares(friendlyPawns, friendlyPawnColor);
+            if ((friendlyPawnAttacks & knightMask) == 0) continue;
+
+            // Check if enemy pawns can attack this square (no enemy pawns on adjacent files ahead)
+            int file = sq & 7;
+            long adjacentFiles = 0L;
+            if (file > 0) adjacentFiles |= julius.game.chessengine.helper.BitHelper.FileMasks[file - 1];
+            if (file < 7) adjacentFiles |= julius.game.chessengine.helper.BitHelper.FileMasks[file + 1];
+            long forwardRanks = isWhite
+                    ? julius.game.chessengine.helper.PawnMoveTables.FORWARD_RANK_MASKS_WHITE[sq]
+                    : julius.game.chessengine.helper.PawnMoveTables.FORWARD_RANK_MASKS_BLACK[sq];
+            boolean canBeAttackedByPawn = (enemyPawns & adjacentFiles & forwardRanks) != 0;
+            if (canBeAttackedByPawn) continue;
+
+            midgameTotals[colorIdx] += KNIGHT_OUTPOST_MIDGAME;
+            endgameTotals[colorIdx] += KNIGHT_OUTPOST_ENDGAME;
+        }
+    }
+
+    private void addRookSeventhRankBonus(long rooks, long seventhRank, long enemyKing, boolean isWhite) {
+        int colorIdx = isWhite ? WHITE : BLACK;
+        long rooksOnSeventh = rooks & seventhRank;
+        if (rooksOnSeventh == 0) return;
+        // Only give bonus if enemy king is on 8th (or 1st for black) rank
+        int enemyKingRank = enemyKing != 0 ? (Long.numberOfTrailingZeros(enemyKing) >> 3) : -1;
+        boolean enemyKingOnBackRank = isWhite ? (enemyKingRank == 7) : (enemyKingRank == 0);
+        if (!enemyKingOnBackRank) return;
+        int rookCount = Long.bitCount(rooksOnSeventh);
+        midgameTotals[colorIdx] += rookCount * ROOK_SEVENTH_RANK_MIDGAME;
+        endgameTotals[colorIdx] += rookCount * ROOK_SEVENTH_RANK_ENDGAME;
+    }
+
+    private static long computePawnAttackMaskForSquares(long pawns, int pawnColor) {
+        long mask = 0L;
+        long remaining = pawns;
+        while (remaining != 0) {
+            int index = Long.numberOfTrailingZeros(remaining);
+            mask |= julius.game.chessengine.helper.PawnMoveTables.PAWN_ATTACKS[pawnColor][index];
+            remaining &= remaining - 1;
+        }
+        return mask;
     }
 
     private void registerPieces(long bitboard, int color, int pieceType) {

--- a/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ThreatModule.java
@@ -133,15 +133,24 @@ public final class ThreatModule implements EvaluationModule {
                 continue;
             }
             long mask = 1L << square;
-            if ((enemyAttacks & mask) == 0) {
-                remaining ^= bit;
-                continue;
-            }
-            if ((friendlyAttacks & mask) != 0) {
+            boolean attackedByEnemy = (enemyAttacks & mask) != 0;
+            boolean defendedByFriendly = (friendlyAttacks & mask) != 0;
+
+            if (!attackedByEnemy) {
                 remaining ^= bit;
                 continue;
             }
 
+            if (defendedByFriendly) {
+                // Defended piece attacked by enemy pawn: half pawn-threat penalty
+                if (typeBits > PAWN && (enemyPawnAttacks & mask) != 0) {
+                    penalty += pawnThreatPenalties[typeBits] / 2;
+                }
+                remaining ^= bit;
+                continue;
+            }
+
+            // Undefended (hanging) piece
             penalty += hangingPenalties[typeBits];
             if (typeBits > PAWN && (enemyPawnAttacks & mask) != 0) {
                 penalty += pawnThreatPenalties[typeBits];


### PR DESCRIPTION
<![CDATA[## Summary

- **Knight outpost bonus** in ActivityModule (+15/+10 midgame/endgame)
- **Rook on 7th rank bonus** when enemy king on back rank (+20/+30)
- **Defended-piece pawn threats** in ThreatModule (half penalty)

## Details

### Knight outposts
Knights on ranks 4-6 (white) / 3-5 (black) that are:
1. Supported by a friendly pawn
2. Cannot be attacked by any enemy pawn (no enemy pawns on adjacent files ahead)

These are strong positional features — outposted knights dominate the board.

### Rook on 7th rank
Rooks on the 7th rank (2nd for black) when the enemy king is confined to the back rank. This is one of the most powerful attacking configurations in chess.

### Defended-piece pawn threats
Previously, the ThreatModule only penalized pieces that were both attacked AND undefended. Now, pieces that are attacked by enemy pawns receive half the pawn-threat penalty even when defended. This reflects the tactical pressure of pawn attacks regardless of defense.

## Test plan
- [ ] Run BestMoveSearchTest
- [ ] Verify improved play in tactical and positional positions

https://claude.ai/code/session_01WSTYQg8gjYH62oozPodK3o]]>