### PR TITLE
v3.9.9: Space advantage + mop-up endgame evaluation

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
@@ -113,7 +113,56 @@ public final class EvaluationPipeline {
         int midgameWeight = blendScale - phase;
         int endgameWeight = phase;
         long blended = (long) midgameTotal * midgameWeight + (long) endgameTotal * endgameWeight;
-        return (int) (blended / blendScale);
+        int score = (int) (blended / blendScale);
+
+        // Mop-up evaluation: in late endgame with material advantage,
+        // encourage driving the losing king toward the corner
+        if (phase > 200) { // deep endgame
+            score += computeMopUpBonus(score);
+        }
+
+        return score;
+    }
+
+    /**
+     * When one side has a significant material advantage in the endgame,
+     * bonus for: (1) losing king far from center, (2) kings close together.
+     */
+    private int computeMopUpBonus(int currentScore) {
+        if (context == null || context.getBoardView() == null) {
+            return 0;
+        }
+        // Only apply if material advantage is significant (> 2 pawns)
+        if (Math.abs(currentScore) < 200) {
+            return 0;
+        }
+        var board = context.getBoardView();
+        long whiteKing = board.getWhiteKing();
+        long blackKing = board.getBlackKing();
+        if (whiteKing == 0 || blackKing == 0) {
+            return 0;
+        }
+        int wkSq = Long.numberOfTrailingZeros(whiteKing);
+        int bkSq = Long.numberOfTrailingZeros(blackKing);
+
+        boolean whiteWinning = currentScore > 0;
+        int losingKingSq = whiteWinning ? bkSq : wkSq;
+
+        // Distance of losing king from center (d4/e4/d5/e5)
+        int losingFile = losingKingSq & 7;
+        int losingRank = losingKingSq >> 3;
+        int fileDist = Math.max(3 - losingFile, losingFile - 4);
+        int rankDist = Math.max(3 - losingRank, losingRank - 4);
+        int cornerDistance = fileDist + rankDist; // 0 at center, up to 6 at corner
+
+        // Distance between kings (encourage winning king to approach)
+        int kingFileDiff = Math.abs((wkSq & 7) - (bkSq & 7));
+        int kingRankDiff = Math.abs((wkSq >> 3) - (bkSq >> 3));
+        int kingDist = Math.max(kingFileDiff, kingRankDiff);
+        int closenessBonus = Math.max(0, 7 - kingDist); // 0 when far apart, 6 when adjacent
+
+        int mopUp = cornerDistance * 5 + closenessBonus * 3;
+        return whiteWinning ? mopUp : -mopUp;
     }
 
     public double getScoreDifference() {

--- a/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/PawnStructureModule.java
@@ -164,6 +164,10 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         int whiteBackwardBase = calculateBackwardPawnPenalty(whitePawns, blackPawns, allPieces, true, backwardPawnPenalty);
         int blackBackwardBase = calculateBackwardPawnPenalty(blackPawns, whitePawns, allPieces, false, backwardPawnPenalty);
 
+        // Space advantage: count pawns beyond the 4th rank (midgame only)
+        int whiteSpace = calculateSpaceBonus(whitePawns, true);
+        int blackSpace = calculateSpaceBonus(blackPawns, false);
+
         int whiteMidgameTotal = structure.whiteCenterPawnBonus
                 + structure.whiteDoubledPawnPenalty
                 + structure.whiteIsolatedPawnPenalty
@@ -174,7 +178,8 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
                 + whitePassed
                 + whiteAdvanceBase
                 + whiteBlockedBase
-                + whiteBackwardBase;
+                + whiteBackwardBase
+                + whiteSpace;
 
         int whiteEndgameTotal = structure.whiteCenterPawnBonus
                 + structure.whiteDoubledPawnPenalty
@@ -198,7 +203,8 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
                 + blackPassed
                 + blackAdvanceBase
                 + blackBlockedBase
-                + blackBackwardBase;
+                + blackBackwardBase
+                + blackSpace;
 
         int blackEndgameTotal = structure.blackCenterPawnBonus
                 + structure.blackDoubledPawnPenalty
@@ -400,6 +406,18 @@ public final class PawnStructureModule implements EvaluationModule, MaterialModu
         int fileDiff = Math.abs((sq1 & 7) - (sq2 & 7));
         int rankDiff = Math.abs((sq1 >> 3) - (sq2 >> 3));
         return Math.max(fileDiff, rankDiff);
+    }
+
+    /**
+     * Space bonus: counts pawns in the opponent's half of the board.
+     * Each pawn beyond the center gives 3 cp midgame bonus for controlling space.
+     */
+    private static int calculateSpaceBonus(long pawns, boolean isWhite) {
+        // White pawns on ranks 5-7 (indices 32-55), black pawns on ranks 2-4 (indices 8-31)
+        long advancedMask = isWhite
+                ? 0x00FFFFFF00000000L  // ranks 5, 6, 7
+                : 0x00000000FFFFFF00L; // ranks 2, 3, 4
+        return Long.bitCount(pawns & advancedMask) * 3;
     }
 
     private int countHalfOpenFilesWithRooks(long rooksBitboard, long friendlyPawns, long enemyPawns) {


### PR DESCRIPTION
<![CDATA[## Summary

- **Space bonus**: pawns in opponent's half +3 cp each (midgame)
- **Mop-up endgame**: drive losing king to corner when winning by >200 cp

## Details

### Space advantage (PawnStructureModule)
Counts pawns that have crossed the center line into enemy territory. Each advanced pawn contributes +3 cp in the midgame, rewarding aggressive pawn play and spatial control.

### Mop-up endgame (EvaluationPipeline)
In deep endgames (phase > 200) with significant material advantage (>200 cp):
- **Corner distance bonus**: +5 cp per unit the losing king is pushed toward the corner (max ~30 cp)
- **King closeness bonus**: +3 cp per unit the winning king approaches the losing king (max ~18 cp)

This helps the engine convert winning endgames by actively centralizing its king and restricting the opponent.

## Test plan
- [ ] Run BestMoveSearchTest — expect improvements in endgame positions
- [ ] Run full test suite

https://claude.ai/code/session_01WSTYQg8gjYH62oozPodK3o]]>