### PR TITLE
v3.9.9: Connected rooks + endgame tuning

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
@@ -529,6 +529,31 @@ public final class ActivityModule implements EvaluationModule {
         // Rook on 7th rank bonus
         addRookSeventhRankBonus(board.getWhiteRooks(), RANK_7, board.getBlackKing(), true);
         addRookSeventhRankBonus(board.getBlackRooks(), RANK_2, board.getWhiteKing(), false);
+
+        // Connected rooks bonus (two rooks defending each other)
+        addConnectedRooksBonus(board.getWhiteRooks(), true);
+        addConnectedRooksBonus(board.getBlackRooks(), false);
+    }
+
+    private static final int CONNECTED_ROOKS_MIDGAME = 10;
+    private static final int CONNECTED_ROOKS_ENDGAME = 15;
+
+    private void addConnectedRooksBonus(long rooks, boolean isWhite) {
+        if (Long.bitCount(rooks) < 2) return;
+        int colorIdx = isWhite ? WHITE : BLACK;
+        // Check if any rook attacks another rook (they see each other on rank or file)
+        long remaining = rooks;
+        while (remaining != 0) {
+            int sq = Long.numberOfTrailingZeros(remaining);
+            remaining &= remaining - 1;
+            long rookAttacks = ROOK_HELPER.calculateRookMoves(sq, allPieces);
+            if ((rookAttacks & rooks) != 0) {
+                // At least one pair of connected rooks
+                midgameTotals[colorIdx] += CONNECTED_ROOKS_MIDGAME;
+                endgameTotals[colorIdx] += CONNECTED_ROOKS_ENDGAME;
+                return; // count once
+            }
+        }
     }
 
     private void addKnightOutpostBonus(long knights, long friendlyPawns, long enemyPawns, boolean isWhite) {

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -42,7 +42,7 @@ population:
       search.aspmaxretriesvolbonushigh: 8.17728313970275
       search.aspmaxretriesmomentumdivisor: 3.415713831580272
       search.ttmainweight: 4.548662134286979
-      activity.endgamemobilityqueen: 2.6515823707404658
+      activity.endgamemobilityqueen: 4.0
       search.nullswingguarddivisor: 73.87380792279565
       search.nulldepthcap: 5.067566954030266
       activity.midgamemobilitybishop: 11.05310596053398
@@ -55,10 +55,10 @@ population:
       pawnstructure.passedpawnfreepathbonusperrank: 17.748791935114653
       moveordering.maxscore: 1.38587574085523E7
       search.lmpperdepth: 7.606071904925005
-      material.bishoppairbonus: 54.93124467907178
+      material.bishoppairbonus: 65.0
       search.aspfloorstreakstepcp: 22.86182365222208
       search.lmrmovelogoffset: 3.480869172172873
-      activity.endgamemobilityrook: 3.0717099959664997
+      activity.endgamemobilityrook: 5.0
       activity.midgamecenterrook: 1.8432445714151602
       moveordering.castlingbonus: 5201.548534057966
       search.lmrhistorybuckets: 5.482618134712996
@@ -90,7 +90,7 @@ population:
       search.nullmaterialcap: 28.72238996352345
       moveordering.category.captureequal: 4.667448156774766
       pawnstructure.islandpenalty: -10.29479683697748
-      activity.endgamemobilityking: 2.8779474672679095
+      activity.endgamemobilityking: 5.0
       threat.hangingpawnpenalty: -20.95388408220842
       search.aspdefaultspancp: 32.81064401529041
       search.lmpbase: 3.746607725506342
@@ -108,7 +108,7 @@ population:
       kingsafety.attackweightrook: 50.0
       search.lmrprotectindexmax: 4.531491799106837
       search.aspmaxretriesdepthdivisor: 1.0156193437773624
-      activity.endgamecenterking: 6.429792404182555
+      activity.endgamecenterking: 10.0
       search.hmphistorymax: 121.92808472289505
       search.drawbias: 0.3171886750767487
       search.qsmaxdeltapawn: 6.650566521587819


### PR DESCRIPTION
<![CDATA[## Summary

- **Connected rooks bonus** (+10/+15 midgame/endgame)
- **Endgame tuning**: stronger bishop pair, more active king, better rook/queen mobility

## Changes

### Connected rooks (ActivityModule)
Two rooks that see each other along a rank or file receive a bonus. Connected rooks are a major positional advantage — they coordinate attacks and defend each other.

### Tuning

| Parameter | Before | After | Reason |
|-----------|--------|-------|--------|
| Bishop pair bonus | 54.9 | 65.0 | Bishop pairs dominate open positions |
| Endgame rook mobility | 3.1 | 5.0 | Rooks need space in endgames |
| Endgame queen mobility | 2.65 | 4.0 | Queen activity matters in endgame |
| Endgame king center | 6.4 | 10.0 | Active king is critical in endgame |
| Endgame king mobility | 2.9 | 5.0 | King must be mobile to support pawns |

## Test plan
- [ ] Run BestMoveSearchTest
- [ ] Run full test suite

https://claude.ai/code/session_01WSTYQg8gjYH62oozPodK3o]]>