### PR TITLE
v3.9.9: Bishop diagonal, pawn storm, trapped pieces, tempo

### DIFF
--- a/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/ActivityModule.java
@@ -742,6 +742,24 @@ public final class ActivityModule implements EvaluationModule {
         int endgameContribution = mobility * endgameMobilityWeights[pieceType]
                 + center * endgameCenterWeights[pieceType];
 
+        // Trapped piece penalty: minor/major pieces with very low mobility
+        if (pieceType != KING && mobility <= 1) {
+            int trappedPenalty = (mobility == 0) ? -30 : -10;
+            midgameContribution += trappedPenalty;
+            endgameContribution += trappedPenalty;
+        }
+
+        // Bishop long diagonal bonus: bishops on main diagonals with many open squares
+        if (pieceType == BISHOP) {
+            long mainDiag = 0x8040201008040201L; // a1-h8
+            long antiDiag = 0x0102040810204080L; // a8-h1
+            long sq = 1L << square;
+            if ((sq & (mainDiag | antiDiag)) != 0 && mobility >= 7) {
+                midgameContribution += 12;
+                endgameContribution += 8;
+            }
+        }
+
         midgameTotals[activity.color] += midgameContribution - activity.midgameScore;
         endgameTotals[activity.color] += endgameContribution - activity.endgameScore;
 

--- a/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
+++ b/src/main/java/julius/game/chessengine/evaluation/EvaluationPipeline.java
@@ -115,6 +115,13 @@ public final class EvaluationPipeline {
         long blended = (long) midgameTotal * midgameWeight + (long) endgameTotal * endgameWeight;
         int score = (int) (blended / blendScale);
 
+        // Tempo bonus: small advantage for the side to move
+        if (context.isWhiteToMove()) {
+            score += 10; // ~0.1 pawn advantage for having the move
+        } else {
+            score -= 10;
+        }
+
         // Mop-up evaluation: in late endgame with material advantage,
         // encourage driving the losing king toward the corner
         if (phase > 200) { // deep endgame

--- a/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
+++ b/src/main/java/julius/game/chessengine/evaluation/KingSafetyModule.java
@@ -295,8 +295,9 @@ public final class KingSafetyModule implements EvaluationModule {
         int shieldPenalty = state.missingShield * missingPawnShieldPenalty;
         int attackPenalty = -state.totalAttackWeight;
         int defenderBonus = state.defenderCount * this.defenderBonus;
+        int pawnStormPenalty = computePawnStormPenalty(enemyPawns, kingSquare, isWhite);
         computeBackrankWeaknessPenalty(state, board, isWhite);
-        int baseMidgame = shieldPenalty + state.filePenalty + attackPenalty + defenderBonus;
+        int baseMidgame = shieldPenalty + state.filePenalty + attackPenalty + defenderBonus + pawnStormPenalty;
         state.midgameKingSafety = baseMidgame + state.backrankWeaknessMidgame;
         state.endgameKingSafety = baseMidgame / 2 + state.backrankWeaknessEndgame;
 
@@ -524,6 +525,36 @@ public final class KingSafetyModule implements EvaluationModule {
             state.zoneAttackWeights[square] += weight;
             relevant &= relevant - 1;
         }
+    }
+
+    /**
+     * Penalty for enemy pawns advancing toward our king. Pawns on the same or
+     * adjacent files within 3 ranks of the king receive a distance-based penalty.
+     */
+    private static int computePawnStormPenalty(long enemyPawns, int kingSquare, boolean isWhite) {
+        if (enemyPawns == 0 || kingSquare < 0) {
+            return 0;
+        }
+        int kingFile = kingSquare & 7;
+        int kingRank = kingSquare >> 3;
+        int penalty = 0;
+        long remaining = enemyPawns;
+        while (remaining != 0) {
+            int sq = Long.numberOfTrailingZeros(remaining);
+            remaining &= remaining - 1;
+            int pawnFile = sq & 7;
+            int pawnRank = sq >> 3;
+            int fileDist = Math.abs(pawnFile - kingFile);
+            if (fileDist > 1) continue; // only same file and adjacent files
+            // Distance in ranks toward the king
+            int rankDist = isWhite ? (pawnRank - kingRank) : (kingRank - pawnRank);
+            if (rankDist <= 0) continue; // pawn is behind or on same rank as king
+            if (rankDist <= 3) {
+                // Closer pawn = bigger threat: 3 ranks away = -4, 2 = -8, 1 = -12
+                penalty -= (4 - rankDist) * 4;
+            }
+        }
+        return penalty;
     }
 
     private static long computeShieldMask(long kingBits, boolean isWhite) {

--- a/src/main/resources/tuning/seed-tunings.yaml
+++ b/src/main/resources/tuning/seed-tunings.yaml
@@ -67,7 +67,7 @@ population:
       moveordering.killer0bonus: 22.89496494174806
       search.nullbasereduction: 3.5471370734329564
       kingsafety.attackweightpawn: 8.831993317370175
-      activity.endgamecenterknight: 8.381255286063753
+      activity.endgamecenterknight: 12.0
       activity.midgamemobilityking: 0.0
       threat.pawnthreatbishoppenalty: -11.803162006658457
       search.aspvolatilityweight: 0.8551099349852392
@@ -89,7 +89,7 @@ population:
       search.lmrcapgoodquiet: 27.208205675668374
       search.nullmaterialcap: 28.72238996352345
       moveordering.category.captureequal: 4.667448156774766
-      pawnstructure.islandpenalty: -10.29479683697748
+      pawnstructure.islandpenalty: -14.0
       activity.endgamemobilityking: 5.0
       threat.hangingpawnpenalty: -20.95388408220842
       search.aspdefaultspancp: 32.81064401529041
@@ -120,11 +120,11 @@ population:
       search.fpmargindepth2: 322.68197246218494
       material.pawnvalue: 146.18558903211488
       kingsafety.attackweightqueen: 32.02409051995434
-      pawnstructure.doubledpawnpenalty: -9.678139647521522
+      pawnstructure.doubledpawnpenalty: -14.0
       search.seeprunenearrootply: 3.6760425768212808
       moveordering.historydecaydivisor: 1.7521454615607943
       pawnstructure.passedpawnbonus: 50.0
-      activity.midgamecenterknight: 3.702564587417092
+      activity.midgamecenterknight: 6.0
       activity.midgamecenterqueen: 3.4406529878224257
       search.aspbumpdepthcp: 3.7085655999707887
       search.nullmaterialweight: 1.9615830794320193


### PR DESCRIPTION
<![CDATA[## Summary

5 new evaluation features + tuning improvements for stronger positional play.

## New features

### Trapped piece penalty (ActivityModule)
- 0 mobility: -30 cp penalty
- 1 mobility: -10 cp penalty
Catches stuck knights, cornered bishops, blocked rooks.

### Bishop long diagonal bonus (ActivityModule)
+12/+8 midgame/endgame for bishops sitting on the main diagonals (a1-h8, a8-h1) with 7+ squares of mobility. Strong fianchetto bishops dominate games.

### Pawn storm detection (KingSafetyModule)
Enemy pawns advancing toward the king on same/adjacent files within 3 ranks receive a penalty (-4 to -12 cp based on proximity). This catches dangerous pawn storms before they open lines.

### Tempo bonus (EvaluationPipeline)
+10 cp for the side to move. Having the initiative is a real advantage in chess — this reflects it in the evaluation.

### Tuning
| Parameter | Before | After |
|-----------|--------|-------|
| Knight midgame center | 3.7 | 6.0 |
| Knight endgame center | 8.4 | 12.0 |
| Doubled pawn penalty | -9.7 | -14.0 |
| Pawn island penalty | -10.3 | -14.0 |

## Test plan
- [ ] Run BestMoveSearchTest
- [ ] Run full test suite

https://claude.ai/code/session_01WSTYQg8gjYH62oozPodK3o]]>